### PR TITLE
MoveIt visualization bug fixes

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -167,7 +167,7 @@ PlanningSceneDisplay::~PlanningSceneDisplay()
 
   planning_scene_render_.reset();
   if (context_ && context_->getSceneManager() && planning_scene_node_)
-    context_->getSceneManager()->destroySceneNode(planning_scene_node_->getName());
+    context_->getSceneManager()->destroySceneNode(planning_scene_node_);
   if (planning_scene_robot_)
     planning_scene_robot_.reset();
   planning_scene_monitor_.reset();

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -379,6 +379,11 @@ void RobotStateDisplay::unsetLinkColor(rviz_default_plugins::robot::Robot* robot
 void RobotStateDisplay::loadRobotModel()
 {
   load_robot_model_ = false;
+  if (robot_description_property_->getStdString().empty())
+  {
+    setStatus(rviz_common::properties::StatusProperty::Error, "RobotModel", "`Robot Description` field can't be empty");
+    return;
+  }
   if (!rdf_loader_)
     rdf_loader_.reset(new rdf_loader::RDFLoader(node_, robot_description_property_->getStdString()));
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -53,7 +53,7 @@ PlanningSceneRender::PlanningSceneRender(Ogre::SceneNode* node, rviz_common::Dis
 
 PlanningSceneRender::~PlanningSceneRender()
 {
-  context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_->getName());
+  context_->getSceneManager()->destroySceneNode(planning_scene_geometry_node_);
 }
 
 void PlanningSceneRender::clear()


### PR DESCRIPTION
### Description

This fixes two bugs

1- Using the name of the SceneNode was throwing an exception in the destructor [see Mike's comment](https://github.com/ros-planning/moveit2/pull/167/files#r375475440)
2- Having an empty robot description will pass an empty string to rdf_loader which will cause it to throw an `empty parameter name` exception

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
