### PR TITLE
Clean up (new PR)

### DIFF
--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -42,7 +42,7 @@ namespace moveit
 namespace tools
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_background_processing.background_processing");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.background_processing");
 
 BackgroundProcessing::BackgroundProcessing()
 {

--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/background_processing/background_processing.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/background_processing/src/background_processing.cpp
+++ b/moveit_core/background_processing/src/background_processing.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/background_processing/background_processing.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
@@ -41,10 +41,7 @@
 #include <moveit_msgs/msg/contact_information.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <rclcpp/rclcpp.hpp>
-#include "rcl/time.h"
-#include <rclcpp/clock.hpp>
-#include <rclcpp/time.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
@@ -41,10 +41,10 @@
 #include <moveit_msgs/msg/contact_information.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include "rcl/time.h"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/time.hpp"
+#include <rclcpp/clock.hpp>
+#include <rclcpp/time.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/collision_detection/allvalid/collision_env_allvalid.h>
 #include <moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_world_allvalid");

--- a/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
@@ -39,7 +39,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_world_allvalid");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.env_allvalid");
 
 const std::string collision_detection::CollisionDetectorAllocatorAllValid::NAME("ALL_VALID");
 

--- a/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
+++ b/moveit_core/collision_detection/src/allvalid/collision_env_allvalid.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/collision_detection/allvalid/collision_env_allvalid.h>
 #include <moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.env_allvalid");

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/collision_detection/collision_env.h>
 #include <limits>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.collision_env");

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/collision_detection/collision_env.h>
 #include <limits>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_robot");

--- a/moveit_core/collision_detection/src/collision_env.cpp
+++ b/moveit_core/collision_detection/src/collision_env.cpp
@@ -39,7 +39,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_robot");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.collision_env");
 
 static inline bool validateScale(double scale)
 {

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -42,7 +42,7 @@
 namespace collision_detection
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_matrix");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.collision_matrix");
 
 AllowedCollisionMatrix::AllowedCollisionMatrix()
 {

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -37,7 +37,7 @@
 #include <moveit/collision_detection/collision_matrix.h>
 #include <boost/bind.hpp>
 #include <iomanip>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -37,7 +37,7 @@
 #include <moveit/collision_detection/collision_matrix.h>
 #include <boost/bind.hpp>
 #include <iomanip>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -41,7 +41,7 @@
 #include <octomap/octomap.h>
 #include <geometric_shapes/shapes.h>
 #include <memory>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.octomap_filter");

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -44,7 +44,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_octomap_filter");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.octomap_filter");
 
 // forward declarations
 bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const double& spacing, const double& iso_value,

--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -41,7 +41,7 @@
 #include <octomap/octomap.h>
 #include <geometric_shapes/shapes.h>
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_octomap_filter");

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -35,7 +35,7 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/collision_detection/world.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace collision_detection

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -41,7 +41,7 @@
 namespace collision_detection
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.world");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.world");
 
 World::World()
 {

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -35,7 +35,7 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/collision_detection/world.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -53,7 +53,7 @@
 namespace collision_detection
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection_fcl.collision_common");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.fcl.collision_common");
 
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)
 {

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -47,7 +47,7 @@
 
 namespace collision_detection
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection_fcl.collision_env_fcl");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.fcl.collision_env_fcl");
 const std::string CollisionDetectorAllocatorFCL::NAME("FCL");
 
 CollisionEnvFCL::CollisionEnvFCL(const robot_model::RobotModelConstPtr& model, double padding, double scale)

--- a/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
@@ -63,7 +63,7 @@ inline void setToHome(robot_state::RobotState& panda_state)
   panda_state.update();
 }
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection_fcl.test.test_fcl_env");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_detection.fcl.test_fcl_env");
 
 class CollisionDetectionEnvTest : public testing::Test
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -55,10 +55,8 @@ DIAGNOSTIC_POP
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include <rclcpp/clock.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp/time.hpp>
-#include <rclcpp/utilities.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -55,10 +55,10 @@ DIAGNOSTIC_POP
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/propagation_distance_field.h>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include "rclcpp/clock.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/utilities.hpp"
+#include <rclcpp/clock.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/utilities.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -42,7 +42,7 @@
 #include <moveit/collision_detection/collision_env.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/thread/mutex.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -42,7 +42,7 @@
 #include <moveit/collision_detection/collision_env.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <boost/thread/mutex.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -34,7 +34,7 @@
 
 /* Author: E. Gil Jones */
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
 #include <boost/thread/mutex.hpp>
 #include <tf2_eigen/tf2_eigen.h>

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -42,8 +42,7 @@
 
 namespace collision_detection
 {
-static const rclcpp::Logger LOGGER =
-    rclcpp::get_logger("moveit_collision_distance_field.collision_common_distance_field");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_distance_field.common_distance_field");
 struct BodyDecompositionCache
 {
   using Comperator = std::owner_less<shapes::ShapeConstWeakPtr>;

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -34,7 +34,6 @@
 
 /* Author: E. Gil Jones */
 
-#include <rclcpp/rclcpp.hpp>
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
 #include <boost/thread/mutex.hpp>
 #include <tf2_eigen/tf2_eigen.h>

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -44,10 +44,10 @@ const static double EPSILON = 0.0001;
 
 namespace collision_detection
 {
-static const rclcpp::Logger LOGGER =
-    rclcpp::get_logger("moveit_collision_distance_field.collision_distance_field_types");
-const rclcpp::Logger PosedBodyPointDecompositionVector::LOGGER = LOGGER;
-const rclcpp::Logger PosedBodySphereDecompositionVector::LOGGER = LOGGER;
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.collision_distance_field.distance_field_types");
+
+const rclcpp::Logger PosedBodyPointDecompositionVector::LOGGER = ::collision_detection::LOGGER;
+const rclcpp::Logger PosedBodySphereDecompositionVector::LOGGER = ::collision_detection::LOGGER;
 
 std::vector<CollisionSphere> determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relative_transform)
 {

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -38,6 +38,7 @@
 #include <geometric_shapes/body_operations.h>
 #include <moveit/distance_field/distance_field.h>
 #include <moveit/distance_field/find_internal_points.h>
+#include <rclcpp/clock.hpp>
 #include <memory>
 
 const static double EPSILON = 0.0001;

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -47,7 +47,7 @@
 namespace collision_detection
 {
 const rclcpp::Logger CollisionEnvDistanceField::LOGGER =
-    rclcpp::get_logger("moveit_collision_distance_field.collision_robot_distance_field");
+    rclcpp::get_logger("moveit.core.collision_distance_field.robot_distance_field");
 const double EPSILON = 0.001f;
 
 const std::string collision_detection::CollisionDetectorAllocatorDistanceField::NAME("DISTANCE_FIELD");

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -39,7 +39,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <vector>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 /**
  * \brief The constraint samplers namespace contains a number of
  * methods for generating samples based on a constraint or set of

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -39,7 +39,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <vector>
-#include <rclcpp/rclcpp.hpp>
+
 /**
  * \brief The constraint samplers namespace contains a number of
  * methods for generating samples based on a constraint or set of

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -38,7 +38,7 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -38,7 +38,6 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -38,9 +38,9 @@
 
 #include <moveit/constraint_samplers/constraint_sampler_allocator.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/duration.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -38,9 +38,6 @@
 
 #include <moveit/constraint_samplers/constraint_sampler_allocator.h>
 #include <moveit/macros/class_forward.h>
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp/clock.hpp>
-#include <rclcpp/duration.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
@@ -38,7 +38,7 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
@@ -38,7 +38,6 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -39,7 +39,6 @@
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
 #include <random_numbers/random_numbers.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -39,7 +39,7 @@
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
 #include <random_numbers/random_numbers.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -37,7 +37,6 @@
 #pragma once
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/src/constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler.cpp
@@ -38,7 +38,7 @@
 
 namespace constraint_samplers
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.constraint_sampler");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.constraint_sampler");
 
 constraint_samplers::ConstraintSampler::ConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene,
                                                           const std::string& group_name)

--- a/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_manager.cpp
@@ -41,7 +41,7 @@
 
 namespace constraint_samplers
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.constraint_sampler_manager");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.constraint_sampler_manager");
 
 ConstraintSamplerPtr ConstraintSamplerManager::selectSampler(const planning_scene::PlanningSceneConstPtr& scene,
                                                              const std::string& group_name,

--- a/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
+++ b/moveit_core/constraint_samplers/src/constraint_sampler_tools.cpp
@@ -39,7 +39,7 @@
 
 namespace constraint_samplers
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.constraint_sampler_tools");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.constraint_sampler_tools");
 
 void visualizeDistribution(const moveit_msgs::msg::Constraints& constr,
                            const planning_scene::PlanningSceneConstPtr& scene, const std::string& group,

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -41,7 +41,7 @@
 
 namespace constraint_samplers
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.default_constraint_samplers");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.default_constraint_samplers");
 bool JointConstraintSampler::configure(const moveit_msgs::msg::Constraints& constr)
 {
   // construct the constraints

--- a/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
+++ b/moveit_core/constraint_samplers/src/union_constraint_sampler.cpp
@@ -40,7 +40,7 @@
 
 namespace constraint_samplers
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.union_constraint_sampler");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.union_constraint_sampler");
 
 struct OrderSamplers
 {

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -36,6 +36,7 @@
 
 #include <angles/angles.h>
 #include "pr2_arm_ik.h"
+#include <rclcpp/logging.hpp>
 
 /**** List of angles (for reference) *******
       th1 = shoulder/turret pan

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -49,7 +49,7 @@
 using namespace angles;
 namespace pr2_arm_kinematics
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constaint_samplers.test.pr2_arm_ik");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.pr2_arm_ik");
 
 PR2ArmIK::PR2ArmIK()
 {

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -44,7 +44,7 @@
 #include <moveit_msgs/srv/get_position_fk.hpp>
 #include <moveit_msgs/srv/get_position_ik.hpp>
 #include <moveit_msgs/msg/kinematic_solver_info.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace pr2_arm_kinematics
 {

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -44,7 +44,6 @@
 #include <moveit_msgs/srv/get_position_fk.hpp>
 #include <moveit_msgs/srv/get_position_ik.hpp>
 #include <moveit_msgs/msg/kinematic_solver_info.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 namespace pr2_arm_kinematics
 {

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -48,7 +48,7 @@ using namespace std;
 
 namespace pr2_arm_kinematics
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.test.pr2_arm_kinematics_plugin");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.pr2_arm_kinematics_plugin");
 
 bool PR2ArmIKSolver::getCount(int& count, const int& max_count, const int& min_count)
 {

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -53,6 +53,8 @@
 
 #include "pr2_arm_kinematics_plugin.h"
 
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.constraint_samplers.test_constraint_samplers");
+
 class LoadPlanningModelsPr2 : public testing::Test
 {
 protected:
@@ -675,8 +677,7 @@ TEST_F(LoadPlanningModelsPr2, PoseConstraintSamplerManager)
     if (s->sample(ks, ks_const, 1))
       succ++;
   }
-  RCLCPP_INFO(rclcpp::get_logger("test_constraint_samplers"),
-              "Success rate for IK Constraint Sampler with position & orientation constraints for one arm: %lf",
+  RCLCPP_INFO(LOGGER, "Success rate for IK Constraint Sampler with position & orientation constraints for one arm: %lf",
               (double)succ / (double)NT);
 
   // add additional ocm with smaller volume
@@ -1108,7 +1109,7 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
     if (s->sample(ks, ks_const, 1))
       succ++;
   }
-  RCLCPP_INFO(rclcpp::get_logger("pr2_arm_kinematics_plugin"),
+  RCLCPP_INFO(LOGGER,
               "Success rate for IK Constraint Sampler with position & orientation constraints for both arms: %lf",
               (double)succ / (double)NT);
 }

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -40,7 +40,7 @@
 #include <string>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 /// Namespace for the base class of a MoveIt controller manager
 namespace moveit_controller_manager

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -40,7 +40,6 @@
 #include <string>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit/macros/class_forward.h>
-#include <rclcpp/rclcpp.hpp>
 
 /// Namespace for the base class of a MoveIt controller manager
 namespace moveit_controller_manager

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -46,7 +46,7 @@
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <moveit/macros/class_forward.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 namespace shapes
 {

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -46,7 +46,7 @@
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace shapes
 {

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -43,7 +43,6 @@
 #include <Eigen/Core>
 #include <set>
 #include <octomap/octomap.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace EigenSTL
 {

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -43,7 +43,7 @@
 #include <Eigen/Core>
 #include <set>
 #include <octomap/octomap.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace EigenSTL
 {

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -40,7 +40,8 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <octomap/octomap.h>
 #include <octomap/OcTree.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/time.hpp>
 
 namespace distance_field
 {

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -45,7 +45,7 @@
 namespace distance_field
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_distance_field.distance_field");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.distance_field");
 
 DistanceField::DistanceField(double size_x, double size_y, double size_z, double resolution, double origin_x,
                              double origin_y, double origin_z)

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -40,7 +40,7 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <octomap/octomap.h>
 #include <octomap/OcTree.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace distance_field
 {

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -39,7 +39,7 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace distance_field
 {

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -39,7 +39,7 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace distance_field
 {

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -44,7 +44,7 @@
 namespace distance_field
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_distance_field.propagation_distance_field");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.distance_field.propagation_distance_field");
 
 PropagationDistanceField::PropagationDistanceField(double size_x, double size_y, double size_z, double resolution,
                                                    double origin_x, double origin_y, double origin_z,

--- a/moveit_core/distance_field/test/test_voxel_grid.cpp
+++ b/moveit_core/distance_field/test/test_voxel_grid.cpp
@@ -37,7 +37,7 @@
 #include <gtest/gtest.h>
 
 #include <moveit/distance_field/voxel_grid.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace distance_field;
 

--- a/moveit_core/distance_field/test/test_voxel_grid.cpp
+++ b/moveit_core/distance_field/test/test_voxel_grid.cpp
@@ -37,7 +37,6 @@
 #include <gtest/gtest.h>
 
 #include <moveit/distance_field/voxel_grid.h>
-#include <rclcpp/rclcpp.hpp>
 
 using namespace distance_field;
 

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -44,7 +44,7 @@
 #include <kdl/chainfksolverpos_recursive.hpp>
 #include <kdl/chainjnttojacsolver.hpp>
 #include <kdl/tree.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace dynamics_solver
 {

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -48,7 +48,7 @@
 
 namespace dynamics_solver
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_dynamics_solver.dynamics_solver");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.dynamics_solver");
 
 namespace
 {

--- a/moveit_core/dynamics_solver/src/dynamics_solver.cpp
+++ b/moveit_core/dynamics_solver/src/dynamics_solver.cpp
@@ -44,7 +44,7 @@
 #include <kdl/chainfksolverpos_recursive.hpp>
 #include <kdl/chainjnttojacsolver.hpp>
 #include <kdl/tree.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace dynamics_solver
 {

--- a/moveit_core/exceptions/src/exceptions.cpp
+++ b/moveit_core/exceptions/src/exceptions.cpp
@@ -35,7 +35,7 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/exceptions/exceptions.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 namespace moveit

--- a/moveit_core/exceptions/src/exceptions.cpp
+++ b/moveit_core/exceptions/src/exceptions.cpp
@@ -40,7 +40,7 @@
 // Logger
 namespace moveit
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_exceptions.exceptions");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.exceptions");
 
 ConstructException::ConstructException(const std::string& what_arg) : std::runtime_error(what_arg)
 {

--- a/moveit_core/exceptions/src/exceptions.cpp
+++ b/moveit_core/exceptions/src/exceptions.cpp
@@ -35,7 +35,7 @@
 /* Author: Acorn Pooley, Ioan Sucan */
 
 #include <moveit/exceptions/exceptions.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // Logger
 namespace moveit

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -46,9 +46,9 @@
 #include <memory>
 #include <typeinfo>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/duration.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace kinematic_constraints
 {

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -44,9 +44,8 @@
 #include <boost/bind.hpp>
 #include <limits>
 #include <memory>
-#include <typeinfo>
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/duration.hpp>
 

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -53,7 +53,7 @@
 namespace kinematic_constraints
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_kinematic_constraints.kinematic_constraints");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.kinematic_constraints");
 
 static double normalizeAngle(double angle)
 {

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -46,7 +46,7 @@ using namespace moveit::core;
 namespace kinematic_constraints
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_kinematic_constraints.utils");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.kinematic_constraints.utils");
 
 moveit_msgs::msg::Constraints mergeConstraints(const moveit_msgs::msg::Constraints& first,
                                                const moveit_msgs::msg::Constraints& second)

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -39,7 +39,8 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit_msgs/msg/move_it_error_codes.hpp>
 #include <moveit/macros/class_forward.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/parameter_client.hpp>
 #include <boost/function.hpp>
 #include <string>
 

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -39,7 +39,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit_msgs/msg/move_it_error_codes.hpp>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <boost/function.hpp>
 #include <string>
 

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -40,7 +40,7 @@
 namespace kinematics
 {
 // Logger
-const rclcpp::Logger KinematicsBase::LOGGER = rclcpp::get_logger("moveit_kinematics_base.kinematics_base");
+const rclcpp::Logger KinematicsBase::LOGGER = rclcpp::get_logger("moveit.core.kinematics.base");
 const double KinematicsBase::DEFAULT_SEARCH_DISCRETIZATION = 0.1;
 const double KinematicsBase::DEFAULT_TIMEOUT = 1.0;
 

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -38,7 +38,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <boost/math/constants/constants.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace kinematics_metrics
 {

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -38,7 +38,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <boost/math/constants/constants.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace kinematics_metrics
 {

--- a/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
+++ b/moveit_core/kinematics_metrics/src/kinematics_metrics.cpp
@@ -42,7 +42,7 @@
 
 namespace kinematics_metrics
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_kinematics_metrics.kinematics_metrics");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.kinematics.metrics");
 
 double KinematicsMetrics::getJointLimitsPenalty(const robot_state::RobotState& state,
                                                 const robot_model::JointModelGroup* joint_model_group) const

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -41,7 +41,7 @@
 #include <moveit/planning_interface/planning_response.h>
 #include <string>
 #include <map>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace planning_scene
 {

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -41,7 +41,7 @@
 #include <moveit/planning_interface/planning_response.h>
 #include <string>
 #include <map>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace planning_scene
 {

--- a/moveit_core/planning_interface/src/planning_interface.cpp
+++ b/moveit_core/planning_interface/src/planning_interface.cpp
@@ -40,7 +40,7 @@
 
 namespace planning_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_planning_interface.planning_interface");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.planning_interface");
 
 namespace
 {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -37,7 +37,7 @@
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <boost/bind.hpp>
 #include <algorithm>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // we could really use some c++11 lambda functions here :)
 

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -43,7 +43,7 @@
 
 namespace planning_request_adapter
 {
-rclcpp::Logger LOGGER = rclcpp::get_logger("moveit").get_child("planning_request_adapter");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.planning_request_adapter");
 
 namespace
 {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -37,7 +37,7 @@
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <boost/bind.hpp>
 #include <algorithm>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // we could really use some c++11 lambda functions here :)
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -55,7 +55,7 @@
 #include <boost/function.hpp>
 #include <boost/concept_check.hpp>
 #include <memory>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -55,7 +55,7 @@
 #include <boost/function.hpp>
 #include <boost/concept_check.hpp>
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -51,7 +51,7 @@
 
 namespace planning_scene
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_planning_scene.planning_scene");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.planning_scene");
 
 const std::string PlanningScene::OCTOMAP_NS = "<octomap>";
 const std::string PlanningScene::DEFAULT_SCENE_NAME = "(noname)";

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -40,7 +40,7 @@
 #include <vector>
 #include <algorithm>
 #include <sstream>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -46,7 +46,7 @@ namespace moveit
 {
 namespace tools
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_profiler.profiler");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.profiler");
 
 Profiler& Profiler::instance()
 {

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -45,7 +45,7 @@ namespace moveit
 {
 namespace core
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_model.floating_joint_model");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_model.floating_joint_model");
 
 FloatingJointModel::FloatingJointModel(const std::string& name) : JointModel(name), angular_distance_weight_(1.0)
 {

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -39,7 +39,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <limits>
 #include <cmath>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -39,7 +39,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <limits>
 #include <cmath>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -42,7 +42,7 @@
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include "order_robot_model_items.inc"
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -50,7 +50,7 @@ namespace core
 {
 namespace
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_model.joint_model_group");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_model.joint_model_group");
 
 // check if a parent or ancestor of joint is included in this group
 bool includesParent(const JointModel* joint, const JointModelGroup* group)

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -42,7 +42,7 @@
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include "order_robot_model_items.inc"
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -45,7 +45,7 @@
 #include <cmath>
 #include <memory>
 #include "order_robot_model_items.inc"
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -45,7 +45,7 @@
 #include <cmath>
 #include <memory>
 #include "order_robot_model_items.inc"
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -51,7 +51,7 @@ namespace moveit
 {
 namespace core
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_model.robot_model");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_model");
 
 RobotModel::RobotModel(const urdf::ModelInterfaceSharedPtr& urdf_model, const srdf::ModelConstSharedPtr& srdf_model)
 {

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -48,7 +48,7 @@ namespace core
  * valid paths from paths with large joint space jumps. */
 static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_state.cartesian_interpolator");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_state.cartesian_interpolator");
 
 double CartesianInterpolator::computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                                                    std::vector<RobotStatePtr>& traj, const LinkModel* link,

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -39,7 +39,7 @@
 #include <geometric_shapes/shape_operations.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/lexical_cast.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -39,7 +39,7 @@
 #include <geometric_shapes/shape_operations.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/lexical_cast.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -52,7 +52,7 @@ namespace core
 namespace
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_state.conversions");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_state.conversions");
 
 static bool _jointStateToRobotState(const sensor_msgs::msg::JointState& joint_state, RobotState& state)
 {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -52,7 +52,7 @@ namespace moveit
 namespace core
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_state.robot_state");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.robot_state");
 
 RobotState::RobotState(const RobotModelConstPtr& robot_model)
   : robot_model_(robot_model)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -45,7 +45,7 @@
 #include <moveit/macros/console_colors.h>
 #include <boost/bind.hpp>
 #include <moveit/robot_model/aabb.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -45,7 +45,7 @@
 #include <moveit/macros/console_colors.h>
 #include <boost/bind.hpp>
 #include <moveit/robot_model/aabb.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -51,7 +51,7 @@
 #endif
 
 #if VISUALIZE_PR2_RVIZ
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <visualization_msgs/msg/marker.h>
 #include <geometric_shapes/shape_operations.h>
 #endif

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -51,7 +51,7 @@
 #endif
 
 #if VISUALIZE_PR2_RVIZ
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <visualization_msgs/msg/marker.h>
 #include <geometric_shapes/shape_operations.h>
 #endif

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -44,10 +44,10 @@
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/utilities.hpp"
+#include <rclcpp/clock.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/utilities.hpp>
 
 namespace robot_trajectory
 {

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -45,7 +45,7 @@
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
 #include <rclcpp/clock.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/time.hpp>
 #include <rclcpp/utilities.hpp>
 

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -39,7 +39,7 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/math/constants/constants.hpp>
 #include <numeric>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace robot_trajectory
 {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -39,7 +39,7 @@
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/math/constants/constants.hpp>
 #include <numeric>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace robot_trajectory
 {

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -41,7 +41,7 @@
 #include <moveit_msgs/msg/joint_limits.hpp>
 #include <moveit_msgs/msg/robot_state.hpp>
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace trajectory_processing
 {

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -41,7 +41,7 @@
 #include <moveit_msgs/msg/joint_limits.hpp>
 #include <moveit_msgs/msg/robot_state.hpp>
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace trajectory_processing
 {

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
@@ -40,7 +40,7 @@
 #include <moveit_msgs/msg/joint_limits.hpp>
 #include <moveit_msgs/msg/robot_state.hpp>
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace trajectory_processing
 {

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
@@ -40,7 +40,7 @@
 #include <moveit_msgs/msg/joint_limits.hpp>
 #include <moveit_msgs/msg/robot_state.hpp>
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace trajectory_processing
 {

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -45,7 +45,7 @@ static const double ALIMIT = 1.0;  // default if not specified in model
 namespace trajectory_processing
 {
 static const rclcpp::Logger LOGGER =
-    rclcpp::get_logger("moveit_trajectory_processing.iterative_spline_parameterization");
+    rclcpp::get_logger("moveit.core.trajectory_processing.iterative_spline_parameterization");
 
 static void fit_cubic_spline(const int n, const double dt[], const double x[], double x1[], double x2[]);
 static void adjust_two_positions(const int n, const double dt[], double x[], double x1[], double x2[],

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -44,7 +44,8 @@ static const double DEFAULT_VEL_MAX = 1.0;
 static const double DEFAULT_ACCEL_MAX = 1.0;
 static const double ROUNDING_THRESHOLD = 0.01;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.iterative_time_parameterization");
+static const rclcpp::Logger LOGGER =
+    rclcpp::get_logger("moveit.core.trajectory_processing.iterative_time_parameterization");
 
 IterativeParabolicTimeParameterization::IterativeParabolicTimeParameterization(unsigned int max_iterations,
                                                                                double max_time_change_per_it)

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -42,7 +42,7 @@
 #include <cmath>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <vector>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <iostream>
 
 namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -42,7 +42,7 @@
 #include <cmath>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <vector>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <iostream>
 
 namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -48,7 +48,7 @@
 namespace trajectory_processing
 {
 static const rclcpp::Logger LOGGER =
-    rclcpp::get_logger("moveit_trajectory_processing.time_optimal_trajectory_generation");
+    rclcpp::get_logger("moveit.core.trajectory_processing.time_optimal_trajectory_generation");
 
 constexpr double EPS = 0.000001;
 class LinearPathSegment : public PathSegment

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -42,7 +42,7 @@
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit/utils/robot_model_test_utils.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.test.test_time_parameterization");

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -45,7 +45,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.test.test_time_parameterization");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.trajectory_processing.test_time_parameterization");
 
 // Static variables used in all tests
 moveit::core::RobotModelConstPtr RMODEL = moveit::core::loadTestingRobotModel("pr2");

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -42,7 +42,7 @@
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit/utils/robot_model_test_utils.h>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.trajectory_processing.test_time_parameterization");

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -147,8 +147,7 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
 
   auto diff_time = std::chrono::system_clock::now() - wt;
 
-  std::cout << "IterativeParabolicTimeParameterization  took " << (std::chrono::system_clock::now() - wt).count()
-            << std::endl;
+  std::cout << "IterativeParabolicTimeParameterization  took " << diff_time.count() << std::endl;
   printTrajectory(TRAJECTORY);
   ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 3.0);
 }

--- a/moveit_core/transforms/src/transforms.cpp
+++ b/moveit_core/transforms/src/transforms.cpp
@@ -44,7 +44,7 @@ namespace moveit
 namespace core
 {
 // Logger
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_transforms.transforms");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.transforms");
 
 Transforms::Transforms(const std::string& target_frame) : target_frame_(target_frame)
 {

--- a/moveit_core/transforms/src/transforms.cpp
+++ b/moveit_core/transforms/src/transforms.cpp
@@ -37,7 +37,7 @@
 #include <moveit/transforms/transforms.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/algorithm/string/trim.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit
 {

--- a/moveit_core/transforms/src/transforms.cpp
+++ b/moveit_core/transforms/src/transforms.cpp
@@ -37,7 +37,7 @@
 #include <moveit/transforms/transforms.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/algorithm/string/trim.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 
 namespace moveit
 {

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Bryce Willey */
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <boost/algorithm/string_regex.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <geometry_msgs/msg/pose.hpp>

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Bryce Willey */
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <boost/algorithm/string_regex.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <geometry_msgs/msg/pose.hpp>

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -46,7 +46,7 @@ namespace moveit
 {
 namespace core
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_utils.robot_model_test_utils");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.core.utils.robot_model_test_utils");
 
 moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -47,7 +47,7 @@
 
 namespace kdl_kinematics_plugin
 {
-static rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_kdl_kinematics_plugin.kdl_kinematics_plugin");
+static rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.kinematics.kdl_kinematics_plugin");
 
 KDLKinematicsPlugin::KDLKinematicsPlugin() : initialized_(false)
 {

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_plugin.cpp
@@ -49,7 +49,7 @@ CLASS_LOADER_REGISTER_CLASS(lma_kinematics_plugin::LMAKinematicsPlugin, kinemati
 
 namespace lma_kinematics_plugin
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_lma_kinematics_plugin.lma_kinematics_plugin");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.kinematics.lma_kinematics_plugin");
 
 LMAKinematicsPlugin::LMAKinematicsPlugin() : initialized_(false)
 {

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -48,7 +48,7 @@ CLASS_LOADER_REGISTER_CLASS(srv_kinematics_plugin::SrvKinematicsPlugin, kinemati
 
 namespace srv_kinematics_plugin
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_srv_kinematics_plugin.srv_kinematics_plugin");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.kinematics.srv_kinematics_plugin");
 
 SrvKinematicsPlugin::SrvKinematicsPlugin() : active_(false)
 {

--- a/moveit_kinematics/test/benchmark_ik.cpp
+++ b/moveit_kinematics/test/benchmark_ik.cpp
@@ -43,7 +43,7 @@
 
 namespace po = boost::program_options;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("cached_ik.measure_ik_call_cost");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.kinematics.benchmark_ik");
 
 /** Benchmark program measuring time to solve inverse kinematics of robot described in robot_description */
 int main(int argc, char* argv[])

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -54,7 +54,7 @@
 
 #include <moveit/utils/robot_model_test_utils.h>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("test_kinematics_plugin");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.kinematics.test_kinematics_plugin");
 const std::string ROBOT_DESCRIPTION_PARAM = "robot_description";
 const double DEFAULT_SEARCH_DISCRETIZATION = 0.01f;
 const double EXPECTED_SUCCESS_RATE = 0.8;

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -41,7 +41,7 @@
 
 #include <utility>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.constrained_goal_sampler");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.constrained_goal_sampler");
 
 ompl_interface::ConstrainedGoalSampler::ConstrainedGoalSampler(const ModelBasedPlanningContext* pc,
                                                                kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_valid_state_sampler.cpp
@@ -40,7 +40,7 @@
 
 #include <utility>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.constrained_valid_state_sampler");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.constrained_valid_state_sampler");
 
 ompl_interface::ValidConstrainedSampler::ValidConstrainedSampler(const ModelBasedPlanningContext* pc,
                                                                  kinematic_constraints::KinematicConstraintSetPtr ks,

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -45,7 +45,7 @@
 
 namespace ompl_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.constraints_library");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.constraints_library");
 namespace
 {
 template <typename T>

--- a/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/state_validity_checker.cpp
@@ -39,7 +39,7 @@
 #include <moveit/profiler/profiler.h>
 #include <rclcpp/rclcpp.hpp>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.state_validity_checker");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.state_validity_checker");
 
 ompl_interface::StateValidityChecker::StateValidityChecker(const ModelBasedPlanningContext* pc)
   : ompl::base::StateValidityChecker(pc->getOMPLSimpleSetup()->getSpaceInformation())

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -71,7 +71,7 @@
 #include "ompl/base/objectives/StateCostIntegralObjective.h"
 #include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.model_based_planning_context");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.model_based_planning_context");
 
 ompl_interface::ModelBasedPlanningContext::ModelBasedPlanningContext(const std::string& name,
                                                                      const ModelBasedPlanningContextSpecification& spec)

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -42,7 +42,7 @@
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.ompl_interface");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.ompl_interface");
 
 ompl_interface::OMPLInterface::OMPLInterface(const robot_model::RobotModelConstPtr& robot_model,
                                              const rclcpp::Node::SharedPtr& node,

--- a/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_planner_manager.cpp
@@ -43,8 +43,7 @@
 
 namespace ompl_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.ompl_planner_manager");
-static const rclcpp::Logger OMPL_LOGGER = rclcpp::get_logger("ompl");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.ompl_planner_manager");
 
 class OMPLPlannerManager : public planning_interface::PlannerManager
 {
@@ -61,16 +60,16 @@ public:
           case ompl::msg::LOG_DEV2:
           case ompl::msg::LOG_DEV1:
           case ompl::msg::LOG_DEBUG:
-            RCLCPP_DEBUG(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
+            RCLCPP_DEBUG(LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_INFO:
-            RCLCPP_INFO(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
+            RCLCPP_INFO(LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_WARN:
-            RCLCPP_WARN(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
+            RCLCPP_WARN(LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_ERROR:
-            RCLCPP_ERROR(OMPL_LOGGER, "%s:%i - %s", filename, line, text.c_str());
+            RCLCPP_ERROR(LOGGER, "%s:%i - %s", filename, line, text.c_str());
             break;
           case ompl::msg::LOG_NONE:
           default:

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -37,7 +37,7 @@
 #include <moveit/ompl_interface/parameterization/model_based_state_space.h>
 #include <utility>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.model_based_state_space");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.model_based_state_space");
 
 ompl_interface::ModelBasedStateSpace::ModelBasedStateSpace(ModelBasedStateSpaceSpecification spec)
   : ompl::base::StateSpace(), spec_(std::move(spec))

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -40,7 +40,7 @@
 
 #include <utility>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.pose_model_state_space");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.pose_model_state_space");
 const std::string ompl_interface::PoseModelStateSpace::PARAMETERIZATION_TYPE = "PoseModel";
 
 ompl_interface::PoseModelStateSpace::PoseModelStateSpace(const ModelBasedStateSpaceSpecification& spec)

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -77,7 +77,7 @@ using namespace std::placeholders;
 
 namespace ompl_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.planning_context_manager");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.planning_context_manager");
 struct PlanningContextManager::CachedContexts
 {
   std::map<std::pair<std::string, std::string>, std::vector<ModelBasedPlanningContextPtr> > contexts_;

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -46,7 +46,7 @@
 #include <boost/filesystem/path.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ompl_planning.test.test_state_space");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planners.ompl.test_state_space");
 
 class LoadPlanningModelsPr2 : public testing::Test
 {

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -38,7 +38,7 @@
 
 namespace collision_detection
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("collision_plugin_loader");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.collision_plugin_loader");
 
 class CollisionPluginLoader::CollisionPluginLoaderImpl
 {

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -42,7 +42,7 @@
 
 namespace constraint_sampler_manager_loader
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.constraint_sampler_manager_loader");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.constraint_sampler_manager_loader");
 
 class ConstraintSamplerManagerLoader::Helper
 {

--- a/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/src/constraint_sampler_manager_loader.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/constraint_sampler_manager_loader/constraint_sampler_manager_loader.h>
 #include <pluginlib/class_loader.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <boost/tokenizer.hpp>
 #include <memory>
 

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -42,7 +42,7 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/profiler/profiler.h>
 
 namespace kinematics_plugin_loader

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -47,7 +47,7 @@
 
 namespace kinematics_plugin_loader
 {
-rclcpp::Logger LOGGER = rclcpp::get_logger("kinematics_plugin_loader");
+rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.kinematics_plugin_loader");
 
 class KinematicsPluginLoader::KinematicsLoaderImpl
 {

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -47,7 +47,7 @@
 
 namespace plan_execution
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.plan_execution");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.plan_execution");
 
 class PlanExecution::DynamicReconfigureImpl
 {
@@ -240,7 +240,7 @@ void plan_execution::PlanExecution::planAndExecuteHelper(ExecutableMotionPlan& p
         RCLCPP_INFO(LOGGER, "Waiting for a %lf seconds before attempting a new plan ...", opt.replan_delay_);
         auto replan_delay_seconds = std::chrono::duration<double>(opt.replan_delay_);
         rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::nanoseconds>(replan_delay_seconds));
-        RCLCPP_INFO(node_->get_logger(), "Done waiting");
+        RCLCPP_INFO(LOGGER, "Done waiting");
       }
     }
   } while (!preempt_requested_ && max_replan_attempts > replan_attempts);

--- a/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_with_sensing.cpp
@@ -46,7 +46,7 @@
 namespace plan_execution
 {
 // using namespace moveit_ros_planning;
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.plan_with_sensing");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.plan_execution.plan_with_sensing");
 
 class PlanWithSensing::DynamicReconfigureImpl
 {

--- a/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
@@ -39,7 +39,7 @@
 
 using namespace std::chrono_literals;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("display_random_state");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.display_random_state");
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -44,7 +44,7 @@ using namespace std::chrono_literals;
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("evaluate_collision_checking_speed");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.evaluate_collision_checking_speed");
 
 void runCollisionDetection(unsigned int id, unsigned int trials, const planning_scene::PlanningScene* scene,
                            const robot_state::RobotState* state)

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
@@ -41,7 +41,7 @@
 
 using namespace std::chrono_literals;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("evaluate_state_operations_speed");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.evaluate_state_operations_speed");
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/kinematics_speed_and_validity_evaluator.cpp
@@ -39,7 +39,7 @@
 #include <moveit/profiler/profiler.h>
 #include <rclcpp/rclcpp.hpp>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("inverse_kinematics_test");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.kinematics_speed_and_validity_evaluator");
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
@@ -42,7 +42,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("print_planning_scene_info");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.print_planning_scene_info");
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/publish_scene_from_text.cpp
@@ -39,7 +39,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 using namespace std::chrono_literals;
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("publish_scene_from_text");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.publish_scene_from_text");
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -39,7 +39,7 @@
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <pluginlib/class_loader.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
 #include <moveit_msgs/msg/display_trajectory.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -42,7 +42,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <sstream>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros_planning.planning_pipeline");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.planning_pipeline");
 
 const std::string planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC = "display_planned_path";
 const std::string planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC = "motion_plan_request";

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -41,7 +41,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.add_iterative_spline_parameterization");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.add_iterative_spline_parameterization");
 
 class AddIterativeSplineParameterization : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -42,7 +42,7 @@ namespace default_planner_request_adapters
 {
 using namespace trajectory_processing;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.add_time_optimal_parameterization");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.add_time_optimal_parameterization");
 
 /** @brief This adapter uses the time-optimal trajectory generation method */
 class AddTimeOptimalParameterization : public planning_request_adapter::PlanningRequestAdapter

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -40,7 +40,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.add_time_parameterization");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.add_time_parameterization");
 
 class AddTimeParameterization : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -43,7 +43,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.fix_start_state_bounds");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.fix_start_state_bounds");
 
 class FixStartStateBounds : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -42,7 +42,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.fix_start_state_collision");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.fix_start_state_collision");
 
 class FixStartStateCollision : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -43,7 +43,7 @@
 
 namespace default_planner_request_adapters
 {
-rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.fix_start_state_path_constraints");
+rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.fix_start_state_path_constraints");
 
 class FixStartStatePathConstraints : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -40,7 +40,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.fix_workspace_bounds");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.fix_workspace_bounds");
 
 class FixWorkspaceBounds : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -40,7 +40,7 @@
 
 namespace default_planner_request_adapters
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.resolve_constraint_frames");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.resolve_constraint_frames");
 
 class ResolveConstraintFrames : public planning_request_adapter::PlanningRequestAdapter
 {

--- a/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
@@ -39,7 +39,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_monitor.demo_scene");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.planning_scene_monitor.demo_scene");
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -41,7 +41,8 @@
 
 #include <limits>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.current_state_monitor");
+static const rclcpp::Logger LOGGER =
+    rclcpp::get_logger("moveit.ros.planning.planning_scene_monitor.current_state_monitor");
 
 planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const rclcpp::Node::SharedPtr& node,
                                                                  const robot_model::RobotModelConstPtr& robot_model,

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -57,7 +57,7 @@
 #include <chrono>
 using namespace std::chrono_literals;
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_monitor.planning_scene_monitor");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.planning_scene_monitor");
 
 namespace planning_scene_monitor
 {

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -40,7 +40,8 @@
 #include <limits>
 #include <memory>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_monitor.trajectory_monitor");
+static const rclcpp::Logger LOGGER =
+    rclcpp::get_logger("moveit.ros.planning.planning_scene_monitor.trajectory_monitor");
 
 planning_scene_monitor::TrajectoryMonitor::TrajectoryMonitor(const CurrentStateMonitorConstPtr& state_monitor,
                                                              double sampling_frequency)

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -55,7 +55,7 @@
 
 namespace rdf_loader
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_rdf_loader.rdf_loader");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.rdf_loader");
 
 RDFLoader::RDFLoader(const std::shared_ptr<rclcpp::Node>& node, const std::string& robot_description)
 {

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -41,7 +41,7 @@
 
 namespace robot_model_loader
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.robot_model_loader");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.robot_model_loader");
 
 RobotModelLoader::RobotModelLoader(const rclcpp::Node::SharedPtr& node, const std::string& robot_description,
                                    bool load_kinematics_solvers)
@@ -193,7 +193,7 @@ void RobotModelLoader::configure(const Options& opt)
   if (model_ && opt.load_kinematics_solvers_)
     loadKinematicsSolvers();
 
-  RCLCPP_DEBUG(node_->get_logger(), "Loaded kinematic model in %d seconds", (clock.now() - start).seconds());
+  RCLCPP_DEBUG(LOGGER, "Loaded kinematic model in %d seconds", (clock.now() - start).seconds());
 }
 
 void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr& kloader)

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -36,7 +36,7 @@
 
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/profiler/profiler.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <typeinfo>
 
 namespace robot_model_loader

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -42,7 +42,7 @@
 
 namespace trajectory_execution_manager
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.trajectory_execution_manager");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.trajectory_execution_manager");
 
 const std::string TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC = "trajectory_execution_event";
 

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_app.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_app.cpp
@@ -38,7 +38,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.trajectory_execution_manager.test_app");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning.trajectory_execution_manager.test_app");
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -44,7 +44,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros_planning_interface.moveit_cpp");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning_interface.moveit_cpp");
 constexpr char PLANNING_PLUGIN_PARAM[] = "planning_plugin";
 
 MoveItCpp::MoveItCpp(const rclcpp::Node::SharedPtr& node, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer)

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -49,7 +49,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros_planning_interface.planning_component");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.planning_interface.moveit_cpp.planning_component");
 
 PlanningComponent::PlanningComponent(const std::string& group_name, const MoveItCppPtr& moveit_cpp)
   : node_(moveit_cpp->getNode()), moveit_cpp_(moveit_cpp), group_name_(group_name)


### PR DESCRIPTION
This PR is a continued effort following the [PR#140](https://github.com/ros-planning/moveit2/pull/140) to address the [issue#102](https://github.com/ros-planning/moveit2/issues/102). The review comments are going to be addressed here. Therefore, [PR#140](https://github.com/ros-planning/moveit2/pull/140) can be closed.

A major change here is to refactor the logger names as `<package>.<library>.<file>` mode. In some situations, `<library>` is ignored if `<library>` and `<file>` are very similar or `<library>` makes the logger names too heavy. Refer to [MIGRATION_GUIDE](https://github.com/ros-planning/moveit2/blob/master/doc/MIGRATION_GUIDE.md) and discussions [here](https://github.com/ros-planning/moveit2/pull/140#discussion_r360439235)
