### PR TITLE
Integration + Demo node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
-<img src="http://moveit.ros.org/assets/images/moveit2_logo_black.png" alt="MoveIt Logo" width="200"/>
+<img src="https://github.com/ros-planning/moveit.ros.org/blob/master/assets/logo/moveit2/moveit_logo-black.png" alt="MoveIt 2 Logo" width="300"/>
 
-The MoveIt Motion Planning Framework for ROS 2
+The MoveIt Motion Planning Framework for **ROS 2**
 
-We are currently working on the upcoming Beta version of MoveIt 2.
-See the [MoveIt's website homepage](https://moveit.ros.org) for release dates and [this document](https://docs.google.com/spreadsheets/d/1aPb3hNP213iPHQIYgcnCYh9cGFUlZmi_06E_9iTSsOI/edit?usp=sharing) for our immediate migration progress.
+Currently we support ROS 2 Eloquent.
+
+- [Overview of MoveIt](http://moveit.ros.org)
+- [Installation Instructions](http://moveit.ros.org/install/)
+- [Documentation](http://moveit.ros.org/documentation/)
+- [Get Involved](http://moveit.ros.org/documentation/contributing/)
+
+## ROS 2 Migration Process and Roadmap
+
+See the [MoveIt website](https://moveit.ros.org) for release dates and [this document](https://docs.google.com/spreadsheets/d/1aPb3hNP213iPHQIYgcnCYh9cGFUlZmi_06E_9iTSsOI/edit?usp=sharing) for the current migration progress.
 
 Implementation instructions for the ROS 2 migration process can be found in our [Migration Guidelines](doc/MIGRATION_GUIDE.md).
 
-### Build from Source
+Plans for future milestones can be found in our [Development Roadmap](https://moveit.ros.org/documentation/contributing/roadmap/).
 
-> Note: Currently, only the moveit\_core packages are being compiled.
+## Build from Source
+
+> Note: See the [migration progress](https://docs.google.com/spreadsheets/d/1aPb3hNP213iPHQIYgcnCYh9cGFUlZmi_06E_9iTSsOI/edit?usp=sharing) for learning what packages are available.
 
 These instructions assume you are running on Ubuntu 18.04.
 
-1. [Install ROS2 Eloquent](https://index.ros.org/doc/ros2/Installation/Linux-Install-Debians/) (Make sure to set `export CHOOSE_ROS_DISTRO=Eloquent` and to source `/opt/ros/eloquent/setup.bash`)
+1. [Install ROS2 Eloquent](https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Install-Debians/) following the installation instructions. Use the desktop installation and don't forget to source the setup script.
 
-1. [Install ROS2 Build Tools](https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/#install-development-tools-and-ros-tools)
+1. [Install ROS2 Build Tools](https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/#install-development-tools-and-ros-tools) up until setting up rosdep (we're using slightly different steps for setting up our workspace)
 
 1. Create a colcon workspace:
 
@@ -27,7 +37,7 @@ These instructions assume you are running on Ubuntu 18.04.
 
         git clone git@github.com:ros-planning/moveit2.git
         vcs import < moveit2/moveit2.repos
-        rosdep install -r --from-path . --ignore-src --rosdistro eloquent -y
+        rosdep install -r --from-paths . --ignore-src --rosdistro eloquent -y
 
 1. Configure and build the workspace:
 
@@ -36,28 +46,14 @@ These instructions assume you are running on Ubuntu 18.04.
 
 1. Source the workspace:
 
-        source $COLCON_WS/install/local_setup.bash
+        source $COLCON_WS/install/setup.bash
+        
+## Getting Started
 
-
-## Roadmap
-The MoveIt Motion Planning Framework **for ROS 2.0**
-
-- [Milestones](#milestones)
-- [Overview of MoveIt!](http://moveit.ros.org)
-- [Installation Instructions](http://moveit.ros.org/install/)
-- [Documentation](http://moveit.ros.org/documentation/)
-- [Get Involved](http://moveit.ros.org/documentation/contributing/)
-- [Migration Guidelines](doc/MIGRATION_GUIDE.md)
+We've prepared a simple demo setup that you can use for quickly spinning up a simulated robot environment with MoveItCpp.
+See the [run_moveit_cpp](moveit_demo_nodes/run_moveit_cpp) demo package for further instructions and information.
 
 
 ## Continuous Integration Status
 
 [![Build Status](https://travis-ci.org/ros-planning/moveit2.svg?branch=master)](https://travis-ci.org/ros-planning/moveit2)
-
-## Docker Containers
-
-TODO [Create ROS2 Docker containers for MoveIt!](https://github.com/ros-planning/moveit2/issues/15)
-
-## ROS Buildfarm
-
-Debian releases of MoveIt2 will not be available during the alpha development stage. Check back May 2019.

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -578,34 +578,33 @@ protected:
    * as the predominant configuration but also allows groupwise specifications.
    */
   template <typename T>
-  inline bool lookupParam(std::shared_ptr<rclcpp::Node>& node, const std::string& param, T& val,
+  inline bool lookupParam(const rclcpp::Node::SharedPtr& node, const std::string& param, T& val,
                           const T& default_val) const
   {
-    rclcpp::SyncParametersClient parameters_lookup(node);
-
-    if (parameters_lookup.has_parameter({ group_name_ + "/" + param }))
+    if (node->has_parameter({ group_name_ + "." + param }))
     {
-      val = parameters_lookup.get_parameter(group_name_ + "/" + param, default_val);
+      node->get_parameter(group_name_ + "." + param, val);
       return true;
     }
 
-    if (parameters_lookup.has_parameter({ param }))
+    if (node->has_parameter({ param }))
     {
-      val = parameters_lookup.get_parameter(param, default_val);
+      node->get_parameter(param, val);
       return true;
     }
 
-    if (parameters_lookup.has_parameter({ "robot_description_kinematics/" + group_name_ + "/" + param }))
+    if (node->has_parameter({ "robot_description_kinematics." + group_name_ + "." + param }))
     {
-      val = parameters_lookup.get_parameter("robot_description_kinematics/" + group_name_ + "/" + param, default_val);
+      node->get_parameter("robot_description_kinematics." + group_name_ + "." + param, val);
       return true;
     }
 
-    if (parameters_lookup.has_parameter({ "robot_description_kinematics/" + param }))
+    if (node->has_parameter("robot_description_kinematics." + param))
     {
-      val = parameters_lookup.get_parameter("robot_description_kinematics/" + param, default_val);
+      node->get_parameter("robot_description_kinematics." + param, val);
       return true;
     }
+
     val = default_val;
     return false;
   }

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -163,7 +163,8 @@ public:
   /// made.
   /// It is assumed that motion plans will be computed for the robot described by \e model
   /// and the node is passed as an argument to get some ROS parameters
-  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node);
+  virtual bool initialize(const robot_model::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
+                          const std::string& parameter_namespace);
 
   /// Get \brief a short string that identifies the planning interface
   virtual std::string getDescription() const;

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -92,7 +92,8 @@ void PlanningContext::setMotionPlanRequest(const MotionPlanRequest& request)
   request_.num_planning_attempts = std::max(1, request_.num_planning_attempts);
 }
 
-bool PlannerManager::initialize(const robot_model::RobotModelConstPtr& /*unused*/, const rclcpp::Node::SharedPtr& node)
+bool PlannerManager::initialize(const robot_model::RobotModelConstPtr& /*unused*/, const rclcpp::Node::SharedPtr& node,
+                                const std::string& parameter_namespace)
 {
   return true;
 }

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -62,9 +62,9 @@ public:
   {
   }
 
-  /** \brief Initialize parameters using the passed Node
-      if no initialization is needed, simply implement as empty */
-  virtual void initialize(const rclcpp::Node::SharedPtr& node) = 0;
+  /** \brief Initialize parameters using the passed Node and parameter namespace.
+      If no initialization is needed, simply implement as empty */
+  virtual void initialize(const rclcpp::Node::SharedPtr& node, const std::string& parameter_namespace) = 0;
 
   /// Get a short string that identifies the planning request adapter
   virtual std::string getDescription() const

--- a/moveit_demo_nodes/run_moveit_cpp/CMakeLists.txt
+++ b/moveit_demo_nodes/run_moveit_cpp/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+project(run_moveit_cpp)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(moveit_ros_planning_interface REQUIRED)
+# This shouldn't be necessary (required by moveit_simple_controller_manager)
+find_package(rosidl_default_runtime REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+add_executable(run_moveit_cpp src/run_moveit_cpp.cpp)
+ament_target_dependencies(run_moveit_cpp
+  moveit_ros_planning_interface
+  Boost
+)
+
+install(TARGETS run_moveit_cpp
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/moveit_demo_nodes/run_moveit_cpp/README.md
+++ b/moveit_demo_nodes/run_moveit_cpp/README.md
@@ -1,0 +1,46 @@
+<img src="https://github.com/ros-planning/moveit.ros.org/blob/master/assets/logo/moveit2/moveit_logo-black.png" alt="MoveIt 2 Logo" width="300"/>
+
+# MoveIt 2 Beta - Demo Setup
+
+The `run_moveit_cpp` package provides a simulated robot setup that shows how to get started with MoveIt 2.
+The demo includes examples for:
+
+* Configuring and loading MoveIt using MoveItCpp
+* Launching a simulated ros2_control driver
+* Visualizing robot and planning scene in RViz
+* Planning and execution of robot trajectories
+
+Overall, the MoveIt 2 Beta Demo provides all necessary features in order to get a simple robot setup running with ROS 2.
+
+## Prerequesites
+
+Before running the demo, there are additional dependencies that need to be installed:
+
+* [ros2_control](https://github.com/ros-controls/ros2_control)
+* [ros2_controllers](https://github.com/ros-controls/ros2_controllers)
+* [fake_joint](https://github.com/tork-a/fake_joint)
+
+For that, simply import `run_moveit_cpp.repos` into your workspace and recompile with colcon (assuming the workspace has already been sourced):
+
+    cd $COLCON_PREFIX_PATH
+    cd ../src
+    vcs import < moveit2/moveit_demo_nodes/run_moveit_cpp/run_moveit_cpp.repos
+    rosdep install --from-paths . --ignore-src --rosdistro eloquent
+    cd ..
+    colcon build
+    source install/setup.bash
+    
+## Running the Demo
+ 
+Now, the demo can be started using the launch file `run_moveit_cpp.launch.py`:
+ 
+     ros2 launch run_moveit_cpp run_moveit_cpp.launch.py
+     
+The launch file should open the RViz GUI showing the Panda robot in extended position.
+The demo starts by computing a simple motion plan which is being visualized via a transparent RobotState display.
+This step alone involves a big range of components, like IK, collision checks, planning scene, robot model, OMPL planning plugin and planner adapters.
+Right after, the trajectory is being executed on a simulated controller (fake_joint) using the `ros2_control` hardware interface.
+As of now, `ros2_control` doesn't support action server interfaces similar to ROS 1, yet.
+We are using the available message topic to publish the plan solution to the trajectory controller for execution.
+Executing trajectories on real hardware either requires implementing a ros2_control interface for the driver or forwarding the trajectories to a ROS 1 message adapter using [ros1_bridge](https://github.com/ros2/ros1_bridge). 
+

--- a/moveit_demo_nodes/run_moveit_cpp/README.md
+++ b/moveit_demo_nodes/run_moveit_cpp/README.md
@@ -20,14 +20,13 @@ Before running the demo, there are additional dependencies that need to be insta
 * [ros2_controllers](https://github.com/ros-controls/ros2_controllers)
 * [fake_joint](https://github.com/tork-a/fake_joint)
 
-For that, simply import `run_moveit_cpp.repos` into your workspace and recompile with colcon (assuming the workspace has already been sourced):
+For that, simply import `run_moveit_cpp.repos` into your workspace and recompile with colcon (assuming the workspace has been compiled and sourced following the [installation instructions](/README.md)):
 
-    cd $COLCON_PREFIX_PATH
-    cd ../src
+    cd $COLCON_WS/src
     vcs import < moveit2/moveit_demo_nodes/run_moveit_cpp/run_moveit_cpp.repos
     rosdep install --from-paths . --ignore-src --rosdistro eloquent
     cd ..
-    colcon build
+    colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release
     source install/setup.bash
     
 ## Running the Demo
@@ -43,4 +42,3 @@ Right after, the trajectory is being executed on a simulated controller (fake_jo
 As of now, `ros2_control` doesn't support action server interfaces similar to ROS 1, yet.
 We are using the available message topic to publish the plan solution to the trajectory controller for execution.
 Executing trajectories on real hardware either requires implementing a ros2_control interface for the driver or forwarding the trajectories to a ROS 1 message adapter using [ros1_bridge](https://github.com/ros2/ros1_bridge). 
-

--- a/moveit_demo_nodes/run_moveit_cpp/config/controllers.yaml
+++ b/moveit_demo_nodes/run_moveit_cpp/config/controllers.yaml
@@ -1,0 +1,24 @@
+controller_names:
+  - panda_arm_controller
+  - hand_controller
+
+panda_arm_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - panda_joint1
+    - panda_joint2
+    - panda_joint3
+    - panda_joint4
+    - panda_joint5
+    - panda_joint6
+    - panda_joint7
+
+hand_controller:
+  action_ns: gripper_action
+  type: GripperCommand
+  default: true
+  joints:
+    - panda_finger_joint1
+    - panda_finger_joint2

--- a/moveit_demo_nodes/run_moveit_cpp/config/moveit_cpp.yaml
+++ b/moveit_demo_nodes/run_moveit_cpp/config/moveit_cpp.yaml
@@ -1,0 +1,19 @@
+run_moveit_cpp:
+  ros__parameters:
+    planning_scene_monitor_options:
+      name: "planning_scene_monitor"
+      robot_description: "robot_description"
+      joint_state_topic: "/joint_states"
+      attached_collision_object_topic: "/moveit_cpp/planning_scene_monitor"
+      publish_planning_scene_topic: "/moveit_cpp/publish_planning_scene"
+      monitored_planning_scene_topic: "/moveit_cpp/monitored_planning_scene"
+      wait_for_initial_state_timeout: 10.0
+    
+    planning_pipelines:
+      #namespace: "moveit_cpp"  # optional, default is ~
+      pipeline_names: ["ompl"]
+    
+    default_planner_options:
+      planning_attempts: 10
+      max_velocity_scaling_factor: 1.0
+      max_acceleration_scaling_factor: 1.0

--- a/moveit_demo_nodes/run_moveit_cpp/config/panda_controllers.yaml
+++ b/moveit_demo_nodes/run_moveit_cpp/config/panda_controllers.yaml
@@ -1,0 +1,18 @@
+fake_joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7
+    write_op_modes:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7

--- a/moveit_demo_nodes/run_moveit_cpp/config/start_positions.yaml
+++ b/moveit_demo_nodes/run_moveit_cpp/config/start_positions.yaml
@@ -1,0 +1,19 @@
+fake_joint_driver_node:
+  ros__parameters:
+    start_position:
+      joints:
+        - panda_joint1
+        - panda_joint2
+        - panda_joint3
+        - panda_joint4
+        - panda_joint5
+        - panda_joint6
+        - panda_joint7
+      values:
+        - 0.0
+        - -0.785
+        - 0.0
+        - -2.356
+        - 0.0
+        - 1.571
+        - 0.785

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -85,6 +85,7 @@ def generate_launch_description():
                                   # TODO(JafarAbdi): Why this launch the two nodes (controller manager and the fake joint driver) with the same name!
                                   # node_name='fake_joint_driver_node',
                                   parameters=[os.path.join(get_package_share_directory("run_moveit_cpp"), "config", "panda_controllers.yaml"),
+                                              os.path.join(get_package_share_directory("run_moveit_cpp"), "config", "start_positions.yaml"),
                                               robot_description]
                                   )
 

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -79,4 +79,13 @@ def generate_launch_description():
                      output='log',
                      arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
 
-    return LaunchDescription([ static_tf, rviz_node, run_moveit_cpp_node ])
+    # Fake joint driver
+    fake_joint_driver_node = Node(package='fake_joint_driver',
+                                  node_executable='fake_joint_driver_node',
+                                  # TODO(JafarAbdi): Why this launch the two nodes (controller manager and the fake joint driver) with the same name!
+                                  # node_name='fake_joint_driver_node',
+                                  parameters=[os.path.join(get_package_share_directory("run_moveit_cpp"), "config", "panda_controllers.yaml"),
+                                              robot_description]
+                                  )
+
+    return LaunchDescription([ static_tf, rviz_node, run_moveit_cpp_node, fake_joint_driver_node ])

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -1,0 +1,68 @@
+import os
+import yaml
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+def load_file(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return file.read()
+    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+def load_yaml(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return yaml.load(file)
+    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def generate_launch_description():
+    # moveit_cpp.yaml is passed by filename for now since it's node specific
+    moveit_cpp_yaml_file_name = get_package_share_directory('run_moveit_cpp') + "/config/moveit_cpp.yaml"
+
+    # Component yaml files are stored inside dicts for now, allowing grouping the configs in separate namespaces
+    robot_description_config = load_file('moveit_resources', 'panda_description/urdf/panda.urdf')
+    robot_description = {'robot_description' : robot_description_config}
+
+    robot_description_semantic_config = load_file('moveit_resources', 'panda_moveit_config/config/panda.srdf')
+    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+
+    kinematics_yaml = load_yaml('moveit_resources', 'panda_moveit_config/config/kinematics.yaml')
+    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+
+    # This config file had to be migrated, so this is temporarily in the config folder of run_moveit_cpp
+    controllers_yaml = load_yaml('run_moveit_cpp', 'config/controllers.yaml')
+    moveit_controllers = { 'moveit_simple_controller_manager' : controllers_yaml }
+
+    ompl_planning_yaml = load_yaml('moveit_resources', 'panda_moveit_config/config/ompl_planning.yaml')
+    ompl_planning_pipeline_config = { 'ompl' : {
+        'planning_plugin' : 'ompl_interface/OMPLPlanner',
+        # TODO(henningkayser): enable planning request adapters
+        #'request_adapters' : """default_planner_request_adapters/AddTimeParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
+        'request_adapters' : '',
+        'start_state_max_bounds_error' : 0.1 } }
+    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
+
+    # Specify run_moveit_cpp node
+    run_moveit_cpp_node = Node(node_name='run_moveit_cpp',
+                               package='run_moveit_cpp',
+                               # NOTE: not clear how to interact with the gdb instance
+                               #prefix='gdb -ex run --args',
+                               node_executable='run_moveit_cpp',
+                               output='screen',
+                               parameters=[moveit_cpp_yaml_file_name,
+                                           robot_description,
+                                           robot_description_semantic,
+                                           kinematics_yaml,
+                                           ompl_planning_pipeline_config,
+                                           moveit_controllers])
+    return LaunchDescription([ run_moveit_cpp_node ])

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -72,7 +72,7 @@ def generate_launch_description():
                      arguments=['-d', rviz_config_file],
                      parameters=[robot_description])
 
-    # RobotStatePublisher
+    # Publish base link TF
     static_tf = Node(package='tf2_ros',
                      node_executable='static_transform_publisher',
                      node_name='static_transform_publisher',

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -64,10 +64,12 @@ def generate_launch_description():
                                            moveit_controllers])
 
     # RViz
+    rviz_config_file = get_package_share_directory('run_moveit_cpp') + "/launch/run_moveit_cpp.rviz"
     rviz_node = Node(package='rviz2',
                      node_executable='rviz2',
                      node_name='rviz2',
                      output='log',
+                     arguments=['-d', rviz_config_file],
                      parameters=[robot_description])
 
     # RobotStatePublisher

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
@@ -49,7 +49,7 @@ Visualization Manager:
       Enabled: true
       Move Group Namespace: ""
       Name: PlanningScene
-      Planning Scene Topic: move_group/monitored_planning_scene
+      Planning Scene Topic: /moveit_cpp/publish_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 0.8999999761581421
@@ -150,7 +150,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: map
+    Fixed Frame: world
     Frame Rate: 30
   Name: root
   Tools:

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
@@ -140,7 +140,7 @@ Visualization Manager:
           Show Trail: false
           Value: true
       Name: RobotState
-      Robot Alpha: 1
+      Robot Alpha: 0.5
       Robot Description: robot_description
       Robot State Topic: display_robot_state
       Show All Links: true

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.rviz
@@ -1,0 +1,228 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /PlanningScene1
+        - /RobotState1
+        - /RobotState1/Status1
+      Splitter Ratio: 0.5
+    Tree Height: 1201
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: moveit_rviz_plugin/PlanningScene
+      Enabled: true
+      Move Group Namespace: ""
+      Name: PlanningScene
+      Planning Scene Topic: move_group/monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.20000000298023224
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: ""
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+    - Attached Body Color: 150; 50; 150
+      Class: moveit_rviz_plugin/RobotState
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        panda_hand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link8:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        panda_rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotState
+      Robot Alpha: 1
+      Robot Description: robot_description
+      Robot State Topic: display_robot_state
+      Show All Links: true
+      Show Highlights: true
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.8008623123168945
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5753980278968811
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.4903981685638428
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1407
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000021600000535fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000004e00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003100000535000000a600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000535fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000031000005350000008c00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000006d10000053500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 2560
+  X: 2560
+  Y: 33

--- a/moveit_demo_nodes/run_moveit_cpp/package.xml
+++ b/moveit_demo_nodes/run_moveit_cpp/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>run_moveit_cpp</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>moveit_ros_planning_interface</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/moveit_demo_nodes/run_moveit_cpp/run_moveit_cpp.repos
+++ b/moveit_demo_nodes/run_moveit_cpp/run_moveit_cpp.repos
@@ -1,0 +1,15 @@
+repositories:
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control
+    version: eloquent
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: eloquent
+
+# TODO(JafarAbdi): Switch to upstream once PR https://github.com/tork-a/fake_joint/pull/7 is merged
+  fake_joint:
+    type: git
+    url: https://github.com/JafarAbdi/fake_joint
+    version: pr-port_to_ros2

--- a/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
+++ b/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
@@ -42,6 +42,7 @@
 #include <moveit/moveit_cpp/planning_component.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit_msgs/msg/display_robot_state.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_cpp_demo");
 
@@ -51,6 +52,9 @@ public:
   MoveItCppDemo(const rclcpp::Node::SharedPtr& node)
     : node_(node)
     , robot_state_publisher_(node_->create_publisher<moveit_msgs::msg::DisplayRobotState>("display_robot_state", 1))
+    , trajectory_publisher_(node_->create_publisher<trajectory_msgs::msg::JointTrajectory>(
+          "/fake_joint_trajectory_controller/joint_trajectory", 1))
+
   {
   }
 
@@ -76,6 +80,13 @@ public:
     // TODO(henningkayser): Enable trajectory execution once controllers are available
     // RCLCPP_INFO(LOGGER, "arm.execute()");
     // arm.execute();
+    // Right now the joint trajectory controller doesn't' support actions and the current way to send trajectory is by
+    // using a publisher
+    // See https://github.com/ros-controls/ros2_controllers/issues/12 for enabling action interface progress
+    RCLCPP_INFO(LOGGER, "Sending the trajectory for execution");
+    moveit_msgs::msg::RobotTrajectory robot_trajectory;
+    arm.getLastPlanSolution()->trajectory->getRobotTrajectoryMsg(robot_trajectory);
+    trajectory_publisher_->publish(robot_trajectory.joint_trajectory);
   }
 
 private:
@@ -103,6 +114,7 @@ private:
 
   rclcpp::Node::SharedPtr node_;
   rclcpp::Publisher<moveit_msgs::msg::DisplayRobotState>::SharedPtr robot_state_publisher_;
+  rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_publisher_;
   moveit::planning_interface::MoveItCppPtr moveit_cpp_;
 };
 

--- a/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
+++ b/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
@@ -69,6 +69,28 @@ public:
     // A little delay before running the plan
     rclcpp::sleep_for(std::chrono::seconds(3));
 
+    moveit_msgs::msg::CollisionObject collision_object;
+    collision_object.header.frame_id = "panda_link0";
+    collision_object.id = "box";
+
+    shape_msgs::msg::SolidPrimitive box;
+    box.type = box.BOX;
+    box.dimensions.resize(3);
+    box.dimensions.at(0) = 0.1;
+    box.dimensions.at(1) = 0.4;
+    box.dimensions.at(2) = 0.1;
+
+    geometry_msgs::msg::Pose box_pose;
+    box_pose.position.x = 0.4;
+    box_pose.position.y = 0.0;
+    box_pose.position.z = 1.0;
+
+    collision_object.primitives.push_back(box);
+    collision_object.primitive_poses.push_back(box_pose);
+    collision_object.operation = collision_object.ADD;
+
+    getPlanningSceneRW()->processCollisionObjectMsg(collision_object);
+
     RCLCPP_INFO(LOGGER, "Set goal");
     arm.setGoal("home");
 
@@ -107,6 +129,11 @@ private:
 
       robot_state_publisher_->publish(waypoint);
     }
+  }
+
+  planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW()
+  {
+    return planning_scene_monitor::LockedPlanningSceneRW(moveit_cpp_->getPlanningSceneMonitor());
   }
 
   rclcpp::Node::SharedPtr node_;

--- a/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
+++ b/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
@@ -1,0 +1,74 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+   Desc: A simple demo node running MoveItCpp for planning and execution
+*/
+
+#include <rclcpp/rclcpp.hpp>
+#include <moveit/moveit_cpp/moveit_cpp.h>
+#include <moveit/moveit_cpp/planning_component.h>
+
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("main");
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  RCLCPP_INFO(LOGGER, "Initialize node");
+  rclcpp::NodeOptions node_options;
+  // This enables loading undeclared parameters
+  // best practice would be to declare parameters in the corresponding classes
+  // and provide descriptions about expected use
+  node_options.automatically_declare_parameters_from_overrides(true);
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("run_moveit_cpp", "", node_options);
+
+  RCLCPP_INFO(LOGGER, "Initialize MoveItCpp");
+  auto moveit_cpp = std::make_shared<moveit::planning_interface::MoveItCpp>(node);
+  RCLCPP_INFO(LOGGER, "Initialize PlanningComponent");
+  moveit::planning_interface::PlanningComponent arm("panda_arm", moveit_cpp);
+  // TODO(henningkayser): Fix segfault
+  // arm.setStartState();
+
+  RCLCPP_INFO(LOGGER, "Set goal");
+  arm.setGoal("home");
+
+  // TODO(henningkayser): Fix segfault
+  // RCLCPP_INFO(LOGGER, "arm.plan()");
+  // arm.plan();
+
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -24,10 +24,10 @@ include_directories(ompl_interface/include
 
 add_subdirectory(ompl_interface)
 
-pluginlib_export_plugin_description_file(moveit_ompl_interface ompl_interface_plugin_description.xml)
-
 ament_export_include_directories(include)
-ament_export_libraries(moveit_ompl_interface)
+ament_export_libraries(moveit_ompl_interface moveit_ompl_planner_plugin)
 ament_export_dependencies(moveit_core ompl)
+
+pluginlib_export_plugin_description_file(moveit_core ompl_interface_plugin_description.xml)
 
 ament_package()

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(moveit_generate_state_database ${MOVEIT_LIB_NAME})
 set_target_properties(moveit_generate_state_database PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 set_target_properties(moveit_generate_state_database PROPERTIES OUTPUT_NAME "generate_state_database")
 
-add_library(moveit_ompl_planner_plugin src/ompl_planner_manager.cpp)
+add_library(moveit_ompl_planner_plugin SHARED src/ompl_planner_manager.cpp)
 set_target_properties(moveit_ompl_planner_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_ompl_planner_plugin
 	moveit_core

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -56,14 +56,16 @@ class OMPLInterface
 public:
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
    * NodeHandle */
-  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model, const rclcpp::Node::SharedPtr& node);
+  OMPLInterface(const robot_model::RobotModelConstPtr& robot_model, const rclcpp::Node::SharedPtr& node,
+                const std::string& parameter_namespace);
 
   /** \brief Initialize OMPL-based planning for a particular robot model. ROS configuration is read from the specified
      NodeHandle. However,
       planner configurations are used as specified in \e pconfig instead of reading them from the ROS parameter server
      */
   OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
-                const planning_interface::PlannerConfigurationMap& pconfig, const rclcpp::Node::SharedPtr& node);
+                const planning_interface::PlannerConfigurationMap& pconfig, const rclcpp::Node::SharedPtr& node,
+                const std::string& parameter_namespace);
 
   virtual ~OMPLInterface();
 
@@ -147,6 +149,7 @@ protected:
                                                double* timeout) const;
 
   rclcpp::Node::SharedPtr node_;  /// The ROS node
+  const std::string parameter_namespace_;
 
   /** \brief The kinematic model for which motion plans are computed */
   robot_model::RobotModelConstPtr robot_model_;

--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -141,7 +141,7 @@ void computeDB(const rclcpp::Node::SharedPtr& node, const planning_scene::Planni
   // required by addConstraintApproximation
   scene->getCurrentStateNonConst().update();
 
-  ompl_interface::OMPLInterface ompl_interface(scene->getRobotModel(), node);
+  ompl_interface::OMPLInterface ompl_interface(scene->getRobotModel(), node, "ompl");
   planning_interface::MotionPlanRequest req;
   req.group_name = params.planning_group;
   req.path_constraints = params.constraints;

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -44,16 +44,7 @@
 namespace ompl_interface
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.ompl_planner_manager");
-
-/*
-#define OMPL_ROS_LOG(ros_log_level)                                                                                    \
-  {                                                                                                                    \
-    ROSCONSOLE_DEFINE_LOCATION(true, ros_log_level, ROSCONSOLE_NAME_PREFIX ".ompl");                                   \
-    if (ROS_UNLIKELY(__rosconsole_define_location__enabled))                                                           \
-      ::ros::console::print(0, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_,    \
-                            filename, line, __ROSCONSOLE_FUNCTION__, "%s", text.c_str());                              \
-  }
-*/
+static const rclcpp::Logger OMPL_LOGGER = rclcpp::get_logger("ompl");
 
 class OMPLPlannerManager : public planning_interface::PlannerManager
 {
@@ -62,8 +53,6 @@ public:
   {
     class OutputHandler : public ompl::msg::OutputHandler
     {
-      const rclcpp::Logger LOGGER = rclcpp::get_logger("ompl");
-
     public:
       void log(const std::string& text, ompl::msg::LogLevel level, const char* filename, int line) override
       {
@@ -72,16 +61,16 @@ public:
           case ompl::msg::LOG_DEV2:
           case ompl::msg::LOG_DEV1:
           case ompl::msg::LOG_DEBUG:
-            RCLCPP_DEBUG(LOGGER, "%s:$i - %s", filename, line, text);
+            RCLCPP_DEBUG(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_INFO:
-            RCLCPP_INFO(LOGGER, "%s:$i - %s", filename, line, text);
+            RCLCPP_INFO(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_WARN:
-            RCLCPP_WARN(LOGGER, "%s:$i - %s", filename, line, text);
+            RCLCPP_WARN(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_ERROR:
-            RCLCPP_ERROR(LOGGER, "%s:$i - %s", filename, line, text);
+            RCLCPP_ERROR(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_NONE:
           default:

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -95,9 +95,10 @@ public:
     ompl::msg::useOutputHandler(output_handler_.get());
   }
 
-  bool initialize(const robot_model::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node) override
+  bool initialize(const robot_model::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
+                  const std::string& parameter_namespace) override
   {
-    ompl_interface_.reset(new OMPLInterface(model, node));
+    ompl_interface_.reset(new OMPLInterface(model, node, parameter_namespace));
     config_settings_ = ompl_interface_->getPlannerConfigurations();
     return true;
   }
@@ -145,4 +146,4 @@ private:
 
 }  // namespace ompl_interface
 
-CLASS_LOADER_REGISTER_CLASS(ompl_interface::OMPLPlannerManager, planning_interface::PlannerManager);
+CLASS_LOADER_REGISTER_CLASS(ompl_interface::OMPLPlannerManager, planning_interface::PlannerManager)

--- a/moveit_planners/ompl/ompl_interface_plugin_description.xml
+++ b/moveit_planners/ompl/ompl_interface_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libmoveit_ompl_planner_plugin">
+<library path="moveit_ompl_planner_plugin">
   <class name="ompl_interface/OMPLPlanner" type="ompl_interface::OMPLPlannerManager" base_class_type="planning_interface::PlannerManager">
     <description>
     </description>

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rclcpp_action REQUIRED)
 
 include_directories(include)
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/moveit_simple_controller_manager.cpp
   src/follow_joint_trajectory_controller_handle.cpp
 )

--- a/moveit_plugins/moveit_simple_controller_manager/moveit_simple_controller_manager_plugin_description.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/moveit_simple_controller_manager_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libmoveit_simple_controller_manager">
+<library path="moveit_simple_controller_manager">
 
   <class name="moveit_simple_controller_manager/MoveItSimpleControllerManager"
          type="moveit_simple_controller_manager::MoveItSimpleControllerManager"

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -71,6 +71,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_msgs
   tf2_msgs
   tf2_geometry_msgs
+  Boost
 )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -49,12 +49,10 @@ class ConstraintSamplerManagerLoader::Helper
 public:
   Helper(const rclcpp::Node::SharedPtr& node, const constraint_samplers::ConstraintSamplerManagerPtr& csm) : node_(node)
   {
-    auto parameters_constraint_sampler = std::make_shared<rclcpp::SyncParametersClient>(node_);
-
-    std::string constraint_samplers;
-    if (parameters_constraint_sampler->has_parameter("constraint_samplers"))
+    if (node_->has_parameter("constraint_samplers"))
     {
-      constraint_samplers = node_->get_parameter("constraint_samplers").get_value<std::string>();
+      std::string constraint_samplers;
+      node_->get_parameter("constraint_samplers", constraint_samplers);
       try
       {
         constraint_sampler_plugin_loader_.reset(

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -299,13 +299,13 @@ robot_model::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const s
         for (const srdf::Model::Group& known_group : known_groups)
         {
           std::string base_param_name = known_group.name_;
-          std::string ksolver_param_name = base_param_name + "/kinematics_solver";
+          std::string ksolver_param_name = base_param_name + ".kinematics_solver";
           RCLCPP_DEBUG(LOGGER, "Looking for param %s ", ksolver_param_name.c_str());
           bool found = node_->has_parameter(ksolver_param_name);
           if (!found)
           {
-            base_param_name = robot_description_ + "_kinematics/" + known_group.name_;
-            ksolver_param_name = base_param_name + "/kinematics_solver";
+            base_param_name = robot_description_ + "_kinematics." + known_group.name_;
+            ksolver_param_name = base_param_name + ".kinematics_solver";
             RCLCPP_DEBUG(LOGGER, "Looking for param %s ", ksolver_param_name.c_str());
             found = node_->has_parameter(ksolver_param_name);
           }

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -71,24 +71,28 @@ public:
 
   /** \brief Given a robot model (\e model), a node handle (\e nh), initialize the planning pipeline.
       \param model The robot model for which this pipeline is initialized.
-      \param nh The ROS node handle that should be used for reading parameters needed for configuration
+      \param node The ROS node that should be used for reading parameters needed for configuration
+      \param the parameter namespace where the planner configurations are stored
       \param planning_plugin_param_name The name of the ROS parameter under which the name of the planning plugin is
      specified
       \param adapter_plugins_param_name The name of the ROS parameter under which the names of the request adapter
      plugins are specified (plugin names separated by space; order matters)
   */
   PlanningPipeline(const robot_model::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node> node,
+                   const std::string& parameter_namespace,
                    const std::string& planning_plugin_param_name = "planning_plugin",
                    const std::string& adapter_plugins_param_name = "request_adapters");
 
   /** \brief Given a robot model (\e model), a node handle (\e nh), initialize the planning pipeline.
       \param model The robot model for which this pipeline is initialized.
-      \param nh The ROS node handle that should be used for reading parameters needed for configuration
+      \param node The ROS node that should be used for reading parameters needed for configuration
+      \param the parameter namespace where the planner configurations are stored
       \param planning_plugin_name The name of the planning plugin to load
       \param adapter_plugins_names The names of the planning request adapter plugins to load
   */
   PlanningPipeline(const robot_model::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node> node,
-                   const std::string& planning_plugin_name, const std::vector<std::string>& adapter_plugin_names);
+                   const std::string& parameter_namespace, const std::string& planning_plugin_name,
+                   const std::vector<std::string>& adapter_plugin_names);
 
   /** \brief Pass a flag telling the pipeline whether or not to publish the computed motion plans on DISPLAY_PATH_TOPIC.
    * Default is true. */
@@ -171,6 +175,7 @@ private:
   void configure();
 
   std::shared_ptr<rclcpp::Node> node_;
+  std::string parameter_namespace_;
   /// Flag indicating whether motion plans should be published as a moveit_msgs::msg::DisplayTrajectory
   bool display_computed_motion_plans_;
   rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory>::SharedPtr display_path_publisher_;

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -55,16 +55,13 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const robot_model::RobotMo
                                                       const std::string& adapter_plugins_param_name)
   : node_(node), parameter_namespace_(parameter_namespace), robot_model_(model)
 {
-  auto planner_plugin_params = std::make_shared<rclcpp::SyncParametersClient>(node);
-
-  if (planner_plugin_params->has_parameter(parameter_namespace_ + "." + planner_plugin_param_name))
-    planner_plugin_name_ =
-        node_->get_parameter(parameter_namespace_ + "." + planner_plugin_param_name).get_value<std::string>();
+  if (node_->has_parameter(parameter_namespace_ + "." + planner_plugin_param_name))
+    node_->get_parameter(parameter_namespace_ + "." + planner_plugin_param_name, planner_plugin_name_);
 
   std::string adapters;
-  if (planner_plugin_params->has_parameter(parameter_namespace_ + "." + adapter_plugins_param_name))
+  if (node_->has_parameter(parameter_namespace_ + "." + adapter_plugins_param_name))
   {
-    adapters = node_->get_parameter(parameter_namespace_ + "." + adapter_plugins_param_name).get_value<std::string>();
+    node_->get_parameter(parameter_namespace_ + "." + adapter_plugins_param_name, adapters);
     boost::char_separator<char> sep(" ");
     boost::tokenizer<boost::char_separator<char> > tok(adapters, sep);
     for (boost::tokenizer<boost::char_separator<char> >::iterator beg = tok.begin(); beg != tok.end(); ++beg)

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -50,7 +50,7 @@ public:
   {
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -52,7 +52,7 @@ public:
   {
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -49,7 +49,7 @@ public:
   {
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -54,7 +54,7 @@ public:
     return planner(planning_scene, req, res);
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 };

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -51,10 +51,10 @@ public:
   static const std::string BOUNDS_PARAM_NAME;
   static const std::string DT_PARAM_NAME;
 
-  void initialize(const rclcpp::Node::SharedPtr& node) override
+  void initialize(const rclcpp::Node::SharedPtr& node, const std::string& parameter_namespace) override
   {
     node_ = node;
-    if (!node_->get_parameter(BOUNDS_PARAM_NAME, bounds_dist_))
+    if (!node_->get_parameter(parameter_namespace + "." + BOUNDS_PARAM_NAME, bounds_dist_))
     {
       bounds_dist_ = 0.05;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f", BOUNDS_PARAM_NAME.c_str(), bounds_dist_);
@@ -64,7 +64,7 @@ public:
       RCLCPP_INFO(LOGGER, "Param '%s' was set to %f", BOUNDS_PARAM_NAME.c_str(), bounds_dist_);
     }
 
-    if (!node_->get_parameter(DT_PARAM_NAME, max_dt_offset_))
+    if (!node_->get_parameter(parameter_namespace + "." + DT_PARAM_NAME, max_dt_offset_))
     {
       max_dt_offset_ = 0.5;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f", DT_PARAM_NAME.c_str(), max_dt_offset_);

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -51,10 +51,10 @@ public:
   static const std::string JIGGLE_PARAM_NAME;
   static const std::string ATTEMPTS_PARAM_NAME;
 
-  void initialize(const rclcpp::Node::SharedPtr& node) override
+  void initialize(const rclcpp::Node::SharedPtr& node, const std::string& parameter_namespace) override
   {
     node_ = node;
-    if (!node_->get_parameter(DT_PARAM_NAME, max_dt_offset_))
+    if (!node_->get_parameter(parameter_namespace + "." + DT_PARAM_NAME, max_dt_offset_))
     {
       max_dt_offset_ = 0.5;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f", DT_PARAM_NAME.c_str(), max_dt_offset_);
@@ -64,7 +64,7 @@ public:
       RCLCPP_INFO(LOGGER, "Param '%s' was set to %f", DT_PARAM_NAME.c_str(), max_dt_offset_);
     }
 
-    if (!node_->get_parameter(JIGGLE_PARAM_NAME, jiggle_fraction_))
+    if (!node_->get_parameter(parameter_namespace + "." + JIGGLE_PARAM_NAME, jiggle_fraction_))
     {
       jiggle_fraction_ = 0.02;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f", JIGGLE_PARAM_NAME.c_str(),
@@ -75,7 +75,7 @@ public:
       RCLCPP_INFO(LOGGER, "Param '%s' was set to %f", JIGGLE_PARAM_NAME.c_str(), jiggle_fraction_);
     }
 
-    if (!node_->get_parameter(ATTEMPTS_PARAM_NAME, sampling_attempts_))
+    if (!node_->get_parameter(parameter_namespace + "." + ATTEMPTS_PARAM_NAME, sampling_attempts_))
     {
       sampling_attempts_ = 100;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f,", ATTEMPTS_PARAM_NAME.c_str(),

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -52,7 +52,7 @@ public:
   {
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -47,10 +47,10 @@ class FixWorkspaceBounds : public planning_request_adapter::PlanningRequestAdapt
 public:
   static const std::string WBOUNDS_PARAM_NAME;
 
-  void initialize(const rclcpp::Node::SharedPtr& node) override
+  void initialize(const rclcpp::Node::SharedPtr& node, const std::string& parameter_namespace) override
   {
     node_ = node;
-    if (!node_->get_parameter(WBOUNDS_PARAM_NAME, workspace_extent_))
+    if (!node_->get_parameter(parameter_namespace + "." + WBOUNDS_PARAM_NAME, workspace_extent_))
     {
       workspace_extent_ = 10.0;
       RCLCPP_INFO(LOGGER, "Param '%s' was not set. Using default value: %f", WBOUNDS_PARAM_NAME.c_str(),

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -49,7 +49,7 @@ public:
   {
   }
 
-  void initialize(const rclcpp::Node::SharedPtr& /* node */) override
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
   {
   }
 

--- a/moveit_ros/planning_interface/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning_interface/moveit_cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_cpp)
 
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/moveit_cpp.cpp
   src/planning_component.cpp
 )

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -60,18 +60,18 @@ public:
   {
     void load(const rclcpp::Node::SharedPtr& node)
     {
-      const std::string ns = "planning_scene_monitor_options.";
-      node->get_parameter_or(ns + "name", name, std::string("planning_scene_monitor"));
-      node->get_parameter_or(ns + "robot_description", robot_description, std::string("robot_description"));
-      node->get_parameter_or(ns + "joint_state_topic", joint_state_topic,
+      const std::string ns = "planning_scene_monitor_options";
+      node->get_parameter_or(ns + ".name", name, std::string("planning_scene_monitor"));
+      node->get_parameter_or(ns + ".robot_description", robot_description, std::string("robot_description"));
+      node->get_parameter_or(ns + ".joint_state_topic", joint_state_topic,
                              planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC);
-      node->get_parameter_or(ns + "attached_collision_object_topic", attached_collision_object_topic,
+      node->get_parameter_or(ns + ".attached_collision_object_topic", attached_collision_object_topic,
                              planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC);
-      node->get_parameter_or(ns + "monitored_planning_scene_topic", monitored_planning_scene_topic,
+      node->get_parameter_or(ns + ".monitored_planning_scene_topic", monitored_planning_scene_topic,
                              planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC);
-      node->get_parameter_or(ns + "publish_planning_scene_topic", publish_planning_scene_topic,
+      node->get_parameter_or(ns + ".publish_planning_scene_topic", publish_planning_scene_topic,
                              planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
-      node->get_parameter_or(ns + "wait_for_initial_state_timeout", wait_for_initial_state_timeout, 0.0);
+      node->get_parameter_or(ns + ".wait_for_initial_state_timeout", wait_for_initial_state_timeout, 0.0);
     }
     std::string name;
     std::string robot_description;

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -86,8 +86,9 @@ MoveItCpp::MoveItCpp(const rclcpp::Node::SharedPtr& node, const Options& options
   }
 
   // TODO(henningkayser): configure trajectory execution manager
-  trajectory_execution_manager_.reset(new trajectory_execution_manager::TrajectoryExecutionManager(
-      node_, robot_model_, planning_scene_monitor_->getStateMonitor()));
+  // NOTE: disabled for now since action clients fail to find non-existent servers
+  // trajectory_execution_manager_.reset(new trajectory_execution_manager::TrajectoryExecutionManager(
+  //     node_, robot_model_, planning_scene_monitor_->getStateMonitor()));
 
   RCLCPP_INFO(LOGGER, "MoveItCpp running");
 }
@@ -139,11 +140,12 @@ bool MoveItCpp::loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& opti
   }
 
   // Wait for complete state to be recieved
-  if (options.wait_for_initial_state_timeout > 0.0)
-  {
-    return planning_scene_monitor_->getStateMonitor()->waitForCurrentState(node_->now(),
-                                                                           options.wait_for_initial_state_timeout);
-  }
+  // TODO(henningkayser): Fix segfault in waitForCurrentState()
+  // if (options.wait_for_initial_state_timeout > 0.0)
+  // {
+  //   return planning_scene_monitor_->getStateMonitor()->waitForCurrentState(node_->now(),
+  //                                                                          options.wait_for_initial_state_timeout);
+  // }
 
   return true;
 }


### PR DESCRIPTION
This integration branch includes various fixups in order to get a runtime demo working. There is a new demo package `run_moveit_cpp` which includes a simple node and launch file config which initializes MoveItCpp for planning/execution. I had to fix up many parameters, but now all components seem to initialize just fine. TrajectoryExecutionManager is disabled (commented inside MoveItCpp) because the action clients were waiting unsuccessfully (we should add a flag for that).
Planning is also currently disabled because of segfaults.