### PR TITLE
Fix linking issue of planning_scene_monitor

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
+++ b/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
@@ -15,6 +15,10 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   moveit_msgs
 )
+target_link_libraries(${MOVEIT_LIB_NAME}
+  moveit_robot_model_loader
+  moveit_collision_plugin_loader
+)
 
 add_executable(demo_scene demos/demo_scene.cpp)
 ament_target_dependencies(demo_scene


### PR DESCRIPTION

This PR intends to fix the linking issue of planning_scene_monitor: seems two non-ROS-package dependencies `moveit_robot_model_loader` and `moveit_collision_plugin_loader` are missing, which resulted in [errors](https://travis-ci.org/ros-planning/moveit2/jobs/643203147#L495) when compiling `trajectory_execution_manager`.