### PR TITLE
OMPL Parameter Loading

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -132,8 +132,8 @@ bool ompl_interface::OMPLInterface::loadPlannerConfiguration(
     const std::map<std::string, std::string>& group_params,
     planning_interface::PlannerConfigurationSettings& planner_config)
 {
-  rcl_interfaces::msg::ListParametersResult planner_params_result = node_->list_parameters(
-      { parameter_namespace_ + ".planner_configs." + planner_id }, 2);
+  rcl_interfaces::msg::ListParametersResult planner_params_result =
+      node_->list_parameters({ parameter_namespace_ + ".planner_configs." + planner_id }, 2);
 
   if (planner_params_result.names.empty())
   {

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -133,7 +133,7 @@ bool ompl_interface::OMPLInterface::loadPlannerConfiguration(
     planning_interface::PlannerConfigurationSettings& planner_config)
 {
   rcl_interfaces::msg::ListParametersResult planner_params_result = node_->list_parameters(
-      { parameter_namespace_ + ".planner_configs." + planner_id }, 1);  // TODO(henningkayser): verify search depth
+      { parameter_namespace_ + ".planner_configs." + planner_id }, 2);
 
   if (planner_params_result.names.empty())
   {
@@ -150,9 +150,9 @@ bool ompl_interface::OMPLInterface::loadPlannerConfiguration(
   // read parameters specific for this configuration
   for (const auto& planner_param : planner_params_result.names)
   {
-    // TODO(henningkayser): verify name is working for config map
-    const rclcpp::Parameter param = node_->get_parameter(parameter_namespace_ + "." + planner_param);
-    planner_config.config[param.get_name()] = param.value_to_string();
+    const rclcpp::Parameter param = node_->get_parameter(planner_param);
+    auto param_name = planner_param.substr(planner_param.find(planner_id) + planner_id.size() + 1);
+    planner_config.config[param_name] = param.value_to_string();
   }
 
   return true;


### PR DESCRIPTION
### Description

While testing out moveit2 I was unable to configure a planner, so I addressing a couple TODOs necessary for ompl parameter loading to work.

1. Depth=1 was always returning an empty set. depth=2 returned all my parameters
2. The parameters from ros come with full namespace eg. it gives `MAIN.planner_configs.RRTConnectkConfigDefault.type`, so stripping off all but the last piece is necessary before caching. (I didn't see an existing way to do this)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
