### PR TITLE
Port moveit ros visualization

### DIFF
--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MOVEIT_LIB_NAME moveit_utils)
 add_library(${MOVEIT_LIB_NAME} SHARED
   src/lexical_casts.cpp
   src/message_checks.cpp
+  src/rclcpp_utils.cpp
 )
 
 ament_target_dependencies(${MOVEIT_LIB_NAME} Boost moveit_msgs)

--- a/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
+++ b/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_NAMES_H
+#define ROSCPP_NAMES_H
+
+#include <string>
+
+// TODO(JafarAbdi): This's taken from ros_comm/../names.cpp for MoveIt 2 beta release -- remove when it's ported
+namespace rclcpp
+{
+namespace names
+{
+std::string clean(const std::string& name);
+
+std::string append(const std::string& left, const std::string& right);
+}  // namespace names
+}  // namespace rclcpp
+
+#endif  // ROSCPP_NAMES_H

--- a/moveit_core/utils/src/rclcpp_utils.cpp
+++ b/moveit_core/utils/src/rclcpp_utils.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2009, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <moveit/utils/rclcpp_utils.h>
+
+namespace rclcpp
+{
+namespace names
+{
+std::string clean(const std::string& name)
+{
+  std::string clean = name;
+
+  size_t pos = clean.find("//");
+  while (pos != std::string::npos)
+  {
+    clean.erase(pos, 1);
+    pos = clean.find("//", pos);
+  }
+
+  if (!name.empty() && *clean.rbegin() == '/')
+  {
+    clean.erase(clean.size() - 1, 1);
+  }
+
+  return clean;
+}
+
+std::string append(const std::string& left, const std::string& right)
+{
+  return clean(left + "/" + right);
+}
+}  // namespace names
+}  // namespace rclcpp

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -54,6 +54,17 @@ set(libraries
 
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  Boost
+  pluginlib
+  rclcpp
+  message_filters
+  srdfdom
+  urdf
+  tf2
+  tf2_eigen
+  tf2_ros
+  Eigen3
+  moveit_ros_occupancy_map_monitor
   moveit_core
   # moveit_ros_perception
   moveit_msgs

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -17,103 +17,77 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Boost REQUIRED thread date_time system filesystem)
-find_package(catkin REQUIRED COMPONENTS
-  class_loader
-  geometric_shapes
-  interactive_markers
-  moveit_ros_perception
-  moveit_ros_planning_interface
-  moveit_ros_robot_interaction
-  moveit_ros_warehouse
-  object_recognition_msgs
-  pluginlib
-  rosconsole
-  roscpp
-  rospy
-  rviz
-  tf2_eigen
-  roscpp
-  rosconsole
-  object_recognition_msgs
-)
-# TODO: Remove when Kinetic support is dropped
-if(rviz_VERSION VERSION_LESS 1.13.1) # Does rviz supports TF2?
-  add_definitions(-DRVIZ_TF1)
-endif()
-
+find_package(ament_cmake REQUIRED)
+find_package(class_loader REQUIRED)
+find_package(geometric_shapes REQUIRED)
+find_package(interactive_markers REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(octomap_msgs REQUIRED)
+find_package(moveit_ros_planning_interface REQUIRED)
+# TODO(JafarAbdi): Uncomment when porting each package
+# find_package(moveit_ros_perception REQUIRED)
+# find_package(moveit_ros_robot_interaction REQUIRED)
+# find_package(moveit_ros_warehouse REQUIRED)
+find_package(object_recognition_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclpy REQUIRED)
+find_package(rviz2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(rviz_ogre_vendor REQUIRED)
 
 # Qt Stuff
-if(rviz_QT_VERSION VERSION_LESS "5")
-	find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
-	include(${QT_USE_FILE})
-  macro(qt_wrap_ui)
-    qt4_wrap_ui(${ARGN})
-  endmacro()
-else()
-	find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
-	set(QT_LIBRARIES Qt5::Widgets)
-  macro(qt_wrap_ui)
-    qt5_wrap_ui(${ARGN})
-  endmacro()
-endif()
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 add_definitions(-DQT_NO_KEYWORDS)
 
-catkin_package(
-  LIBRARIES
-    moveit_motion_planning_rviz_plugin_core
-    moveit_planning_scene_rviz_plugin_core
-    moveit_robot_state_rviz_plugin_core
-    moveit_rviz_plugin_render_tools
-    moveit_trajectory_rviz_plugin_core
-  INCLUDE_DIRS
-    motion_planning_rviz_plugin/include
-    planning_scene_rviz_plugin/include
-    robot_state_rviz_plugin/include
-    rviz_plugin_render_tools/include
-    trajectory_rviz_plugin/include
-  CATKIN_DEPENDS
-    moveit_ros_planning_interface
-    moveit_ros_robot_interaction
-    object_recognition_msgs
-  DEPENDS
-    EIGEN3
-)
-
-catkin_install_python(PROGRAMS scripts/moveit_joy.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-catkin_python_setup()
+# catkin_install_python(PROGRAMS scripts/moveit_joy.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+# catkin_python_setup()
 
 include_directories(rviz_plugin_render_tools/include
                     robot_state_rviz_plugin/include
                     planning_scene_rviz_plugin/include
-                    motion_planning_rviz_plugin/include
-                    trajectory_rviz_plugin/include
-                    ${Boost_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS})
-
-include_directories(SYSTEM
-                    ${EIGEN3_INCLUDE_DIRS}
-                    ${QT_INCLUDE_DIR})
+                    #motion_planning_rviz_plugin/include
+                    #trajectory_rviz_plugin/include
+)
 
 add_subdirectory(rviz_plugin_render_tools)
 add_subdirectory(robot_state_rviz_plugin)
 add_subdirectory(planning_scene_rviz_plugin)
-add_subdirectory(motion_planning_rviz_plugin)
-add_subdirectory(trajectory_rviz_plugin)
+# add_subdirectory(motion_planning_rviz_plugin)
+# add_subdirectory(trajectory_rviz_plugin)
 
-install(FILES
-  motion_planning_rviz_plugin_description.xml
-  trajectory_rviz_plugin_description.xml
-  planning_scene_rviz_plugin_description.xml
-  robot_state_rviz_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY icons DESTINATION share)
 
-install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+#pluginlib_export_plugin_description_file(rviz_common motion_planning_rviz_plugin_description.xml)
+#pluginlib_export_plugin_description_file(rviz_common trajectory_rviz_plugin_description.xml)
+pluginlib_export_plugin_description_file(rviz_common planning_scene_rviz_plugin_description.xml)
+pluginlib_export_plugin_description_file(rviz_common robot_state_rviz_plugin_description.xml)
 
-if (CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
-  add_rostest(test/moveit_joy.test)
-endif()
+#if (CATKIN_ENABLE_TESTING)
+#  find_package(rostest REQUIRED)
+#  add_rostest(test/moveit_joy.test)
+#endif()
+
+ament_export_include_directories(include)
+ament_export_dependencies(class_loader)
+ament_export_dependencies(geometric_shapes)
+ament_export_dependencies(interactive_markers)
+ament_export_dependencies(moveit_ros_planning)
+ament_export_dependencies(moveit_msgs)
+ament_export_dependencies(moveit_core)
+ament_export_dependencies(octomap_msgs)
+ament_export_dependencies(object_recognition_msgs)
+ament_export_dependencies(pluginlib)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rclpy)
+ament_export_dependencies(rviz2)
+ament_export_dependencies(tf2_eigen)
+ament_export_dependencies(Eigen3)
+ament_export_dependencies(rviz_ogre_vendor)
+ament_package()

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -17,7 +17,7 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>class_loader</build_depend>
@@ -28,21 +28,22 @@
 
   <depend>geometric_shapes</depend>
   <depend>interactive_markers</depend>
-  <depend>moveit_ros_robot_interaction</depend>
-  <depend>moveit_ros_perception</depend>
+  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_robot_interaction -->
+  <!--depend>moveit_ros_robot_interaction</depend-->
+  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_perception -->
+  <!--depend>moveit_ros_perception</depend-->
   <depend>moveit_ros_planning_interface</depend>
-  <depend>moveit_ros_warehouse</depend>
+  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_warehouse -->
+  <!--depend>moveit_ros_warehouse</depend-->
   <depend>object_recognition_msgs</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
-  <depend>rosconsole</depend>
-  <depend>roscpp</depend>
-  <depend>rospy</depend>
-  <depend>rviz</depend>
+  <depend>rclcpp</depend>
+  <depend>rclpy</depend>
+  <depend>rviz2</depend>
   <depend>tf2_eigen</depend>
 
-  <test_depend>rostest</test_depend>
-
   <export>
+    <build_type>ament_cmake</build_type>
     <rviz plugin="${prefix}/robot_state_rviz_plugin_description.xml"/>
     <rviz plugin="${prefix}/planning_scene_rviz_plugin_description.xml"/>
     <rviz plugin="${prefix}/motion_planning_rviz_plugin_description.xml"/>

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -1,18 +1,35 @@
 set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 
-add_library(${MOVEIT_LIB_NAME}_core
+add_library(${MOVEIT_LIB_NAME}_core SHARED
   src/planning_scene_display.cpp
-  include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
+)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools rviz_ogre_vendor::OgreMain)
+ament_target_dependencies(${MOVEIT_LIB_NAME}_core
+    rclcpp
+    rviz2
+    moveit_ros_planning_interface
+    moveit_ros_planning
+    moveit_msgs
+    pluginlib
+    Boost
+)
 
-add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core  Qt5::Widgets)
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+    pluginlib
+)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+ament_export_libraries(
+    ${MOVEIT_LIB_NAME}_core
+    ${MOVEIT_LIB_NAME}
+)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -36,35 +36,20 @@
 
 #pragma once
 
-#include <rviz/display.h>
-
+#include <rviz_common/display.hpp>
+#include <rviz_default_plugins/robot/robot.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
 #ifndef Q_MOC_RUN
 #include <moveit/rviz_plugin_render_tools/planning_scene_render.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/background_processing/background_processing.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #endif
-
-namespace Ogre
-{
-class SceneNode;
-}
-
-namespace rviz
-{
-class Robot;
-class Property;
-class StringProperty;
-class BoolProperty;
-class FloatProperty;
-class RosTopicProperty;
-class ColorProperty;
-class EnumProperty;
-}
 
 namespace moveit_rviz_plugin
 {
-class PlanningSceneDisplay : public rviz::Display
+class PlanningSceneDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
@@ -72,8 +57,8 @@ public:
   PlanningSceneDisplay(bool listen_to_planning_scene = true, bool show_scene_robot = true);
   ~PlanningSceneDisplay() override;
 
-  void load(const rviz::Config& config) override;
-  void save(rviz::Config config) const override;
+  void load(const rviz_common::Config& config) override;
+  void save(rviz_common::Config config) const override;
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
@@ -105,7 +90,7 @@ public:
   const robot_model::RobotModelConstPtr& getRobotModel() const;
 
   /// wait for robot state more recent than t
-  bool waitForCurrentRobotState(const ros::Time& t = ros::Time::now());
+  bool waitForCurrentRobotState(const rclcpp::Time& t = rclcpp::Clock().now());
   /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
   /// get write access to planning scene
@@ -137,7 +122,7 @@ protected Q_SLOTS:
 protected:
   /// This function reloads the robot model and reinitializes the PlanningSceneMonitor
   /// It can be called either from the Main Loop or from a Background thread
-  void loadRobotModel();
+  void loadRobotModel(const rclcpp::Node::SharedPtr& node);
 
   /// This function is used by loadRobotModel() and should only be called in the MainLoop
   /// You probably should not call this function directly
@@ -145,7 +130,8 @@ protected:
 
   /// This function constructs a new planning scene. Probably this should be called in a background thread
   /// as it may take some time to complete its execution
-  virtual planning_scene_monitor::PlanningSceneMonitorPtr createPlanningSceneMonitor();
+  virtual planning_scene_monitor::PlanningSceneMonitorPtr
+  createPlanningSceneMonitor(const rclcpp::Node::SharedPtr& node);
 
   /// This is an event called by loadRobotModel() in the MainLoop; do not call directly
   virtual void onRobotModelLoaded();
@@ -158,11 +144,11 @@ protected:
   void executeMainLoopJobs();
   void sceneMonitorReceivedUpdate(planning_scene_monitor::PlanningSceneMonitor::SceneUpdateType update_type);
   void renderPlanningScene();
-  void setLinkColor(rviz::Robot* robot, const std::string& link_name, const QColor& color);
-  void unsetLinkColor(rviz::Robot* robot, const std::string& link_name);
-  void setGroupColor(rviz::Robot* robot, const std::string& group_name, const QColor& color);
-  void unsetGroupColor(rviz::Robot* robot, const std::string& group_name);
-  void unsetAllColors(rviz::Robot* robot);
+  void setLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name, const QColor& color);
+  void unsetLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name);
+  void setGroupColor(rviz_default_plugins::robot::Robot* robot, const std::string& group_name, const QColor& color);
+  void unsetGroupColor(rviz_default_plugins::robot::Robot* robot, const std::string& group_name);
+  void unsetAllColors(rviz_default_plugins::robot::Robot* robot);
 
   // overrides from Display
   void onInitialize() override;
@@ -192,23 +178,23 @@ protected:
   bool planning_scene_needs_render_;
   float current_scene_time_;
 
-  rviz::Property* scene_category_;
-  rviz::Property* robot_category_;
+  rviz_common::properties::Property* scene_category_;
+  rviz_common::properties::Property* robot_category_;
 
-  rviz::StringProperty* move_group_ns_property_;
-  rviz::StringProperty* robot_description_property_;
-  rviz::StringProperty* scene_name_property_;
-  rviz::BoolProperty* scene_enabled_property_;
-  rviz::BoolProperty* scene_robot_visual_enabled_property_;
-  rviz::BoolProperty* scene_robot_collision_enabled_property_;
-  rviz::RosTopicProperty* planning_scene_topic_property_;
-  rviz::FloatProperty* robot_alpha_property_;
-  rviz::FloatProperty* scene_alpha_property_;
-  rviz::ColorProperty* scene_color_property_;
-  rviz::ColorProperty* attached_body_color_property_;
-  rviz::FloatProperty* scene_display_time_property_;
-  rviz::EnumProperty* octree_render_property_;
-  rviz::EnumProperty* octree_coloring_property_;
+  rviz_common::properties::StringProperty* move_group_ns_property_;
+  rviz_common::properties::StringProperty* robot_description_property_;
+  rviz_common::properties::StringProperty* scene_name_property_;
+  rviz_common::properties::BoolProperty* scene_enabled_property_;
+  rviz_common::properties::BoolProperty* scene_robot_visual_enabled_property_;
+  rviz_common::properties::BoolProperty* scene_robot_collision_enabled_property_;
+  rviz_common::properties::RosTopicProperty* planning_scene_topic_property_;
+  rviz_common::properties::FloatProperty* robot_alpha_property_;
+  rviz_common::properties::FloatProperty* scene_alpha_property_;
+  rviz_common::properties::ColorProperty* scene_color_property_;
+  rviz_common::properties::ColorProperty* attached_body_color_property_;
+  rviz_common::properties::FloatProperty* scene_display_time_property_;
+  rviz_common::properties::EnumProperty* octree_render_property_;
+  rviz_common::properties::EnumProperty* octree_coloring_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/plugin_init.cpp
@@ -37,4 +37,4 @@
 #include <class_loader/class_loader.hpp>
 #include <moveit/planning_scene_rviz_plugin/planning_scene_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::PlanningSceneDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::PlanningSceneDisplay, rviz_common::Display)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin_description.xml
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin_description.xml
@@ -1,5 +1,5 @@
-<library path="libmoveit_planning_scene_rviz_plugin">
-  <class name="moveit_rviz_plugin/PlanningScene" type="moveit_rviz_plugin::PlanningSceneDisplay" base_class_type="rviz::Display">
+<library path="moveit_planning_scene_rviz_plugin">
+  <class name="moveit_rviz_plugin/PlanningScene" type="moveit_rviz_plugin::PlanningSceneDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a planning scene.
     </description>

--- a/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -1,20 +1,38 @@
-
 set(MOVEIT_LIB_NAME moveit_robot_state_rviz_plugin)
-add_library(${MOVEIT_LIB_NAME}_core
+add_library(${MOVEIT_LIB_NAME}_core SHARED
   src/robot_state_display.cpp
   include/moveit/robot_state_rviz_plugin/robot_state_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools
-  ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME}_core
+    moveit_rviz_plugin_render_tools
+    rviz_ogre_vendor::OgreMain
+)
+ament_target_dependencies(${MOVEIT_LIB_NAME}_core
+    rclcpp
+    rviz2
+    moveit_ros_planning
+    moveit_msgs
+    pluginlib
+    Boost
+)
 
-add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+    rclcpp
+    pluginlib
+    Boost
+)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 
+ament_export_libraries(
+    ${MOVEIT_LIB_NAME}_core
+    ${MOVEIT_LIB_NAME}
+)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -36,35 +36,22 @@
 
 #pragma once
 
-#include <rviz/display.h>
+#include <rviz_common/display.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
 
 #ifndef Q_MOC_RUN
 #include <moveit/rdf_loader/rdf_loader.h>
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit_msgs/msg/display_robot_state.hpp>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #endif
-
-namespace Ogre
-{
-class SceneNode;
-}
-
-namespace rviz
-{
-class Robot;
-class StringProperty;
-class BoolProperty;
-class FloatProperty;
-class RosTopicProperty;
-class ColorProperty;
-}
 
 namespace moveit_rviz_plugin
 {
 class RobotStateVisualization;
 
-class RobotStateDisplay : public rviz::Display
+class RobotStateDisplay : public rviz_common::Display
 {
   Q_OBJECT
 
@@ -109,13 +96,13 @@ protected:
    */
   void calculateOffsetPosition();
 
-  void setLinkColor(rviz::Robot* robot, const std::string& link_name, const QColor& color);
-  void unsetLinkColor(rviz::Robot* robot, const std::string& link_name);
+  void setLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name, const QColor& color);
+  void unsetLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name);
 
-  void newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstPtr& state);
+  void newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state);
 
   void setRobotHighlights(const moveit_msgs::msg::DisplayRobotState::_highlight_links_type& highlight_links);
-  void setHighlight(const std::string& link_name, const std_msgs::ColorRGBA& color);
+  void setHighlight(const std::string& link_name, const std_msgs::msg::ColorRGBA& color);
   void unsetHighlight(const std::string& link_name);
 
   // overrides from Display
@@ -125,26 +112,26 @@ protected:
   void fixedFrameChanged() override;
 
   // render the robot
-  ros::NodeHandle root_nh_;
-  ros::Subscriber robot_state_subscriber_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<moveit_msgs::msg::DisplayRobotState>::SharedPtr robot_state_subscriber_;
 
   RobotStateVisualizationPtr robot_;
   rdf_loader::RDFLoaderPtr rdf_loader_;
   robot_model::RobotModelConstPtr robot_model_;
   robot_state::RobotStatePtr robot_state_;
-  std::map<std::string, std_msgs::ColorRGBA> highlights_;
+  std::map<std::string, std_msgs::msg::ColorRGBA> highlights_;
   bool update_state_;
   bool load_robot_model_;  // for delayed robot initialization
 
-  rviz::StringProperty* robot_description_property_;
-  rviz::StringProperty* root_link_name_property_;
-  rviz::RosTopicProperty* robot_state_topic_property_;
-  rviz::FloatProperty* robot_alpha_property_;
-  rviz::ColorProperty* attached_body_color_property_;
-  rviz::BoolProperty* enable_link_highlight_;
-  rviz::BoolProperty* enable_visual_visible_;
-  rviz::BoolProperty* enable_collision_visible_;
-  rviz::BoolProperty* show_all_links_;
+  rviz_common::properties::StringProperty* robot_description_property_;
+  rviz_common::properties::StringProperty* root_link_name_property_;
+  rviz_common::properties::RosTopicProperty* robot_state_topic_property_;
+  rviz_common::properties::FloatProperty* robot_alpha_property_;
+  rviz_common::properties::ColorProperty* attached_body_color_property_;
+  rviz_common::properties::BoolProperty* enable_link_highlight_;
+  rviz_common::properties::BoolProperty* enable_visual_visible_;
+  rviz_common::properties::BoolProperty* enable_collision_visible_;
+  rviz_common::properties::BoolProperty* show_all_links_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/plugin_init.cpp
@@ -37,4 +37,4 @@
 #include <class_loader/class_loader.hpp>
 #include <moveit/robot_state_rviz_plugin/robot_state_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::RobotStateDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::RobotStateDisplay, rviz_common::Display)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -41,18 +41,18 @@
 #include <moveit/macros/diagnostics.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/visualization_manager.h>
-#include <rviz/robot/robot.h>
-#include <rviz/robot/robot_link.h>
+// #include <rviz/visualization_manager.h>
+#include <rviz_default_plugins/robot/robot.hpp>
+#include <rviz_default_plugins/robot/robot_link.hpp>
 
-#include <rviz/properties/property.h>
-#include <rviz/properties/string_property.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/color_property.h>
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
@@ -65,42 +65,43 @@ namespace moveit_rviz_plugin
 // ******************************************************************************************
 RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false), load_robot_model_(false)
 {
-  robot_description_property_ = new rviz::StringProperty(
+  robot_description_property_ = new rviz_common::properties::StringProperty(
       "Robot Description", "robot_description", "The name of the ROS parameter where the URDF for the robot is loaded",
       this, SLOT(changedRobotDescription()), this);
 
-  robot_state_topic_property_ = new rviz::RosTopicProperty(
-      "Robot State Topic", "display_robot_state", ros::message_traits::datatype<moveit_msgs::msg::DisplayRobotState>(),
+  robot_state_topic_property_ = new rviz_common::properties::RosTopicProperty(
+      "Robot State Topic", "display_robot_state",
+      rosidl_generator_traits::data_type<moveit_msgs::msg::DisplayRobotState>(),
       "The topic on which the moveit_msgs::msg::DisplayRobotState messages are received", this,
       SLOT(changedRobotStateTopic()), this);
 
   // Planning scene category -------------------------------------------------------------------------------------------
-  root_link_name_property_ =
-      new rviz::StringProperty("Robot Root Link", "", "Shows the name of the root link for the robot model", this,
-                               SLOT(changedRootLinkName()), this);
+  root_link_name_property_ = new rviz_common::properties::StringProperty(
+      "Robot Root Link", "", "Shows the name of the root link for the robot model", this, SLOT(changedRootLinkName()),
+      this);
   root_link_name_property_->setReadOnly(true);
 
-  robot_alpha_property_ = new rviz::FloatProperty("Robot Alpha", 1.0f, "Specifies the alpha for the robot links", this,
-                                                  SLOT(changedRobotSceneAlpha()), this);
+  robot_alpha_property_ = new rviz_common::properties::FloatProperty(
+      "Robot Alpha", 1.0f, "Specifies the alpha for the robot links", this, SLOT(changedRobotSceneAlpha()), this);
   robot_alpha_property_->setMin(0.0);
   robot_alpha_property_->setMax(1.0);
 
-  attached_body_color_property_ =
-      new rviz::ColorProperty("Attached Body Color", QColor(150, 50, 150), "The color for the attached bodies", this,
-                              SLOT(changedAttachedBodyColor()), this);
+  attached_body_color_property_ = new rviz_common::properties::ColorProperty(
+      "Attached Body Color", QColor(150, 50, 150), "The color for the attached bodies", this,
+      SLOT(changedAttachedBodyColor()), this);
 
-  enable_link_highlight_ =
-      new rviz::BoolProperty("Show Highlights", true, "Specifies whether link highlighting is enabled", this,
-                             SLOT(changedEnableLinkHighlight()), this);
-  enable_visual_visible_ =
-      new rviz::BoolProperty("Visual Enabled", true, "Whether to display the visual representation of the robot.", this,
-                             SLOT(changedEnableVisualVisible()), this);
-  enable_collision_visible_ = new rviz::BoolProperty("Collision Enabled", false,
-                                                     "Whether to display the collision representation of the robot.",
-                                                     this, SLOT(changedEnableCollisionVisible()), this);
+  enable_link_highlight_ = new rviz_common::properties::BoolProperty("Show Highlights", true,
+                                                                     "Specifies whether link highlighting is enabled",
+                                                                     this, SLOT(changedEnableLinkHighlight()), this);
+  enable_visual_visible_ = new rviz_common::properties::BoolProperty(
+      "Visual Enabled", true, "Whether to display the visual representation of the robot.", this,
+      SLOT(changedEnableVisualVisible()), this);
+  enable_collision_visible_ = new rviz_common::properties::BoolProperty(
+      "Collision Enabled", false, "Whether to display the collision representation of the robot.", this,
+      SLOT(changedEnableCollisionVisible()), this);
 
-  show_all_links_ = new rviz::BoolProperty("Show All Links", true, "Toggle all links visibility on or off.", this,
-                                           SLOT(changedAllLinks()), this);
+  show_all_links_ = new rviz_common::properties::BoolProperty(
+      "Show All Links", true, "Toggle all links visibility on or off.", this, SLOT(changedAllLinks()), this);
 }
 
 // ******************************************************************************************
@@ -138,9 +139,9 @@ void RobotStateDisplay::changedAllLinks()
   }
 }
 
-void RobotStateDisplay::setHighlight(const std::string& link_name, const std_msgs::ColorRGBA& color)
+void RobotStateDisplay::setHighlight(const std::string& link_name, const std_msgs::msg::ColorRGBA& color)
 {
-  rviz::RobotLink* link = robot_->getRobot().getLink(link_name);
+  rviz_default_plugins::robot::RobotLink* link = robot_->getRobot().getLink(link_name);
   if (link)
   {
     link->setColor(color.r, color.g, color.b);
@@ -150,7 +151,7 @@ void RobotStateDisplay::setHighlight(const std::string& link_name, const std_msg
 
 void RobotStateDisplay::unsetHighlight(const std::string& link_name)
 {
-  rviz::RobotLink* link = robot_->getRobot().getLink(link_name);
+  rviz_default_plugins::robot::RobotLink* link = robot_->getRobot().getLink(link_name);
   if (link)
   {
     link->unsetColor();
@@ -162,14 +163,14 @@ void RobotStateDisplay::changedEnableLinkHighlight()
 {
   if (enable_link_highlight_->getBool())
   {
-    for (std::pair<const std::string, std_msgs::ColorRGBA>& highlight : highlights_)
+    for (std::pair<const std::string, std_msgs::msg::ColorRGBA>& highlight : highlights_)
     {
       setHighlight(highlight.first, highlight.second);
     }
   }
   else
   {
-    for (std::pair<const std::string, std_msgs::ColorRGBA>& highlight : highlights_)
+    for (std::pair<const std::string, std_msgs::msg::ColorRGBA>& highlight : highlights_)
     {
       unsetHighlight(highlight.first);
     }
@@ -186,18 +187,13 @@ void RobotStateDisplay::changedEnableCollisionVisible()
   robot_->setCollisionVisible(enable_collision_visible_->getBool());
 }
 
-static bool operator!=(const std_msgs::ColorRGBA& a, const std_msgs::ColorRGBA& b)
-{
-  return a.r != b.r || a.g != b.g || a.b != b.b || a.a != b.a;
-}
-
 void RobotStateDisplay::setRobotHighlights(
     const moveit_msgs::msg::DisplayRobotState::_highlight_links_type& highlight_links)
 {
   if (highlight_links.empty() && highlights_.empty())
     return;
 
-  std::map<std::string, std_msgs::ColorRGBA> highlights;
+  std::map<std::string, std_msgs::msg::ColorRGBA> highlights;
   for (const moveit_msgs::msg::ObjectColor& highlight_link : highlight_links)
   {
     highlights[highlight_link.id] = highlight_link.color;
@@ -205,8 +201,8 @@ void RobotStateDisplay::setRobotHighlights(
 
   if (enable_link_highlight_->getBool())
   {
-    std::map<std::string, std_msgs::ColorRGBA>::iterator ho = highlights_.begin();
-    std::map<std::string, std_msgs::ColorRGBA>::iterator hn = highlights.begin();
+    std::map<std::string, std_msgs::msg::ColorRGBA>::iterator ho = highlights_.begin();
+    std::map<std::string, std_msgs::msg::ColorRGBA>::iterator hn = highlights.begin();
     while (ho != highlights_.end() || hn != highlights.end())
     {
       if (ho == highlights_.end())
@@ -251,7 +247,7 @@ void RobotStateDisplay::changedAttachedBodyColor()
   if (robot_)
   {
     QColor color = attached_body_color_property_->getColor();
-    std_msgs::ColorRGBA color_msg;
+    std_msgs::msg::ColorRGBA color_msg;
     color_msg.r = color.redF();
     color_msg.g = color.greenF();
     color_msg.b = color.blueF();
@@ -277,7 +273,7 @@ void RobotStateDisplay::changedRobotSceneAlpha()
   {
     robot_->setAlpha(robot_alpha_property_->getFloat());
     QColor color = attached_body_color_property_->getColor();
-    std_msgs::ColorRGBA color_msg;
+    std_msgs::msg::ColorRGBA color_msg;
     color_msg.r = color.redF();
     color_msg.g = color.greenF();
     color_msg.b = color.blueF();
@@ -289,20 +285,19 @@ void RobotStateDisplay::changedRobotSceneAlpha()
 
 void RobotStateDisplay::changedRobotStateTopic()
 {
-  robot_state_subscriber_.shutdown();
-
+  using namespace std::placeholders;
   // reset model to default state, we don't want to show previous messages
   if (static_cast<bool>(robot_state_))
     robot_state_->setToDefaultValues();
   update_state_ = true;
   robot_->setVisible(false);
-  setStatus(rviz::StatusProperty::Warn, "RobotState", "No msg received");
+  setStatus(rviz_common::properties::StatusProperty::Warn, "RobotState", "No msg received");
 
-  robot_state_subscriber_ = root_nh_.subscribe(robot_state_topic_property_->getStdString(), 10,
-                                               &RobotStateDisplay::newRobotStateCallback, this);
+  robot_state_subscriber_ = node_->create_subscription<moveit_msgs::msg::DisplayRobotState>(
+      robot_state_topic_property_->getStdString(), 10, std::bind(&RobotStateDisplay::newRobotStateCallback, this, _1));
 }
 
-void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotStateConstPtr& state_msg)
+void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state_msg)
 {
   if (!robot_model_)
     return;
@@ -319,7 +314,7 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRob
   {
     robot_state_->setToDefaultValues();
     setRobotHighlights(moveit_msgs::msg::DisplayRobotState::_highlight_links_type());
-    setStatus(rviz::StatusProperty::Error, "RobotState", e.what());
+    setStatus(rviz_common::properties::StatusProperty::Error, "RobotState", e.what());
     robot_->setVisible(false);
     return;
   }
@@ -328,9 +323,9 @@ void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRob
   {
     robot_->setVisible(!state_msg->hide);
     if (robot_->isVisible())
-      setStatus(rviz::StatusProperty::Ok, "RobotState", "");
+      setStatus(rviz_common::properties::StatusProperty::Ok, "RobotState", "");
     else
-      setStatus(rviz::StatusProperty::Warn, "RobotState", "Hidden");
+      setStatus(rviz_common::properties::StatusProperty::Warn, "RobotState", "Hidden");
   }
 
   update_state_ = true;
@@ -351,18 +346,19 @@ void RobotStateDisplay::setVisible(bool visible)
   robot_->setVisible(visible);
 }
 
-void RobotStateDisplay::setLinkColor(rviz::Robot* robot, const std::string& link_name, const QColor& color)
+void RobotStateDisplay::setLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name,
+                                     const QColor& color)
 {
-  rviz::RobotLink* link = robot->getLink(link_name);
+  rviz_default_plugins::robot::RobotLink* link = robot->getLink(link_name);
 
   // Check if link exists
   if (link)
     link->setColor(color.redF(), color.greenF(), color.blueF());
 }
 
-void RobotStateDisplay::unsetLinkColor(rviz::Robot* robot, const std::string& link_name)
+void RobotStateDisplay::unsetLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name)
 {
-  rviz::RobotLink* link = robot->getLink(link_name);
+  rviz_default_plugins::robot::RobotLink* link = robot->getLink(link_name);
 
   // Check if link exists
   if (link)
@@ -376,7 +372,7 @@ void RobotStateDisplay::loadRobotModel()
 {
   load_robot_model_ = false;
   if (!rdf_loader_)
-    rdf_loader_.reset(new rdf_loader::RDFLoader(robot_description_property_->getStdString()));
+    rdf_loader_.reset(new rdf_loader::RDFLoader(node_, robot_description_property_->getStdString()));
 
   if (rdf_loader_->getURDF())
   {
@@ -390,13 +386,13 @@ void RobotStateDisplay::loadRobotModel()
     root_link_name_property_->setStdString(getRobotModel()->getRootLinkName());
     root_link_name_property_->blockSignals(old_state);
     update_state_ = true;
-    setStatus(rviz::StatusProperty::Ok, "RobotModel", "Loaded successfully");
+    setStatus(rviz_common::properties::StatusProperty::Ok, "RobotModel", "Loaded successfully");
 
     changedEnableVisualVisible();
     changedEnableCollisionVisible();
   }
   else
-    setStatus(rviz::StatusProperty::Error, "RobotModel", "Loading failed");
+    setStatus(rviz_common::properties::StatusProperty::Error, "RobotModel", "Loading failed");
 
   highlights_.clear();
 }
@@ -413,7 +409,7 @@ void RobotStateDisplay::onEnable()
 // ******************************************************************************************
 void RobotStateDisplay::onDisable()
 {
-  robot_state_subscriber_.shutdown();
+  robot_state_subscriber_.reset();
   if (robot_)
     robot_->setVisible(false);
   Display::onDisable();
@@ -452,7 +448,7 @@ void RobotStateDisplay::calculateOffsetPosition()
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
 
-  context_->getFrameManager()->getTransform(getRobotModel()->getModelFrame(), ros::Time(0), position, orientation);
+  context_->getFrameManager()->getTransform(getRobotModel()->getModelFrame(), rclcpp::Time(0), position, orientation);
 
   scene_node_->setPosition(position);
   scene_node_->setOrientation(orientation);

--- a/moveit_ros/visualization/robot_state_rviz_plugin_description.xml
+++ b/moveit_ros/visualization/robot_state_rviz_plugin_description.xml
@@ -1,5 +1,5 @@
-<library path="libmoveit_robot_state_rviz_plugin">
-  <class name="moveit_rviz_plugin/RobotState" type="moveit_rviz_plugin::RobotStateDisplay" base_class_type="rviz::Display">
+<library path="moveit_robot_state_rviz_plugin">
+  <class name="moveit_rviz_plugin/RobotState" type="moveit_rviz_plugin::RobotStateDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays a robot state.
     </description>

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -13,7 +13,7 @@ set(HEADERS
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/render_shapes.cpp
   src/robot_state_visualization.cpp
   src/planning_scene_render.cpp
@@ -26,15 +26,21 @@ add_library(${MOVEIT_LIB_NAME}
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 target_link_libraries(${MOVEIT_LIB_NAME}
-  ${catkin_LIBRARIES}
-  ${OGRE_LIBRARIES}
-  ${QT_LIBRARIES}
-  ${Boost_LIBRARIES}
+    rviz_ogre_vendor::OgreMain
+    Qt5::Widgets
 )
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+    rclcpp
+    rviz2
+    moveit_core
+    Boost
+    octomap_msgs
+)
+
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS
   include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
   include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
   include/moveit/rviz_plugin_render_tools/trajectory_panel.h
+  include/ogre_helpers/mesh_shape.hpp
 )
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -20,7 +21,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/octomap_render.cpp
   src/trajectory_visualization.cpp
   src/trajectory_panel.cpp
-  ${HEADERS}
+  src/mesh_shape.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -39,25 +39,12 @@
 #include <memory>
 #include <vector>
 #include <moveit/macros/diagnostics.h>
+#include <octomap/octomap.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/ogre_helpers/point_cloud.h>
+#include <rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp>
+#include <rviz_common/properties/color_property.hpp>
 DIAGNOSTIC_POP
-#include <moveit/rviz_plugin_render_tools/octomap_render.h>
-
-namespace octomap
-{
-class OcTree;
-}
-
-namespace Ogre
-{
-class SceneManager;
-class SceneNode;
-class AxisAlignedBox;
-class Vector3;
-class Quaternion;
-}
 
 namespace moveit_rviz_plugin
 {
@@ -85,14 +72,15 @@ public:
   void setOrientation(const Ogre::Quaternion& orientation);
 
 private:
-  void setColor(double z_pos, double min_z, double max_z, double color_factor, rviz::PointCloud::Point* point);
-  void setProbColor(double prob, rviz::PointCloud::Point* point);
+  void setColor(double z_pos, double min_z, double max_z, double color_factor,
+                rviz_rendering::PointCloud::Point* point);
+  void setProbColor(double prob, rviz_rendering::PointCloud::Point* point);
 
   void octreeDecoding(const std::shared_ptr<const octomap::OcTree>& octree,
                       OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode);
 
   // Ogre-rviz point clouds
-  std::vector<rviz::PointCloud*> cloud_;
+  std::vector<rviz_rendering::PointCloud*> cloud_;
   std::shared_ptr<const octomap::OcTree> octree_;
 
   Ogre::SceneNode* scene_node_;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_link_updater.h
@@ -39,14 +39,14 @@
 #include <moveit/macros/diagnostics.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/robot/link_updater.h>
+#include <rviz_default_plugins/robot/link_updater.hpp>
 DIAGNOSTIC_POP
 #include <moveit/robot_state/robot_state.h>
 
 namespace moveit_rviz_plugin
 {
 /** \brief Update the links of an rviz::Robot using a robot_state::RobotState */
-class PlanningLinkUpdater : public rviz::LinkUpdater
+class PlanningLinkUpdater : public rviz_default_plugins::robot::LinkUpdater
 {
 public:
   PlanningLinkUpdater(const robot_state::RobotStateConstPtr& state) : kinematic_state_(state)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/planning_scene_render.h
@@ -39,18 +39,8 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/rviz_plugin_render_tools/render_shapes.h>
-#include <rviz/helpers/color.h>
+#include <rviz_common/properties/color_property.hpp>
 #include <OgreMaterial.h>
-
-namespace Ogre
-{
-class SceneNode;
-}
-
-namespace rviz
-{
-class DisplayContext;
-}
 
 namespace moveit_rviz_plugin
 {
@@ -61,7 +51,7 @@ MOVEIT_CLASS_FORWARD(PlanningSceneRender)
 class PlanningSceneRender
 {
 public:
-  PlanningSceneRender(Ogre::SceneNode* root_node, rviz::DisplayContext* context,
+  PlanningSceneRender(Ogre::SceneNode* root_node, rviz_common::DisplayContext* context,
                       const RobotStateVisualizationPtr& robot);
   ~PlanningSceneRender();
 
@@ -75,14 +65,15 @@ public:
     return scene_robot_;
   }
 
-  void renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene, const rviz::Color& default_scene_color,
-                           const rviz::Color& default_attached_color, OctreeVoxelRenderMode voxel_render_mode,
+  void renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene,
+                           const Ogre::ColourValue& default_scene_color,
+                           const Ogre::ColourValue& default_attached_color, OctreeVoxelRenderMode voxel_render_mode,
                            OctreeVoxelColorMode voxel_color_mode, float default_scene_alpha);
   void clear();
 
 private:
   Ogre::SceneNode* planning_scene_geometry_node_;
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
   RenderShapesPtr render_shapes_;
   RobotStateVisualizationPtr scene_robot_;
 };

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/render_shapes.h
@@ -39,21 +39,13 @@
 #include <moveit/rviz_plugin_render_tools/octomap_render.h>
 #include <moveit/macros/class_forward.h>
 #include <geometric_shapes/shapes.h>
-#include <rviz/helpers/color.h>
+#include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/display_context.hpp>
+#include <rviz_rendering/objects/shape.hpp>
+#include <OgreColourValue.h>
 #include <Eigen/Geometry>
 #include <string>
 #include <memory>
-
-namespace Ogre
-{
-class SceneNode;
-}
-
-namespace rviz
-{
-class DisplayContext;
-class Shape;
-}
 
 namespace moveit_rviz_plugin
 {
@@ -63,19 +55,19 @@ MOVEIT_CLASS_FORWARD(RenderShapes)
 class RenderShapes
 {
 public:
-  RenderShapes(rviz::DisplayContext* context);
+  RenderShapes(rviz_common::DisplayContext* context);
   ~RenderShapes();
 
   void renderShape(Ogre::SceneNode* node, const shapes::Shape* s, const Eigen::Isometry3d& p,
                    OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
-                   const rviz::Color& color, float alpha);
+                   const Ogre::ColourValue& color, float alpha);
   void updateShapeColors(float r, float g, float b, float a);
   void clear();
 
 private:
-  rviz::DisplayContext* context_;
+  rviz_common::DisplayContext* context_;
 
-  std::vector<std::unique_ptr<rviz::Shape> > scene_shapes_;
+  std::vector<std::unique_ptr<rviz_rendering::Shape> > scene_shapes_;
   std::vector<OcTreeRenderPtr> octree_voxel_grids_;
 };
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/robot_state_visualization.h
@@ -42,7 +42,7 @@
 #include <moveit/macros/diagnostics.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/robot/robot.h>
+#include <rviz_default_plugins/robot/robot.hpp>
 DIAGNOSTIC_POP
 
 namespace moveit_rviz_plugin
@@ -54,10 +54,10 @@ MOVEIT_CLASS_FORWARD(RobotStateVisualization)
 class RobotStateVisualization
 {
 public:
-  RobotStateVisualization(Ogre::SceneNode* root_node, rviz::DisplayContext* context, const std::string& name,
-                          rviz::Property* parent_property);
+  RobotStateVisualization(Ogre::SceneNode* root_node, rviz_common::DisplayContext* context, const std::string& name,
+                          rviz_common::properties::Property* parent_property);
 
-  rviz::Robot& getRobot()
+  rviz_default_plugins::robot::Robot& getRobot()
   {
     return robot_;
   }
@@ -67,13 +67,13 @@ public:
 
   void update(const robot_state::RobotStateConstPtr& kinematic_state);
   void update(const robot_state::RobotStateConstPtr& kinematic_state,
-              const std_msgs::ColorRGBA& default_attached_object_color);
+              const std_msgs::msg::ColorRGBA& default_attached_object_color);
   void update(const robot_state::RobotStateConstPtr& kinematic_state,
-              const std_msgs::ColorRGBA& default_attached_object_color,
-              const std::map<std::string, std_msgs::ColorRGBA>& color_map);
-  void setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color);
+              const std_msgs::msg::ColorRGBA& default_attached_object_color,
+              const std::map<std::string, std_msgs::msg::ColorRGBA>& color_map);
+  void setDefaultAttachedObjectColor(const std_msgs::msg::ColorRGBA& default_attached_object_color);
   /// update color of all attached object shapes
-  void updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color);
+  void updateAttachedObjectColors(const std_msgs::msg::ColorRGBA& attached_object_color);
 
   bool isVisible() const
   {
@@ -102,11 +102,11 @@ public:
 
 private:
   void updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
-                    const std_msgs::ColorRGBA& default_attached_object_color,
-                    const std::map<std::string, std_msgs::ColorRGBA>* color_map);
-  rviz::Robot robot_;
+                    const std_msgs::msg::ColorRGBA& default_attached_object_color,
+                    const std::map<std::string, std_msgs::msg::ColorRGBA>* color_map);
+  rviz_default_plugins::robot::Robot robot_;
   RenderShapesPtr render_shapes_;
-  std_msgs::ColorRGBA default_attached_object_color_;
+  std_msgs::msg::ColorRGBA default_attached_object_color_;
   OctreeVoxelRenderMode octree_voxel_render_mode_;
   OctreeVoxelColorMode octree_voxel_color_mode_;
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_panel.h
@@ -37,10 +37,10 @@
 #pragma once
 
 #ifndef Q_MOC_RUN
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #endif
 
-#include <rviz/panel.h>
+#include <rviz_common/panel.hpp>
 
 #include <QSlider>
 #include <QLabel>
@@ -48,7 +48,7 @@
 
 namespace moveit_rviz_plugin
 {
-class TrajectoryPanel : public rviz::Panel
+class TrajectoryPanel : public rviz_common::Panel
 {
   Q_OBJECT
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -38,33 +38,20 @@
 
 #include <boost/thread/mutex.hpp>
 #include <moveit/macros/class_forward.h>
-#include <rviz/display.h>
-#include <rviz/panel_dock_widget.h>
+#include <rviz_common/display.hpp>
+#include <rviz_common/panel_dock_widget.hpp>
+#include <rviz_common/properties/int_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
 
 #ifndef Q_MOC_RUN
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit/rviz_plugin_render_tools/trajectory_panel.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit_msgs/msg/display_trajectory.hpp>
 #endif
-
-namespace rviz
-{
-class Robot;
-class Shape;
-class Property;
-class IntProperty;
-class StringProperty;
-class BoolProperty;
-class FloatProperty;
-class RosTopicProperty;
-class EditableEnumProperty;
-class ColorProperty;
-class MovableText;
-}
 
 namespace moveit_rviz_plugin
 {
@@ -81,14 +68,15 @@ public:
    * \param display - the rviz::Display from the parent
    * \return true on success
    */
-  TrajectoryVisualization(rviz::Property* widget, rviz::Display* display);
+  TrajectoryVisualization(rviz_common::properties::Property* widget, rviz_common::Display* display);
 
   ~TrajectoryVisualization() override;
 
   virtual void update(float wall_dt, float ros_dt);
   virtual void reset();
 
-  void onInitialize(Ogre::SceneNode* scene_node, rviz::DisplayContext* context, const ros::NodeHandle& update_nh);
+  void onInitialize(const rclcpp::Node::SharedPtr& node, Ogre::SceneNode* scene_node,
+                    rviz_common::DisplayContext* context);
   void onRobotModelLoaded(const robot_model::RobotModelConstPtr& robot_model);
   void onEnable();
   void onDisable();
@@ -121,22 +109,22 @@ protected:
   /**
    * \brief ROS callback for an incoming path message
    */
-  void incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstPtr& msg);
+  void incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg);
   float getStateDisplayTime();
   void clearTrajectoryTrail();
 
   // Handles actually drawing the robot along motion plans
   RobotStateVisualizationPtr display_path_robot_;
-  std_msgs::ColorRGBA default_attached_object_color_;
+  std_msgs::msg::ColorRGBA default_attached_object_color_;
 
   // Handle colouring of robot
-  void setRobotColor(rviz::Robot* robot, const QColor& color);
-  void unsetRobotColor(rviz::Robot* robot);
+  void setRobotColor(rviz_default_plugins::robot::Robot* robot, const QColor& color);
+  void unsetRobotColor(rviz_default_plugins::robot::Robot* robot);
 
   robot_trajectory::RobotTrajectoryPtr displaying_trajectory_message_;
   robot_trajectory::RobotTrajectoryPtr trajectory_message_to_display_;
   std::vector<RobotStateVisualizationUniquePtr> trajectory_trail_;
-  ros::Subscriber trajectory_topic_sub_;
+  rclcpp::Subscription<moveit_msgs::msg::DisplayTrajectory>::SharedPtr trajectory_topic_sub_;
   bool animating_path_;
   bool drop_displaying_trajectory_;
   int current_state_;
@@ -147,26 +135,26 @@ protected:
   robot_state::RobotStatePtr robot_state_;
 
   // Pointers from parent display taht we save
-  rviz::Display* display_;  // the parent display that this class populates
-  rviz::Property* widget_;
+  rviz_common::Display* display_;  // the parent display that this class populates
+  rviz_common::properties::Property* widget_;
   Ogre::SceneNode* scene_node_;
-  rviz::DisplayContext* context_;
-  ros::NodeHandle update_nh_;
+  rviz_common::DisplayContext* context_;
+  rclcpp::Node::SharedPtr node_;
   TrajectoryPanel* trajectory_slider_panel_;
-  rviz::PanelDockWidget* trajectory_slider_dock_panel_;
+  rviz_common::PanelDockWidget* trajectory_slider_dock_panel_;
 
   // Properties
-  rviz::BoolProperty* display_path_visual_enabled_property_;
-  rviz::BoolProperty* display_path_collision_enabled_property_;
-  rviz::EditableEnumProperty* state_display_time_property_;
-  rviz::RosTopicProperty* trajectory_topic_property_;
-  rviz::FloatProperty* robot_path_alpha_property_;
-  rviz::BoolProperty* loop_display_property_;
-  rviz::BoolProperty* trail_display_property_;
-  rviz::BoolProperty* interrupt_display_property_;
-  rviz::ColorProperty* robot_color_property_;
-  rviz::BoolProperty* enable_robot_color_property_;
-  rviz::IntProperty* trail_step_size_property_;
+  rviz_common::properties::BoolProperty* display_path_visual_enabled_property_;
+  rviz_common::properties::BoolProperty* display_path_collision_enabled_property_;
+  rviz_common::properties::EditableEnumProperty* state_display_time_property_;
+  rviz_common::properties::RosTopicProperty* trajectory_topic_property_;
+  rviz_common::properties::FloatProperty* robot_path_alpha_property_;
+  rviz_common::properties::BoolProperty* loop_display_property_;
+  rviz_common::properties::BoolProperty* trail_display_property_;
+  rviz_common::properties::BoolProperty* interrupt_display_property_;
+  rviz_common::properties::ColorProperty* robot_color_property_;
+  rviz_common::properties::BoolProperty* enable_robot_color_property_;
+  rviz_common::properties::IntProperty* trail_step_size_property_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OGRE_TOOLS_MESH_SHAPE_H
+#define OGRE_TOOLS_MESH_SHAPE_H
+
+#include <rviz_rendering/objects/shape.hpp>
+
+namespace Ogre
+{
+class ManualObject;
+}
+
+// TODO(JafarAbdi): This's taken from https://github.com/ros2/rviz for MoveIt 2 beta release -- remove when it's ported
+namespace rviz_rendering
+{
+/** \brief This class allows constructing Ogre shapes manually, from triangle lists.
+
+    For example:
+    Assuming we have a set of mesh triangles represented like this:
+    \verbatim
+    struct Triangle
+    {
+      unsigned v1, v2, v3; // index for the 3 vertices that make up a triangle
+    };
+    std::vector<Triangle> triangles;
+    std::vector<Ogre::Vector3> vertices;
+    std::vector<Ogre::Vector3> normals; // normal at every vertex
+    \endverbatim
+
+    we can use this class to render the mesh as follows:
+    \verbatim
+    rviz::MeshShape *shape = new MeshShape(scene_manager);
+    mesh->estimateVertexCount(vertices.size());
+    mesh->beginTriangles();
+    for (std::size_t i = 0 ; i < vertices.size() ; ++i)
+      mesh->addVertex(vertices[i], normals[i]);
+    for (std::size_t i = 0 ; i < triangles.size() ; ++i)
+      mesh->addTriangle(triangles[i].v1, triangles[i].v2, triangles[i].v3);
+    mesh->endTriangles();
+    \endverbatim
+ */
+class MeshShape : public Shape
+{
+public:
+  /**
+   * \brief Constructor
+   *
+   * @param scene_manager The scene manager this object is associated with
+   * @param parent_node A scene node to use as the parent of this object.  If NULL, uses the root scene node.
+   */
+  MeshShape(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node = NULL);
+  virtual ~MeshShape();
+
+  /* \brief Estimate the number of vertices ahead of time. */
+  void estimateVertexCount(size_t vcount);
+
+  /** \brief Start adding triangles to the mesh */
+  void beginTriangles();
+
+  /** \brief Add a vertex to the mesh (no normal defined). If using
+      this function only (not using addTriangle()) it is assumed that
+      triangles are added by specifying the 3 vertices in order (3
+      consecutive calls to this function). This means there must be
+      3*n calls to this function to add n triangles. If addTriangle()
+      is used, indexing in the defined vertices is done. */
+  void addVertex(const Ogre::Vector3& position);
+
+  /** \brief Add a vertex to the mesh with a normal defined. If using
+      this function only (not using addTriangle()) it is assumed that
+      triangles are added by specifying the 3 vertices in order (3
+      consecutive calls to this function). This means there must be
+      3*n calls to this function to add n triangles.If addTriangle()
+      is used, indexing in the defined vertices is done.  */
+  void addVertex(const Ogre::Vector3& position, const Ogre::Vector3& normal);
+
+  /** \brief Add a vertex to the mesh with normal and color defined. If using
+      this function only (not using addTriangle()) it is assumed that
+      triangles are added by specifying the 3 vertices in order (3
+      consecutive calls to this function). This means there must be
+      3*n calls to this function to add n triangles.If addTriangle()
+      is used, indexing in the defined vertices is done. */
+  void addVertex(const Ogre::Vector3& position, const Ogre::Vector3& normal, const Ogre::ColourValue& color);
+
+  /** \brief Add normal for a vertex */
+  void addNormal(const Ogre::Vector3& normal);
+
+  /** \brief Add color for a vertex */
+  void addColor(const Ogre::ColourValue& color);
+
+  /** \brief Add a triangle by indexing in the defined vertices. */
+  void addTriangle(unsigned int p1, unsigned int p2, unsigned int p3);
+
+  /** \brief Notify that the set of triangles to add is complete. No more triangles can be added, beginTriangles() can
+   * no longer be called unless clear() was called. */
+  void endTriangles();
+
+  /** \brief Clear the mesh */
+  void clear();
+
+  /** \brief Get the manual object created for the mesh */
+  Ogre::ManualObject* getManualObject()
+  {
+    return manual_object_;
+  }
+
+private:
+  // true in between calls to beginTriangles() and endTriangles()
+  bool started_;
+  Ogre::ManualObject* manual_object_;
+};
+
+}  // namespace rviz
+
+#endif

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ogre_helpers/mesh_shape.hpp>
+
+#include <OgreMesh.h>
+#include <OgreMeshManager.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreEntity.h>
+#include <OgreMaterialManager.h>
+#include <OgreManualObject.h>
+
+#include <boost/lexical_cast.hpp>
+#include <rviz_common/logging.hpp>
+
+namespace rviz_rendering
+{
+MeshShape::MeshShape(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node)
+  : Shape(Shape::Mesh, scene_manager, parent_node), started_(false)
+{
+  static uint32_t count = 0;
+  manual_object_ =
+      scene_manager->createManualObject("MeshShape_ManualObject" + boost::lexical_cast<std::string>(count++));
+  material_->setCullingMode(Ogre::CULL_NONE);
+}
+
+MeshShape::~MeshShape()
+{
+  clear();
+  scene_manager_->destroyManualObject(manual_object_);
+}
+
+void MeshShape::estimateVertexCount(size_t vcount)
+{
+  if (entity_ == NULL && started_ == false)
+    manual_object_->estimateVertexCount(vcount);
+}
+
+void MeshShape::beginTriangles()
+{
+  if (!started_ && entity_)
+  {
+    RVIZ_COMMON_LOG_WARNING("Cannot modify mesh once construction is complete");
+    return;
+  }
+
+  if (!started_)
+  {
+    started_ = true;
+    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+  }
+}
+
+void MeshShape::addVertex(const Ogre::Vector3& position)
+{
+  beginTriangles();
+  manual_object_->position(position);
+}
+
+void MeshShape::addVertex(const Ogre::Vector3& position, const Ogre::Vector3& normal)
+{
+  beginTriangles();
+  manual_object_->position(position);
+  manual_object_->normal(normal);
+}
+
+void MeshShape::addVertex(const Ogre::Vector3& position, const Ogre::Vector3& normal, const Ogre::ColourValue& color)
+{
+  beginTriangles();
+  manual_object_->position(position);
+  manual_object_->normal(normal);
+  manual_object_->colour(color);
+}
+
+void MeshShape::addNormal(const Ogre::Vector3& normal)
+{
+  manual_object_->normal(normal);
+}
+
+void MeshShape::addColor(const Ogre::ColourValue& color)
+{
+  manual_object_->colour(color);
+}
+
+void MeshShape::addTriangle(unsigned int v1, unsigned int v2, unsigned int v3)
+{
+  manual_object_->triangle(v1, v2, v3);
+}
+
+void MeshShape::endTriangles()
+{
+  if (started_)
+  {
+    started_ = false;
+    manual_object_->end();
+    static uint32_t count = 0;
+    std::string name = "ConvertedMeshShape@" + boost::lexical_cast<std::string>(count++);
+    manual_object_->convertToMesh(name);
+    entity_ = scene_manager_->createEntity(name);
+    if (entity_)
+    {
+      entity_->setMaterialName(material_name_);
+      offset_node_->attachObject(entity_);
+    }
+    else
+      RVIZ_COMMON_LOG_ERROR("Unable to construct triangle mesh");
+  }
+  else
+    RVIZ_COMMON_LOG_ERROR("No triangles added");
+}
+
+void MeshShape::clear()
+{
+  if (entity_)
+  {
+    entity_->detachFromParent();
+    Ogre::MeshManager::getSingleton().remove(entity_->getMesh()->getName());
+    scene_manager_->destroyEntity(entity_);
+    entity_ = NULL;
+  }
+  manual_object_->clear();
+  started_ = false;
+}
+
+}  // namespace rviz_rendering

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -38,18 +38,16 @@
 
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <octomap_msgs/Octomap.h>
+#include <octomap_msgs/msg/octomap.hpp>
 #include <octomap/octomap.h>
 DIAGNOSTIC_POP
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
-#include <rviz/ogre_helpers/point_cloud.h>
-
 namespace moveit_rviz_plugin
 {
-typedef std::vector<rviz::PointCloud::Point> VPoint;
+typedef std::vector<rviz_rendering::PointCloud::Point> VPoint;
 typedef std::vector<VPoint> VVPoint;
 
 OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
@@ -80,9 +78,9 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
   {
     std::stringstream sname;
     sname << "PointCloud Nr." << i;
-    cloud_[i] = new rviz::PointCloud();
+    cloud_[i] = new rviz_rendering::PointCloud();
     cloud_[i]->setName(sname.str());
-    cloud_[i]->setRenderMode(rviz::PointCloud::RM_BOXES);
+    cloud_[i]->setRenderMode(rviz_rendering::PointCloud::RM_BOXES);
     scene_node_->attachObject(cloud_[i]);
   }
 
@@ -111,7 +109,7 @@ void moveit_rviz_plugin::OcTreeRender::setOrientation(const Ogre::Quaternion& or
 
 // method taken from octomap_server package
 void OcTreeRender::setColor(double z_pos, double min_z, double max_z, double color_factor,
-                            rviz::PointCloud::Point* point)
+                            rviz_rendering::PointCloud::Point* point)
 {
   int i;
   double m, n, f;
@@ -212,7 +210,7 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
 
       if (display_voxel)
       {
-        rviz::PointCloud::Point new_point;
+        rviz_rendering::PointCloud::Point new_point;
 
         new_point.position.x = it.getX();
         new_point.position.y = it.getY();
@@ -249,7 +247,7 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
     cloud_[i]->clear();
     cloud_[i]->setDimensions(size, size, size);
 
-    cloud_[i]->addPoints(&point_buf[i].front(), point_buf[i].size());
+    cloud_[i]->addPoints(point_buf[i].begin(), point_buf[i].end());
     point_buf[i].clear();
   }
 }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
@@ -35,8 +35,8 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
-#include <OgreQuaternion.h>
 #include <OgreVector3.h>
+#include <OgreQuaternion.h>
 
 bool moveit_rviz_plugin::PlanningLinkUpdater::getLinkTransforms(const std::string& link_name,
                                                                 Ogre::Vector3& visual_position,

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -37,14 +37,14 @@
 #include <moveit/rviz_plugin_render_tools/planning_scene_render.h>
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit/rviz_plugin_render_tools/render_shapes.h>
-#include <rviz/display_context.h>
+#include <rviz_common/display_context.hpp>
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
 namespace moveit_rviz_plugin
 {
-PlanningSceneRender::PlanningSceneRender(Ogre::SceneNode* node, rviz::DisplayContext* context,
+PlanningSceneRender::PlanningSceneRender(Ogre::SceneNode* node, rviz_common::DisplayContext* context,
                                          const RobotStateVisualizationPtr& robot)
   : planning_scene_geometry_node_(node->createChildSceneNode()), context_(context), scene_robot_(robot)
 {
@@ -62,8 +62,8 @@ void PlanningSceneRender::clear()
 }
 
 void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningSceneConstPtr& scene,
-                                              const rviz::Color& default_env_color,
-                                              const rviz::Color& default_attached_color,
+                                              const Ogre::ColourValue& default_env_color,
+                                              const Ogre::ColourValue& default_attached_color,
                                               OctreeVoxelRenderMode octree_voxel_rendering,
                                               OctreeVoxelColorMode octree_color_mode, float default_scene_alpha)
 {
@@ -77,10 +77,10 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     robot_state::RobotState* rs = new robot_state::RobotState(scene->getCurrentState());
     rs->update();
 
-    std_msgs::ColorRGBA color;
-    color.r = default_attached_color.r_;
-    color.g = default_attached_color.g_;
-    color.b = default_attached_color.b_;
+    std_msgs::msg::ColorRGBA color;
+    color.r = default_attached_color.r;
+    color.g = default_attached_color.g;
+    color.b = default_attached_color.b;
     color.a = 1.0f;
     planning_scene::ObjectColorMap color_map;
     scene->getKnownObjectColors(color_map);
@@ -91,14 +91,14 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
   for (const std::string& id : ids)
   {
     collision_detection::CollisionEnv::ObjectConstPtr object = scene->getWorld()->getObject(id);
-    rviz::Color color = default_env_color;
+    Ogre::ColourValue color = default_env_color;
     float alpha = default_scene_alpha;
     if (scene->hasObjectColor(id))
     {
-      const std_msgs::ColorRGBA& c = scene->getObjectColor(id);
-      color.r_ = c.r;
-      color.g_ = c.g;
-      color.b_ = c.b;
+      const std_msgs::msg::ColorRGBA& c = scene->getObjectColor(id);
+      color.r = c.r;
+      color.g = c.g;
+      color.b = c.b;
       alpha = c.a;
     }
     for (std::size_t j = 0; j < object->shapes_.size(); ++j)

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/render_shapes.cpp
@@ -42,15 +42,13 @@
 #include <OgreSceneManager.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
-
-#include <rviz/ogre_helpers/shape.h>
-#include <rviz/ogre_helpers/mesh_shape.h>
-
+#include <rviz_rendering/objects/shape.hpp>
+#include <ogre_helpers/mesh_shape.hpp>
 #include <moveit/macros/diagnostics.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/display_context.h>
-#include <rviz/robot/robot.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_default_plugins/robot/robot.hpp>
 DIAGNOSTIC_POP
 
 #include <boost/lexical_cast.hpp>
@@ -60,7 +58,7 @@ DIAGNOSTIC_POP
 
 namespace moveit_rviz_plugin
 {
-RenderShapes::RenderShapes(rviz::DisplayContext* context) : context_(context)
+RenderShapes::RenderShapes(rviz_common::DisplayContext* context) : context_(context)
 {
 }
 
@@ -77,9 +75,9 @@ void RenderShapes::clear()
 
 void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, const Eigen::Isometry3d& p,
                                OctreeVoxelRenderMode octree_voxel_rendering, OctreeVoxelColorMode octree_color_mode,
-                               const rviz::Color& color, float alpha)
+                               const Ogre::ColourValue& color, float alpha)
 {
-  rviz::Shape* ogre_shape = nullptr;
+  rviz_rendering::Shape* ogre_shape = nullptr;
   Eigen::Vector3d translation = p.translation();
   Ogre::Vector3 position(translation.x(), translation.y(), translation.z());
   Eigen::Quaterniond q(p.rotation());
@@ -98,21 +96,21 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
   {
     case shapes::SPHERE:
     {
-      ogre_shape = new rviz::Shape(rviz::Shape::Sphere, context_->getSceneManager(), node);
+      ogre_shape = new rviz_rendering::Shape(rviz_rendering::Shape::Sphere, context_->getSceneManager(), node);
       double d = 2.0 * static_cast<const shapes::Sphere*>(s)->radius;
       ogre_shape->setScale(Ogre::Vector3(d, d, d));
     }
     break;
     case shapes::BOX:
     {
-      ogre_shape = new rviz::Shape(rviz::Shape::Cube, context_->getSceneManager(), node);
+      ogre_shape = new rviz_rendering::Shape(rviz_rendering::Shape::Cube, context_->getSceneManager(), node);
       const double* sz = static_cast<const shapes::Box*>(s)->size;
       ogre_shape->setScale(Ogre::Vector3(sz[0], sz[1], sz[2]));
     }
     break;
     case shapes::CYLINDER:
     {
-      ogre_shape = new rviz::Shape(rviz::Shape::Cylinder, context_->getSceneManager(), node);
+      ogre_shape = new rviz_rendering::Shape(rviz_rendering::Shape::Cylinder, context_->getSceneManager(), node);
       double d = 2.0 * static_cast<const shapes::Cylinder*>(s)->radius;
       double z = static_cast<const shapes::Cylinder*>(s)->length;
       ogre_shape->setScale(Ogre::Vector3(d, z, d));  // the shape has z as major axis, but the rendered cylinder has y
@@ -124,7 +122,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
       const shapes::Mesh* mesh = static_cast<const shapes::Mesh*>(s);
       if (mesh->triangle_count > 0)
       {
-        rviz::MeshShape* m = new rviz::MeshShape(context_->getSceneManager(), node);
+        rviz_rendering::MeshShape* m = new rviz_rendering::MeshShape(context_->getSceneManager(), node);
         ogre_shape = m;
 
         Ogre::Vector3 normal(0.0, 0.0, 0.0);
@@ -174,7 +172,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
 
   if (ogre_shape)
   {
-    ogre_shape->setColor(color.r_, color.g_, color.b_, alpha);
+    ogre_shape->setColor(color);
 
     if (s->type == shapes::CYLINDER)
     {
@@ -193,7 +191,7 @@ void RenderShapes::renderShape(Ogre::SceneNode* node, const shapes::Shape* s, co
 
 void RenderShapes::updateShapeColors(float r, float g, float b, float a)
 {
-  for (const std::unique_ptr<rviz::Shape>& shape : scene_shapes_)
+  for (const std::unique_ptr<rviz_rendering::Shape>& shape : scene_shapes_)
     shape->setColor(r, g, b, a);
 }
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -37,12 +37,14 @@
 #include <moveit/rviz_plugin_render_tools/robot_state_visualization.h>
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
 #include <moveit/rviz_plugin_render_tools/render_shapes.h>
+#include <rviz_common/properties/parse_color.hpp>
 #include <QApplication>
 
 namespace moveit_rviz_plugin
 {
-RobotStateVisualization::RobotStateVisualization(Ogre::SceneNode* root_node, rviz::DisplayContext* context,
-                                                 const std::string& name, rviz::Property* parent_property)
+RobotStateVisualization::RobotStateVisualization(Ogre::SceneNode* root_node, rviz_common::DisplayContext* context,
+                                                 const std::string& name,
+                                                 rviz_common::properties::Property* parent_property)
   : robot_(root_node, context, name, parent_property)
   , octree_voxel_render_mode_(OCTOMAP_OCCUPIED_VOXELS)
   , octree_voxel_color_mode_(OCTOMAP_Z_AXIS_COLOR)
@@ -75,12 +77,13 @@ void RobotStateVisualization::clear()
   robot_.clear();
 }
 
-void RobotStateVisualization::setDefaultAttachedObjectColor(const std_msgs::ColorRGBA& default_attached_object_color)
+void RobotStateVisualization::setDefaultAttachedObjectColor(
+    const std_msgs::msg::ColorRGBA& default_attached_object_color)
 {
   default_attached_object_color_ = default_attached_object_color;
 }
 
-void RobotStateVisualization::updateAttachedObjectColors(const std_msgs::ColorRGBA& attached_object_color)
+void RobotStateVisualization::updateAttachedObjectColors(const std_msgs::msg::ColorRGBA& attached_object_color)
 {
   render_shapes_->updateShapeColors(attached_object_color.r, attached_object_color.g, attached_object_color.b,
                                     robot_.getAlpha());
@@ -92,21 +95,21 @@ void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kine
 }
 
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,
-                                     const std_msgs::ColorRGBA& default_attached_object_color)
+                                     const std_msgs::msg::ColorRGBA& default_attached_object_color)
 {
   updateHelper(kinematic_state, default_attached_object_color, nullptr);
 }
 
 void RobotStateVisualization::update(const robot_state::RobotStateConstPtr& kinematic_state,
-                                     const std_msgs::ColorRGBA& default_attached_object_color,
-                                     const std::map<std::string, std_msgs::ColorRGBA>& color_map)
+                                     const std_msgs::msg::ColorRGBA& default_attached_object_color,
+                                     const std::map<std::string, std_msgs::msg::ColorRGBA>& color_map)
 {
   updateHelper(kinematic_state, default_attached_object_color, &color_map);
 }
 
 void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr& kinematic_state,
-                                           const std_msgs::ColorRGBA& default_attached_object_color,
-                                           const std::map<std::string, std_msgs::ColorRGBA>* color_map)
+                                           const std_msgs::msg::ColorRGBA& default_attached_object_color,
+                                           const std::map<std::string, std_msgs::msg::ColorRGBA>* color_map)
 {
   robot_.update(PlanningLinkUpdater(kinematic_state));
   render_shapes_->clear();
@@ -115,11 +118,11 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
   kinematic_state->getAttachedBodies(attached_bodies);
   for (const robot_state::AttachedBody* attached_body : attached_bodies)
   {
-    std_msgs::ColorRGBA color = default_attached_object_color;
+    std_msgs::msg::ColorRGBA color = default_attached_object_color;
     float alpha = robot_.getAlpha();
     if (color_map)
     {
-      std::map<std::string, std_msgs::ColorRGBA>::const_iterator it = color_map->find(attached_body->getName());
+      std::map<std::string, std_msgs::msg::ColorRGBA>::const_iterator it = color_map->find(attached_body->getName());
       if (it != color_map->end())
       {  // render attached bodies with a color that is a bit different
         color.r = std::max(1.0f, it->second.r * 1.05f);
@@ -128,7 +131,7 @@ void RobotStateVisualization::updateHelper(const robot_state::RobotStateConstPtr
         alpha = color.a = it->second.a;
       }
     }
-    rviz::Color rcolor(color.r, color.g, color.b);
+    Ogre::ColourValue rcolor(color.r, color.g, color.b);
     const EigenSTL::vector_Isometry3d& ab_t = attached_body->getGlobalCollisionBodyTransforms();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)


### PR DESCRIPTION
### Description

Depends on [common_planning_interface_objects](https://github.com/ros-planning/moveit2/pull/159) and [planning_scene_monitor](https://github.com/ros-planning/moveit2/pull/112)

rviz_plugin_render_tools and robot_state_rviz_plugin are ported the remaining one for the beta release is planning_scene_rviz_plugin (should we port the remaining two .?)

TODO:
- [x] Port package.xml

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
