### PR TITLE
Fix Docker build (ci, source)

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -74,7 +74,8 @@ RUN mkdir src && \
     vcs import < moveit2.repos && \
     apt-get -qq update && \
     rosdep update -q && \
-    rosdep install -q -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # TODO(henningkayser): Remove --skip-keys=catkin when octomap is released
+    rosdep install -q -y --from-paths . --ignore-src --skip-keys=catkin --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/* && \
     #

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -21,7 +21,8 @@ RUN mkdir src && \
 RUN apt-get -qq update && \
     apt-get -qq dist-upgrade && \
     rosdep update && \
-    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # TODO(henningkayser): Remove --skip-keys=catkin when octomap is released
+    rosdep install -y --from-paths . --ignore-src --skip-keys=catkin --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 
 # Build the workspace

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -51,7 +51,7 @@
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl</test_depend>
-  <test_depend>rosunit</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Docker failed because rosdep couldn't resolve `rosunit` in `moveit_core` and `catkin` in `octomap`.
`rosunit` is now replaced by `ament_cmake_gtest` and `catkin` is skipped in the `rosdep install` command directly.