### PR TITLE
Re-enable moveit_ros_planning & CMakeLists fixes

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
@@ -5,6 +5,7 @@ set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_V
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   urdf
+  pluginlib
   class_loader
   ament_index_cpp
   moveit_core

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -26,9 +26,7 @@
   <depend>moveit_msgs</depend>
   <depend>message_filters</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
-  <depend>actionlib</depend>
-  <depend>dynamic_reconfigure</depend>
-  <depend>rosconsole</depend>
+  <depend>rclcpp_action</depend>
   <depend>rclcpp</depend>
   <depend>srdfdom</depend>
   <depend>urdf</depend>

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -22,7 +22,8 @@
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
   <depend>moveit_core</depend>
-  <depend>moveit_ros_occupancy_map_monitor</depend>
+  <!-- TODO(JafarAbdi): Uncomment when porting planning scene monitor -->
+  <!-- <depend>moveit_ros_occupancy_map_monitor</depend> -->
   <depend>moveit_msgs</depend>
   <depend>message_filters</depend>
   <depend version_gte="1.11.2">pluginlib</depend>


### PR DESCRIPTION
### Description

The reason why I added `moveit_rdf_loader` and `moveit_kinematics_plugin_loader` in `target_link_libraries` because they don't have a `*Config.cmake` file, after making `moveit_kinematics_plugin_loader` library `SHARED` I got some weird linking errors fixed them by adding the dependencies from the same package in `target_link_libraries`

[ament_target_dependencies reference](https://github.com/ament/ament_cmake/blob/master/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
