### PR TITLE
Fix node uninitialized bug

### DIFF
--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -260,10 +260,12 @@ bool PR2ArmKinematicsPlugin::isActive()
   return active_;
 }
 
-bool PR2ArmKinematicsPlugin::initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
+bool PR2ArmKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node,
+                                        const moveit::core::RobotModel& robot_model, const std::string& group_name,
                                         const std::string& base_frame, const std::vector<std::string>& tip_frames,
                                         double search_discretization)
 {
+  node_ = node;
   storeValues(robot_model, group_name, base_frame, tip_frames, search_discretization);
   const bool verbose = false;
   std::string xml_string;

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -218,9 +218,9 @@ public:
    * @brief  Initialization function for the kinematics
    * @return True if initialization was successful, false otherwise
    */
-  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                  double search_discretization) override;
+  bool initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                  const std::string& group_name, const std::string& base_frame,
+                  const std::vector<std::string>& tip_frames, double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -72,15 +72,16 @@ protected:
 
   void SetUp() override
   {
+    node_ = rclcpp::Node::make_shared("test_constraint_samplers");
     robot_model_ = moveit::core::loadTestingRobotModel("pr2");
 
     pr2_kinematics_plugin_right_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);
-    pr2_kinematics_plugin_right_arm_->initialize(*robot_model_, "right_arm", "torso_lift_link", { "r_wrist_roll_link" },
-                                                 .01);
+    pr2_kinematics_plugin_right_arm_->initialize(node_, *robot_model_, "right_arm", "torso_lift_link",
+                                                 { "r_wrist_roll_link" }, .01);
 
     pr2_kinematics_plugin_left_arm_.reset(new pr2_arm_kinematics::PR2ArmKinematicsPlugin);
-    pr2_kinematics_plugin_left_arm_->initialize(*robot_model_, "left_arm", "torso_lift_link", { "l_wrist_roll_link" },
-                                                .01);
+    pr2_kinematics_plugin_left_arm_->initialize(node_, *robot_model_, "left_arm", "torso_lift_link",
+                                                { "l_wrist_roll_link" }, .01);
 
     func_right_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverRightArm, this, _1);
     func_left_arm_ = boost::bind(&LoadPlanningModelsPr2::getKinematicsSolverLeftArm, this, _1);
@@ -101,6 +102,7 @@ protected:
   }
 
 protected:
+  rclcpp::Node::SharedPtr node_;
   robot_model::RobotModelPtr robot_model_;
   planning_scene::PlanningScenePtr ps_;
   pr2_arm_kinematics::PR2ArmKinematicsPluginPtr pr2_kinematics_plugin_right_arm_;
@@ -1113,6 +1115,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
 
 int main(int argc, char** argv)
 {
+  rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -377,9 +377,9 @@ public:
    * Default implementation returns false and issues a warning to implement this new API.
    * TODO: Make this method purely virtual after some soaking time, replacing the fallback.
    */
-  virtual bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                          const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                          double search_discretization);
+  virtual bool initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                          const std::string& group_name, const std::string& base_frame,
+                          const std::vector<std::string>& tip_frames, double search_discretization);
 
   /**
    * @brief  Return the name of the group that the solver is operating on

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -88,9 +88,9 @@ bool KinematicsBase::initialize(const std::string& robot_description, const std:
   return false;
 }
 
-bool KinematicsBase::initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                                const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                                double search_discretization)
+bool KinematicsBase::initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                                const std::string& group_name, const std::string& base_frame,
+                                const std::vector<std::string>& tip_frames, double search_discretization)
 {
   RCLCPP_ERROR(LOGGER, "IK plugin for group '%s' relies on deprecated API.", group_name.c_str());
   return false;


### PR DESCRIPTION
### Description

Adding a node as a parameter for the initialize function of kienamtics_base otherwise, the kinematics plugins will segfault due to using a null node, this's related to the moveit_kinematics [PR](https://github.com/ros-planning/moveit2/pull/128) 
 
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
