### PR TITLE
Fixing docker

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qq update && \
 
 # Build the workspace
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh &&\
-    colcon build --symlink-install \
+    colcon build \
 	        --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 			  --ament-cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	        --event-handlers desktop_notification- status-


### PR DESCRIPTION
### Description

This should fix the docker build, compiling with `--symlink-install` flag causes moveit_core library targets to not get installed in `moveit_core/lib` folder (they will get installed directly in `moveit_core` folder, which causes errors about finding its libraries

[occupancy_map_monitor](https://github.com/ros-planning/moveit2/pull/148) should be merged first, otherwise rosdep will complain `moveit_ros_planning: Cannot locate rosdep definition for [moveit_ros_occupancy_map_monitor]`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
