### PR TITLE
Upgrade docker images to ROS 2 Eloquent

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -1,7 +1,7 @@
-# moveit/moveit2:dashing-ci-testing
+# moveit/moveit2:eloquent-ci-testing
 # CI image using the ROS testing repository
 
-ARG ROS_DISTRO=dashing
+ARG ROS_DISTRO=eloquent
 FROM moveit/moveit2:${ROS_DISTRO}-ci
 
 MAINTAINER Dave Coleman dave@picknik.ai

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,7 +1,7 @@
-# moveit/moveit2:dashing-ci
+# moveit/moveit2:eloquent-ci
 # ROS base image augmented with all MoveIt dependencies to use for CI on Travis
 
-ARG ROS_DISTRO=dashing
+ARG ROS_DISTRO=eloquent
 FROM ros:${ROS_DISTRO}-ros-base-bionic
 
 MAINTAINER Robert Haschke rhaschke@techfak.uni-bielefeld.de

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,7 +1,7 @@
-# moveit/moveit2:dashing-release
+# moveit/moveit2:eloquent-release
 # Full debian-based install of MoveIt using apt-get
 
-FROM ros:dashing-ros-base-bionic
+FROM ros:eloquent-ros-base-bionic
 MAINTAINER Dave Coleman dave@picknik.ai
 
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build the workspace
-RUN . /opt/ros/eloquent/setup.sh &&\
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh &&\
     colcon build --symlink-install \
 	        --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 			  --ament-cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,7 +1,7 @@
-# moveit/moveit2:dashing-source
+# moveit/moveit2:eloquent-source
 # Downloads the moveit source code and install remaining debian dependencies
 
-ARG ROS_DISTRO=dashing
+ARG ROS_DISTRO=eloquent
 FROM moveit/moveit2:${ROS_DISTRO}-ci-testing
 
 MAINTAINER Robert Haschke rhaschke@techfak.uni-bielefeld.de
@@ -30,7 +30,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build the workspace
-RUN . /opt/ros/dashing/setup.sh &&\
+RUN . /opt/ros/eloquent/setup.sh &&\
     colcon build --symlink-install \
 	        --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 			  --ament-cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
I switched to eloquent as default right away as we are dropping support for dashing in the future.