### PR TITLE
Cleaning up Docker

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -66,23 +66,19 @@ RUN apt-get -qq update && \
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*
 
-# Download moveit source, so that we can get necessary dependencies
+# Download moveit source and fetch all necessary dependencies
 RUN mkdir src && \
     cd $ROS_WS/src && \
     # TODO(mlautman): This should be changed to use vcs in the future
-    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit2/master/moveit.rosinstall
-
-# Download all MoveIt dependencies
-RUN \
+    wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit2/master/moveit.rosinstall && \
     apt-get -qq update && \
     rosdep update -q && \
     rosdep install -q -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     # Clear apt-cache to reduce image size
-    rm -rf /var/lib/apt/lists/*
-
-# Remove the source code from this container
-# TODO: in the future we may want to keep this here for further optimization of later containers
-RUN cd $ROS_WS && \
+    rm -rf /var/lib/apt/lists/* && \
+    #
+    # Remove the source code from this container
+    cd $ROS_WS && \
     rm -rf src/
 
 # Continous Integration Setting

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get -qq update && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 
-    # Build the workspace
-RUN colcon build --symlink-install --event-handlers console_direct+
+# Build the workspace
+RUN . /opt/ros/crystal/setup.sh &&\
+    colcon build --symlink-install --event-handlers desktop_notification-


### PR DESCRIPTION
This augments https://github.com/ros-planning/moveit2/pull/57 to successfully build the source docker image: Sourcing the ROS underlay was missing.
Also, I cleaned up the ci docker image as originally promised my Mike in https://github.com/ros-planning/moveit2/pull/46#event-2228195081.

As can be seen [here](https://cloud.docker.com/u/moveit/repository/docker/moveit/moveit2/builds), the source docker image wasn't yet built.