### PR TITLE
Increase CMake version to 3.10.2 per REP 2000 for Ubuntu Bionic / Crystal

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_core)
 
 #suppress spurious errors: https://github.com/fkie/catkin_lint/issues/62

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_kinematics)
 
 add_compile_options(-std=c++14)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(_PACKAGE_NAME_)
 
 add_compile_options(-std=c++14)

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_planners_ompl)
 
 # At least C++11 required for OMPL

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_benchmarks)
 
 set(MOVEIT_LIB_NAME moveit_ros_benchmarks)

--- a/moveit_ros/manipulation/CMakeLists.txt
+++ b/moveit_ros/manipulation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_manipulation)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_move_group)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_perception)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_planning)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_planning_interface)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_robot_interaction)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_visualization)
 
 add_compile_options(-std=c++14)

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_warehouse)
 
 add_compile_options(-std=c++14)

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_setup_assistant)
 
 add_compile_options(-std=c++14)


### PR DESCRIPTION
Rather than doing these for each package individually, e.g. https://github.com/ros-planning/moveit2/pull/10#discussion_r259637946

See http://www.ros.org/reps/rep-2000.html

This assumes we will not be building ROS2 on 16.04, which from my understanding ROS2 isn't really supported there.