### PR TITLE
Port occupancy_map_monitor to ROS2

### DIFF
--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -1,9 +1,16 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_occupancy_map_monitor)
 set(MOVEIT_LIB_NAME ${PROJECT_NAME})
 
 set(CMAKE_CXX_STANDARD 14)
+
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Disable -Wpedantic warnings due to the warnings in ros-dashing-octomap
+# TODO: add -Wpedantic warnings back when PR(https://github.com/OctoMap/octomap/pull/275) is merged
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wno-pedantic)
+endif()
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -15,54 +22,69 @@ if(APPLE)
   find_package(X11 REQUIRED)
 endif(APPLE)
 
-find_package(catkin REQUIRED COMPONENTS
-  moveit_core
-  moveit_msgs
-  pluginlib
-)
-
+find_package(moveit_core REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(octomap REQUIRED)
+find_package(geometric_shapes REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${MOVEIT_LIB_NAME}
-  CATKIN_DEPENDS
-    moveit_core
-    moveit_msgs
-  DEPENDS
-    EIGEN3
-    OCTOMAP
-)
-
-include_directories(include
-                    ${Boost_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS}
-                    )
+include_directories(include)
 include_directories(SYSTEM
                     ${EIGEN3_INCLUDE_DIRS}
                     ${X11_INCLUDE_DIR}
                     )
 
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/occupancy_map_monitor.cpp
   src/occupancy_map_updater.cpp
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  moveit_msgs
+  pluginlib
+  octomap
+  geometric_shapes
+  Boost
+)
 
 add_executable(moveit_ros_occupancy_map_server src/occupancy_map_server.cpp)
-target_link_libraries(moveit_ros_occupancy_map_server ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_ros_occupancy_map_server
+  rclcpp
+  moveit_core
+  moveit_msgs
+  pluginlib
+  octomap
+  geometric_shapes
+  Boost
+)
+target_link_libraries(moveit_ros_occupancy_map_server ${MOVEIT_LIB_NAME})
 
-install(TARGETS ${MOVEIT_LIB_NAME}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+ament_export_include_directories(include)
+ament_export_interfaces(${MOVEIT_LIB_NAME} HAS_LIBRARY_TARGET)
+ament_export_libraries(${MOVEIT_LIB_NAME})
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(eigen3_cmake_module)
+ament_export_dependencies(moveit_core)
+ament_export_dependencies(moveit_msgs)
+ament_export_dependencies(pluginlib)
+ament_export_dependencies(octomap)
+ament_export_dependencies(geometric_shapes)
+ament_export_dependencies(Boost)
+
+install(
+  TARGETS ${MOVEIT_LIB_NAME}
+  EXPORT  ${MOVEIT_LIB_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(TARGETS moveit_ros_occupancy_map_server
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  DESTINATION lib/${PROJECT_NAME}/
 )
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
+
+ament_package()

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -48,7 +48,8 @@ typedef unsigned int ShapeHandle;
 typedef std::map<ShapeHandle, Eigen::Isometry3d, std::less<ShapeHandle>,
                  Eigen::aligned_allocator<std::pair<const ShapeHandle, Eigen::Isometry3d> > >
     ShapeTransformCache;
-typedef boost::function<bool(const std::string& target_frame, const ros::Time& target_time, ShapeTransformCache& cache)>
+typedef boost::function<bool(const std::string& target_frame, const rclcpp::Time& target_time,
+                             ShapeTransformCache& cache)>
     TransformCacheProvider;
 
 class OccupancyMapMonitor;
@@ -68,7 +69,8 @@ public:
 
   /** @brief Set updater params using struct that comes from parsing a yaml string. This must be called after
    * setMonitor() */
-  virtual bool setParams(XmlRpc::XmlRpcValue& params) = 0;
+  // TODO rework this function
+  // virtual bool setParams(XmlRpc::XmlRpcValue& params) = 0;
 
   /** @brief Do any necessary setup (subscribe to ros topics, etc.). This call assumes setMonitor() and setParams() have
    * been previously called. */
@@ -105,9 +107,10 @@ protected:
   ShapeTransformCache transform_cache_;
   bool debug_info_;
 
-  bool updateTransformCache(const std::string& target_frame, const ros::Time& target_time);
+  bool updateTransformCache(const std::string& target_frame, const rclcpp::Time& target_time);
 
-  static void readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, double* value);
-  static void readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, unsigned int* value);
+  // TODO rework this function
+  // static void readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, double* value);
+  // static void readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, unsigned int* value);
 };
 }

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -17,15 +17,25 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
+  <depend>rclcpp</depend>
   <depend>moveit_core</depend>
   <depend>moveit_msgs</depend>
   <depend>octomap</depend>
+  <depend>geometric_shapes</depend>
+
   <depend version_gte="1.11.2">pluginlib</depend>
 
   <build_depend>eigen</build_depend>
+  <build_export_depend>eigen</build_export_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -41,8 +41,6 @@
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 // #include <XmlRpcException.h>
 #include <boost/bind.hpp>
-#include <rcutils/logging_macros.h>
-#include <rcutils/time.h>
 
 namespace occupancy_map_monitor
 {
@@ -288,7 +286,8 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
         std::map<ShapeHandle, ShapeHandle>::const_iterator jt = mesh_handles_[index].find(it.first);
         if (jt == mesh_handles_[index].end())
         {
-          RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Incorrect mapping of mesh handles");
+          rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+          RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Incorrect mapping of mesh handles");
           return false;
         }
         else

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -34,41 +34,35 @@
 
 /* Author: Ioan Sucan, Jon Binney */
 
-#include <ros/ros.h>
-#include <moveit_msgs/SaveMap.h>
-#include <moveit_msgs/LoadMap.h>
+#include <rclcpp/rclcpp.hpp>
+#include <moveit_msgs/srv/save_map.hpp>
+#include <moveit_msgs/srv/load_map.hpp>
 #include <moveit/occupancy_map_monitor/occupancy_map.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
-#include <XmlRpcException.h>
+// #include <XmlRpcException.h>
+#include <boost/bind.hpp>
+#include <rcutils/logging_macros.h>
+#include <rcutils/time.h>
 
 namespace occupancy_map_monitor
 {
-OccupancyMapMonitor::OccupancyMapMonitor(double map_resolution)
-  : map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), nh_("~"), active_(false)
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.occupancy_map_monitor");
+
+OccupancyMapMonitor::OccupancyMapMonitor(const rclcpp::Node::SharedPtr& node, double map_resolution)
+  : map_resolution_(map_resolution), debug_info_(false), mesh_handle_count_(0), node_(node), active_(false)
 {
   initialize();
 }
 
-OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
+OccupancyMapMonitor::OccupancyMapMonitor(const rclcpp::Node::SharedPtr& node,
+                                         const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
                                          const std::string& map_frame, double map_resolution)
   : tf_buffer_(tf_buffer)
   , map_frame_(map_frame)
   , map_resolution_(map_resolution)
   , debug_info_(false)
   , mesh_handle_count_(0)
-  , nh_("~")
-{
-  initialize();
-}
-
-OccupancyMapMonitor::OccupancyMapMonitor(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, ros::NodeHandle& nh,
-                                         const std::string& map_frame, double map_resolution)
-  : tf_buffer_(tf_buffer)
-  , map_frame_(map_frame)
-  , map_resolution_(map_resolution)
-  , debug_info_(false)
-  , mesh_handle_count_(0)
-  , nh_(nh)
+  , node_(node)
 {
   initialize();
 }
@@ -77,106 +71,120 @@ void OccupancyMapMonitor::initialize()
 {
   /* load params from param server */
   if (map_resolution_ <= std::numeric_limits<double>::epsilon())
-    if (!nh_.getParam("octomap_resolution", map_resolution_))
+    if (!node_->get_parameter("octomap_resolution", map_resolution_))
     {
       map_resolution_ = 0.1;
-      ROS_WARN("Resolution not specified for Octomap. Assuming resolution = %g instead", map_resolution_);
+      RCLCPP_WARN(LOGGER, "Resolution not specified for Octomap. Assuming resolution = %g instead", map_resolution_);
     }
-  ROS_DEBUG("Using resolution = %lf m for building octomap", map_resolution_);
+  RCLCPP_DEBUG(LOGGER, "Using resolution = %lf m for building octomap", map_resolution_);
 
   if (map_frame_.empty())
-    if (!nh_.getParam("octomap_frame", map_frame_))
+    if (!node_->get_parameter("octomap_frame", map_frame_))
       if (tf_buffer_)
-        ROS_WARN("No target frame specified for Octomap. No transforms will be applied to received data.");
+        RCLCPP_WARN(LOGGER, "No target frame specified for Octomap. No transforms will be applied to received data.");
 
   if (!tf_buffer_ && !map_frame_.empty())
-    ROS_WARN("Target frame specified but no TF instance specified. No transforms will be applied to received data.");
+    RCLCPP_WARN(LOGGER,
+                "Target frame specified but no TF instance specified. No transforms will be applied to received data.");
 
   tree_.reset(new OccMapTree(map_resolution_));
   tree_const_ = tree_;
 
-  XmlRpc::XmlRpcValue sensor_list;
-  if (nh_.getParam("sensors", sensor_list))
-  {
-    try
-    {
-      if (sensor_list.getType() == XmlRpc::XmlRpcValue::TypeArray)
-        for (int32_t i = 0; i < sensor_list.size(); ++i)
-        {
-          if (sensor_list[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
-          {
-            ROS_ERROR("Params for octomap updater %d not a struct; ignoring.", i);
-            continue;
-          }
+  // TODO rework this in ROS2
+  // XmlRpc::XmlRpcValue sensor_list;
+  // if (nh_.getParam("sensors", sensor_list))
+  // {
+  //   try
+  //   {
+  //     if (sensor_list.getType() == XmlRpc::XmlRpcValue::TypeArray)
+  //       for (int32_t i = 0; i < sensor_list.size(); ++i)
+  //       {
+  //         if (sensor_list[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  //         {
+  //           ROS_ERROR("Params for octomap updater %d not a struct; ignoring.", i);
+  //           continue;
+  //         }
 
-          if (!sensor_list[i].hasMember("sensor_plugin"))
-          {
-            ROS_ERROR("No sensor plugin specified for octomap updater %d; ignoring.", i);
-            continue;
-          }
+  //         if (!sensor_list[i].hasMember("sensor_plugin"))
+  //         {
+  //           ROS_ERROR("No sensor plugin specified for octomap updater %d; ignoring.", i);
+  //           continue;
+  //         }
 
-          std::string sensor_plugin = std::string(sensor_list[i]["sensor_plugin"]);
-          if (sensor_plugin.empty() || sensor_plugin[0] == '~')
-          {
-            ROS_INFO("Skipping octomap updater plugin '%s'", sensor_plugin.c_str());
-            continue;
-          }
+  //         std::string sensor_plugin = std::string(sensor_list[i]["sensor_plugin"]);
+  //         if (sensor_plugin.empty() || sensor_plugin[0] == '~')
+  //         {
+  //           ROS_INFO("Skipping octomap updater plugin '%s'", sensor_plugin.c_str());
+  //           continue;
+  //         }
 
-          if (!updater_plugin_loader_)
-          {
-            try
-            {
-              updater_plugin_loader_.reset(new pluginlib::ClassLoader<OccupancyMapUpdater>(
-                  "moveit_ros_perception", "occupancy_map_monitor::OccupancyMapUpdater"));
-            }
-            catch (pluginlib::PluginlibException& ex)
-            {
-              ROS_FATAL_STREAM("Exception while creating octomap updater plugin loader " << ex.what());
-            }
-          }
+  //         if (!updater_plugin_loader_)
+  //         {
+  //           try
+  //           {
+  //             updater_plugin_loader_.reset(new pluginlib::ClassLoader<OccupancyMapUpdater>(
+  //                 "moveit_ros_perception", "occupancy_map_monitor::OccupancyMapUpdater"));
+  //           }
+  //           catch (pluginlib::PluginlibException& ex)
+  //           {
+  //             ROS_FATAL_STREAM("Exception while creating octomap updater plugin loader " << ex.what());
+  //           }
+  //         }
 
-          OccupancyMapUpdaterPtr up;
-          try
-          {
-            up = updater_plugin_loader_->createUniqueInstance(sensor_plugin);
-            up->setMonitor(this);
-          }
-          catch (pluginlib::PluginlibException& ex)
-          {
-            ROS_ERROR_STREAM("Exception while loading octomap updater '" << sensor_plugin << "': " << ex.what()
-                                                                         << std::endl);
-          }
-          if (up)
-          {
-            /* pass the params struct directly in to the updater */
-            if (!up->setParams(sensor_list[i]))
-            {
-              ROS_ERROR("Failed to configure updater of type %s", up->getType().c_str());
-              continue;
-            }
+  //         OccupancyMapUpdaterPtr up;
+  //         try
+  //         {
+  //           up = updater_plugin_loader_->createUniqueInstance(sensor_plugin);
+  //           up->setMonitor(this);
+  //         }
+  //         catch (pluginlib::PluginlibException& ex)
+  //         {
+  //           ROS_ERROR_STREAM("Exception while loading octomap updater '" << sensor_plugin << "': " << ex.what()
+  //                                                                        << std::endl);
+  //         }
+  //         if (up)
+  //         {
+  //           /* pass the params struct directly in to the updater */
+  //           if (!up->setParams(sensor_list[i]))
+  //           {
+  //             ROS_ERROR("Failed to configure updater of type %s", up->getType().c_str());
+  //             continue;
+  //           }
 
-            if (!up->initialize())
-            {
-              ROS_ERROR("Unable to initialize map updater of type %s (plugin %s)", up->getType().c_str(),
-                        sensor_plugin.c_str());
-              continue;
-            }
+  //           if (!up->initialize())
+  //           {
+  //             ROS_ERROR("Unable to initialize map updater of type %s (plugin %s)", up->getType().c_str(),
+  //                       sensor_plugin.c_str());
+  //             continue;
+  //           }
 
-            addUpdater(up);
-          }
-        }
-      else
-        ROS_ERROR("List of sensors must be an array!");
-    }
-    catch (XmlRpc::XmlRpcException& ex)
-    {
-      ROS_ERROR("XmlRpc Exception: %s", ex.getMessage().c_str());
-    }
-  }
+  //           addUpdater(up);
+  //         }
+  //       }
+  //     else
+  //       ROS_ERROR("List of sensors must be an array!");
+  //   }
+  //   catch (XmlRpc::XmlRpcException& ex)
+  //   {
+  //     ROS_ERROR("XmlRpc Exception: %s", ex.getMessage().c_str());
+  //   }
+  // }
 
   /* advertise a service for loading octomaps from disk */
-  save_map_srv_ = nh_.advertiseService("save_map", &OccupancyMapMonitor::saveMapCallback, this);
-  load_map_srv_ = nh_.advertiseService("load_map", &OccupancyMapMonitor::loadMapCallback, this);
+  auto save_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t> request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request> request,
+                                          std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response) -> bool {
+    return saveMapCallback(request_header, request, response);
+  };
+
+  auto load_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t> request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request> request,
+                                          std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response) -> bool {
+    return loadMapCallback(request_header, request, response);
+  };
+
+  save_map_srv_ = node_->create_service<moveit_msgs::srv::SaveMap>("save_map", save_map_service_callback);
+  load_map_srv_ = node_->create_service<moveit_msgs::srv::LoadMap>("load_map", load_map_service_callback);
 }
 
 void OccupancyMapMonitor::addUpdater(const OccupancyMapUpdaterPtr& updater)
@@ -204,7 +212,7 @@ void OccupancyMapMonitor::addUpdater(const OccupancyMapUpdaterPtr& updater)
       updater->setTransformCacheCallback(transform_cache_callback_);
   }
   else
-    ROS_ERROR("NULL updater was specified");
+    RCLCPP_ERROR(LOGGER, "NULL updater was specified");
 }
 
 void OccupancyMapMonitor::publishDebugInformation(bool flag)
@@ -268,7 +276,7 @@ void OccupancyMapMonitor::setTransformCacheCallback(const TransformCacheProvider
 }
 
 bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::string& target_frame,
-                                                 const ros::Time& target_time, ShapeTransformCache& cache) const
+                                                 const rclcpp::Time& target_time, ShapeTransformCache& cache) const
 {
   if (transform_cache_callback_)
   {
@@ -280,7 +288,7 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
         std::map<ShapeHandle, ShapeHandle>::const_iterator jt = mesh_handles_[index].find(it.first);
         if (jt == mesh_handles_[index].end())
         {
-          ROS_ERROR_THROTTLE(1, "Incorrect mapping of mesh handles");
+          RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Incorrect mapping of mesh handles");
           return false;
         }
         else
@@ -295,42 +303,44 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
     return false;
 }
 
-bool OccupancyMapMonitor::saveMapCallback(moveit_msgs::srv::SaveMap::Request& request,
-                                          moveit_msgs::srv::SaveMap::Response& response)
+bool OccupancyMapMonitor::saveMapCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request> request,
+                                          std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response)
 {
-  ROS_INFO("Writing map to %s", request.filename.c_str());
+  RCLCPP_INFO(LOGGER, "Writing map to %s", request->filename.c_str());
   tree_->lockRead();
   try
   {
-    response.success = tree_->writeBinary(request.filename);
+    response->success = tree_->writeBinary(request->filename);
   }
   catch (...)
   {
-    response.success = false;
+    response->success = false;
   }
   tree_->unlockRead();
   return true;
 }
 
-bool OccupancyMapMonitor::loadMapCallback(moveit_msgs::srv::LoadMap::Request& request,
-                                          moveit_msgs::srv::LoadMap::Response& response)
+bool OccupancyMapMonitor::loadMapCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request> request,
+                                          std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response)
 {
-  ROS_INFO("Reading map from %s", request.filename.c_str());
+  RCLCPP_INFO(LOGGER, "Reading map from %s", request->filename.c_str());
 
   /* load the octree from disk */
   tree_->lockWrite();
   try
   {
-    response.success = tree_->readBinary(request.filename);
+    response->success = tree_->readBinary(request->filename);
   }
   catch (...)
   {
-    ROS_ERROR("Failed to load map from file");
-    response.success = false;
+    RCLCPP_ERROR(LOGGER, "Failed to load map from file");
+    response->success = false;
   }
   tree_->unlockWrite();
 
-  if (response.success)
+  if (response->success)
     tree_->triggerUpdateCallback();
 
   return true;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -35,27 +35,31 @@
 /* Author: Jon Binney, Ioan Sucan */
 
 #include <memory>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <octomap_msgs/conversions.h>
+#include <boost/bind.hpp>
 
-static void publishOctomap(ros::Publisher* octree_binary_pub, occupancy_map_monitor::OccupancyMapMonitor* server)
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.occupancy_map_server");
+
+static void publishOctomap(rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr octree_binary_pub,
+                           occupancy_map_monitor::OccupancyMapMonitor* server)
 {
-  octomap_msgs::Octomap map;
+  octomap_msgs::msg::Octomap map;
 
   map.header.frame_id = server->getMapFrame();
-  map.header.stamp = ros::Time::now();
+  map.header.stamp = rclcpp::Clock().now();
 
   server->getOcTreePtr()->lockRead();
   try
   {
     if (!octomap_msgs::binaryMapToMsgData(*server->getOcTreePtr(), map.data))
-      ROS_ERROR_THROTTLE(1, "Could not generate OctoMap message");
+      RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Could not generate OctoMap message");
   }
   catch (...)
   {
-    ROS_ERROR_THROTTLE(1, "Exception thrown while generating OctoMap message");
+    RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Exception thrown while generating OctoMap message");
   }
   server->getOcTreePtr()->unlockRead();
 
@@ -64,15 +68,17 @@ static void publishOctomap(ros::Publisher* octree_binary_pub, occupancy_map_moni
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "occupancy_map_server");
-  ros::NodeHandle nh;
-  ros::Publisher octree_binary_pub = nh.advertise<octomap_msgs::Octomap>("octomap_binary", 1);
-  std::shared_ptr<tf2_ros::Buffer> buffer = std::make_shared<tf2_ros::Buffer>(ros::Duration(5.0));
-  std::shared_ptr<tf2_ros::TransformListener> listener = std::make_shared<tf2_ros::TransformListener>(*buffer, nh);
-  occupancy_map_monitor::OccupancyMapMonitor server(buffer);
-  server.setUpdateCallback(boost::bind(&publishOctomap, &octree_binary_pub, &server));
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("occupancy_map_server");
+  auto octree_binary_pub =
+      node->create_publisher<octomap_msgs::msg::Octomap>("octomap_binary", RMW_QOS_POLICY_HISTORY_KEEP_LAST);
+  auto clock_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  std::shared_ptr<tf2_ros::Buffer> buffer = std::make_shared<tf2_ros::Buffer>(clock_ptr, tf2::durationFromSec(5.0));
+  std::shared_ptr<tf2_ros::TransformListener> listener = std::make_shared<tf2_ros::TransformListener>(*buffer, node);
+  occupancy_map_monitor::OccupancyMapMonitor server(node, buffer);
+  server.setUpdateCallback(boost::bind(&publishOctomap, octree_binary_pub, &server));
   server.startMonitor();
 
-  ros::spin();
+  rclcpp::spin(node);
   return 0;
 }

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -52,14 +52,15 @@ static void publishOctomap(rclcpp::Publisher<octomap_msgs::msg::Octomap>::Shared
   map.header.stamp = rclcpp::Clock().now();
 
   server->getOcTreePtr()->lockRead();
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   try
   {
     if (!octomap_msgs::binaryMapToMsgData(*server->getOcTreePtr(), map.data))
-      RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Could not generate OctoMap message");
+      RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Could not generate OctoMap message");
   }
   catch (...)
   {
-    RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1, "Exception thrown while generating OctoMap message");
+    RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Exception thrown while generating OctoMap message");
   }
   server->getOcTreePtr()->unlockRead();
 

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -39,6 +39,8 @@
 
 namespace occupancy_map_monitor
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.occupancy_map_updater");
+
 OccupancyMapUpdater::OccupancyMapUpdater(const std::string& type) : type_(type)
 {
 }
@@ -51,31 +53,35 @@ void OccupancyMapUpdater::setMonitor(OccupancyMapMonitor* monitor)
   tree_ = monitor->getOcTreePtr();
 }
 
-void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, double* value)
-{
-  if (params.hasMember(param_name))
-  {
-    if (params[param_name].getType() == XmlRpc::XmlRpcValue::TypeInt)
-      *value = (int)params[param_name];
-    else
-      *value = (double)params[param_name];
-  }
-}
+// TODO rework this function
+// void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, double* value)
+// {
+//   if (params.hasMember(param_name))
+//   {
+//     if (params[param_name].getType() == XmlRpc::XmlRpcValue::TypeInt)
+//       *value = (int)params[param_name];
+//     else
+//       *value = (double)params[param_name];
+//   }
+// }
 
-void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, unsigned int* value)
-{
-  if (params.hasMember(param_name))
-    *value = (int)params[param_name];
-}
+// TODO rework this function
+// void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue& params, const std::string& param_name, unsigned int*
+// value)
+// {
+//   if (params.hasMember(param_name))
+//     *value = (int)params[param_name];
+// }
 
-bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, const ros::Time& target_time)
+bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, const rclcpp::Time& target_time)
 {
   transform_cache_.clear();
   if (transform_provider_callback_)
     return transform_provider_callback_(target_frame, target_time, transform_cache_);
   else
   {
-    ROS_WARN_THROTTLE(1, "No callback provided for updating the transform cache for octomap updaters");
+    RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1,
+                               "No callback provided for updating the transform cache for octomap updaters");
     return false;
   }
 }

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -80,8 +80,9 @@ bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, 
     return transform_provider_callback_(target_frame, target_time, transform_cache_);
   else
   {
-    RCUTILS_LOG_ERROR_THROTTLE(rcutils_steady_time_now, 1,
-                               "No callback provided for updating the transform cache for octomap updaters");
+    rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+    RCLCPP_WARN_THROTTLE(LOGGER, steady_clock, 1000,
+                         "No callback provided for updating the transform cache for octomap updaters");
     return false;
   }
 }


### PR DESCRIPTION
#112 is blocked by `occupancy_map_monitor`, please see https://github.com/ros-planning/moveit2/blob/fa81678b965eafcb1e8c72018ba4d99ab2593255/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h#L45

This work followed AcutronicRobotics' porting, but didn't use the original commits. Because `occupancy_map_monitor` was moved from `moveit_ros` to `moveit_ros_perception`([ref](https://github.com/AcutronicRobotics/moveit2/tree/master/moveit_ros/perception/occupancy_map_monitor)), the original commits are very difficult to directly use. 
