### PR TITLE
Fix moveit visualization

### DIFF
--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -53,7 +53,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 )
 
 set(THIS_PACKAGE_LIBRARIES
-#  moveit_common_planning_interface_objects
+  moveit_common_planning_interface_objects
 #  moveit_planning_scene_interface
 #  moveit_move_group_interface
   moveit_cpp

--- a/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
@@ -14,5 +14,3 @@ install(TARGETS ${MOVEIT_LIB_NAME}
   RUNTIME DESTINATION bin)
 
 install(DIRECTORY include/ DESTINATION include)
-
-ament_export_libraries(${MOVEIT_LIB_NAME})

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -37,6 +37,8 @@ find_package(rclpy REQUIRED)
 find_package(rviz2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_default_plugins REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 
 # Qt Stuff
@@ -62,7 +64,7 @@ add_subdirectory(planning_scene_rviz_plugin)
 # add_subdirectory(motion_planning_rviz_plugin)
 # add_subdirectory(trajectory_rviz_plugin)
 
-install(DIRECTORY icons DESTINATION share)
+install(DIRECTORY icons DESTINATION share/${PROJECT_NAME})
 
 #pluginlib_export_plugin_description_file(rviz_common motion_planning_rviz_plugin_description.xml)
 #pluginlib_export_plugin_description_file(rviz_common trajectory_rviz_plugin_description.xml)
@@ -74,11 +76,11 @@ pluginlib_export_plugin_description_file(rviz_common robot_state_rviz_plugin_des
 #  add_rostest(test/moveit_joy.test)
 #endif()
 
-ament_export_include_directories(include)
 ament_export_dependencies(class_loader)
 ament_export_dependencies(geometric_shapes)
 ament_export_dependencies(interactive_markers)
 ament_export_dependencies(moveit_ros_planning)
+ament_export_dependencies(moveit_ros_planning_interface)
 ament_export_dependencies(moveit_msgs)
 ament_export_dependencies(moveit_core)
 ament_export_dependencies(octomap_msgs)

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 
 add_library(${MOVEIT_LIB_NAME}_core SHARED
   src/planning_scene_display.cpp
-)
+  include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools rviz_ogre_vendor::OgreMain)
 ament_target_dependencies(${MOVEIT_LIB_NAME}_core

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -122,7 +122,7 @@ protected Q_SLOTS:
 protected:
   /// This function reloads the robot model and reinitializes the PlanningSceneMonitor
   /// It can be called either from the Main Loop or from a Background thread
-  void loadRobotModel(const rclcpp::Node::SharedPtr& node);
+  void loadRobotModel();
 
   /// This function is used by loadRobotModel() and should only be called in the MainLoop
   /// You probably should not call this function directly
@@ -130,8 +130,7 @@ protected:
 
   /// This function constructs a new planning scene. Probably this should be called in a background thread
   /// as it may take some time to complete its execution
-  virtual planning_scene_monitor::PlanningSceneMonitorPtr
-  createPlanningSceneMonitor(const rclcpp::Node::SharedPtr& node);
+  virtual planning_scene_monitor::PlanningSceneMonitorPtr createPlanningSceneMonitor();
 
   /// This is an event called by loadRobotModel() in the MainLoop; do not call directly
   virtual void onRobotModelLoaded();
@@ -195,6 +194,9 @@ protected:
   rviz_common::properties::FloatProperty* scene_display_time_property_;
   rviz_common::properties::EnumProperty* octree_render_property_;
   rviz_common::properties::EnumProperty* octree_coloring_property_;
+
+  // rclcpp node
+  rclcpp::Node::SharedPtr node_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -112,6 +112,14 @@ RobotStateDisplay::~RobotStateDisplay() = default;
 void RobotStateDisplay::onInitialize()
 {
   Display::onInitialize();
+  auto ros_node_abstraction = context_->getRosNodeAbstraction().lock();
+  if (!ros_node_abstraction)
+  {
+    RVIZ_COMMON_LOG_WARNING("Unable to lock weak_ptr from DisplayContext in RobotStateDisplay constructor");
+    return;
+  }
+  robot_state_topic_property_->initialize(ros_node_abstraction);
+  node_ = ros_node_abstraction->get_raw_node();
   robot_.reset(new RobotStateVisualization(scene_node_, context_, "Robot State", this));
   changedEnableVisualVisible();
   changedEnableCollisionVisible();
@@ -448,7 +456,8 @@ void RobotStateDisplay::calculateOffsetPosition()
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
 
-  context_->getFrameManager()->getTransform(getRobotModel()->getModelFrame(), rclcpp::Time(0), position, orientation);
+  context_->getFrameManager()->getTransform(getRobotModel()->getModelFrame(), rclcpp::Time(0, 0, RCL_ROS_TIME),
+                                            position, orientation);
 
   scene_node_->setPosition(position);
   scene_node_->setOrientation(orientation);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -22,17 +22,19 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/trajectory_visualization.cpp
   src/trajectory_panel.cpp
   src/mesh_shape.cpp
+  ${HEADERS}
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 target_link_libraries(${MOVEIT_LIB_NAME}
     rviz_ogre_vendor::OgreMain
     Qt5::Widgets
+    rviz_common::rviz_common
+    rviz_default_plugins::rviz_default_plugins
 )
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
     rclcpp
-    rviz2
     moveit_core
     Boost
     octomap_msgs


### PR DESCRIPTION
### Description

This fixes the undefined symbol error we were getting when loading the RobotState rviz2 plugin

Now loading RobotState plugin gives, which I think is related to rdf_loader (not sure)

```
Thread 1 "rviz2" received signal SIGSEGV, Segmentation fault.
0x00007ffff65af330 in rclcpp::Node::has_parameter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const () from /opt/ros/eloquent/lib/librclcpp.so
```

And loading PlanningSene plugin gives  
```
[INFO] [moveit_rdf_loader.rdf_loader]: Robot model parameter not found! Did you remap 'robot_description'?
[ERROR] [moveit_ros.planning_scene_monitor.planning_scene_monitor]: Robot model not loaded
```
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
