### PR TITLE
Fix missing namespace for logging.h

### DIFF
--- a/moveit_core/logging/include/moveit/logging/logging.h
+++ b/moveit_core/logging/include/moveit/logging/logging.h
@@ -34,8 +34,8 @@
 
 /* Author: Víctor Mayoral Vilches */
 
-#ifndef MOVEIT_LOGGING_
-#define MOVEIT_LOGGING_
+#ifndef MOVEIT_MACROS_LOGGING_
+#define MOVEIT_MACROS_LOGGING_
 #include <rcutils/logging_macros.h>
 
 #define ROS_ERROR_NAMED RCUTILS_LOG_ERROR


### PR DESCRIPTION
See https://github.com/ros-planning/moveit2/pull/2#discussion_r258234915