### PR TITLE
[Draft/ReferenceOnly] Port motion_planning_rviz (with submodules robot_interaction, fake_controller_manager)

### DIFF
--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -13,10 +13,11 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(moveit_msgs REQUIRED)
+find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 # find_package(moveit_ros_warehouse REQUIRED)
 # find_package(moveit_ros_manipulation REQUIRED)
-# find_package(moveit_ros_move_group REQUIRED)
+find_package(moveit_ros_move_group REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
@@ -50,14 +51,14 @@ find_package(Eigen3 REQUIRED)
 set(THIS_PACKAGE_INCLUDE_DIRS
 #  py_bindings_tools/include
   common_planning_interface_objects/include
-#  planning_scene_interface/include
+  planning_scene_interface/include
 #  move_group_interface/include
   moveit_cpp/include
 )
 
 set(THIS_PACKAGE_LIBRARIES
   moveit_common_planning_interface_objects
-#  moveit_planning_scene_interface
+  moveit_planning_scene_interface
 #  moveit_move_group_interface
   moveit_cpp
 #  moveit_py_bindings_tools
@@ -66,10 +67,11 @@ set(THIS_PACKAGE_LIBRARIES
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   geometry_msgs
   moveit_msgs
+  moveit_core
   moveit_ros_planning
 #  moveit_ros_warehouse
 #  moveit_ros_manipulation
-#  moveit_ros_move_group
+  moveit_ros_move_group
   tf2
   tf2_eigen
   tf2_geometry_msgs
@@ -84,7 +86,7 @@ include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 
 # add_subdirectory(py_bindings_tools)
 add_subdirectory(common_planning_interface_objects)
-# add_subdirectory(planning_scene_interface)
+add_subdirectory(planning_scene_interface)
 # add_subdirectory(move_group_interface)
 # add_subdirectory(robot_interface)
 # add_subdirectory(test)

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -52,14 +52,14 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 #  py_bindings_tools/include
   common_planning_interface_objects/include
   planning_scene_interface/include
-#  move_group_interface/include
+  move_group_interface/include
   moveit_cpp/include
 )
 
 set(THIS_PACKAGE_LIBRARIES
   moveit_common_planning_interface_objects
   moveit_planning_scene_interface
-#  moveit_move_group_interface
+  moveit_move_group_interface
   moveit_cpp
 #  moveit_py_bindings_tools
 )
@@ -87,7 +87,7 @@ include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 # add_subdirectory(py_bindings_tools)
 add_subdirectory(common_planning_interface_objects)
 add_subdirectory(planning_scene_interface)
-# add_subdirectory(move_group_interface)
+add_subdirectory(move_group_interface)
 # add_subdirectory(robot_interface)
 # add_subdirectory(test)
 add_subdirectory(moveit_cpp)

--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,33 +1,40 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
-add_library(${MOVEIT_LIB_NAME} src/move_group_interface.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/move_group_interface.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects moveit_planning_scene_interface ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects moveit_planning_scene_interface)
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  moveit_ros_occupancy_map_monitor
+  moveit_ros_move_group
+  moveit_ros_planning
+  moveit_msgs
+  moveit_core
+)
 
-add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_move_group.cpp)
-target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} eigenpy::eigenpy ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_py_bindings_tools)
-add_dependencies(${MOVEIT_LIB_NAME}_python ${catkin_EXPORTED_TARGETS})
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_move_group_interface PREFIX "")
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}")
+# TODO (ddengster) : port wrap_python_move_group
+#add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_move_group.cpp)
+#target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${eigenpy_LIBRARIES} ${PYTHON_LIBRARIES} ${LIBS} ${Boost_LIBRARIES} moveit_py_bindings_tools)
+#add_dependencies(${MOVEIT_LIB_NAME}_python)
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_move_group_interface PREFIX "")
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY "bin")
 if(WIN32)
-  set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES SUFFIX .pyd)
-endif()
+#  set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES SUFFIX .pyd)
+endif(WIN32)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  EXPORT ${MOVEIT_LIB_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
-install(TARGETS ${MOVEIT_LIB_NAME}_python
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
+#install(TARGETS ${MOVEIT_LIB_NAME}_python
+#  ARCHIVE DESTINATION bin
+#  LIBRARY DESTINATION bin
+#  RUNTIME DESTINATION bin)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
-add_executable(demo src/demo.cpp)
-target_link_libraries(demo ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+#add_executable(demo src/demo.cpp)
+#target_link_libraries(demo ${MOVEIT_LIB_NAME} ${LIBS} ${Boost_LIBRARIES})

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -44,13 +44,18 @@
 #include <moveit_msgs/msg/planner_interface_description.hpp>
 #include <moveit_msgs/msg/constraints.hpp>
 #include <moveit_msgs/msg/grasp.hpp>
-#include <moveit_msgs/msg/place_location.hpp>
-#include <moveit_msgs/action/pickup_goal.h>
-#include <moveit_msgs/action/place_goal.h>
+// #include <moveit_msgs/msg/place_location.hpp>
+
+// #include <moveit_msgs/action/pickup.hpp>
+// #include <moveit_msgs/action/place.hpp>
+#include <moveit_msgs/action/move_group.hpp>
+#include <moveit_msgs/action/execute_trajectory.hpp>
+
 #include <moveit_msgs/msg/motion_plan_request.hpp>
-#include <moveit_msgs/action/move_group_action.h>
 #include <geometry_msgs/msg/pose_stamped.h>
-#include <actionlib/client/simple_action_client.h>
+
+#include <rclcpp_action/rclcpp_action.hpp>
+
 #include <memory>
 #include <utility>
 #include <tf2_ros/buffer.h>
@@ -105,9 +110,8 @@ public:
   /** \brief Specification of options to use when constructing the MoveGroupInterface class */
   struct Options
   {
-    Options(std::string group_name, std::string desc = ROBOT_DESCRIPTION,
-            const ros::NodeHandle& node_handle = ros::NodeHandle())
-      : group_name_(std::move(group_name)), robot_description_(std::move(desc)), node_handle_(node_handle)
+    Options(std::string group_name, std::string desc = ROBOT_DESCRIPTION, const rclcpp::Node::SharedPtr& node = nullptr)
+      : group_name_(std::move(group_name)), robot_description_(std::move(desc)), node_(node)
     {
     }
 
@@ -120,7 +124,7 @@ public:
     /// Optionally, an instance of the RobotModel to use can be also specified
     moveit::core::RobotModelConstPtr robot_model_;
 
-    ros::NodeHandle node_handle_;
+    rclcpp::Node::SharedPtr node_;
   };
 
   MOVEIT_STRUCT_FORWARD(Plan)
@@ -150,9 +154,7 @@ public:
     */
   MoveGroupInterface(const Options& opt,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
-                     const ros::WallDuration& wait_for_servers = ros::WallDuration());
-  [[deprecated]] MoveGroupInterface(const Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                    const ros::Duration& wait_for_servers);
+                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(0.0));
 
   /**
       \brief Construct a client for the MoveGroup action for a particular \e group.
@@ -163,9 +165,7 @@ public:
     */
   MoveGroupInterface(const std::string& group,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
-                     const ros::WallDuration& wait_for_servers = ros::WallDuration());
-  [[deprecated]] MoveGroupInterface(const std::string& group, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                    const ros::Duration& wait_for_servers);
+                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(0.0));
 
   ~MoveGroupInterface();
 
@@ -190,7 +190,7 @@ public:
   moveit::core::RobotModelConstPtr getRobotModel() const;
 
   /** \brief Get the ROS node handle of this instance operates on */
-  const ros::NodeHandle& getNodeHandle() const;
+  rclcpp::Node::SharedPtr getNodeHandle();
 
   /** \brief Get the name of the frame in which the robot is planning */
   const std::string& getPlanningFrame() const;
@@ -715,7 +715,8 @@ public:
   /** \brief Get the move_group action client used by the \e MoveGroupInterface.
       The client can be used for querying the execution state of the trajectory and abort trajectory execution
       during asynchronous execution. */
-  actionlib::SimpleActionClient<moveit_msgs::action::MoveGroupAction>& getMoveGroupClient() const;
+
+  rclcpp_action::Client<moveit_msgs::action::MoveGroup>& getMoveGroupClient() const;
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified
      target.
@@ -732,13 +733,13 @@ public:
   MoveItErrorCode asyncExecute(const Plan& plan);
 
   /** \brief Given a \e robot trajectory, execute it without waiting for completion. */
-  MoveItErrorCode asyncExecute(const moveit_msgs::RobotTrajectory& trajectory);
+  MoveItErrorCode asyncExecute(const moveit_msgs::msg::RobotTrajectory& trajectory);
 
   /** \brief Given a \e plan, execute it while waiting for completion. */
   MoveItErrorCode execute(const Plan& plan);
 
   /** \brief Given a \e robot trajectory, execute it while waiting for completion. */
-  MoveItErrorCode execute(const moveit_msgs::RobotTrajectory& trajectory);
+  MoveItErrorCode execute(const moveit_msgs::msg::RobotTrajectory& trajectory);
 
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
@@ -785,18 +786,19 @@ public:
   void constructMotionPlanRequest(moveit_msgs::msg::MotionPlanRequest& request);
 
   /** \brief Build a PickupGoal for an object named \e object and store it in \e goal_out */
-  moveit_msgs::action::PickupGoal constructPickupGoal(const std::string& object,
-                                                      std::vector<moveit_msgs::msg::Grasp> grasps,
-                                                      bool plan_only) const;
 
-  /** \brief Build a PlaceGoal for an object named \e object and store it in \e goal_out */
-  moveit_msgs::action::PlaceGoal constructPlaceGoal(const std::string& object,
-                                                    std::vector<moveit_msgs::msg::PlaceLocation> locations,
-                                                    bool plan_only) const;
-
-  /** \brief Convert a vector of PoseStamped to a vector of PlaceLocation */
-  std::vector<moveit_msgs::msg::PlaceLocation>
-  posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const;
+  //  moveit_msgs::action::Pickup::Goal constructPickupGoal(const std::string& object,
+  //                                                      std::vector<moveit_msgs::msg::Grasp> grasps,
+  //                                                      bool plan_only) const;
+  //
+  //  /** \brief Build a PlaceGoal for an object named \e object and store it in \e goal_out */
+  //  moveit_msgs::action::Place::Goal constructPlaceGoal(const std::string& object,
+  //                                                    std::vector<moveit_msgs::msg::PlaceLocation> locations,
+  //                                                    bool plan_only) const;
+  //
+  //  /** \brief Convert a vector of PoseStamped to a vector of PlaceLocation */
+  //  std::vector<moveit_msgs::msg::PlaceLocation>
+  //  posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const;
 
   /**@}*/
 
@@ -808,69 +810,73 @@ public:
   /** \brief Pick up an object
 
       This applies a number of hard-coded default grasps */
-  MoveItErrorCode pick(const std::string& object, bool plan_only = false)
-  {
-    return pick(constructPickupGoal(object, std::vector<moveit_msgs::msg::Grasp>(), plan_only));
-  }
-
+  //  MoveItErrorCode pick(const std::string& object, bool plan_only = false)
+  //  {
+  //    return pick(constructPickupGoal(object, std::vector<moveit_msgs::msg::Grasp>(), plan_only));
+  //  }
+  //
   /** \brief Pick up an object given a grasp pose */
-  MoveItErrorCode pick(const std::string& object, const moveit_msgs::msg::Grasp& grasp, bool plan_only = false)
-  {
-    return pick(constructPickupGoal(object, { grasp }, plan_only));
-  }
-
+  //  MoveItErrorCode pick(const std::string& object, const moveit_msgs::msg::Grasp& grasp, bool plan_only = false)
+  //  {
+  //    return pick(constructPickupGoal(object, { grasp }, plan_only));
+  //  }
+  //
   /** \brief Pick up an object given possible grasp poses */
-  MoveItErrorCode pick(const std::string& object, std::vector<moveit_msgs::msg::Grasp> grasps, bool plan_only = false)
-  {
-    return pick(constructPickupGoal(object, std::move(grasps), plan_only));
-  }
+  //  MoveItErrorCode pick(const std::string& object, std::vector<moveit_msgs::msg::Grasp> grasps, bool plan_only =
+  //  false)
+  //  {
+  //    return pick(constructPickupGoal(object, std::move(grasps), plan_only));
+  //  }
 
   /** \brief Pick up an object given a PickupGoal
 
       Use as follows: first create the goal with constructPickupGoal(), then set \e possible_grasps and any other
       desired variable in the goal, and finally pass it on to this function */
-  MoveItErrorCode pick(const moveit_msgs::action::PickupGoal& goal);
+
+  // MoveItErrorCode pick(const moveit_msgs::action::Pickup::Goal& goal);
 
   /** \brief Pick up an object
 
       calls the external moveit_msgs::srv::GraspPlanning service "plan_grasps" to compute possible grasps */
-  MoveItErrorCode planGraspsAndPick(const std::string& object = "", bool plan_only = false);
+  // MoveItErrorCode planGraspsAndPick(const std::string& object = "", bool plan_only = false);
 
   /** \brief Pick up an object
       calls the external moveit_msgs::srv::GraspPlanning service "plan_grasps" to compute possible grasps */
-  MoveItErrorCode planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool plan_only = false);
+  // MoveItErrorCode planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool plan_only = false);
 
   /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
-  MoveItErrorCode place(const std::string& object, bool plan_only = false)
-  {
-    return place(constructPlaceGoal(object, std::vector<moveit_msgs::msg::PlaceLocation>(), plan_only));
-  }
+  //  MoveItErrorCode place(const std::string& object, bool plan_only = false)
+  //  {
+  //    return place(constructPlaceGoal(object, std::vector<moveit_msgs::msg::PlaceLocation>(), plan_only));
+  //  }
 
   /** \brief Place an object at one of the specified possible locations */
-  MoveItErrorCode place(const std::string& object, std::vector<moveit_msgs::msg::PlaceLocation> locations,
-                        bool plan_only = false)
-  {
-    return place(constructPlaceGoal(object, std::move(locations), plan_only));
-  }
+  //  MoveItErrorCode place(const std::string& object, std::vector<moveit_msgs::msg::PlaceLocation> locations,
+  //                        bool plan_only = false)
+  //  {
+  //    return place(constructPlaceGoal(object, std::move(locations), plan_only));
+  //  }
 
   /** \brief Place an object at one of the specified possible locations */
-  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::msg::PoseStamped>& poses,
-                        bool plan_only = false)
-  {
-    return place(constructPlaceGoal(object, posesToPlaceLocations(poses), plan_only));
-  }
+  //  MoveItErrorCode place(const std::string& object, const std::vector<geometry_msgs::msg::PoseStamped>& poses,
+  //                        bool plan_only = false)
+  //  {
+  //    return place(constructPlaceGoal(object, posesToPlaceLocations(poses), plan_only));
+  //  }
 
   /** \brief Place an object at one of the specified possible location */
-  MoveItErrorCode place(const std::string& object, const geometry_msgs::msg::PoseStamped& pose, bool plan_only = false)
-  {
-    return place(constructPlaceGoal(object, posesToPlaceLocations({ pose }), plan_only));
-  }
+  //  MoveItErrorCode place(const std::string& object, const geometry_msgs::msg::PoseStamped& pose, bool plan_only =
+  //  false)
+  //  {
+  //    return place(constructPlaceGoal(object, posesToPlaceLocations({ pose }), plan_only));
+  //  }
 
   /** \brief Place an object given a PlaceGoal
 
       Use as follows: first create the goal with constructPlaceGoal(), then set \e place_locations and any other
       desired variable in the goal, and finally pass it on to this function */
-  MoveItErrorCode place(const moveit_msgs::action::PlaceGoal& goal);
+
+  // MoveItErrorCode place(const moveit_msgs::action::Place::Goal& goal);
 
   /** \brief Given the name of an object in the planning scene, make
       the object attached to a link of the robot.  If no link name is

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -39,10 +39,10 @@
 #include <stdexcept>
 #include <sstream>
 #include <memory>
-#include <moveit/warehouse/constraints_storage.h>
+// TODO(JafarAbdi): Enable once moveit_ros_warehouse is ported
+// #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/move_group/capability_names.h>
-#include <moveit/move_group_pick_place_capability/capability_names.h>
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
@@ -50,23 +50,23 @@
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_state/conversions.h>
-#include <moveit_msgs/action/pickup_action.h>
-#include <moveit_msgs/action/execute_trajectory_action.h>
-#include <moveit_msgs/action/place_action.h>
-#include <moveit_msgs/srv/execute_known_trajectory.h>
-#include <moveit_msgs/srv/query_planner_interfaces.h>
-#include <moveit_msgs/srv/get_cartesian_path.h>
-#include <moveit_msgs/srv/grasp_planning.h>
+#include <moveit_msgs/action/execute_trajectory.hpp>
+#include <moveit_msgs/srv/execute_known_trajectory.hpp>
+#include <moveit_msgs/srv/query_planner_interfaces.hpp>
+#include <moveit_msgs/srv/get_cartesian_path.hpp>
+#include <moveit_msgs/srv/grasp_planning.hpp>
 #include <moveit_msgs/srv/get_planner_params.hpp>
 #include <moveit_msgs/srv/set_planner_params.hpp>
+// TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
+// #include <moveit_msgs/msg/place_location.hpp>
+// #include <moveit_msgs/action/pickup.hpp>
+// #include <moveit_msgs/action/place.hpp>
 
-#include <std_msgs/msg/string.h>
+#include <std_msgs/msg/string.hpp>
 #include <geometry_msgs/msg/transform_stamped.h>
 #include <tf2/utils.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_ros/transform_listener.h>
-#include <ros/console.h>
-#include <ros/ros.h>
 
 namespace moveit
 {
@@ -76,8 +76,7 @@ const std::string MoveGroupInterface::ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
 
 const std::string GRASP_PLANNING_SERVICE_NAME = "plan_grasps";  // name of the service that can be used to plan grasps
-
-const std::string LOGNAME = "move_group_interface";
+const rclcpp::Logger LOGGER = rclcpp::get_logger("move_group_interface");
 
 namespace
 {
@@ -94,22 +93,24 @@ class MoveGroupInterface::MoveGroupInterfaceImpl
 {
 public:
   MoveGroupInterfaceImpl(const Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                         const ros::WallDuration& wait_for_servers)
-    : opt_(opt), node_handle_(opt.node_handle_), tf_buffer_(tf_buffer)
+                         const rclcpp::Duration& wait_for_servers)
+    : opt_(opt), node_(opt.node_), tf_buffer_(tf_buffer)
   {
-    robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(opt.robot_description_);
+    if (!node_)
+      node_ = std::make_shared<rclcpp::Node>("MoveGroupInterfaceNode");
+    robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(node_, opt.robot_description_);
     if (!getRobotModel())
     {
       std::string error = "Unable to construct robot model. Please make sure all needed information is on the "
                           "parameter server.";
-      ROS_FATAL_STREAM_NAMED(LOGNAME, error);
+      RCLCPP_FATAL_STREAM(LOGGER, error);
       throw std::runtime_error(error);
     }
 
     if (!getRobotModel()->hasJointModelGroup(opt.group_name_))
     {
       std::string error = "Group '" + opt.group_name_ + "' was not found.";
-      ROS_FATAL_STREAM_NAMED(LOGNAME, error);
+      RCLCPP_FATAL_STREAM(LOGGER, error);
       throw std::runtime_error(error);
     }
 
@@ -126,113 +127,55 @@ public:
     goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
     allowed_planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    node_handle_.param<double>("robot_description_planning/joint_limits/default_velocity_scaling_factor",
-                               max_velocity_scaling_factor_, 0.1);
-    node_handle_.param<double>("robot_description_planning/joint_limits/default_acceleration_scaling_factor",
-                               max_acceleration_scaling_factor_, 0.1);
+    node_->get_parameter_or<double>("robot_description_planning.joint_limits.default_velocity_scaling_factor",
+                                    max_velocity_scaling_factor_, 0.1);
+    node_->get_parameter_or<double>("robot_description_planning.joint_limits.default_acceleration_scaling_factor",
+                                    max_acceleration_scaling_factor_, 0.1);
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())
       end_effector_link_ = joint_model_group_->getLinkModelNames().back();
     pose_reference_frame_ = getRobotModel()->getModelFrame();
 
-    trajectory_event_publisher_ = node_handle_.advertise<std_msgs::msg::String>(
-        trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC, 1, false);
-    attached_object_publisher_ = node_handle_.advertise<moveit_msgs::msg::AttachedCollisionObject>(
-        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1, false);
+    trajectory_event_publisher_ = node_->create_publisher<std_msgs::msg::String>(
+        trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC, 1);
+    attached_object_publisher_ = node_->create_publisher<moveit_msgs::msg::AttachedCollisionObject>(
+        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1);
 
-    current_state_monitor_ = getSharedStateMonitor(robot_model_, tf_buffer_, node_handle_);
+    current_state_monitor_ = getSharedStateMonitor(node_, robot_model_, tf_buffer_);
 
-    ros::WallTime timeout_for_servers = ros::WallTime::now() + wait_for_servers;
-    if (wait_for_servers == ros::WallDuration())
-      timeout_for_servers = ros::WallTime();  // wait for ever
-    double allotted_time = wait_for_servers.toSec();
+    rclcpp::Time timeout_for_servers = node_->get_clock()->now() + wait_for_servers;
+    if (wait_for_servers == rclcpp::Duration(0.0))
+      timeout_for_servers = rclcpp::Time();  // wait for ever
+    double allotted_time = wait_for_servers.seconds();
 
-    move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::action::MoveGroupAction>(
-        node_handle_, move_group::MOVE_ACTION, false));
-    waitForAction(move_action_client_, move_group::MOVE_ACTION, timeout_for_servers, allotted_time);
-
-    pick_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::action::PickupAction>(
-        node_handle_, move_group::PICKUP_ACTION, false));
-    waitForAction(pick_action_client_, move_group::PICKUP_ACTION, timeout_for_servers, allotted_time);
-
-    place_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::action::PlaceAction>(
-        node_handle_, move_group::PLACE_ACTION, false));
-    waitForAction(place_action_client_, move_group::PLACE_ACTION, timeout_for_servers, allotted_time);
-
-    execute_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::action::ExecuteTrajectoryAction>(
-        node_handle_, move_group::EXECUTE_ACTION_NAME, false));
-    waitForAction(execute_action_client_, move_group::EXECUTE_ACTION_NAME, timeout_for_servers, allotted_time);
+    move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(node_, move_group::MOVE_ACTION);
+    move_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
+    // TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
+    // pick_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Pickup>(
+    //        node_, move_group::PICKUP_ACTION);
+    //    pick_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
+    //
+    //    place_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Place>(
+    //        node_, move_group::PLACE_ACTION);
+    //    place_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
+    execute_action_client_ =
+        rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(node_, move_group::EXECUTE_ACTION_NAME);
+    execute_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
 
     query_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);
     get_params_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::GetPlannerParams>(move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::GetPlannerParams>(move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
     set_params_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::SetPlannerParams>(move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::SetPlannerParams>(move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
 
     cartesian_path_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
 
-    plan_grasps_service_ = node_handle_.serviceClient<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
+    plan_grasps_service_ = node_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
-    ROS_INFO_STREAM_NAMED(LOGNAME, "Ready to take commands for planning group " << opt.group_name_ << ".");
-  }
-
-  template <typename T>
-  void waitForAction(const T& action, const std::string& name, const ros::WallTime& timeout, double allotted_time) const
-  {
-    ROS_DEBUG_NAMED(LOGNAME, "Waiting for move_group action server (%s)...", name.c_str());
-
-    // wait for the server (and spin as needed)
-    if (timeout == ros::WallTime())  // wait forever
-    {
-      while (node_handle_.ok() && !action->isServerConnected())
-      {
-        ros::WallDuration(0.001).sleep();
-        // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
-        if (queue)
-        {
-          queue->callAvailable();
-        }
-        else  // in case of nodelets and specific callback queue implementations
-        {
-          ROS_WARN_ONCE_NAMED(LOGNAME, "Non-default CallbackQueue: Waiting for external queue "
-                                       "handling.");
-        }
-      }
-    }
-    else  // wait with timeout
-    {
-      while (node_handle_.ok() && !action->isServerConnected() && timeout > ros::WallTime::now())
-      {
-        ros::WallDuration(0.001).sleep();
-        // explicit ros::spinOnce on the callback queue used by NodeHandle that manages the action client
-        ros::CallbackQueue* queue = dynamic_cast<ros::CallbackQueue*>(node_handle_.getCallbackQueue());
-        if (queue)
-        {
-          queue->callAvailable();
-        }
-        else  // in case of nodelets and specific callback queue implementations
-        {
-          ROS_WARN_ONCE_NAMED(LOGNAME, "Non-default CallbackQueue: Waiting for external queue "
-                                       "handling.");
-        }
-      }
-    }
-
-    if (!action->isServerConnected())
-    {
-      std::stringstream error;
-      error << "Unable to connect to move_group action server '" << name << "' within allotted time (" << allotted_time
-            << "s)";
-      throw std::runtime_error(error.str());
-    }
-    else
-    {
-      ROS_DEBUG_NAMED(LOGNAME, "Connected to '%s'", name.c_str());
-    }
+    RCLCPP_INFO_STREAM(LOGGER, "Ready to take commands for planning group " << opt.group_name_ << ".");
   }
 
   ~MoveGroupInterfaceImpl()
@@ -261,35 +204,43 @@ public:
     return joint_model_group_;
   }
 
-  actionlib::SimpleActionClient<moveit_msgs::action::MoveGroupAction>& getMoveGroupClient() const
+  rclcpp_action::Client<moveit_msgs::action::MoveGroup>& getMoveGroupClient() const
   {
     return *move_action_client_;
   }
 
   bool getInterfaceDescription(moveit_msgs::msg::PlannerInterfaceDescription& desc)
   {
-    moveit_msgs::srv::QueryPlannerInterfaces::Request req;
-    moveit_msgs::srv::QueryPlannerInterfaces::Response res;
-    if (query_service_.call(req, res))
-      if (!res.planner_interfaces.empty())
-      {
-        desc = res.planner_interfaces.front();
-        return true;
-      }
+    auto req = std::make_shared<moveit_msgs::srv::QueryPlannerInterfaces::Request>();
+    moveit_msgs::srv::QueryPlannerInterfaces::Response::SharedPtr response;
+
+    auto res = query_service_->async_send_request(req);
+
+    // wait until future is done
+    response = res.get();
+    if (!response->planner_interfaces.empty())
+    {
+      desc = response->planner_interfaces.front();
+      return true;
+    }
     return false;
   }
 
   std::map<std::string, std::string> getPlannerParams(const std::string& planner_id, const std::string& group = "")
   {
-    moveit_msgs::srv::GetPlannerParams::Request req;
-    moveit_msgs::srv::GetPlannerParams::Response res;
-    req.planner_config = planner_id;
-    req.group = group;
+    auto req = std::make_shared<moveit_msgs::srv::GetPlannerParams::Request>();
+    moveit_msgs::srv::GetPlannerParams::Response::SharedPtr response;
+    req->planner_config = planner_id;
+    req->group = group;
     std::map<std::string, std::string> result;
-    if (get_params_service_.call(req, res))
+
+    auto res = get_params_service_->async_send_request(req);
+    // if (get_params_service_.call(req, res))
+    if (rclcpp::spin_until_future_complete(node_, res) == rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      for (unsigned int i = 0, end = res.params.keys.size(); i < end; ++i)
-        result[res.params.keys[i]] = res.params.values[i];
+      response = res.get();
+      for (unsigned int i = 0, end = response->params.keys.size(); i < end; ++i)
+        result[response->params.keys[i]] = response->params.values[i];
     }
     return result;
   }
@@ -297,17 +248,16 @@ public:
   void setPlannerParams(const std::string& planner_id, const std::string& group,
                         const std::map<std::string, std::string>& params, bool replace = false)
   {
-    moveit_msgs::srv::SetPlannerParams::Request req;
-    moveit_msgs::srv::SetPlannerParams::Response res;
-    req.planner_config = planner_id;
-    req.group = group;
-    req.replace = replace;
+    auto req = std::make_shared<moveit_msgs::srv::SetPlannerParams::Request>();
+    req->planner_config = planner_id;
+    req->group = group;
+    req->replace = replace;
     for (const std::pair<const std::string, std::string>& param : params)
     {
-      req.params.keys.push_back(param.first);
-      req.params.values.push_back(param.second);
+      req->params.keys.push_back(param.first);
+      req->params.values.push_back(param.second);
     }
-    set_params_service_.call(req, res);
+    set_params_service_->async_send_request(req);
   }
 
   std::string getDefaultPlannerId(const std::string& group) const
@@ -315,11 +265,11 @@ public:
     std::stringstream param_name;
     param_name << "move_group";
     if (!group.empty())
-      param_name << "/" << group;
-    param_name << "/default_planner_config";
+      param_name << "." << group;
+    param_name << ".default_planner_config";
 
     std::string default_planner_config;
-    node_handle_.getParam(param_name.str(), default_planner_config);
+    node_->get_parameter(param_name.str(), default_planner_config);
     return default_planner_config;
   }
 
@@ -352,16 +302,18 @@ public:
   {
     if (target_value > 1.0)
     {
-      ROS_WARN_NAMED(LOGNAME, "Limiting max_%s (%.2f) to 1.0.", factor_name, target_value);
+      RCLCPP_WARN(rclcpp::get_logger("move_group_interface"), "Limiting max_%s (%.2f) to 1.0.", factor_name,
+                  target_value);
       variable = 1.0;
     }
     else if (target_value <= 0.0)
     {
-      node_handle_.param<double>(std::string("robot_description_planning/default_") + factor_name, variable,
-                                 fallback_value);
+      node_->get_parameter_or<double>(std::string("robot_description_planning.default_") + factor_name, variable,
+                                      fallback_value);
       if (target_value < 0.0)
       {
-        ROS_WARN_NAMED(LOGNAME, "max_%s < 0.0! Setting to default: %.2f.", factor_name, variable);
+        RCLCPP_WARN(rclcpp::get_logger("move_group_interface"), "max_%s < 0.0! Setting to default: %.2f.", factor_name,
+                    variable);
       }
     }
     else
@@ -444,8 +396,8 @@ public:
         }
         else
         {
-          ROS_ERROR_NAMED(LOGNAME, "Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
-                          getRobotModel()->getModelFrame().c_str());
+          RCLCPP_ERROR(LOGGER, "Unable to transform from frame '%s' to frame '%s'", frame.c_str(),
+                       getRobotModel()->getModelFrame().c_str());
           return false;
         }
       }
@@ -493,7 +445,7 @@ public:
     const std::string& eef = end_effector_link.empty() ? end_effector_link_ : end_effector_link;
     if (eef.empty())
     {
-      ROS_ERROR_NAMED(LOGNAME, "No end-effector to set the pose for");
+      RCLCPP_ERROR(LOGGER, "No end-effector to set the pose for");
       return false;
     }
     else
@@ -502,7 +454,7 @@ public:
       // make sure we don't store an actual stamp, since that will become stale can potentially cause tf errors
       std::vector<geometry_msgs::msg::PoseStamped>& stored_poses = pose_targets_[eef];
       for (geometry_msgs::msg::PoseStamped& stored_pose : stored_poses)
-        stored_pose.header.stamp = ros::Time(0);
+        stored_pose.header.stamp = rclcpp::Time(0);
     }
     return true;
   }
@@ -518,14 +470,14 @@ public:
     const std::string& eef = end_effector_link.empty() ? end_effector_link_ : end_effector_link;
 
     // if multiple pose targets are set, return the first one
-    std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped> >::const_iterator jt = pose_targets_.find(eef);
+    std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped>>::const_iterator jt = pose_targets_.find(eef);
     if (jt != pose_targets_.end())
       if (!jt->second.empty())
         return jt->second.at(0);
 
     // or return an error
     static const geometry_msgs::msg::PoseStamped UNKNOWN;
-    ROS_ERROR_NAMED(LOGNAME, "Pose for end-effector '%s' not known.", eef.c_str());
+    RCLCPP_ERROR(LOGGER, "Pose for end-effector '%s' not known.", eef.c_str());
     return UNKNOWN;
   }
 
@@ -533,14 +485,14 @@ public:
   {
     const std::string& eef = end_effector_link.empty() ? end_effector_link_ : end_effector_link;
 
-    std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped> >::const_iterator jt = pose_targets_.find(eef);
+    std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped>>::const_iterator jt = pose_targets_.find(eef);
     if (jt != pose_targets_.end())
       if (!jt->second.empty())
         return jt->second;
 
     // or return an error
     static const std::vector<geometry_msgs::msg::PoseStamped> EMPTY;
-    ROS_ERROR_NAMED(LOGNAME, "Poses for end-effector '%s' are not known.", eef.c_str());
+    RCLCPP_ERROR(LOGGER, "Poses for end-effector '%s' are not known.", eef.c_str());
     return EMPTY;
   }
 
@@ -573,7 +525,7 @@ public:
   {
     if (!current_state_monitor_)
     {
-      ROS_ERROR_NAMED(LOGNAME, "Unable to monitor current robot state");
+      RCLCPP_ERROR(LOGGER, "Unable to monitor current robot state");
       return false;
     }
 
@@ -589,7 +541,7 @@ public:
   {
     if (!current_state_monitor_)
     {
-      ROS_ERROR_NAMED(LOGNAME, "Unable to get current robot state");
+      RCLCPP_ERROR(LOGGER, "Unable to get current robot state");
       return false;
     }
 
@@ -597,9 +549,9 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    if (!current_state_monitor_->waitForCurrentState(ros::Time::now(), wait_seconds))
+    if (!current_state_monitor_->waitForCurrentState(rclcpp::Clock().now(), wait_seconds))
     {
-      ROS_ERROR_NAMED(LOGNAME, "Failed to fetch current robot state");
+      RCLCPP_ERROR(LOGGER, "Failed to fetch current robot state");
       return false;
     }
 
@@ -608,156 +560,136 @@ public:
   }
 
   /** \brief Convert a vector of PoseStamped to a vector of PlaceLocation */
-  std::vector<moveit_msgs::msg::PlaceLocation>
-  posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const
-  {
-    std::vector<moveit_msgs::msg::PlaceLocation> locations;
-    for (const geometry_msgs::msg::PoseStamped& pose : poses)
-    {
-      moveit_msgs::action::PlaceLocation location;
-      location.pre_place_approach.direction.vector.z = -1.0;
-      location.post_place_retreat.direction.vector.x = -1.0;
-      location.pre_place_approach.direction.header.frame_id = getRobotModel()->getModelFrame();
-      location.post_place_retreat.direction.header.frame_id = end_effector_link_;
+  //  std::vector<moveit_msgs::msg::PlaceLocation>
+  //  posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const
+  //  {
+  //    std::vector<moveit_msgs::msg::PlaceLocation> locations;
+  //    for (const geometry_msgs::msg::PoseStamped& pose : poses)
+  //    {
+  //      moveit_msgs::msg::PlaceLocation location;
+  //      location.pre_place_approach.direction.vector.z = -1.0;
+  //      location.post_place_retreat.direction.vector.x = -1.0;
+  //      location.pre_place_approach.direction.header.frame_id = getRobotModel()->getModelFrame();
+  //      location.post_place_retreat.direction.header.frame_id = end_effector_link_;
+  //
+  //      location.pre_place_approach.min_distance = 0.1;
+  //      location.pre_place_approach.desired_distance = 0.2;
+  //      location.post_place_retreat.min_distance = 0.0;
+  //      location.post_place_retreat.desired_distance = 0.2;
+  //      // location.post_place_posture is filled by the pick&place lib with the getDetachPosture from the AttachedBody
+  //
+  //      location.place_pose = pose;
+  //      locations.push_back(location);
+  //    }
+  //    RCLCPP_DEBUG(LOGGER, "Move group interface has %u place locations",
+  //                    (unsigned int)locations.size());
+  //    return locations;
+  //  }
 
-      location.pre_place_approach.min_distance = 0.1;
-      location.pre_place_approach.desired_distance = 0.2;
-      location.post_place_retreat.min_distance = 0.0;
-      location.post_place_retreat.desired_distance = 0.2;
-      // location.post_place_posture is filled by the pick&place lib with the getDetachPosture from the AttachedBody
+  //  MoveItErrorCode place(const moveit_msgs::action::Place::Goal& goal)
+  //  {
+  //    if (!place_action_client_ || !place_action_client_->action_server_is_ready())
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Place action client not found/not ready");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //
+  //    int64_t timeout = 3.0;
+  //    auto future = place_action_client_->async_send_goal(goal);
+  //    if (rclcpp::spin_until_future_complete(node_, future, std::chrono::seconds(timeout)) !=
+  //      rclcpp::executor::FutureReturnCode::SUCCESS)
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Place action timeout reached");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //    return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+  //  }
 
-      location.place_pose = pose;
-      locations.push_back(location);
-    }
-    ROS_DEBUG_NAMED(LOGNAME, "Move group interface has %u place locations", (unsigned int)locations.size());
-    return locations;
-  }
+  //  MoveItErrorCode pick(const moveit_msgs::action::Pickup::Goal& goal)
+  //  {
+  //    if (!pick_action_client_ || !pick_action_client_->action_server_is_ready())
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Pick action client not found/not ready");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //
+  //    int64_t timeout = 3.0;
+  //    auto future = pick_action_client_->async_send_goal(goal);
+  //    if (rclcpp::spin_until_future_complete(node_, future, std::chrono::seconds(timeout)) !=
+  //      rclcpp::executor::FutureReturnCode::SUCCESS)
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Pick action timeout reached");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //    return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+  //  }
 
-  MoveItErrorCode place(const moveit_msgs::action::PlaceGoal& goal)
-  {
-    if (!place_action_client_)
-    {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "place action client not found");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
-    }
-    if (!place_action_client_->isServerConnected())
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "place action server not connected");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
+  //  MoveItErrorCode planGraspsAndPick(const std::string& object, bool plan_only = false)
+  //  {
+  //    if (object.empty())
+  //    {
+  //      return planGraspsAndPick(moveit_msgs::msg::CollisionObject());
+  //    }
+  //
+  //    PlanningSceneInterface psi;
+  //    std::map<std::string, moveit_msgs::msg::CollisionObject> objects =
+  //        psi.getObjects(std::vector<std::string>(1, object));
+  //
+  //    if (objects.empty())
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Asked for grasps for the object '"
+  //                                                         << object << "', but the object could not be found");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::INVALID_OBJECT_NAME);
+  //    }
+  //
+  //    return planGraspsAndPick(objects[object], plan_only);
+  //  }
 
-    place_action_client_->sendGoal(goal);
-    ROS_DEBUG_NAMED(LOGNAME, "Sent place goal with %d locations", (int)goal.place_locations.size());
-    if (!place_action_client_->waitForResult())
-    {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "Place action returned early");
-    }
-    if (place_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
-    {
-      return MoveItErrorCode(place_action_client_->getResult()->error_code);
-    }
-    else
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "Fail: " << place_action_client_->getState().toString() << ": "
-                                              << place_action_client_->getState().getText());
-      return MoveItErrorCode(place_action_client_->getResult()->error_code);
-    }
-  }
-
-  MoveItErrorCode pick(const moveit_msgs::action::PickupGoal& goal)
-  {
-    if (!pick_action_client_)
-    {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "pick action client not found");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
-    }
-    if (!pick_action_client_->isServerConnected())
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "pick action server not connected");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
-
-    pick_action_client_->sendGoal(goal);
-    if (!pick_action_client_->waitForResult())
-    {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "Pickup action returned early");
-    }
-    if (pick_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
-    {
-      return MoveItErrorCode(pick_action_client_->getResult()->error_code);
-    }
-    else
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "Fail: " << pick_action_client_->getState().toString() << ": "
-                                              << pick_action_client_->getState().getText());
-      return MoveItErrorCode(pick_action_client_->getResult()->error_code);
-    }
-  }
-
-  MoveItErrorCode planGraspsAndPick(const std::string& object, bool plan_only = false)
-  {
-    if (object.empty())
-    {
-      return planGraspsAndPick(moveit_msgs::msg::CollisionObject());
-    }
-
-    PlanningSceneInterface psi;
-    std::map<std::string, moveit_msgs::msg::CollisionObject> objects =
-        psi.getObjects(std::vector<std::string>(1, object));
-
-    if (objects.empty())
-    {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "Asked for grasps for the object '" << object
-                                                                          << "', but the object could not be found");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::INVALID_OBJECT_NAME);
-    }
-
-    return planGraspsAndPick(objects[object], plan_only);
-  }
-
-  MoveItErrorCode planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool plan_only = false)
-  {
-    if (!plan_grasps_service_.exists())
-    {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "Grasp planning service '"
-                                          << GRASP_PLANNING_SERVICE_NAME
-                                          << "' is not available."
-                                             " This has to be implemented and started separately.");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
-
-    moveit_msgs::srv::GraspPlanning::Request request;
-    moveit_msgs::srv::GraspPlanning::Response response;
-
-    request.group_name = opt_.group_name_;
-    request.target = object;
-    request.support_surfaces.push_back(support_surface_);
-
-    ROS_DEBUG_NAMED(LOGNAME, "Calling grasp planner...");
-    if (!plan_grasps_service_.call(request, response) ||
-        response.error_code.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
-    {
-      ROS_ERROR_NAMED(LOGNAME, "Grasp planning failed. Unable to pick.");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
-    }
-
-    return pick(constructPickupGoal(object.id, std::move(response.grasps), plan_only));
-  }
+  //  MoveItErrorCode planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool plan_only = false)
+  //  {
+  //    if (!plan_grasps_service_)
+  //    {
+  //      RCLCPP_ERROR_STREAM(LOGGER, "Grasp planning service '"
+  //                                                         << GRASP_PLANNING_SERVICE_NAME
+  //                                                         << "' is not available."
+  //                                                            " This has to be implemented and started separately.");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //
+  //    auto request = std::make_shared<moveit_msgs::srv::GraspPlanning::Request>();
+  //    moveit_msgs::srv::GraspPlanning::Response::SharedPtr response;
+  //
+  //    request->group_name = opt_.group_name_;
+  //    request->target = object;
+  //    request->support_surfaces.push_back(support_surface_);
+  //
+  //    RCLCPP_DEBUG(LOGGER, "Calling grasp planner...");
+  //
+  //    auto res = plan_grasps_service_->async_send_request(request);
+  //    if (rclcpp::spin_until_future_complete(node_, res) !=
+  //          rclcpp::executor::FutureReturnCode::SUCCESS)
+  //    {
+  //      RCLCPP_ERROR(LOGGER, "Grasp planning failed. Unable to pick.");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //    response = res.get();
+  //    if (response->error_code.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
+  //    {
+  //      RCLCPP_ERROR(LOGGER, "Grasp planning failed. Unable to pick.");
+  //      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
+  //    }
+  //    return pick(constructPickupGoal(object.id, std::move(response->grasps), plan_only));
+  //  }
 
   MoveItErrorCode plan(Plan& plan)
   {
-    if (!move_action_client_)
+    if (!move_action_client_ || !move_action_client_->action_server_is_ready())
     {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "move action client not found");
+      RCLCPP_INFO_STREAM(LOGGER, "MoveGroup action client/server not ready");
       return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
     }
-    if (!move_action_client_->isServerConnected())
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "move action server not connected");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
 
-    moveit_msgs::action::MoveGroupGoal goal;
+    moveit_msgs::action::MoveGroup::Goal goal;
     constructGoal(goal);
     goal.planning_options.plan_only = true;
     goal.planning_options.look_around = false;
@@ -765,40 +697,78 @@ public:
     goal.planning_options.planning_scene_diff.is_diff = true;
     goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
 
-    move_action_client_->sendGoal(goal);
-    if (!move_action_client_->waitForResult())
+    bool done = false;
+    rclcpp_action::ResultCode code = rclcpp_action::ResultCode::UNKNOWN;
+    std::shared_ptr<moveit_msgs::action::MoveGroup_Result> res;
+    auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
+
+    send_goal_opts.goal_response_callback =
+        [&](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr> future) {
+          auto goal_handle = future.get();
+          if (!goal_handle)
+            RCLCPP_INFO(LOGGER, "Planning request rejected");
+          else
+            RCLCPP_INFO(LOGGER, "Planning request accepted");
+        };
+    send_goal_opts.result_callback =
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::WrappedResult& result) {
+          res = result.result;
+          code = result.code;
+          done = true;
+
+          switch (result.code)
+          {
+            case rclcpp_action::ResultCode::SUCCEEDED:
+              RCLCPP_INFO(LOGGER, "Planning request complete!");
+              break;
+            case rclcpp_action::ResultCode::ABORTED:
+              RCLCPP_INFO(LOGGER, "Planning request aborted");
+              return;
+            case rclcpp_action::ResultCode::CANCELED:
+              RCLCPP_INFO(LOGGER, "Planning request canceled");
+              return;
+            default:
+              RCLCPP_INFO(LOGGER, "Planning request unknown result code");
+              return;
+          }
+        };
+
+    auto goal_handle_future = move_action_client_->async_send_goal(goal, send_goal_opts);
+    goal_handle_future.wait();
+
+    // wait until send_goal_opts.result_callback is called
+    double timeout = 9999.0;
+    rclcpp::Time start_time = node_->now();
+    rclcpp::Duration wait = rclcpp::Duration::from_seconds(timeout);
+    auto end_time = start_time + wait;
+    while (!done && node_->now() < end_time)
     {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "MoveGroup action returned early");
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    if (move_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
+
+    if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
-      plan.trajectory_ = move_action_client_->getResult()->planned_trajectory;
-      plan.start_state_ = move_action_client_->getResult()->trajectory_start;
-      plan.planning_time_ = move_action_client_->getResult()->planning_time;
-      return MoveItErrorCode(move_action_client_->getResult()->error_code);
+      RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::plan() failed or timeout reached");
+      return false;
     }
-    else
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "Fail: " << move_action_client_->getState().toString() << ": "
-                                              << move_action_client_->getState().getText());
-      return MoveItErrorCode(move_action_client_->getResult()->error_code);
-    }
+
+    plan.trajectory_ = res->planned_trajectory;
+    plan.start_state_ = res->trajectory_start;
+    plan.planning_time_ = res->planning_time;
+    RCLCPP_INFO(LOGGER, "time taken to generate plan: %g seconds", plan.planning_time_);
+
+    return res->error_code;
   }
 
   MoveItErrorCode move(bool wait)
   {
-    if (!move_action_client_)
+    if (!move_action_client_ || !move_action_client_->action_server_is_ready())
     {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "move action client not found");
+      RCLCPP_INFO_STREAM(LOGGER, "MoveGroup action client/server not ready");
       return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
     }
-    if (!move_action_client_->isServerConnected())
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "move action server not connected");
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
 
-    moveit_msgs::action::MoveGroupGoal goal;
+    moveit_msgs::action::MoveGroup::Goal goal;
     constructGoal(goal);
     goal.planning_options.plan_only = false;
     goal.planning_options.look_around = can_look_;
@@ -807,66 +777,134 @@ public:
     goal.planning_options.planning_scene_diff.is_diff = true;
     goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
 
-    move_action_client_->sendGoal(goal);
+    bool done = false;
+    rclcpp_action::ResultCode code = rclcpp_action::ResultCode::UNKNOWN;
+    std::shared_ptr<moveit_msgs::action::MoveGroup_Result> res;
+    auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
+
+    send_goal_opts.goal_response_callback =
+        [&](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr> future) {
+          auto goal_handle = future.get();
+          if (!goal_handle)
+            RCLCPP_INFO(LOGGER, "Plan and Execute request rejected");
+          else
+            RCLCPP_INFO(LOGGER, "Plan and Execute request accepted");
+        };
+    send_goal_opts.result_callback =
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::WrappedResult& result) {
+          res = result.result;
+          code = result.code;
+          done = true;
+
+          switch (result.code)
+          {
+            case rclcpp_action::ResultCode::SUCCEEDED:
+              RCLCPP_INFO(LOGGER, "Plan and Execute request complete!");
+              break;
+            case rclcpp_action::ResultCode::ABORTED:
+              RCLCPP_INFO(LOGGER, "Plan and Execute request aborted");
+              return;
+            case rclcpp_action::ResultCode::CANCELED:
+              RCLCPP_INFO(LOGGER, "Plan and Execute request canceled");
+              return;
+            default:
+              RCLCPP_INFO(LOGGER, "Plan and Execute request unknown result code");
+              return;
+          }
+        };
+    auto goal_handle_future = move_action_client_->async_send_goal(goal, send_goal_opts);
     if (!wait)
+      return MoveItErrorCode::SUCCESS;
+    goal_handle_future.wait();
+
+    // wait until send_goal_opts.result_callback is called
+    double timeout = 9999.0;
+    rclcpp::Time start_time = node_->now();
+    rclcpp::Duration waitdur = rclcpp::Duration::from_seconds(timeout);
+    auto end_time = start_time + waitdur;
+    while (!done && node_->now() < end_time)
     {
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    if (!move_action_client_->waitForResult())
+    if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "MoveGroup action returned early");
+      RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::move() failed or timeout reached");
+      return false;
     }
-
-    if (move_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
-    {
-      return MoveItErrorCode(move_action_client_->getResult()->error_code);
-    }
-    else
-    {
-      ROS_INFO_STREAM_NAMED(LOGNAME, move_action_client_->getState().toString()
-                                         << ": " << move_action_client_->getState().getText());
-      return MoveItErrorCode(move_action_client_->getResult()->error_code);
-    }
+    return res->error_code;
   }
 
-  MoveItErrorCode execute(const moveit_msgs::RobotTrajectory& trajectory, bool wait)
+  MoveItErrorCode execute(const moveit_msgs::msg::RobotTrajectory& trajectory, bool wait)
   {
-    if (!execute_action_client_)
+    if (!execute_action_client_ || !execute_action_client_->action_server_is_ready())
     {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "execute action client not found");
+      RCLCPP_INFO_STREAM(LOGGER, "execute_action_client_ client/server not ready");
       return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::FAILURE);
     }
-    if (!execute_action_client_->isServerConnected())
-    {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "execute action server not connected");
-      return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::COMMUNICATION_FAILURE);
-    }
 
-    moveit_msgs::action::ExecuteTrajectoryGoal goal;
+    bool done = false;
+    rclcpp_action::ResultCode code = rclcpp_action::ResultCode::UNKNOWN;
+    std::shared_ptr<moveit_msgs::action::ExecuteTrajectory_Result> res;
+    auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::ExecuteTrajectory>::SendGoalOptions();
+
+    send_goal_opts.goal_response_callback = [&](
+        std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::SharedPtr> future) {
+      auto goal_handle = future.get();
+      if (!goal_handle)
+      {
+        RCLCPP_INFO(LOGGER, "Execute request rejected");
+      }
+      else
+        RCLCPP_INFO(LOGGER, "Execute request accepted");
+    };
+    send_goal_opts.result_callback =
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::WrappedResult& result) {
+          res = result.result;
+          code = result.code;
+          done = true;
+
+          switch (result.code)
+          {
+            case rclcpp_action::ResultCode::SUCCEEDED:
+              RCLCPP_INFO(LOGGER, "Execute request success!");
+              break;
+            case rclcpp_action::ResultCode::ABORTED:
+              RCLCPP_INFO(LOGGER, "Execute request aborted");
+              return;
+            case rclcpp_action::ResultCode::CANCELED:
+              RCLCPP_INFO(LOGGER, "Execute request canceled");
+              return;
+            default:
+              RCLCPP_INFO(LOGGER, "Execute request unknown result code");
+              return;
+          }
+        };
+
+    moveit_msgs::action::ExecuteTrajectory::Goal goal;
     goal.trajectory = trajectory;
 
-    execute_action_client_->sendGoal(goal);
+    auto goal_handle_future = execute_action_client_->async_send_goal(goal, send_goal_opts);
     if (!wait)
+      return MoveItErrorCode::SUCCESS;
+    goal_handle_future.wait();
+
+    // wait until send_goal_opts.result_callback is called
+    double timeout = 9999.0;
+    rclcpp::Time start_time = node_->now();
+    rclcpp::Duration waitdur = rclcpp::Duration::from_seconds(timeout);
+    auto end_time = start_time + waitdur;
+    while (!done && node_->now() < end_time)
     {
-      return MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    if (!execute_action_client_->waitForResult())
+    if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "ExecuteTrajectory action returned early");
+      RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::execute() failed or timeout reached");
+      return false;
     }
-
-    if (execute_action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
-    {
-      return MoveItErrorCode(execute_action_client_->getResult()->error_code);
-    }
-    else
-    {
-      ROS_INFO_STREAM_NAMED(LOGNAME, execute_action_client_->getState().toString()
-                                         << ": " << execute_action_client_->getState().getText());
-      return MoveItErrorCode(execute_action_client_->getResult()->error_code);
-    }
+    return res->error_code;
   }
 
   double computeCartesianPath(const std::vector<geometry_msgs::msg::Pose>& waypoints, double step,
@@ -874,31 +912,33 @@ public:
                               const moveit_msgs::msg::Constraints& path_constraints, bool avoid_collisions,
                               moveit_msgs::msg::MoveItErrorCodes& error_code)
   {
-    moveit_msgs::srv::GetCartesianPath::Request req;
-    moveit_msgs::srv::GetCartesianPath::Response res;
+    auto req = std::make_shared<moveit_msgs::srv::GetCartesianPath::Request>();
+    moveit_msgs::srv::GetCartesianPath::Response::SharedPtr response;
 
     if (considered_start_state_)
-      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, req.start_state);
+      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, req->start_state);
     else
-      req.start_state.is_diff = true;
+      req->start_state.is_diff = true;
 
-    req.group_name = opt_.group_name_;
-    req.header.frame_id = getPoseReferenceFrame();
-    req.header.stamp = ros::Time::now();
-    req.waypoints = waypoints;
-    req.max_step = step;
-    req.jump_threshold = jump_threshold;
-    req.path_constraints = path_constraints;
-    req.avoid_collisions = avoid_collisions;
-    req.link_name = getEndEffectorLink();
+    req->group_name = opt_.group_name_;
+    req->header.frame_id = getPoseReferenceFrame();
+    req->header.stamp = getClock()->now();
+    req->waypoints = waypoints;
+    req->max_step = step;
+    req->jump_threshold = jump_threshold;
+    req->path_constraints = path_constraints;
+    req->avoid_collisions = avoid_collisions;
+    req->link_name = getEndEffectorLink();
 
-    if (cartesian_path_service_.call(req, res))
+    auto res = cartesian_path_service_->async_send_request(req);
+    if (rclcpp::spin_until_future_complete(node_, res) == rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      error_code = res.error_code;
-      if (res.error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
+      response = res.get();
+      error_code = response->error_code;
+      if (response->error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
       {
-        msg = res.solution;
-        return res.fraction;
+        msg = response->solution;
+        return response->fraction;
       }
       else
         return -1.0;
@@ -916,7 +956,7 @@ public:
     {
       std_msgs::msg::String event;
       event.data = "stop";
-      trajectory_event_publisher_.publish(event);
+      trajectory_event_publisher_->publish(event);
     }
   }
 
@@ -931,7 +971,7 @@ public:
     }
     if (l.empty())
     {
-      ROS_ERROR_NAMED(LOGNAME, "No known link to attach object '%s' to", object.c_str());
+      RCLCPP_ERROR(LOGGER, "No known link to attach object '%s' to", object.c_str());
       return false;
     }
     moveit_msgs::msg::AttachedCollisionObject aco;
@@ -942,7 +982,7 @@ public:
     else
       aco.touch_links = touch_links;
     aco.object.operation = moveit_msgs::msg::CollisionObject::ADD;
-    attached_object_publisher_.publish(aco);
+    attached_object_publisher_->publish(aco);
     return true;
   }
 
@@ -962,11 +1002,11 @@ public:
       for (const std::string& lname : lnames)
       {
         aco.link_name = lname;
-        attached_object_publisher_.publish(aco);
+        attached_object_publisher_->publish(aco);
       }
     }
     else
-      attached_object_publisher_.publish(aco);
+      attached_object_publisher_->publish(aco);
     return true;
   }
 
@@ -1014,13 +1054,13 @@ public:
   void allowLooking(bool flag)
   {
     can_look_ = flag;
-    ROS_INFO_NAMED(LOGNAME, "Looking around: %s", can_look_ ? "yes" : "no");
+    RCLCPP_INFO(LOGGER, "Looking around: %s", can_look_ ? "yes" : "no");
   }
 
   void allowReplanning(bool flag)
   {
     can_replan_ = flag;
-    ROS_INFO_NAMED(LOGNAME, "Replanning: %s", can_replan_ ? "yes" : "no");
+    RCLCPP_INFO(LOGGER, "Replanning: %s", can_replan_ ? "yes" : "no");
   }
 
   void setReplanningDelay(double delay)
@@ -1083,7 +1123,7 @@ public:
       }
     }
     else
-      ROS_ERROR_NAMED(LOGNAME, "Unable to construct MotionPlanRequest representation");
+      RCLCPP_ERROR(LOGGER, "Unable to construct MotionPlanRequest representation");
 
     if (path_constraints_)
       request.path_constraints = *path_constraints_;
@@ -1091,65 +1131,65 @@ public:
       request.trajectory_constraints = *trajectory_constraints_;
   }
 
-  void constructGoal(moveit_msgs::action::MoveGroupGoal& goal) const
+  void constructGoal(moveit_msgs::action::MoveGroup::Goal& goal) const
   {
     constructMotionPlanRequest(goal.request);
   }
 
-  moveit_msgs::action::PickupGoal constructPickupGoal(const std::string& object,
-                                                      std::vector<moveit_msgs::msg::Grasp>&& grasps,
-                                                      bool plan_only = false) const
-  {
-    moveit_msgs::action::PickupGoal goal;
-    goal.target_name = object;
-    goal.group_name = opt_.group_name_;
-    goal.end_effector = getEndEffector();
-    goal.support_surface_name = support_surface_;
-    goal.possible_grasps = std::move(grasps);
-    if (!support_surface_.empty())
-      goal.allow_gripper_support_collision = true;
+  //  moveit_msgs::action::Pickup::Goal constructPickupGoal(const std::string& object,
+  //                                                      std::vector<moveit_msgs::msg::Grasp>&& grasps,
+  //                                                      bool plan_only = false) const
+  //  {
+  //    moveit_msgs::action::Pickup::Goal goal;
+  //    goal.target_name = object;
+  //    goal.group_name = opt_.group_name_;
+  //    goal.end_effector = getEndEffector();
+  //    goal.support_surface_name = support_surface_;
+  //    goal.possible_grasps = std::move(grasps);
+  //    if (!support_surface_.empty())
+  //      goal.allow_gripper_support_collision = true;
+  //
+  //    if (path_constraints_)
+  //      goal.path_constraints = *path_constraints_;
+  //
+  //    goal.planner_id = planner_id_;
+  //    goal.allowed_planning_time = allowed_planning_time_;
+  //
+  //    goal.planning_options.plan_only = plan_only;
+  //    goal.planning_options.look_around = can_look_;
+  //    goal.planning_options.replan = can_replan_;
+  //    goal.planning_options.replan_delay = replan_delay_;
+  //    goal.planning_options.planning_scene_diff.is_diff = true;
+  //    goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
+  //    return goal;
+  //  }
 
-    if (path_constraints_)
-      goal.path_constraints = *path_constraints_;
-
-    goal.planner_id = planner_id_;
-    goal.allowed_planning_time = allowed_planning_time_;
-
-    goal.planning_options.plan_only = plan_only;
-    goal.planning_options.look_around = can_look_;
-    goal.planning_options.replan = can_replan_;
-    goal.planning_options.replan_delay = replan_delay_;
-    goal.planning_options.planning_scene_diff.is_diff = true;
-    goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
-    return goal;
-  }
-
-  moveit_msgs::action::PlaceGoal constructPlaceGoal(const std::string& object,
-                                                    std::vector<moveit_msgs::msg::PlaceLocation>&& locations,
-                                                    bool plan_only = false) const
-  {
-    moveit_msgs::action::PlaceGoal goal;
-    goal.group_name = opt_.group_name_;
-    goal.attached_object_name = object;
-    goal.support_surface_name = support_surface_;
-    goal.place_locations = std::move(locations);
-    if (!support_surface_.empty())
-      goal.allow_gripper_support_collision = true;
-
-    if (path_constraints_)
-      goal.path_constraints = *path_constraints_;
-
-    goal.planner_id = planner_id_;
-    goal.allowed_planning_time = allowed_planning_time_;
-
-    goal.planning_options.plan_only = plan_only;
-    goal.planning_options.look_around = can_look_;
-    goal.planning_options.replan = can_replan_;
-    goal.planning_options.replan_delay = replan_delay_;
-    goal.planning_options.planning_scene_diff.is_diff = true;
-    goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
-    return goal;
-  }
+  //  moveit_msgs::action::Place::Goal constructPlaceGoal(const std::string& object,
+  //                                                    std::vector<moveit_msgs::msg::PlaceLocation>&& locations,
+  //                                                    bool plan_only = false) const
+  //  {
+  //    moveit_msgs::action::Place::Goal goal;
+  //    goal.group_name = opt_.group_name_;
+  //    goal.attached_object_name = object;
+  //    goal.support_surface_name = support_surface_;
+  //    goal.place_locations = std::move(locations);
+  //    if (!support_surface_.empty())
+  //      goal.allow_gripper_support_collision = true;
+  //
+  //    if (path_constraints_)
+  //      goal.path_constraints = *path_constraints_;
+  //
+  //    goal.planner_id = planner_id_;
+  //    goal.allowed_planning_time = allowed_planning_time_;
+  //
+  //    goal.planning_options.plan_only = plan_only;
+  //    goal.planning_options.look_around = can_look_;
+  //    goal.planning_options.replan = can_replan_;
+  //    goal.planning_options.replan_delay = replan_delay_;
+  //    goal.planning_options.planning_scene_diff.is_diff = true;
+  //    goal.planning_options.planning_scene_diff.robot_state.is_diff = true;
+  //    return goal;
+  //  }
 
   void setPathConstraints(const moveit_msgs::msg::Constraints& constraint)
   {
@@ -1158,19 +1198,22 @@ public:
 
   bool setPathConstraints(const std::string& constraint)
   {
-    if (constraints_storage_)
-    {
-      moveit_warehouse::ConstraintsWithMetadata msg_m;
-      if (constraints_storage_->getConstraints(msg_m, constraint, robot_model_->getName(), opt_.group_name_))
-      {
-        path_constraints_.reset(new moveit_msgs::msg::Constraints(static_cast<moveit_msgs::msg::Constraints>(*msg_m)));
-        return true;
-      }
-      else
-        return false;
-    }
-    else
-      return false;
+    // TODO(JafarAbdi): Enable once moveit_ros_warehouse is ported
+    //    if (constraints_storage_)
+    //    {
+    //
+    //      moveit_warehouse::ConstraintsWithMetadata msg_m;
+    //      if (constraints_storage_->getConstraints(msg_m, constraint, robot_model_->getName(), opt_.group_name_))
+    //      {
+    //        path_constraints_.reset(new
+    //        moveit_msgs::msg::Constraints(static_cast<moveit_msgs::msg::Constraints>(*msg_m)));
+    //        return true;
+    //      }
+    //      else
+    //        return false;
+    //    }
+    //    else
+    return false;
   }
 
   void clearPathConstraints()
@@ -1192,13 +1235,14 @@ public:
   {
     while (initializing_constraints_)
     {
-      static ros::WallDuration d(0.01);
-      d.sleep();
+      std::chrono::duration<double> d(0.01);
+      rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::nanoseconds>(d), rclcpp::Context::SharedPtr(nullptr));
     }
 
     std::vector<std::string> c;
-    if (constraints_storage_)
-      constraints_storage_->getKnownConstraints(c, robot_model_->getName(), opt_.group_name_);
+    // TODO(JafarAbdi): Enable once moveit_ros_warehouse is ported
+    //    if (constraints_storage_)
+    //      constraints_storage_->getKnownConstraints(c, robot_model_->getName(), opt_.group_name_);
 
     return c;
   }
@@ -1231,7 +1275,7 @@ public:
   void setWorkspace(double minx, double miny, double minz, double maxx, double maxy, double maxz)
   {
     workspace_parameters_.header.frame_id = getRobotModel()->getModelFrame();
-    workspace_parameters_.header.stamp = ros::Time::now();
+    workspace_parameters_.header.stamp = getClock()->now();
     workspace_parameters_.min_corner.x = minx;
     workspace_parameters_.min_corner.y = miny;
     workspace_parameters_.min_corner.z = minz;
@@ -1240,35 +1284,42 @@ public:
     workspace_parameters_.max_corner.z = maxz;
   }
 
+  rclcpp::Clock::SharedPtr getClock()
+  {
+    return node_->get_clock();
+  }
+
 private:
   void initializeConstraintsStorageThread(const std::string& host, unsigned int port)
   {
     // Set up db
-    try
-    {
-      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
-      conn->setParams(host, port);
-      if (conn->connect())
-      {
-        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
-      }
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR_NAMED(LOGNAME, "%s", ex.what());
-    }
+    // TODO(JafarAbdi): Enable once moveit_ros_warehouse is ported
+    //    try
+    //    {
+    //      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+    //      conn->setParams(host, port);
+    //      if (conn->connect())
+    //      {
+    //        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+    //      }
+    //    }
+    //    catch (std::exception& ex)
+    //    {
+    //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+    //    }
     initializing_constraints_ = false;
   }
 
   Options opt_;
-  ros::NodeHandle node_handle_;
+  rclcpp::Node::SharedPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr current_state_monitor_;
-  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::action::MoveGroupAction> > move_action_client_;
-  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::action::ExecuteTrajectoryAction> > execute_action_client_;
-  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::action::PickupAction> > pick_action_client_;
-  std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::action::PlaceAction> > place_action_client_;
+
+  std::shared_ptr<rclcpp_action::Client<moveit_msgs::action::MoveGroup>> move_action_client_;
+  // std::shared_ptr<rclcpp_action::Client<moveit_msgs::action::Pickup>> pick_action_client_;
+  // std::shared_ptr<rclcpp_action::Client<moveit_msgs::action::Place>> place_action_client_;
+  std::shared_ptr<rclcpp_action::Client<moveit_msgs::action::ExecuteTrajectory>> execute_action_client_;
 
   // general planning params
   moveit::core::RobotStatePtr considered_start_state_;
@@ -1291,7 +1342,7 @@ private:
 
   // pose goal;
   // for each link we have a set of possible goal locations;
-  std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped> > pose_targets_;
+  std::map<std::string, std::vector<geometry_msgs::msg::PoseStamped>> pose_targets_;
 
   // common properties for goals
   ActiveTargetType active_target_;
@@ -1302,43 +1353,31 @@ private:
   std::string support_surface_;
 
   // ROS communication
-  ros::Publisher trajectory_event_publisher_;
-  ros::Publisher attached_object_publisher_;
-  ros::ServiceClient query_service_;
-  ros::ServiceClient get_params_service_;
-  ros::ServiceClient set_params_service_;
-  ros::ServiceClient cartesian_path_service_;
-  ros::ServiceClient plan_grasps_service_;
-  std::unique_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr trajectory_event_publisher_;
+  rclcpp::Publisher<moveit_msgs::msg::AttachedCollisionObject>::SharedPtr attached_object_publisher_;
+  rclcpp::Client<moveit_msgs::srv::QueryPlannerInterfaces>::SharedPtr query_service_;
+  rclcpp::Client<moveit_msgs::srv::GetPlannerParams>::SharedPtr get_params_service_;
+  rclcpp::Client<moveit_msgs::srv::SetPlannerParams>::SharedPtr set_params_service_;
+  rclcpp::Client<moveit_msgs::srv::GetCartesianPath>::SharedPtr cartesian_path_service_;
+  rclcpp::Client<moveit_msgs::srv::GraspPlanning>::SharedPtr plan_grasps_service_;
+  // TODO(JafarAbdi): Enable once moveit_ros_warehouse is ported
+  // std::unique_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
   std::unique_ptr<boost::thread> constraints_init_thread_;
   bool initializing_constraints_;
 };
 
 MoveGroupInterface::MoveGroupInterface(const std::string& group_name, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                       const ros::WallDuration& wait_for_servers)
+                                       const rclcpp::Duration& wait_for_servers)
 {
-  if (!ros::ok())
+  if (!rclcpp::ok())
     throw std::runtime_error("ROS does not seem to be running");
   impl_ = new MoveGroupInterfaceImpl(Options(group_name), tf_buffer ? tf_buffer : getSharedTF(), wait_for_servers);
 }
 
-MoveGroupInterface::MoveGroupInterface(const std::string& group, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                       const ros::Duration& wait_for_servers)
-  : MoveGroupInterface(group, tf_buffer, ros::WallDuration(wait_for_servers.toSec()))
-{
-}
-
 MoveGroupInterface::MoveGroupInterface(const Options& opt, const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                       const ros::WallDuration& wait_for_servers)
+                                       const rclcpp::Duration& wait_for_servers)
 {
   impl_ = new MoveGroupInterfaceImpl(opt, tf_buffer ? tf_buffer : getSharedTF(), wait_for_servers);
-}
-
-MoveGroupInterface::MoveGroupInterface(const MoveGroupInterface::Options& opt,
-                                       const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
-                                       const ros::Duration& wait_for_servers)
-  : MoveGroupInterface(opt, tf_buffer, ros::WallDuration(wait_for_servers.toSec()))
-{
 }
 
 MoveGroupInterface::~MoveGroupInterface()
@@ -1382,9 +1421,9 @@ moveit::core::RobotModelConstPtr MoveGroupInterface::getRobotModel() const
   return impl_->getRobotModel();
 }
 
-const ros::NodeHandle& MoveGroupInterface::getNodeHandle() const
+rclcpp::Node::SharedPtr MoveGroupInterface::getNodeHandle()
 {
-  return impl_->getOptions().node_handle_;
+  return impl_->getOptions().node_;
 }
 
 bool MoveGroupInterface::getInterfaceDescription(moveit_msgs::msg::PlannerInterfaceDescription& desc) const
@@ -1439,7 +1478,7 @@ MoveItErrorCode MoveGroupInterface::asyncMove()
   return impl_->move(false);
 }
 
-actionlib::SimpleActionClient<moveit_msgs::action::MoveGroupAction>& MoveGroupInterface::getMoveGroupClient() const
+rclcpp_action::Client<moveit_msgs::action::MoveGroup>& MoveGroupInterface::getMoveGroupClient() const
 {
   return impl_->getMoveGroupClient();
 }
@@ -1454,7 +1493,7 @@ MoveItErrorCode MoveGroupInterface::asyncExecute(const Plan& plan)
   return impl_->execute(plan.trajectory_, false);
 }
 
-MoveItErrorCode MoveGroupInterface::asyncExecute(const moveit_msgs::RobotTrajectory& trajectory)
+MoveItErrorCode MoveGroupInterface::asyncExecute(const moveit_msgs::msg::RobotTrajectory& trajectory)
 {
   return impl_->execute(trajectory, false);
 }
@@ -1464,7 +1503,7 @@ MoveItErrorCode MoveGroupInterface::execute(const Plan& plan)
   return impl_->execute(plan.trajectory_, true);
 }
 
-MoveItErrorCode MoveGroupInterface::execute(const moveit_msgs::RobotTrajectory& trajectory)
+MoveItErrorCode MoveGroupInterface::execute(const moveit_msgs::msg::RobotTrajectory& trajectory)
 {
   return impl_->execute(trajectory, true);
 }
@@ -1474,44 +1513,45 @@ MoveItErrorCode MoveGroupInterface::plan(Plan& plan)
   return impl_->plan(plan);
 }
 
-moveit_msgs::action::PickupGoal MoveGroupInterface::constructPickupGoal(const std::string& object,
-                                                                        std::vector<moveit_msgs::msg::Grasp> grasps,
-                                                                        bool plan_only = false) const
-{
-  return impl_->constructPickupGoal(object, std::move(grasps), plan_only);
-}
-
-moveit_msgs::action::PlaceGoal MoveGroupInterface::constructPlaceGoal(
-    const std::string& object, std::vector<moveit_msgs::msg::PlaceLocation> locations, bool plan_only = false) const
-{
-  return impl_->constructPlaceGoal(object, std::move(locations), plan_only);
-}
-
-std::vector<moveit_msgs::msg::PlaceLocation>
-MoveGroupInterface::posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const
-{
-  return impl_->posesToPlaceLocations(poses);
-}
-
-MoveItErrorCode MoveGroupInterface::pick(const moveit_msgs::action::PickupGoal& goal)
-{
-  return impl_->pick(goal);
-}
-
-MoveItErrorCode MoveGroupInterface::planGraspsAndPick(const std::string& object, bool plan_only)
-{
-  return impl_->planGraspsAndPick(object, plan_only);
-}
-
-MoveItErrorCode MoveGroupInterface::planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool plan_only)
-{
-  return impl_->planGraspsAndPick(object, plan_only);
-}
-
-MoveItErrorCode MoveGroupInterface::place(const moveit_msgs::action::PlaceGoal& goal)
-{
-  return impl_->place(goal);
-}
+// moveit_msgs::action::Pickup::Goal MoveGroupInterface::constructPickupGoal(const std::string& object,
+//                                                                        std::vector<moveit_msgs::msg::Grasp> grasps,
+//                                                                        bool plan_only = false) const
+//{
+//  return impl_->constructPickupGoal(object, std::move(grasps), plan_only);
+//}
+//
+// moveit_msgs::action::Place::Goal MoveGroupInterface::constructPlaceGoal(
+//    const std::string& object, std::vector<moveit_msgs::msg::PlaceLocation> locations, bool plan_only = false) const
+//{
+//  return impl_->constructPlaceGoal(object, std::move(locations), plan_only);
+//}
+//
+// std::vector<moveit_msgs::msg::PlaceLocation>
+// MoveGroupInterface::posesToPlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& poses) const
+//{
+//  return impl_->posesToPlaceLocations(poses);
+//}
+//
+// MoveItErrorCode MoveGroupInterface::pick(const moveit_msgs::action::Pickup::Goal& goal)
+//{
+//  return impl_->pick(goal);
+//}
+//
+// MoveItErrorCode MoveGroupInterface::planGraspsAndPick(const std::string& object, bool plan_only)
+//{
+//  return impl_->planGraspsAndPick(object, plan_only);
+//}
+//
+// MoveItErrorCode MoveGroupInterface::planGraspsAndPick(const moveit_msgs::msg::CollisionObject& object, bool
+// plan_only)
+//{
+//  return impl_->planGraspsAndPick(object, plan_only);
+//}
+//
+// MoveItErrorCode MoveGroupInterface::place(const moveit_msgs::action::Place::Goal& goal)
+//{
+//  return impl_->place(goal);
+//}
 
 double MoveGroupInterface::computeCartesianPath(const std::vector<geometry_msgs::msg::Pose>& waypoints, double eef_step,
                                                 double jump_threshold, moveit_msgs::msg::RobotTrajectory& trajectory,
@@ -1581,7 +1621,7 @@ const std::vector<std::string>& MoveGroupInterface::getLinkNames() const
 
 std::map<std::string, double> MoveGroupInterface::getNamedTargetValues(const std::string& name) const
 {
-  std::map<std::string, std::vector<double> >::const_iterator it = remembered_joint_values_.find(name);
+  std::map<std::string, std::vector<double>>::const_iterator it = remembered_joint_values_.find(name);
   std::map<std::string, double> positions;
 
   if (it != remembered_joint_values_.cend())
@@ -1601,7 +1641,7 @@ std::map<std::string, double> MoveGroupInterface::getNamedTargetValues(const std
 
 bool MoveGroupInterface::setNamedTarget(const std::string& name)
 {
-  std::map<std::string, std::vector<double> >::const_iterator it = remembered_joint_values_.find(name);
+  std::map<std::string, std::vector<double>>::const_iterator it = remembered_joint_values_.find(name);
   if (it != remembered_joint_values_.end())
   {
     return setJointValueTarget(it->second);
@@ -1613,7 +1653,7 @@ bool MoveGroupInterface::setNamedTarget(const std::string& name)
       impl_->setTargetType(JOINT);
       return true;
     }
-    ROS_ERROR_NAMED(LOGNAME, "The requested named target '%s' does not exist", name.c_str());
+    RCLCPP_ERROR(LOGGER, "The requested named target '%s' does not exist", name.c_str());
     return false;
   }
 }
@@ -1639,8 +1679,8 @@ bool MoveGroupInterface::setJointValueTarget(const std::map<std::string, double>
   {
     if (std::find(allowed.begin(), allowed.end(), pair.first) == allowed.end())
     {
-      ROS_ERROR_STREAM("joint variable " << pair.first << " is not part of group "
-                                         << impl_->getJointModelGroup()->getName());
+      RCLCPP_ERROR_STREAM(LOGGER, "joint variable " << pair.first << " is not part of group "
+                                                    << impl_->getJointModelGroup()->getName());
       return false;
     }
   }
@@ -1658,8 +1698,8 @@ bool MoveGroupInterface::setJointValueTarget(const std::vector<std::string>& var
   {
     if (std::find(allowed.begin(), allowed.end(), variable_name) == allowed.end())
     {
-      ROS_ERROR_STREAM("joint variable " << variable_name << " is not part of group "
-                                         << impl_->getJointModelGroup()->getName());
+      RCLCPP_ERROR_STREAM(LOGGER, "joint variable " << variable_name << " is not part of group "
+                                                    << impl_->getJointModelGroup()->getName());
       return false;
     }
   }
@@ -1692,7 +1732,8 @@ bool MoveGroupInterface::setJointValueTarget(const std::string& joint_name, cons
     return impl_->getTargetRobotState().satisfiesBounds(jm, impl_->getGoalJointTolerance());
   }
 
-  ROS_ERROR_STREAM("joint " << joint_name << " is not part of group " << impl_->getJointModelGroup()->getName());
+  RCLCPP_ERROR_STREAM(LOGGER, "joint " << joint_name << " is not part of group "
+                                       << impl_->getJointModelGroup()->getName());
   return false;
 }
 
@@ -1790,7 +1831,7 @@ bool MoveGroupInterface::setPoseTarget(const Eigen::Isometry3d& pose, const std:
   std::vector<geometry_msgs::msg::PoseStamped> pose_msg(1);
   pose_msg[0].pose = tf2::toMsg(pose);
   pose_msg[0].header.frame_id = getPoseReferenceFrame();
-  pose_msg[0].header.stamp = ros::Time::now();
+  pose_msg[0].header.stamp = impl_->getClock()->now();
   return setPoseTargets(pose_msg, end_effector_link);
 }
 
@@ -1799,7 +1840,7 @@ bool MoveGroupInterface::setPoseTarget(const geometry_msgs::msg::Pose& target, c
   std::vector<geometry_msgs::msg::PoseStamped> pose_msg(1);
   pose_msg[0].pose = target;
   pose_msg[0].header.frame_id = getPoseReferenceFrame();
-  pose_msg[0].header.stamp = ros::Time::now();
+  pose_msg[0].header.stamp = impl_->getClock()->now();
   return setPoseTargets(pose_msg, end_effector_link);
 }
 
@@ -1813,7 +1854,7 @@ bool MoveGroupInterface::setPoseTarget(const geometry_msgs::msg::PoseStamped& ta
 bool MoveGroupInterface::setPoseTargets(const EigenSTL::vector_Isometry3d& target, const std::string& end_effector_link)
 {
   std::vector<geometry_msgs::msg::PoseStamped> pose_out(target.size());
-  ros::Time tm = ros::Time::now();
+  rclcpp::Time tm = impl_->getClock()->now();
   const std::string& frame_id = getPoseReferenceFrame();
   for (std::size_t i = 0; i < target.size(); ++i)
   {
@@ -1828,7 +1869,7 @@ bool MoveGroupInterface::setPoseTargets(const std::vector<geometry_msgs::msg::Po
                                         const std::string& end_effector_link)
 {
   std::vector<geometry_msgs::msg::PoseStamped> target_stamped(target.size());
-  ros::Time tm = ros::Time::now();
+  rclcpp::Time tm = impl_->getClock()->now();
   const std::string& frame_id = getPoseReferenceFrame();
   for (std::size_t i = 0; i < target.size(); ++i)
   {
@@ -1844,7 +1885,7 @@ bool MoveGroupInterface::setPoseTargets(const std::vector<geometry_msgs::msg::Po
 {
   if (target.empty())
   {
-    ROS_ERROR_NAMED(LOGNAME, "No pose specified as goal target");
+    RCLCPP_ERROR(LOGGER, "No pose specified as goal target");
     return false;
   }
   else
@@ -1875,7 +1916,7 @@ inline void transformPose(const tf2_ros::Buffer& tf_buffer, const std::string& d
     geometry_msgs::msg::PoseStamped target_in(target);
     tf_buffer.transform(target_in, target, desired_frame);
     // we leave the stamp to ros::Time(0) on purpose
-    target.header.stamp = ros::Time(0);
+    target.header.stamp = rclcpp::Time(0);
   }
 }
 }  // namespace
@@ -2033,7 +2074,7 @@ geometry_msgs::msg::PoseStamped MoveGroupInterface::getRandomPose(const std::str
   Eigen::Isometry3d pose;
   pose.setIdentity();
   if (eef.empty())
-    ROS_ERROR_NAMED(LOGNAME, "No end-effector specified");
+    RCLCPP_ERROR(LOGGER, "No end-effector specified");
   else
   {
     moveit::core::RobotStatePtr current_state;
@@ -2046,7 +2087,7 @@ geometry_msgs::msg::PoseStamped MoveGroupInterface::getRandomPose(const std::str
     }
   }
   geometry_msgs::msg::PoseStamped pose_msg;
-  pose_msg.header.stamp = ros::Time::now();
+  pose_msg.header.stamp = impl_->getClock()->now();
   pose_msg.header.frame_id = impl_->getRobotModel()->getModelFrame();
   pose_msg.pose = tf2::toMsg(pose);
   return pose_msg;
@@ -2058,7 +2099,7 @@ geometry_msgs::msg::PoseStamped MoveGroupInterface::getCurrentPose(const std::st
   Eigen::Isometry3d pose;
   pose.setIdentity();
   if (eef.empty())
-    ROS_ERROR_NAMED(LOGNAME, "No end-effector specified");
+    RCLCPP_ERROR(LOGGER, "No end-effector specified");
   else
   {
     moveit::core::RobotStatePtr current_state;
@@ -2070,7 +2111,7 @@ geometry_msgs::msg::PoseStamped MoveGroupInterface::getCurrentPose(const std::st
     }
   }
   geometry_msgs::msg::PoseStamped pose_msg;
-  pose_msg.header.stamp = ros::Time::now();
+  pose_msg.header.stamp = impl_->getClock()->now();
   pose_msg.header.frame_id = impl_->getRobotModel()->getModelFrame();
   pose_msg.pose = tf2::toMsg(pose);
   return pose_msg;
@@ -2081,7 +2122,7 @@ std::vector<double> MoveGroupInterface::getCurrentRPY(const std::string& end_eff
   std::vector<double> result;
   const std::string& eef = end_effector_link.empty() ? getEndEffectorLink() : end_effector_link;
   if (eef.empty())
-    ROS_ERROR_NAMED(LOGNAME, "No end-effector specified");
+    RCLCPP_ERROR(LOGGER, "No end-effector specified");
   else
   {
     moveit::core::RobotStatePtr current_state;
@@ -2091,9 +2132,9 @@ std::vector<double> MoveGroupInterface::getCurrentRPY(const std::string& end_eff
       if (lm)
       {
         result.resize(3);
-        geometry_msgs::TransformStamped tfs = tf2::eigenToTransform(current_state->getGlobalLinkTransform(lm));
+        geometry_msgs::msg::TransformStamped tfs = tf2::eigenToTransform(current_state->getGlobalLinkTransform(lm));
         double pitch, roll, yaw;
-        tf2::getEulerYPR<geometry_msgs::Quaternion>(tfs.transform.rotation, yaw, pitch, roll);
+        tf2::getEulerYPR<geometry_msgs::msg::Quaternion>(tfs.transform.rotation, yaw, pitch, roll);
         result[0] = roll;
         result[1] = pitch;
         result[2] = yaw;

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -23,8 +23,7 @@
   <depend>moveit_ros_planning</depend>
   <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_warehouse -->
   <!--depend>moveit_ros_warehouse</depend-->
-  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_move_group -->
-  <!-- depend>moveit_ros_move_group</depend-->
+  <depend>moveit_ros_move_group</depend>
   <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_manipulation -->
   <!--depend>moveit_ros_manipulation</depend-->
   <depend>rclcpp</depend>

--- a/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
@@ -1,26 +1,26 @@
 set(MOVEIT_LIB_NAME moveit_planning_scene_interface)
 
-add_library(${MOVEIT_LIB_NAME} src/planning_scene_interface.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/planning_scene_interface.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_common_planning_interface_objects ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME} moveit_msgs moveit_core moveit_ros_move_group)
 
-add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_planning_scene_interface.cpp)
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_py_bindings_tools)
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_planning_scene_interface PREFIX "")
-set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}")
+# TODO(JafarAbdi): Support python wrapper
+#add_library(${MOVEIT_LIB_NAME}_python src/wrap_python_planning_scene_interface.cpp)
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+#target_link_libraries(${MOVEIT_LIB_NAME}_python ${MOVEIT_LIB_NAME} ${PYTHON_LIBRARIES} ${LIBS} ${Boost_LIBRARIES} moveit_py_bindings_tools)
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES OUTPUT_NAME _moveit_planning_scene_interface PREFIX "")
+#set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES LIBRARY_OUTPUT_DIRECTORY "bin")
 if(WIN32)
-  set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES SUFFIX .pyd)
-endif()
+#  set_target_properties(${MOVEIT_LIB_NAME}_python PROPERTIES SUFFIX .pyd)
+endif(WIN32)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
+  EXPORT ${MOVEIT_LIB_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 
-install(TARGETS ${MOVEIT_LIB_NAME}_python
-  DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
+#install(TARGETS ${MOVEIT_LIB_NAME}_python
+#  DESTINATION bin)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION planning_scene_interface/include)

--- a/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -40,7 +40,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/msg/object_color.hpp>
 #include <moveit_msgs/msg/collision_object.hpp>
-#include <moveit_msgs/AttachedCollisionObject.h>
+#include <moveit_msgs/msg/attached_collision_object.hpp>
 #include <moveit_msgs/msg/planning_scene.hpp>
 
 namespace moveit
@@ -86,7 +86,7 @@ public:
   };
 
   /** \brief Get the poses from the objects identified by the given object ids list. */
-  std::map<std::string, geometry_msgs::Pose> getObjectPoses(const std::vector<std::string>& object_ids);
+  std::map<std::string, geometry_msgs::msg::Pose> getObjectPoses(const std::vector<std::string>& object_ids);
 
   /** \brief Get the objects identified by the given object ids list. If no ids are provided, return all the known
    * objects. */
@@ -105,7 +105,7 @@ public:
   /** \brief Apply collision object to the planning scene of the move_group node synchronously.
       Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene */
   bool applyCollisionObject(const moveit_msgs::msg::CollisionObject& collision_object,
-                            const std_msgs::ColorRGBA& object_color);
+                            const std_msgs::msg::ColorRGBA& object_color);
 
   /** \brief Apply collision objects to the planning scene of the move_group node synchronously.
       Other PlanningSceneMonitors will NOT receive the update unless they subscribe to move_group's monitored scene.

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -36,60 +36,57 @@
 
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/move_group/capability_names.h>
-#include <moveit_msgs/msg/get_planning_scene.h>
-#include <moveit_msgs/msg/apply_planning_scene.h>
-#include <ros/ros.h>
+#include <moveit_msgs/srv/get_planning_scene.hpp>
+#include <moveit_msgs/srv/apply_planning_scene.hpp>
 #include <algorithm>
 
 namespace moveit
 {
 namespace planning_interface
 {
-static const std::string LOGNAME = "planning_scene_interface";
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_interface.planning_scene_interface");
 
 class PlanningSceneInterface::PlanningSceneInterfaceImpl
 {
 public:
-  explicit PlanningSceneInterfaceImpl(const std::string& ns = "", bool wait = true)
+  explicit PlanningSceneInterfaceImpl(const std::string& ns = "", bool wait = true) : node_(new rclcpp::Node(ns))
   {
-    node_handle_ = ros::NodeHandle(ns);
-    planning_scene_diff_publisher_ = node_handle_.advertise<moveit_msgs::msg::PlanningScene>("planning_scene", 1);
+    planning_scene_diff_publisher_ = node_->create_publisher<moveit_msgs::msg::PlanningScene>("planning_scene", 1);
     planning_scene_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::GetPlanningScene>(move_group::GET_PLANNING_SCENE_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::GetPlanningScene>(move_group::GET_PLANNING_SCENE_SERVICE_NAME);
     apply_planning_scene_service_ =
-        node_handle_.serviceClient<moveit_msgs::srv::ApplyPlanningScene>(move_group::APPLY_PLANNING_SCENE_SERVICE_NAME);
+        node_->create_client<moveit_msgs::srv::ApplyPlanningScene>(move_group::APPLY_PLANNING_SCENE_SERVICE_NAME);
 
     if (wait)
     {
-      waitForService(planning_scene_service_);
-      waitForService(apply_planning_scene_service_);
-    }
-    else
-    {
-      if (!planning_scene_service_.exists() || !apply_planning_scene_service_.exists())
-      {
-        throw std::runtime_error("ROS services not available");
-      }
+      waitForService(std::static_pointer_cast<rclcpp::ClientBase>(planning_scene_service_));
+      waitForService(std::static_pointer_cast<rclcpp::ClientBase>(apply_planning_scene_service_));
     }
   }
 
   std::vector<std::string> getKnownObjectNames(bool with_type)
   {
-    moveit_msgs::srv::GetPlanningScene::Request request;
-    moveit_msgs::srv::GetPlanningScene::Response response;
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    moveit_msgs::srv::GetPlanningScene::Response::SharedPtr response;
     std::vector<std::string> result;
-    request.components.components = request.components.WORLD_OBJECT_NAMES;
-    if (!planning_scene_service_.call(request, response))
+    request->components.components = request->components.WORLD_OBJECT_NAMES;
+
+    auto res = planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) != rclcpp::executor::FutureReturnCode::SUCCESS)
+    {
       return result;
+    }
+    response = res.get();
+
     if (with_type)
     {
-      for (const moveit_msgs::msg::CollisionObject& collision_object : response.scene.world.collision_objects)
+      for (const moveit_msgs::msg::CollisionObject& collision_object : response->scene.world.collision_objects)
         if (!collision_object.type.key.empty())
           result.push_back(collision_object.id);
     }
     else
     {
-      for (const moveit_msgs::msg::CollisionObject& collision_object : response.scene.world.collision_objects)
+      for (const moveit_msgs::msg::CollisionObject& collision_object : response->scene.world.collision_objects)
         result.push_back(collision_object.id);
     }
     return result;
@@ -98,17 +95,20 @@ public:
   std::vector<std::string> getKnownObjectNamesInROI(double minx, double miny, double minz, double maxx, double maxy,
                                                     double maxz, bool with_type, std::vector<std::string>& types)
   {
-    moveit_msgs::srv::GetPlanningScene::Request request;
-    moveit_msgs::srv::GetPlanningScene::Response response;
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    moveit_msgs::srv::GetPlanningScene::Response::SharedPtr response;
     std::vector<std::string> result;
-    request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
-    if (!planning_scene_service_.call(request, response))
+    request->components.components = request->components.WORLD_OBJECT_GEOMETRY;
+
+    auto res = planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) != rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object names");
+      RCLCPP_WARN(LOGGER, "Could not call planning scene service to get object names");
       return result;
     }
+    response = res.get();
 
-    for (const moveit_msgs::msg::CollisionObject& collision_object : response.scene.world.collision_objects)
+    for (const moveit_msgs::msg::CollisionObject& collision_object : response->scene.world.collision_objects)
     {
       if (with_type && collision_object.type.key.empty())
         continue;
@@ -142,44 +142,50 @@ public:
 
   std::map<std::string, geometry_msgs::msg::Pose> getObjectPoses(const std::vector<std::string>& object_ids)
   {
-    moveit_msgs::srv::GetPlanningScene::Request request;
-    moveit_msgs::srv::GetPlanningScene::Response response;
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    moveit_msgs::srv::GetPlanningScene::Response::SharedPtr response;
     std::map<std::string, geometry_msgs::msg::Pose> result;
-    request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
-    if (!planning_scene_service_.call(request, response))
-    {
-      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object names");
-      return result;
-    }
+    request->components.components = request->components.WORLD_OBJECT_GEOMETRY;
 
-    for (const moveit_msgs::msg::CollisionObject& collision_object : response.scene.world.collision_objects)
+    auto res = planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) == rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      if (std::find(object_ids.begin(), object_ids.end(), collision_object.id) != object_ids.end())
+      response = res.get();
+      for (const moveit_msgs::msg::CollisionObject& collision_object : response->scene.world.collision_objects)
       {
-        if (collision_object.mesh_poses.empty() && collision_object.primitive_poses.empty())
-          continue;
-        if (!collision_object.mesh_poses.empty())
-          result[collision_object.id] = collision_object.mesh_poses[0];
-        else
-          result[collision_object.id] = collision_object.primitive_poses[0];
+        if (std::find(object_ids.begin(), object_ids.end(), collision_object.id) != object_ids.end())
+        {
+          if (collision_object.mesh_poses.empty() && collision_object.primitive_poses.empty())
+            continue;
+          if (!collision_object.mesh_poses.empty())
+            result[collision_object.id] = collision_object.mesh_poses[0];
+          else
+            result[collision_object.id] = collision_object.primitive_poses[0];
+        }
       }
     }
+    else
+      RCLCPP_WARN(LOGGER, "Could not call planning scene service to get object names");
+
     return result;
   }
 
   std::map<std::string, moveit_msgs::msg::CollisionObject> getObjects(const std::vector<std::string>& object_ids)
   {
-    moveit_msgs::srv::GetPlanningScene::Request request;
-    moveit_msgs::srv::GetPlanningScene::Response response;
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    moveit_msgs::srv::GetPlanningScene::Response::SharedPtr response;
     std::map<std::string, moveit_msgs::msg::CollisionObject> result;
-    request.components.components = request.components.WORLD_OBJECT_GEOMETRY;
-    if (!planning_scene_service_.call(request, response))
+    request->components.components = request->components.WORLD_OBJECT_GEOMETRY;
+
+    auto res = planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) != rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get object geometries");
+      RCLCPP_WARN(LOGGER, "Could not call planning scene service to get object geometries");
       return result;
     }
+    response = res.get();
 
-    for (const moveit_msgs::msg::CollisionObject& collision_object : response.scene.world.collision_objects)
+    for (const moveit_msgs::msg::CollisionObject& collision_object : response->scene.world.collision_objects)
     {
       if (object_ids.empty() ||
           std::find(object_ids.begin(), object_ids.end(), collision_object.id) != object_ids.end())
@@ -193,18 +199,21 @@ public:
   std::map<std::string, moveit_msgs::msg::AttachedCollisionObject>
   getAttachedObjects(const std::vector<std::string>& object_ids)
   {
-    moveit_msgs::srv::GetPlanningScene::Request request;
-    moveit_msgs::srv::GetPlanningScene::Response response;
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    moveit_msgs::srv::GetPlanningScene::Response::SharedPtr response;
     std::map<std::string, moveit_msgs::msg::AttachedCollisionObject> result;
-    request.components.components = request.components.ROBOT_STATE_ATTACHED_OBJECTS;
-    if (!planning_scene_service_.call(request, response))
+    request->components.components = request->components.ROBOT_STATE_ATTACHED_OBJECTS;
+
+    auto res = planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) != rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      ROS_WARN_NAMED(LOGNAME, "Could not call planning scene service to get attached object geometries");
+      RCLCPP_WARN(LOGGER, "Could not call planning scene service to get attached object geometries");
       return result;
     }
+    response = res.get();
 
     for (const moveit_msgs::msg::AttachedCollisionObject& attached_collision_object :
-         response.scene.robot_state.attached_collision_objects)
+         response->scene.robot_state.attached_collision_objects)
     {
       if (object_ids.empty() ||
           std::find(object_ids.begin(), object_ids.end(), attached_collision_object.object.id) != object_ids.end())
@@ -217,15 +226,17 @@ public:
 
   bool applyPlanningScene(const moveit_msgs::msg::PlanningScene& planning_scene)
   {
-    moveit_msgs::srv::ApplyPlanningScene::Request request;
-    moveit_msgs::srv::ApplyPlanningScene::Response response;
-    request.scene = planning_scene;
-    if (!apply_planning_scene_service_.call(request, response))
+    auto request = std::make_shared<moveit_msgs::srv::ApplyPlanningScene::Request>();
+    moveit_msgs::srv::ApplyPlanningScene::Response::SharedPtr response;
+    request->scene = planning_scene;
+
+    auto res = apply_planning_scene_service_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(node_, res) != rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      ROS_WARN_NAMED(LOGNAME, "Failed to call ApplyPlanningScene service");
-      return false;
+      RCLCPP_WARN(LOGGER, "Failed to call ApplyPlanningScene service");
     }
-    return response.success;
+    response = res.get();
+    return response->success;
   }
 
   void addCollisionObjects(const std::vector<moveit_msgs::msg::CollisionObject>& collision_objects,
@@ -244,7 +255,7 @@ public:
     }
 
     planning_scene.is_diff = true;
-    planning_scene_diff_publisher_.publish(planning_scene);
+    planning_scene_diff_publisher_->publish(planning_scene);
   }
 
   void removeCollisionObjects(const std::vector<std::string>& object_ids) const
@@ -258,25 +269,27 @@ public:
       planning_scene.world.collision_objects.push_back(object);
     }
     planning_scene.is_diff = true;
-    planning_scene_diff_publisher_.publish(planning_scene);
+    planning_scene_diff_publisher_->publish(planning_scene);
   }
 
 private:
-  void waitForService(ros::ServiceClient& srv)
+  void waitForService(std::shared_ptr<rclcpp::ClientBase> srv)
   {
-    ros::Duration time_before_warning(5.0);
-    srv.waitForExistence(time_before_warning);
-    if (!srv.exists())
+    // rclcpp::Duration time_before_warning(5.0);
+    // srv.waitForExistence(time_before_warning);
+    std::chrono::duration<double> d(5.0);
+    srv->wait_for_service(std::chrono::duration_cast<std::chrono::nanoseconds>(d));
+    if (!srv->service_is_ready())
     {
-      ROS_WARN_STREAM_NAMED(LOGNAME, "service '" << srv.getService() << "' not advertised yet. Continue waiting...");
-      srv.waitForExistence();
+      RCLCPP_WARN_STREAM(LOGGER, "service '" << srv->get_service_name() << "' not advertised yet. Continue waiting...");
+      srv->wait_for_service();
     }
   }
 
-  ros::NodeHandle node_handle_;
-  ros::ServiceClient planning_scene_service_;
-  ros::ServiceClient apply_planning_scene_service_;
-  ros::Publisher planning_scene_diff_publisher_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Client<moveit_msgs::srv::GetPlanningScene>::SharedPtr planning_scene_service_;
+  rclcpp::Client<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr apply_planning_scene_service_;
+  rclcpp::Publisher<moveit_msgs::msg::PlanningScene>::SharedPtr planning_scene_diff_publisher_;
   moveit::core::RobotModelConstPtr robot_model_;
 };
 

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -31,11 +31,12 @@ find_package(octomap_msgs REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 # TODO(JafarAbdi): Uncomment when porting each package
 # find_package(moveit_ros_perception REQUIRED)
-# find_package(moveit_ros_robot_interaction REQUIRED)
+find_package(moveit_ros_robot_interaction REQUIRED)
 # find_package(moveit_ros_warehouse REQUIRED)
 find_package(object_recognition_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(rviz2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
@@ -62,19 +63,19 @@ add_definitions(-DQT_NO_KEYWORDS)
 include_directories(rviz_plugin_render_tools/include
                     robot_state_rviz_plugin/include
                     planning_scene_rviz_plugin/include
-                    #motion_planning_rviz_plugin/include
+                    motion_planning_rviz_plugin/include
                     trajectory_rviz_plugin/include
 )
 
 add_subdirectory(rviz_plugin_render_tools)
 add_subdirectory(robot_state_rviz_plugin)
 add_subdirectory(planning_scene_rviz_plugin)
-# add_subdirectory(motion_planning_rviz_plugin)
+add_subdirectory(motion_planning_rviz_plugin)
 add_subdirectory(trajectory_rviz_plugin)
 
 install(DIRECTORY icons DESTINATION share/${PROJECT_NAME})
 
-#pluginlib_export_plugin_description_file(rviz_common motion_planning_rviz_plugin_description.xml)
+pluginlib_export_plugin_description_file(rviz_common motion_planning_rviz_plugin_description.xml)
 pluginlib_export_plugin_description_file(rviz_common trajectory_rviz_plugin_description.xml)
 pluginlib_export_plugin_description_file(rviz_common planning_scene_rviz_plugin_description.xml)
 pluginlib_export_plugin_description_file(rviz_common robot_state_rviz_plugin_description.xml)
@@ -92,9 +93,11 @@ ament_export_dependencies(moveit_ros_planning_interface)
 ament_export_dependencies(moveit_msgs)
 ament_export_dependencies(moveit_core)
 ament_export_dependencies(octomap_msgs)
+ament_export_dependencies(moveit_ros_robot_interaction)
 ament_export_dependencies(object_recognition_msgs)
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(rclcpp)
+ament_export_dependencies(rclcpp_action)
 ament_export_dependencies(rclpy)
 ament_export_dependencies(rviz2)
 ament_export_dependencies(tf2_eigen)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -4,7 +4,7 @@ set(HEADERS
   include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
   include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
 )
-qt_wrap_ui(UIC_FILES
+qt5_wrap_ui(UIC_FILES
   src/ui/motion_planning_rviz_plugin_frame.ui
   src/ui/motion_planning_rviz_plugin_frame_joints.ui
 )
@@ -27,20 +27,36 @@ set(SOURCE_FILES
 )
 
 set(MOVEIT_LIB_NAME moveit_motion_planning_rviz_plugin)
-add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${HEADERS} ${UIC_FILES})
+add_library(${MOVEIT_LIB_NAME}_core SHARED ${SOURCE_FILES} ${HEADERS} ${UIC_FILES})
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core
-  moveit_rviz_plugin_render_tools
-  moveit_planning_scene_rviz_plugin_core
-  ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools moveit_planning_scene_rviz_plugin)
+ament_target_dependencies(${MOVEIT_LIB_NAME}_core
+  Boost
+  moveit_ros_robot_interaction
+  moveit_ros_planning_interface
+  rviz2
+  rviz_ogre_vendor
+  Qt5
+  pluginlib
+)
 
-add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  Boost
+  moveit_ros_robot_interaction
+  pluginlib
+)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+ament_export_libraries(
+  ${MOVEIT_LIB_NAME}_core
+  ${MOVEIT_LIB_NAME}
+)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -36,8 +36,8 @@
 
 #pragma once
 
-#include <rviz/display.h>
-#include <rviz/panel_dock_widget.h>
+#include <rviz_common/display.hpp>
+#include <rviz_common/panel_dock_widget.hpp>
 #include <moveit/planning_scene_rviz_plugin/planning_scene_display.h>
 #include <moveit/rviz_plugin_render_tools/trajectory_visualization.h>
 
@@ -50,9 +50,9 @@
 #include <moveit/kinematics_metrics/kinematics_metrics.h>
 #include <moveit/dynamics_solver/dynamics_solver.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <std_msgs/String.h>
+#include <std_msgs/msg/string.hpp>
 #include <moveit_msgs/msg/display_trajectory.hpp>
 #endif
 
@@ -63,10 +63,16 @@ namespace Ogre
 class SceneNode;
 }
 
-namespace rviz
+namespace rviz_rendering
 {
-class Robot;
 class Shape;
+class MovableText;
+}
+
+namespace rviz_common
+{
+namespace properties
+{
 class Property;
 class StringProperty;
 class BoolProperty;
@@ -75,7 +81,16 @@ class RosTopicProperty;
 class EditableEnumProperty;
 class ColorProperty;
 class MovableText;
-}  // namespace rviz
+}  // namespace properties
+}  // namespace rviz_common
+
+namespace rviz_default_plugins
+{
+namespace robot
+{
+class Robot;
+}
+}
 
 namespace moveit_rviz_plugin
 {
@@ -88,13 +103,11 @@ public:
 
   ~MotionPlanningDisplay() override;
 
-  void load(const rviz::Config& config) override;
-  void save(rviz::Config config) const override;
+  void load(const rviz_common::Config& config) override;
+  void save(rviz_common::Config config) const override;
 
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
-
-  void setName(const QString& name) override;
 
   moveit::core::RobotStateConstPtr getQueryStartState() const
   {
@@ -143,8 +156,8 @@ public:
 
   // Pick Place
   void clearPlaceLocationsDisplay();
-  void visualizePlaceLocations(const std::vector<geometry_msgs::PoseStamped>& place_poses);
-  std::vector<std::shared_ptr<rviz::Shape> > place_locations_display_;
+  void visualizePlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& place_poses);
+  std::vector<std::shared_ptr<rviz_rendering::Shape> > place_locations_display_;
 
   std::string getCurrentPlanningGroup() const;
 
@@ -232,7 +245,7 @@ protected:
   void setQueryStateHelper(bool use_start_state, const std::string& v);
   void populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
-  void selectPlanningGroupCallback(const std_msgs::StringConstPtr& msg);
+  void selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg);
 
   // overrides from Display
   void onInitialize() override;
@@ -245,17 +258,16 @@ protected:
 
   Ogre::SceneNode* text_display_scene_node_;  ///< displays texts
   bool text_display_for_start_;               ///< indicates whether the text display is for the start state or not
-  rviz::MovableText* text_to_display_;
+  rviz_rendering::MovableText* text_to_display_;
 
-  ros::Subscriber planning_group_sub_;
-  ros::NodeHandle private_handle_, node_handle_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr planning_group_sub_;
 
   // render the workspace box
-  std::unique_ptr<rviz::Shape> workspace_box_;
+  std::unique_ptr<rviz_rendering::Shape> workspace_box_;
 
   // the planning frame
   MotionPlanningFrame* frame_;
-  rviz::PanelDockWidget* frame_dock_;
+  rviz_common::PanelDockWidget* frame_dock_;
 
   // robot interaction
   robot_interaction::RobotInteractionPtr robot_interaction_;
@@ -287,30 +299,30 @@ protected:
   TrajectoryVisualizationPtr trajectory_visual_;
 
   // properties to show on side panel
-  rviz::Property* path_category_;
-  rviz::Property* plan_category_;
-  rviz::Property* metrics_category_;
+  rviz_common::properties::Property* path_category_;
+  rviz_common::properties::Property* plan_category_;
+  rviz_common::properties::Property* metrics_category_;
 
-  rviz::EditableEnumProperty* planning_group_property_;
-  rviz::BoolProperty* query_start_state_property_;
-  rviz::BoolProperty* query_goal_state_property_;
-  rviz::FloatProperty* query_marker_scale_property_;
-  rviz::ColorProperty* query_start_color_property_;
-  rviz::ColorProperty* query_goal_color_property_;
-  rviz::FloatProperty* query_start_alpha_property_;
-  rviz::FloatProperty* query_goal_alpha_property_;
-  rviz::ColorProperty* query_colliding_link_color_property_;
-  rviz::ColorProperty* query_outside_joint_limits_link_color_property_;
+  rviz_common::properties::EditableEnumProperty* planning_group_property_;
+  rviz_common::properties::BoolProperty* query_start_state_property_;
+  rviz_common::properties::BoolProperty* query_goal_state_property_;
+  rviz_common::properties::FloatProperty* query_marker_scale_property_;
+  rviz_common::properties::ColorProperty* query_start_color_property_;
+  rviz_common::properties::ColorProperty* query_goal_color_property_;
+  rviz_common::properties::FloatProperty* query_start_alpha_property_;
+  rviz_common::properties::FloatProperty* query_goal_alpha_property_;
+  rviz_common::properties::ColorProperty* query_colliding_link_color_property_;
+  rviz_common::properties::ColorProperty* query_outside_joint_limits_link_color_property_;
 
-  rviz::BoolProperty* compute_weight_limit_property_;
-  rviz::BoolProperty* show_manipulability_index_property_;
-  rviz::BoolProperty* show_manipulability_property_;
-  rviz::BoolProperty* show_joint_torques_property_;
-  rviz::FloatProperty* metrics_set_payload_property_;
-  rviz::FloatProperty* metrics_text_height_property_;
-  rviz::BoolProperty* show_workspace_property_;
+  rviz_common::properties::BoolProperty* compute_weight_limit_property_;
+  rviz_common::properties::BoolProperty* show_manipulability_index_property_;
+  rviz_common::properties::BoolProperty* show_manipulability_property_;
+  rviz_common::properties::BoolProperty* show_joint_torques_property_;
+  rviz_common::properties::FloatProperty* metrics_set_payload_property_;
+  rviz_common::properties::FloatProperty* metrics_text_height_property_;
+  rviz_common::properties::BoolProperty* show_workspace_property_;
 
-  rviz::Display* int_marker_display_;
+  rviz_common::Display* int_marker_display_;
 };
 
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
@@ -40,7 +40,7 @@
 #include <moveit/macros/diagnostics.h>
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/properties/property_tree_widget.h>
+#include <rviz_common/properties/property_tree_widget.hpp>
 DIAGNOSTIC_POP
 
 namespace moveit
@@ -53,7 +53,7 @@ MOVEIT_CLASS_FORWARD(MoveGroupInterface)
 
 namespace moveit_rviz_plugin
 {
-class MotionPlanningParamWidget : public rviz::PropertyTreeWidget
+class MotionPlanningParamWidget : public rviz_common::properties::PropertyTreeWidget
 {
   Q_OBJECT
 public:
@@ -71,10 +71,10 @@ private Q_SLOTS:
   void changedValue();
 
 private:
-  rviz::Property* createPropertyTree();
+  rviz_common::properties::Property* createPropertyTree();
 
 private:
-  rviz::PropertyTreeModel* property_tree_model_;
+  rviz_common::properties::PropertyTreeModel* property_tree_model_;
 
   moveit::planning_interface::MoveGroupInterfacePtr move_group_;
   std::string group_name_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -42,27 +42,27 @@
 
 DIAGNOSTIC_PUSH
 SILENT_UNUSED_PARAM
-#include <rviz/visualization_manager.h>
-#include <rviz/robot/robot.h>
-#include <rviz/robot/robot_link.h>
+#include <rviz_default_plugins/robot/robot.hpp>
+#include <rviz_default_plugins/robot/robot_link.hpp>
+#include <rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp>
 
-#include <rviz/properties/property.h>
-#include <rviz/properties/string_property.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/editable_enum_property.h>
-#include <rviz/properties/color_property.h>
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
-#include <rviz/panel_dock_widget.h>
-#include <rviz/window_manager_interface.h>
-#include <rviz/display_factory.h>
-#include <rviz/ogre_helpers/movable_text.h>
+#include <rviz_common/properties/property.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/editable_enum_property.hpp>
+#include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
+#include <rviz_common/panel_dock_widget.hpp>
+#include <rviz_common/window_manager_interface.hpp>
+#include <rviz_common/display.hpp>
+#include <rviz_rendering/objects/movable_text.hpp>
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <rviz/ogre_helpers/shape.h>
+#include <rviz_rendering/objects/shape.hpp>
 DIAGNOSTIC_POP
 
 #include <moveit/robot_state/conversions.h>
@@ -71,21 +71,22 @@ DIAGNOSTIC_POP
 #include <boost/format.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <QShortcut>
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
+#include <moveit/utils/rclcpp_utils.h>
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_display");
+
 // ******************************************************************************************
 // Base class contructor
 // ******************************************************************************************
 MotionPlanningDisplay::MotionPlanningDisplay()
   : PlanningSceneDisplay()
   , text_to_display_(nullptr)
-  , private_handle_("~")
   , frame_(nullptr)
   , frame_dock_(nullptr)
   , menu_handler_start_(new interactive_markers::MenuHandler)
@@ -93,83 +94,84 @@ MotionPlanningDisplay::MotionPlanningDisplay()
   , int_marker_display_(nullptr)
 {
   // Category Groups
-  plan_category_ = new rviz::Property("Planning Request", QVariant(), "", this);
-  metrics_category_ = new rviz::Property("Planning Metrics", QVariant(), "", this);
-  path_category_ = new rviz::Property("Planned Path", QVariant(), "", this);
+  plan_category_ = new rviz_common::properties::Property("Planning Request", QVariant(), "", this);
+  metrics_category_ = new rviz_common::properties::Property("Planning Metrics", QVariant(), "", this);
+  path_category_ = new rviz_common::properties::Property("Planned Path", QVariant(), "", this);
 
   // Metrics category -----------------------------------------------------------------------------------------
-  compute_weight_limit_property_ = new rviz::BoolProperty(
+  compute_weight_limit_property_ = new rviz_common::properties::BoolProperty(
       "Show Weight Limit", false, "Shows the weight limit at a particular pose for an end-effector", metrics_category_,
       SLOT(changedShowWeightLimit()), this);
 
-  show_manipulability_index_property_ =
-      new rviz::BoolProperty("Show Manipulability Index", false, "Shows the manipulability index for an end-effector",
-                             metrics_category_, SLOT(changedShowManipulabilityIndex()), this);
+  show_manipulability_index_property_ = new rviz_common::properties::BoolProperty(
+      "Show Manipulability Index", false, "Shows the manipulability index for an end-effector", metrics_category_,
+      SLOT(changedShowManipulabilityIndex()), this);
 
-  show_manipulability_property_ =
-      new rviz::BoolProperty("Show Manipulability", false, "Shows the manipulability for an end-effector",
-                             metrics_category_, SLOT(changedShowManipulability()), this);
+  show_manipulability_property_ = new rviz_common::properties::BoolProperty(
+      "Show Manipulability", false, "Shows the manipulability for an end-effector", metrics_category_,
+      SLOT(changedShowManipulability()), this);
 
-  show_joint_torques_property_ = new rviz::BoolProperty("Show Joint Torques", false,
-                                                        "Shows the joint torques for a given configuration and payload",
-                                                        metrics_category_, SLOT(changedShowJointTorques()), this);
+  show_joint_torques_property_ = new rviz_common::properties::BoolProperty(
+      "Show Joint Torques", false, "Shows the joint torques for a given configuration and payload", metrics_category_,
+      SLOT(changedShowJointTorques()), this);
 
   metrics_set_payload_property_ =
-      new rviz::FloatProperty("Payload", 1.0f, "Specify the payload at the end effector (kg)", metrics_category_,
-                              SLOT(changedMetricsSetPayload()), this);
+      new rviz_common::properties::FloatProperty("Payload", 1.0f, "Specify the payload at the end effector (kg)",
+                                                 metrics_category_, SLOT(changedMetricsSetPayload()), this);
   metrics_set_payload_property_->setMin(0.0);
 
-  metrics_text_height_property_ = new rviz::FloatProperty("TextHeight", 0.08f, "Text height", metrics_category_,
-                                                          SLOT(changedMetricsTextHeight()), this);
+  metrics_text_height_property_ = new rviz_common::properties::FloatProperty(
+      "TextHeight", 0.08f, "Text height", metrics_category_, SLOT(changedMetricsTextHeight()), this);
   metrics_text_height_property_->setMin(0.001);
 
   // Planning request category -----------------------------------------------------------------------------------------
 
-  planning_group_property_ = new rviz::EditableEnumProperty(
+  planning_group_property_ = new rviz_common::properties::EditableEnumProperty(
       "Planning Group", "", "The name of the group of links to plan for (from the ones defined in the SRDF)",
       plan_category_, SLOT(changedPlanningGroup()), this);
-  show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false, "Shows the axis-aligned bounding box for "
-                                                                             "the workspace allowed for planning",
-                                                    plan_category_, SLOT(changedWorkspace()), this);
-  query_start_state_property_ =
-      new rviz::BoolProperty("Query Start State", false, "Set a custom start state for the motion planning query",
-                             plan_category_, SLOT(changedQueryStartState()), this);
-  query_goal_state_property_ =
-      new rviz::BoolProperty("Query Goal State", true, "Shows the goal state for the motion planning query",
-                             plan_category_, SLOT(changedQueryGoalState()), this);
-  query_marker_scale_property_ =
-      new rviz::FloatProperty("Interactive Marker Size", 0.0f,
-                              "Specifies scale of the interactive marker overlayed on the robot. 0 is auto scale.",
-                              plan_category_, SLOT(changedQueryMarkerScale()), this);
+  show_workspace_property_ =
+      new rviz_common::properties::BoolProperty("Show Workspace", false, "Shows the axis-aligned bounding box for "
+                                                                         "the workspace allowed for planning",
+                                                plan_category_, SLOT(changedWorkspace()), this);
+  query_start_state_property_ = new rviz_common::properties::BoolProperty(
+      "Query Start State", false, "Set a custom start state for the motion planning query", plan_category_,
+      SLOT(changedQueryStartState()), this);
+  query_goal_state_property_ = new rviz_common::properties::BoolProperty(
+      "Query Goal State", true, "Shows the goal state for the motion planning query", plan_category_,
+      SLOT(changedQueryGoalState()), this);
+  query_marker_scale_property_ = new rviz_common::properties::FloatProperty(
+      "Interactive Marker Size", 0.0f,
+      "Specifies scale of the interactive marker overlayed on the robot. 0 is auto scale.", plan_category_,
+      SLOT(changedQueryMarkerScale()), this);
   query_marker_scale_property_->setMin(0.0f);
 
-  query_start_color_property_ =
-      new rviz::ColorProperty("Start State Color", QColor(0, 255, 0), "The highlight color for the start state",
-                              plan_category_, SLOT(changedQueryStartColor()), this);
+  query_start_color_property_ = new rviz_common::properties::ColorProperty(
+      "Start State Color", QColor(0, 255, 0), "The highlight color for the start state", plan_category_,
+      SLOT(changedQueryStartColor()), this);
   query_start_alpha_property_ =
-      new rviz::FloatProperty("Start State Alpha", 1.0f, "Specifies the alpha for the robot links", plan_category_,
-                              SLOT(changedQueryStartAlpha()), this);
+      new rviz_common::properties::FloatProperty("Start State Alpha", 1.0f, "Specifies the alpha for the robot links",
+                                                 plan_category_, SLOT(changedQueryStartAlpha()), this);
   query_start_alpha_property_->setMin(0.0);
   query_start_alpha_property_->setMax(1.0);
 
-  query_goal_color_property_ =
-      new rviz::ColorProperty("Goal State Color", QColor(250, 128, 0), "The highlight color for the goal state",
-                              plan_category_, SLOT(changedQueryGoalColor()), this);
+  query_goal_color_property_ = new rviz_common::properties::ColorProperty(
+      "Goal State Color", QColor(250, 128, 0), "The highlight color for the goal state", plan_category_,
+      SLOT(changedQueryGoalColor()), this);
 
   query_goal_alpha_property_ =
-      new rviz::FloatProperty("Goal State Alpha", 1.0f, "Specifies the alpha for the robot links", plan_category_,
-                              SLOT(changedQueryGoalAlpha()), this);
+      new rviz_common::properties::FloatProperty("Goal State Alpha", 1.0f, "Specifies the alpha for the robot links",
+                                                 plan_category_, SLOT(changedQueryGoalAlpha()), this);
   query_goal_alpha_property_->setMin(0.0);
   query_goal_alpha_property_->setMax(1.0);
 
-  query_colliding_link_color_property_ =
-      new rviz::ColorProperty("Colliding Link Color", QColor(255, 0, 0), "The highlight color for colliding links",
-                              plan_category_, SLOT(changedQueryCollidingLinkColor()), this);
+  query_colliding_link_color_property_ = new rviz_common::properties::ColorProperty(
+      "Colliding Link Color", QColor(255, 0, 0), "The highlight color for colliding links", plan_category_,
+      SLOT(changedQueryCollidingLinkColor()), this);
 
-  query_outside_joint_limits_link_color_property_ =
-      new rviz::ColorProperty("Joint Violation Color", QColor(255, 0, 255),
-                              "The highlight color for child links of joints that are outside bounds", plan_category_,
-                              SLOT(changedQueryJointViolationColor()), this);
+  query_outside_joint_limits_link_color_property_ = new rviz_common::properties::ColorProperty(
+      "Joint Violation Color", QColor(255, 0, 255),
+      "The highlight color for child links of joints that are outside bounds", plan_category_,
+      SLOT(changedQueryJointViolationColor()), this);
 
   // Trajectory playback / planned path category ---------------------------------------------
   trajectory_visual_.reset(new TrajectoryVisualization(path_category_, this));
@@ -200,7 +202,7 @@ void MotionPlanningDisplay::onInitialize()
   PlanningSceneDisplay::onInitialize();
 
   // Planned Path Display
-  trajectory_visual_->onInitialize(planning_scene_node_, context_, update_nh_);
+  trajectory_visual_->onInitialize(node_, planning_scene_node_, context_);
   QColor qcolor = attached_body_color_property_->getColor();
   trajectory_visual_->setDefaultAttachedObjectColor(qcolor);
 
@@ -209,7 +211,7 @@ void MotionPlanningDisplay::onInitialize()
   query_robot_start_->setCollisionVisible(false);
   query_robot_start_->setVisualVisible(true);
   query_robot_start_->setVisible(query_start_state_property_->getBool());
-  std_msgs::ColorRGBA color;
+  std_msgs::msg::ColorRGBA color;
   qcolor = query_start_color_property_->getColor();
   color.r = qcolor.redF();
   color.g = qcolor.greenF();
@@ -228,7 +230,7 @@ void MotionPlanningDisplay::onInitialize()
   color.b = qcolor.blueF();
   query_robot_goal_->setDefaultAttachedObjectColor(color);
 
-  rviz::WindowManagerInterface* window_context = context_->getWindowManager();
+  rviz_common::WindowManagerInterface* window_context = context_->getWindowManager();
   frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
   connect(frame_, SIGNAL(configChanged()), this->getModel(), SIGNAL(configChanged()));
   resetStatusTextColor();
@@ -244,12 +246,12 @@ void MotionPlanningDisplay::onInitialize()
     frame_dock_->setIcon(getIcon());
   }
 
-  int_marker_display_ = context_->getDisplayFactory()->make("rviz/InteractiveMarkers");
+  int_marker_display_ = new rviz_default_plugins::displays::InteractiveMarkerDisplay();
   int_marker_display_->initialize(context_);
 
   text_display_scene_node_ = planning_scene_node_->createChildSceneNode();
-  text_to_display_ = new rviz::MovableText("EMPTY");
-  text_to_display_->setTextAlignment(rviz::MovableText::H_CENTER, rviz::MovableText::V_CENTER);
+  text_to_display_ = new rviz_rendering::MovableText("EMPTY");
+  text_to_display_->setTextAlignment(rviz_rendering::MovableText::H_CENTER, rviz_rendering::MovableText::V_CENTER);
   text_to_display_->setCharacterHeight(metrics_text_height_property_->getFloat());
   text_to_display_->showOnTop();
   text_to_display_->setVisible(false);
@@ -274,16 +276,17 @@ void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)
 {
   if (enable)
   {
-    planning_group_sub_ = node_handle_.subscribe("/rviz/moveit/select_planning_group", 1,
-                                                 &MotionPlanningDisplay::selectPlanningGroupCallback, this);
+    planning_group_sub_ = node_->create_subscription<std_msgs::msg::String>(
+        "/rviz/moveit/select_planning_group", 1,
+        std::bind(&MotionPlanningDisplay::selectPlanningGroupCallback, this, std::placeholders::_1));
   }
   else
   {
-    planning_group_sub_.shutdown();
+    planning_group_sub_.reset();
   }
 }
 
-void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::StringConstPtr& msg)
+void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg)
 {
   // synchronize ROS callback with main loop
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changePlanningGroup, this, msg->data));
@@ -306,17 +309,6 @@ void MotionPlanningDisplay::reset()
 
   query_robot_start_->setVisible(query_start_state_property_->getBool());
   query_robot_goal_->setVisible(query_goal_state_property_->getBool());
-}
-
-void MotionPlanningDisplay::setName(const QString& name)
-{
-  BoolProperty::setName(name);
-  if (frame_dock_)
-  {
-    frame_dock_->setWindowTitle(name);
-    frame_dock_->setObjectName(name);
-  }
-  trajectory_visual_->setName(name);
 }
 
 void MotionPlanningDisplay::backgroundJobUpdate(moveit::tools::BackgroundProcessing::JobEvent /*unused*/,
@@ -469,7 +461,8 @@ void MotionPlanningDisplay::renderWorkspaceBox()
 
   if (!workspace_box_)
   {
-    workspace_box_.reset(new rviz::Shape(rviz::Shape::Cube, context_->getSceneManager(), planning_scene_node_));
+    workspace_box_.reset(
+        new rviz_rendering::Shape(rviz_rendering::Shape::Cube, context_->getSceneManager(), planning_scene_node_));
     workspace_box_->setColor(0.0f, 0.0f, 0.6f, 0.3f);
   }
 
@@ -533,7 +526,7 @@ void MotionPlanningDisplay::computeMetricsInternal(std::map<std::string, double>
   if (kinematics_metrics_)
   {
     if (position_only_ik_.find(ee.parent_group) == position_only_ik_.end())
-      private_handle_.param(ee.parent_group + "/position_only_ik", position_only_ik_[ee.parent_group], false);
+      node_->get_parameter_or(ee.parent_group + ".position_only_ik", position_only_ik_[ee.parent_group], false);
 
     double manipulability_index, manipulability;
     bool position_ik = position_only_ik_[ee.parent_group];
@@ -838,7 +831,7 @@ void MotionPlanningDisplay::publishInteractiveMarkers(bool pose_update)
 
 void MotionPlanningDisplay::changedQueryStartColor()
 {
-  std_msgs::ColorRGBA color;
+  std_msgs::msg::ColorRGBA color;
   QColor qcolor = query_start_color_property_->getColor();
   color.r = qcolor.redF();
   color.g = qcolor.greenF();
@@ -868,7 +861,7 @@ void MotionPlanningDisplay::changedQueryMarkerScale()
 
 void MotionPlanningDisplay::changedQueryGoalColor()
 {
-  std_msgs::ColorRGBA color;
+  std_msgs::msg::ColorRGBA color;
   QColor qcolor = query_goal_color_property_->getColor();
   color.r = qcolor.redF();
   color.g = qcolor.greenF();
@@ -1022,7 +1015,7 @@ void MotionPlanningDisplay::changePlanningGroup(const std::string& group)
     planning_group_property_->setStdString(group);
   }
   else
-    ROS_ERROR("Group [%s] not found in the robot model.", group.c_str());
+    RCLCPP_ERROR(LOGGER, "Group [%s] not found in the robot model.", group.c_str());
 }
 
 void MotionPlanningDisplay::changedPlanningGroup()
@@ -1133,7 +1126,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
   robot_interaction_.reset(
-      new robot_interaction::RobotInteraction(getRobotModel(), "rviz_moveit_motion_planning_display"));
+      new robot_interaction::RobotInteraction(getRobotModel(), node_, "rviz_moveit_motion_planning_display"));
   robot_interaction::KinematicOptions o;
   o.state_validity_callback_ = boost::bind(&MotionPlanningDisplay::isIKSolutionCollisionFree, this, _1, _2, _3);
   robot_interaction_->getKinematicOptionsMap()->setOptions(
@@ -1174,7 +1167,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   modified_groups_.clear();
   kinematics_metrics_.reset(new kinematics_metrics::KinematicsMetrics(getRobotModel()));
 
-  geometry_msgs::Vector3 gravity_vector;
+  geometry_msgs::msg::Vector3 gravity_vector;
   gravity_vector.x = 0.0;
   gravity_vector.y = 0.0;
   gravity_vector.z = 9.81;
@@ -1305,23 +1298,22 @@ void MotionPlanningDisplay::updateInternal(float wall_dt, float ros_dt)
   renderWorkspaceBox();
 }
 
-void MotionPlanningDisplay::load(const rviz::Config& config)
+void MotionPlanningDisplay::load(const rviz_common::Config& config)
 {
   PlanningSceneDisplay::load(config);
   if (frame_)
   {
     QString host;
-    ros::NodeHandle nh;
     std::string host_param;
     if (config.mapGetString("MoveIt_Warehouse_Host", &host))
       frame_->ui_->database_host->setText(host);
-    else if (nh.getParam("warehouse_host", host_param))
+    else if (node_->get_parameter("warehouse_host", host_param))
     {
       host = QString::fromStdString(host_param);
       frame_->ui_->database_host->setText(host);
     }
     int port;
-    if (config.mapGetInt("MoveIt_Warehouse_Port", &port) || nh.getParam("warehouse_port", port))
+    if (config.mapGetInt("MoveIt_Warehouse_Port", &port) || node_->get_parameter("warehouse_port", port))
       frame_->ui_->database_port->setValue(port);
     float d;
     if (config.mapGetFloat("MoveIt_Planning_Time", &d))
@@ -1350,8 +1342,8 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     if (config.mapGetBool("MoveIt_Allow_Approximate_IK", &b))
       frame_->ui_->approximate_ik->setChecked(b);
 
-    rviz::Config workspace = config.mapGetChild("MoveIt_Workspace");
-    rviz::Config ws_center = workspace.mapGetChild("Center");
+    rviz_common::Config workspace = config.mapGetChild("MoveIt_Workspace");
+    rviz_common::Config ws_center = workspace.mapGetChild("Center");
     float val;
     if (ws_center.mapGetFloat("X", &val))
       frame_->ui_->wcenter_x->setValue(val);
@@ -1360,7 +1352,7 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     if (ws_center.mapGetFloat("Z", &val))
       frame_->ui_->wcenter_z->setValue(val);
 
-    rviz::Config ws_size = workspace.mapGetChild("Size");
+    rviz_common::Config ws_size = workspace.mapGetChild("Size");
     if (ws_size.isValid())
     {
       if (ws_size.mapGetFloat("X", &val))
@@ -1372,10 +1364,9 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     }
     else
     {
-      std::string node_name = ros::names::append(getMoveGroupNS(), "move_group");
-      ros::NodeHandle nh(node_name);
+      std::string node_name = rclcpp::names::append(getMoveGroupNS(), "move_group");
       double val;
-      if (nh.getParam("default_workspace_bounds", val))
+      if (node_->get_parameter("default_workspace_bounds", val))
       {
         frame_->ui_->wsize_x->setValue(val);
         frame_->ui_->wsize_y->setValue(val);
@@ -1385,7 +1376,7 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
   }
 }
 
-void MotionPlanningDisplay::save(rviz::Config config) const
+void MotionPlanningDisplay::save(rviz_common::Config config) const
 {
   PlanningSceneDisplay::save(config);
   if (frame_)
@@ -1408,12 +1399,12 @@ void MotionPlanningDisplay::save(rviz::Config config) const
     config.mapSetValue("MoveIt_Use_Constraint_Aware_IK", frame_->ui_->collision_aware_ik->isChecked());
     config.mapSetValue("MoveIt_Allow_Approximate_IK", frame_->ui_->approximate_ik->isChecked());
 
-    rviz::Config workspace = config.mapMakeChild("MoveIt_Workspace");
-    rviz::Config ws_center = workspace.mapMakeChild("Center");
+    rviz_common::Config workspace = config.mapMakeChild("MoveIt_Workspace");
+    rviz_common::Config ws_center = workspace.mapMakeChild("Center");
     ws_center.mapSetValue("X", frame_->ui_->wcenter_x->value());
     ws_center.mapSetValue("Y", frame_->ui_->wcenter_y->value());
     ws_center.mapSetValue("Z", frame_->ui_->wcenter_z->value());
-    rviz::Config ws_size = workspace.mapMakeChild("Size");
+    rviz_common::Config ws_size = workspace.mapMakeChild("Size");
     ws_size.mapSetValue("X", frame_->ui_->wsize_x->value());
     ws_size.mapSetValue("Y", frame_->ui_->wsize_y->value());
     ws_size.mapSetValue("Z", frame_->ui_->wsize_z->value());
@@ -1431,18 +1422,19 @@ void MotionPlanningDisplay::fixedFrameChanged()
 // Pick and place
 void MotionPlanningDisplay::clearPlaceLocationsDisplay()
 {
-  for (std::shared_ptr<rviz::Shape>& place_location_shape : place_locations_display_)
+  for (std::shared_ptr<rviz_rendering::Shape>& place_location_shape : place_locations_display_)
     place_location_shape.reset();
   place_locations_display_.clear();
 }
 
-void MotionPlanningDisplay::visualizePlaceLocations(const std::vector<geometry_msgs::PoseStamped>& place_poses)
+void MotionPlanningDisplay::visualizePlaceLocations(const std::vector<geometry_msgs::msg::PoseStamped>& place_poses)
 {
   clearPlaceLocationsDisplay();
   place_locations_display_.resize(place_poses.size());
   for (std::size_t i = 0; i < place_poses.size(); ++i)
   {
-    place_locations_display_[i].reset(new rviz::Shape(rviz::Shape::Sphere, context_->getSceneManager()));
+    place_locations_display_[i].reset(
+        new rviz_rendering::Shape(rviz_rendering::Shape::Sphere, context_->getSceneManager()));
     place_locations_display_[i]->setColor(1.0f, 0.0f, 0.0f, 0.3f);
     Ogre::Vector3 center(place_poses[i].pose.position.x, place_poses[i].pose.position.y,
                          place_poses[i].pose.position.z);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -33,16 +33,15 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan */
-
-#include <moveit/warehouse/planning_scene_storage.h>
-#include <moveit/warehouse/constraints_storage.h>
-#include <moveit/warehouse/state_storage.h>
-
+// TODO (ddengster): Enable when moveit_ros_warehouse is ported
+// #include <moveit/warehouse/planning_scene_storage.h>
+// #include <moveit/warehouse/constraints_storage.h>
+// #include <moveit/warehouse/state_storage.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 
-#include <rviz/display_context.h>
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/window_manager_interface.hpp>
 
 #include <QMessageBox>
 #include <QInputDialog>
@@ -51,6 +50,8 @@
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_context");
+
 void MotionPlanningFrame::databaseConnectButtonClicked()
 {
   planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClicked, this),
@@ -98,45 +99,47 @@ void MotionPlanningFrame::resetDbButtonClicked()
 
 void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    planning_scene_storage_.reset();
-    robot_state_storage_.reset();
-    constraints_storage_.reset();
-    planning_display_->addMainLoopJob(
-        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
-  }
-  else
-  {
-    planning_display_->addMainLoopJob(
-        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
-    try
-    {
-      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
-      conn->setParams(ui_->database_host->text().toStdString(), ui_->database_port->value(), 5.0);
-      if (conn->connect())
-      {
-        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
-        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
-        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
-      }
-      else
-      {
-        planning_display_->addMainLoopJob(
-            boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
-        return;
-      }
-    }
-    catch (std::exception& ex)
-    {
-      planning_display_->addMainLoopJob(
-          boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
-      ROS_ERROR("%s", ex.what());
-      return;
-    }
-    planning_display_->addMainLoopJob(
-        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
-  }
+  RCLCPP_WARN(LOGGER, "compute database functionality isn't supported yet");
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    planning_scene_storage_.reset();
+  //    robot_state_storage_.reset();
+  //    constraints_storage_.reset();
+  //    planning_display_->addMainLoopJob(
+  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
+  //  }
+  //  else
+  //  {
+  //    planning_display_->addMainLoopJob(
+  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
+  //    try
+  //    {
+  //      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  //      conn->setParams(ui_->database_host->text().toStdString(), ui_->database_port->value(), 5.0);
+  //      if (conn->connect())
+  //      {
+  //        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
+  //        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
+  //        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+  //      }
+  //      else
+  //      {
+  //        planning_display_->addMainLoopJob(
+  //            boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+  //        return;
+  //      }
+  //    }
+  //    catch (std::exception& ex)
+  //    {
+  //      planning_display_->addMainLoopJob(
+  //          boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+  //      ROS_ERROR("%s", ex.what());
+  //      return;
+  //    }
+  //    planning_display_->addMainLoopJob(
+  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
+  //  }
 }
 
 void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
@@ -197,11 +200,12 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
 
 void MotionPlanningFrame::computeResetDbButtonClicked(const std::string& db)
 {
-  if (db == "Constraints" && constraints_storage_)
-    constraints_storage_->reset();
-  else if (db == "Robot States" && robot_state_storage_)
-    robot_state_storage_->reset();
-  else if (db == "Planning Scenes")
-    planning_scene_storage_->reset();
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (db == "Constraints" && constraints_storage_)
+  //    constraints_storage_->reset();
+  //  else if (db == "Robot States" && robot_state_storage_)
+  //    robot_state_storage_->reset();
+  //  else if (db == "Planning Scenes")
+  //    planning_scene_storage_->reset();
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -40,9 +40,13 @@
 #include "ui_motion_planning_rviz_plugin_frame_joints.h"
 #include <QPainter>
 #include <QSlider>
+#include <QEvent>
+#include <QMouseEvent>
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_joints_widget");
+
 JMGItemModel::JMGItemModel(const moveit::core::RobotState& robot_state, const std::string& group_name, QObject* parent)
   : QAbstractTableModel(parent), robot_state_(robot_state), jmg_(nullptr)
 {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -39,7 +39,7 @@
 
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_state/conversions.h>
-#include <object_recognition_msgs/ObjectRecognitionGoal.h>
+#include <object_recognition_msgs/action/object_recognition.hpp>
 
 #include <tf2_eigen/tf2_eigen.h>
 
@@ -47,21 +47,24 @@
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_manipulation");
+
 /////////////// Object Detection ///////////////////////
 void MotionPlanningFrame::detectObjectsButtonClicked()
 {
-  if (!semantic_world_)
-  {
-    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
-    if (ps)
-    {
-      semantic_world_.reset(new moveit::semantic_world::SemanticWorld(ps));
-    }
-    if (semantic_world_)
-    {
-      semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_perception is ported
+  //  if (!semantic_world_)
+  //  {
+  //    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+  //    if (ps)
+  //    {
+  //      semantic_world_.reset(new moveit::semantic_world::SemanticWorld(ps));
+  //    }
+  //    if (semantic_world_)
+  //    {
+  //      semantic_world_->addTableCallback(boost::bind(&MotionPlanningFrame::updateTables, this));
+  //    }
+  //  }
   planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::triggerObjectDetection, this),
                                       "detect objects");
 }
@@ -79,8 +82,8 @@ void MotionPlanningFrame::processDetectedObjects()
   double max_y = ui_->roi_center_y->value() + ui_->roi_size_y->value() / 2.0;
   double max_z = ui_->roi_center_z->value() + ui_->roi_size_z->value() / 2.0;
 
-  ros::Time start_time = ros::Time::now();
-  while (object_ids.empty() && ros::Time::now() - start_time <= ros::Duration(3.0))
+  rclcpp::Time start_time = rclcpp::Clock().now();
+  while (object_ids.empty() && (rclcpp::Clock().now() - start_time) <= rclcpp::Duration(3.0))
   {
     // collect all objects in region of interest
     {
@@ -102,10 +105,10 @@ void MotionPlanningFrame::processDetectedObjects()
       if (!object_ids.empty())
         break;
     }
-    ros::Duration(0.5).sleep();
+    rclcpp::sleep_for(std::chrono::milliseconds(500));
   }
 
-  ROS_DEBUG("Found %d objects", (int)object_ids.size());
+  RCLCPP_DEBUG(LOGGER, "Found %d objects", (int)object_ids.size());
   updateDetectedObjectsList(object_ids);
 }
 
@@ -114,11 +117,11 @@ void MotionPlanningFrame::selectedDetectedObjectChanged()
   QList<QListWidgetItem*> sel = ui_->detected_objects_list->selectedItems();
   if (sel.empty())
   {
-    ROS_INFO("No objects to select");
+    RCLCPP_INFO(LOGGER, "No objects to select");
     return;
   }
   planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
-  std_msgs::ColorRGBA pick_object_color;
+  std_msgs::msg::ColorRGBA pick_object_color;
   pick_object_color.r = 1.0;
   pick_object_color.g = 0.0;
   pick_object_color.b = 0.0;
@@ -141,35 +144,29 @@ void MotionPlanningFrame::triggerObjectDetection()
 {
   if (!object_recognition_client_)
   {
-    object_recognition_client_.reset(
-        new actionlib::SimpleActionClient<object_recognition_msgs::ObjectRecognitionAction>(OBJECT_RECOGNITION_ACTION,
-                                                                                            false));
-    try
+    object_recognition_client_ = rclcpp_action::create_client<object_recognition_msgs::action::ObjectRecognition>(
+        node_, OBJECT_RECOGNITION_ACTION);
+    if (!object_recognition_client_->wait_for_action_server(std::chrono::seconds(3)))
     {
-      waitForAction(object_recognition_client_, nh_, ros::Duration(3.0), OBJECT_RECOGNITION_ACTION);
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR("Object recognition action: %s", ex.what());
+      RCLCPP_ERROR(LOGGER, "Object recognition action server not responsive");
       return;
     }
   }
-  object_recognition_msgs::ObjectRecognitionGoal goal;
-  object_recognition_client_->sendGoal(goal);
-  if (!object_recognition_client_->waitForResult())
+
+  object_recognition_msgs::action::ObjectRecognition::Goal goal;
+  auto goal_handle_future = object_recognition_client_->async_send_goal(goal);
+  goal_handle_future.wait();
+  if (goal_handle_future.get()->get_status() != rclcpp_action::GoalStatus::STATUS_SUCCEEDED)
   {
-    ROS_INFO_STREAM("Object recognition client returned early");
-  }
-  if (object_recognition_client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED)
-  {
-    ROS_WARN_STREAM("Fail: " << object_recognition_client_->getState().toString() << ": "
-                             << object_recognition_client_->getState().getText());
+    RCLCPP_ERROR(LOGGER, "ObjectRecognition client: send goal call failed");
+    return;
   }
 }
 
-void MotionPlanningFrame::listenDetectedObjects(const object_recognition_msgs::RecognizedObjectArrayPtr& /*msg*/)
+void MotionPlanningFrame::listenDetectedObjects(
+    const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr /*msg*/)
 {
-  ros::Duration(1.0).sleep();
+  rclcpp::sleep_for(std::chrono::seconds(1));
   planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::processDetectedObjects, this));
 }
 
@@ -199,13 +196,15 @@ void MotionPlanningFrame::updateDetectedObjectsList(const std::vector<std::strin
 /////////////////////// Support Surfaces ///////////////////////
 void MotionPlanningFrame::updateTables()
 {
-  ROS_DEBUG("Update table callback");
+  RCLCPP_DEBUG(LOGGER, "Update table callback");
   planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::publishTables, this), "publish tables");
 }
 
 void MotionPlanningFrame::publishTables()
 {
-  semantic_world_->addTablesToCollisionWorld();
+  // TODO (ddengster): Enable when moveit_ros_perception is ported
+  // semantic_world_->addTablesToCollisionWorld();
+
   planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::updateSupportSurfacesList, this));
 }
 
@@ -214,11 +213,11 @@ void MotionPlanningFrame::selectedSupportSurfaceChanged()
   QList<QListWidgetItem*> sel = ui_->support_surfaces_list->selectedItems();
   if (sel.empty())
   {
-    ROS_INFO("No tables to select");
+    RCLCPP_INFO(LOGGER, "No tables to select");
     return;
   }
   planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
-  std_msgs::ColorRGBA selected_support_surface_color;
+  std_msgs::msg::ColorRGBA selected_support_surface_color;
   selected_support_surface_color.r = 0.0;
   selected_support_surface_color.g = 0.0;
   selected_support_surface_color.b = 1.0;
@@ -242,8 +241,11 @@ void MotionPlanningFrame::updateSupportSurfacesList()
   double max_x = ui_->roi_center_x->value() + ui_->roi_size_x->value() / 2.0;
   double max_y = ui_->roi_center_y->value() + ui_->roi_size_y->value() / 2.0;
   double max_z = ui_->roi_center_z->value() + ui_->roi_size_z->value() / 2.0;
-  std::vector<std::string> support_ids = semantic_world_->getTableNamesInROI(min_x, min_y, min_z, max_x, max_y, max_z);
-  ROS_INFO("%d Tables in collision world", (int)support_ids.size());
+  // TODO (ddengster): Enable when moveit_ros_perception is ported
+  // std::vector<std::string> support_ids = semantic_world_->getTableNamesInROI(min_x, min_y, min_z, max_x, max_y,
+  // max_z);
+  std::vector<std::string> support_ids;
+  RCLCPP_INFO(LOGGER, "%d Tables in collision world", (int)support_ids.size());
 
   ui_->support_surfaces_list->setUpdatesEnabled(false);
   bool old_state = ui_->support_surfaces_list->blockSignals(true);
@@ -267,39 +269,41 @@ void MotionPlanningFrame::updateSupportSurfacesList()
 /////////////////////////////// Pick & Place /////////////////////////////////
 void MotionPlanningFrame::pickObjectButtonClicked()
 {
-  QList<QListWidgetItem*> sel = ui_->detected_objects_list->selectedItems();
-  QList<QListWidgetItem*> sel_table = ui_->support_surfaces_list->selectedItems();
-
-  std::string group_name = planning_display_->getCurrentPlanningGroup();
-  if (sel.empty())
-  {
-    ROS_INFO("No objects to pick");
-    return;
-  }
-  pick_object_name_[group_name] = sel[0]->text().toStdString();
-
-  if (!sel_table.empty())
-    support_surface_name_ = sel_table[0]->text().toStdString();
-  else
-  {
-    if (semantic_world_)
-    {
-      const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
-      if (ps->getWorld()->hasObject(pick_object_name_[group_name]))
-      {
-        geometry_msgs::Pose object_pose(tf2::toMsg(ps->getWorld()->getTransform(pick_object_name_[group_name])));
-        ROS_DEBUG_STREAM("Finding current table for object: " << pick_object_name_[group_name]);
-        support_surface_name_ = semantic_world_->findObjectTable(object_pose);
-      }
-      else
-        support_surface_name_.clear();
-    }
-    else
-      support_surface_name_.clear();
-  }
-  ROS_INFO("Trying to pick up object %s from support surface %s", pick_object_name_[group_name].c_str(),
-           support_surface_name_.c_str());
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::pickObject, this), "pick");
+  RCLCPP_WARN_STREAM(LOGGER, "Pick & Place capability isn't supported yet");
+  //  QList<QListWidgetItem*> sel = ui_->detected_objects_list->selectedItems();
+  //  QList<QListWidgetItem*> sel_table = ui_->support_surfaces_list->selectedItems();
+  //
+  //  std::string group_name = planning_display_->getCurrentPlanningGroup();
+  //  if (sel.empty())
+  //  {
+  //    RCLCPP_INFO(LOGGER, "No objects to pick");
+  //    return;
+  //  }
+  //  pick_object_name_[group_name] = sel[0]->text().toStdString();
+  //
+  //  if (!sel_table.empty())
+  //    support_surface_name_ = sel_table[0]->text().toStdString();
+  //  else
+  //  {
+  //    if (semantic_world_)
+  //    {
+  //      const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
+  //      if (ps->getWorld()->hasObject(pick_object_name_[group_name]))
+  //      {
+  //        geometry_msgs::msg::Pose
+  //        object_pose(tf2::toMsg(ps->getWorld()->getTransform(pick_object_name_[group_name])));
+  //        RCLCPP_DEBUG(LOGGER, "Finding current table for object: " << pick_object_name_[group_name]);
+  //        support_surface_name_ = semantic_world_->findObjectTable(object_pose);
+  //      }
+  //      else
+  //        support_surface_name_.clear();
+  //    }
+  //    else
+  //      support_surface_name_.clear();
+  //  }
+  //  RCLCPP_INFO(LOGGER, "Trying to pick up object %s from support surface %s", pick_object_name_[group_name].c_str(),
+  //           support_surface_name_.c_str());
+  //  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::pickObject, this), "pick");
 }
 
 void MotionPlanningFrame::placeObjectButtonClicked()
@@ -312,7 +316,7 @@ void MotionPlanningFrame::placeObjectButtonClicked()
   else
   {
     support_surface_name_.clear();
-    ROS_ERROR("Need to specify table to place object on");
+    RCLCPP_ERROR(LOGGER, "Need to specify table to place object on");
     return;
   }
 
@@ -323,7 +327,7 @@ void MotionPlanningFrame::placeObjectButtonClicked()
   const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
   if (!ps)
   {
-    ROS_ERROR("No planning scene");
+    RCLCPP_ERROR(LOGGER, "No planning scene");
     return;
   }
   const moveit::core::JointModelGroup* jmg = ps->getCurrentState().getJointModelGroup(group_name);
@@ -332,44 +336,45 @@ void MotionPlanningFrame::placeObjectButtonClicked()
 
   if (attached_bodies.empty())
   {
-    ROS_ERROR("No bodies to place");
+    RCLCPP_ERROR(LOGGER, "No bodies to place");
     return;
   }
 
-  geometry_msgs::Quaternion upright_orientation;
+  geometry_msgs::msg::Quaternion upright_orientation;
   upright_orientation.w = 1.0;
 
   // Else place the first one
   place_poses_.clear();
-  place_poses_ = semantic_world_->generatePlacePoses(support_surface_name_, attached_bodies[0]->getShapes()[0],
-                                                     upright_orientation, 0.1);
-  planning_display_->visualizePlaceLocations(place_poses_);
-  place_object_name_ = attached_bodies[0]->getName();
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::placeObject, this), "place");
+  // TODO (ddengster): Enable when moveit_ros_perception is ported
+  //  place_poses_ = semantic_world_->generatePlacePoses(support_surface_name_, attached_bodies[0]->getShapes()[0],
+  //                                                     upright_orientation, 0.1);
+  //  planning_display_->visualizePlaceLocations(place_poses_);
+  //  place_object_name_ = attached_bodies[0]->getName();
+  //  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::placeObject, this), "place");
 }
 
-void MotionPlanningFrame::pickObject()
-{
-  std::string group_name = planning_display_->getCurrentPlanningGroup();
-  ui_->pick_button->setEnabled(false);
-  if (pick_object_name_.find(group_name) == pick_object_name_.end())
-  {
-    ROS_ERROR("No pick object set for this group");
-    return;
-  }
-  if (!support_surface_name_.empty())
-  {
-    move_group_->setSupportSurfaceName(support_surface_name_);
-  }
-  if (move_group_->pick(pick_object_name_[group_name]))
-  {
-    ui_->place_button->setEnabled(true);
-  }
-}
-
-void MotionPlanningFrame::placeObject()
-{
-  move_group_->place(place_object_name_, place_poses_);
-  return;
-}
+// void MotionPlanningFrame::pickObject()
+//{
+//  std::string group_name = planning_display_->getCurrentPlanningGroup();
+//  ui_->pick_button->setEnabled(false);
+//  if (pick_object_name_.find(group_name) == pick_object_name_.end())
+//  {
+//    RCLCPP_ERROR(LOGGER, "No pick object set for this group");
+//    return;
+//  }
+//  if (!support_surface_name_.empty())
+//  {
+//    move_group_->setSupportSurfaceName(support_surface_name_);
+//  }
+//  if (move_group_->pick(pick_object_name_[group_name]))
+//  {
+//    ui_->place_button->setEnabled(true);
+//  }
+//}
+//
+// void MotionPlanningFrame::placeObject()
+//{
+//  move_group_->place(place_object_name_, place_poses_);
+//  return;
+//}
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -33,19 +33,19 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan, Mario Prats */
-
-#include <moveit/warehouse/planning_scene_storage.h>
+// TODO (ddengster): Enable when moveit_ros_warehouse is ported
+// #include <moveit/warehouse/planning_scene_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_interaction/interactive_marker_helpers.h>
 
-#include <interactive_markers/tools.h>
+#include <interactive_markers/tools.hpp>
 
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/frame_manager_iface.hpp>
+#include <rviz_common/window_manager_interface.hpp>
 
 #include <tf2_eigen/tf2_eigen.h>
 #include <geometric_shapes/shape_operations.h>
@@ -73,6 +73,8 @@ QString subframe_poses_to_qstring(const moveit::core::FixedTransformsMap& subfra
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_objects");
+
 void MotionPlanningFrame::shapesComboBoxChanged(const QString& text)
 {
   switch (ui_->shapes_combo_box->currentData().toInt())  // fetch shape ID from current combobox item
@@ -118,9 +120,9 @@ void MotionPlanningFrame::publishScene()
   const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
   if (ps)
   {
-    moveit_msgs::PlanningScene msg;
+    moveit_msgs::msg::PlanningScene msg;
     ps->getPlanningSceneMsg(msg);
-    planning_scene_publisher_.publish(msg);
+    planning_scene_publisher_->publish(msg);
     setLocalSceneEdited(false);
   }
 }
@@ -143,7 +145,7 @@ void MotionPlanningFrame::clearScene()
     ps->getCurrentStateNonConst().clearAttachedBodies();
     moveit_msgs::msg::PlanningScene msg;
     ps->getPlanningSceneMsg(msg);
-    planning_scene_publisher_.publish(msg);
+    planning_scene_publisher_->publish(msg);
     setLocalSceneEdited(false);
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
     planning_display_->queueRenderSceneGeometry();
@@ -237,7 +239,7 @@ static QString decideStatusText(const collision_detection::CollisionEnv::ObjectC
       status_text += "one " + shape_names[0];
     else
     {
-      status_text += QString::fromStdString(boost::lexical_cast<std::string>(shape_names.size())) + " shapes:";
+      status_text += QString::fromStdString(std::to_string(shape_names.size())) + " shapes:";
       for (const QString& shape_name : shape_names)
         status_text += " " + shape_name;
     }
@@ -424,7 +426,7 @@ void MotionPlanningFrame::collisionObjectChanged(QListWidgetItem* item)
 }
 
 /* Receives feedback from the interactive marker and updates the shape pose in the world accordingly */
-void MotionPlanningFrame::imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback& feedback)
+void MotionPlanningFrame::imProcessFeedback(visualization_msgs::msg::InteractiveMarkerFeedback& feedback)
 {
   bool old_state = ui_->object_x->blockSignals(true);
   ui_->object_x->setValue(feedback.pose.position.x);
@@ -480,12 +482,12 @@ void MotionPlanningFrame::copySelectedCollisionObject()
     {
       name += " ";
       unsigned int n = 1;
-      while (ps->getWorld()->hasObject(name + boost::lexical_cast<std::string>(n)))
+      while (ps->getWorld()->hasObject(name + std::to_string(n)))
         n++;
-      name += boost::lexical_cast<std::string>(n);
+      name += std::to_string(n);
     }
     ps->getWorldNonConst()->addToObject(name, obj->shapes_, obj->shape_poses_);
-    ROS_DEBUG("Copied collision object to '%s'", name.c_str());
+    RCLCPP_DEBUG(LOGGER, "Copied collision object to '%s'", name.c_str());
   }
   setLocalSceneEdited();
   planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
@@ -493,108 +495,112 @@ void MotionPlanningFrame::copySelectedCollisionObject()
 
 void MotionPlanningFrame::computeSaveSceneButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    moveit_msgs::msg::PlanningScene msg;
-    planning_display_->getPlanningSceneRO()->getPlanningSceneMsg(msg);
-    try
-    {
-      planning_scene_storage_->removePlanningScene(msg.name);
-      planning_scene_storage_->addPlanningScene(msg);
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR("%s", ex.what());
-    }
-
-    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    moveit_msgs::msg::PlanningScene msg;
+  //    planning_display_->getPlanningSceneRO()->getPlanningSceneMsg(msg);
+  //    try
+  //    {
+  //      planning_scene_storage_->removePlanningScene(msg.name);
+  //      planning_scene_storage_->addPlanningScene(msg);
+  //    }
+  //    catch (std::exception& ex)
+  //    {
+  //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //    }
+  //
+  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //  }
 }
 
 void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene, const std::string& query_name)
 {
   moveit_msgs::msg::MotionPlanRequest mreq;
   constructPlanningRequest(mreq);
-  if (planning_scene_storage_)
-  {
-    try
-    {
-      if (!query_name.empty())
-        planning_scene_storage_->removePlanningQuery(scene, query_name);
-      planning_scene_storage_->addPlanningQuery(mreq, scene, query_name);
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR("%s", ex.what());
-    }
-
-    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    try
+  //    {
+  //      if (!query_name.empty())
+  //        planning_scene_storage_->removePlanningQuery(scene, query_name);
+  //      planning_scene_storage_->addPlanningQuery(mreq, scene, query_name);
+  //    }
+  //    catch (std::exception& ex)
+  //    {
+  //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //    }
+  //
+  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //  }
 }
 
 void MotionPlanningFrame::computeDeleteSceneButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-    if (!sel.empty())
-    {
-      QTreeWidgetItem* s = sel.front();
-      if (s->type() == ITEM_TYPE_SCENE)
-      {
-        std::string scene = s->text(0).toStdString();
-        try
-        {
-          planning_scene_storage_->removePlanningScene(scene);
-        }
-        catch (std::exception& ex)
-        {
-          ROS_ERROR("%s", ex.what());
-        }
-      }
-      else
-      {
-        // if we selected a query name, then we overwrite that query
-        std::string scene = s->parent()->text(0).toStdString();
-        try
-        {
-          planning_scene_storage_->removePlanningScene(scene);
-        }
-        catch (std::exception& ex)
-        {
-          ROS_ERROR("%s", ex.what());
-        }
-      }
-      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+  //    if (!sel.empty())
+  //    {
+  //      QTreeWidgetItem* s = sel.front();
+  //      if (s->type() == ITEM_TYPE_SCENE)
+  //      {
+  //        std::string scene = s->text(0).toStdString();
+  //        try
+  //        {
+  //          planning_scene_storage_->removePlanningScene(scene);
+  //        }
+  //        catch (std::exception& ex)
+  //        {
+  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //        }
+  //      }
+  //      else
+  //      {
+  //        // if we selected a query name, then we overwrite that query
+  //        std::string scene = s->parent()->text(0).toStdString();
+  //        try
+  //        {
+  //          planning_scene_storage_->removePlanningScene(scene);
+  //        }
+  //        catch (std::exception& ex)
+  //        {
+  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //        }
+  //      }
+  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //    }
+  //  }
 }
 
 void MotionPlanningFrame::computeDeleteQueryButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-    if (!sel.empty())
-    {
-      QTreeWidgetItem* s = sel.front();
-      if (s->type() == ITEM_TYPE_QUERY)
-      {
-        std::string scene = s->parent()->text(0).toStdString();
-        std::string query_name = s->text(0).toStdString();
-        try
-        {
-          planning_scene_storage_->removePlanningQuery(scene, query_name);
-        }
-        catch (std::exception& ex)
-        {
-          ROS_ERROR("%s", ex.what());
-        }
-        planning_display_->addMainLoopJob(
-            boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
-      }
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+  //    if (!sel.empty())
+  //    {
+  //      QTreeWidgetItem* s = sel.front();
+  //      if (s->type() == ITEM_TYPE_QUERY)
+  //      {
+  //        std::string scene = s->parent()->text(0).toStdString();
+  //        std::string query_name = s->text(0).toStdString();
+  //        try
+  //        {
+  //          planning_scene_storage_->removePlanningQuery(scene, query_name);
+  //        }
+  //        catch (std::exception& ex)
+  //        {
+  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //        }
+  //        planning_display_->addMainLoopJob(
+  //            boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
+  //      }
+  //    }
+  //  }
 }
 
 void MotionPlanningFrame::computeDeleteQueryButtonClickedHelper(QTreeWidgetItem* s)
@@ -642,121 +648,129 @@ void MotionPlanningFrame::checkPlanningSceneTreeEnabledButtons()
 
 void MotionPlanningFrame::computeLoadSceneButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-    if (!sel.empty())
-    {
-      QTreeWidgetItem* s = sel.front();
-      if (s->type() == ITEM_TYPE_SCENE)
-      {
-        std::string scene = s->text(0).toStdString();
-        ROS_DEBUG("Attempting to load scene '%s'", scene.c_str());
-        moveit_warehouse::PlanningSceneWithMetadata scene_m;
-        bool got_ps = false;
-        try
-        {
-          got_ps = planning_scene_storage_->getPlanningScene(scene_m, scene);
-        }
-        catch (std::exception& ex)
-        {
-          ROS_ERROR("%s", ex.what());
-        }
-
-        if (got_ps)
-        {
-          ROS_INFO("Loaded scene '%s'", scene.c_str());
-          if (planning_display_->getPlanningSceneMonitor())
-          {
-            if (scene_m->robot_model_name != planning_display_->getRobotModel()->getName())
-            {
-              ROS_INFO("Scene '%s' was saved for robot '%s' but we are using robot '%s'. Using scene geometry only",
-                       scene.c_str(), scene_m->robot_model_name.c_str(),
-                       planning_display_->getRobotModel()->getName().c_str());
-              planning_scene_world_publisher_.publish(scene_m->world);
-              // publish the parts that are not in the world
-              moveit_msgs::msg::PlanningScene diff;
-              diff.is_diff = true;
-              diff.name = scene_m->name;
-              planning_scene_publisher_.publish(diff);
-            }
-            else
-              planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
-          }
-          else
-            planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
-        }
-        else
-          ROS_WARN("Failed to load scene '%s'. Has the message format changed since the scene was saved?",
-                   scene.c_str());
-      }
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+  //    if (!sel.empty())
+  //    {
+  //      QTreeWidgetItem* s = sel.front();
+  //      if (s->type() == ITEM_TYPE_SCENE)
+  //      {
+  //        std::string scene = s->text(0).toStdString();
+  //        RCLCPP_DEBUG(LOGGER, "Attempting to load scene '%s'", scene.c_str());
+  //
+  //        moveit_warehouse::PlanningSceneWithMetadata scene_m;
+  //        bool got_ps = false;
+  //        try
+  //        {
+  //          got_ps = planning_scene_storage_->getPlanningScene(scene_m, scene);
+  //        }
+  //        catch (std::exception& ex)
+  //        {
+  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //        }
+  //
+  //        if (got_ps)
+  //        {
+  //          RCLCPP_INFO(LOGGER, "Loaded scene '%s'", scene.c_str());
+  //          if (planning_display_->getPlanningSceneMonitor())
+  //          {
+  //            if (scene_m->robot_model_name != planning_display_->getRobotModel()->getName())
+  //            {
+  //              RCLCPP_INFO(LOGGER, "Scene '%s' was saved for robot '%s' but we are using robot '%s'. Using scene
+  //              geometry only",
+  //                       scene.c_str(), scene_m->robot_model_name.c_str(),
+  //                       planning_display_->getRobotModel()->getName().c_str());
+  //              planning_scene_world_publisher_.publish(scene_m->world);
+  //              // publish the parts that are not in the world
+  //              moveit_msgs::msg::PlanningScene diff;
+  //              diff.is_diff = true;
+  //              diff.name = scene_m->name;
+  //              planning_scene_publisher_.publish(diff);
+  //            }
+  //            else
+  //              planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
+  //          }
+  //          else
+  //            planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
+  //        }
+  //        else
+  //          RCLCPP_WARN(LOGGER, "Failed to load scene '%s'. Has the message format changed since the scene was
+  //          saved?",
+  //                   scene.c_str());
+  //      }
+  //    }
+  //  }
 }
 
 void MotionPlanningFrame::computeLoadQueryButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-    if (!sel.empty())
-    {
-      QTreeWidgetItem* s = sel.front();
-      if (s->type() == ITEM_TYPE_QUERY)
-      {
-        std::string scene = s->parent()->text(0).toStdString();
-        std::string query_name = s->text(0).toStdString();
-        moveit_warehouse::MotionPlanRequestWithMetadata mp;
-        bool got_q = false;
-        try
-        {
-          got_q = planning_scene_storage_->getPlanningQuery(mp, scene, query_name);
-        }
-        catch (std::exception& ex)
-        {
-          ROS_ERROR("%s", ex.what());
-        }
-
-        if (got_q)
-        {
-          moveit::core::RobotStatePtr start_state(
-              new moveit::core::RobotState(*planning_display_->getQueryStartState()));
-          moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
-                                                  mp->start_state, *start_state);
-          planning_display_->setQueryStartState(*start_state);
-
-          moveit::core::RobotStatePtr goal_state(new moveit::core::RobotState(*planning_display_->getQueryGoalState()));
-          for (const moveit_msgs::Constraints& goal_constraint : mp->goal_constraints)
-            if (!goal_constraint.joint_constraints.empty())
-            {
-              std::map<std::string, double> vals;
-              for (const moveit_msgs::JointConstraint& joint_constraint : goal_constraint.joint_constraints)
-                vals[joint_constraint.joint_name] = joint_constraint.position;
-              goal_state->setVariablePositions(vals);
-              break;
-            }
-          planning_display_->setQueryGoalState(*goal_state);
-        }
-        else
-          ROS_ERROR("Failed to load planning query '%s'. Has the message format changed since the query was saved?",
-                    query_name.c_str());
-      }
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+  //    if (!sel.empty())
+  //    {
+  //      QTreeWidgetItem* s = sel.front();
+  //      if (s->type() == ITEM_TYPE_QUERY)
+  //      {
+  //        std::string scene = s->parent()->text(0).toStdString();
+  //        std::string query_name = s->text(0).toStdString();
+  //
+  //        moveit_warehouse::MotionPlanRequestWithMetadata mp;
+  //        bool got_q = false;
+  //        try
+  //        {
+  //          got_q = planning_scene_storage_->getPlanningQuery(mp, scene, query_name);
+  //        }
+  //        catch (std::exception& ex)
+  //        {
+  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //        }
+  //
+  //        if (got_q)
+  //        {
+  //          moveit::core::RobotStatePtr start_state(
+  //              new moveit::core::RobotState(*planning_display_->getQueryStartState()));
+  //          moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
+  //                                                  mp->start_state, *start_state);
+  //          planning_display_->setQueryStartState(*start_state);
+  //
+  //          moveit::core::RobotStatePtr goal_state(new
+  //          moveit::core::RobotState(*planning_display_->getQueryGoalState()));
+  //          for (const moveit_msgs::msg::Constraints& goal_constraint : mp->goal_constraints)
+  //            if (!goal_constraint.joint_constraints.empty())
+  //            {
+  //              std::map<std::string, double> vals;
+  //              for (const moveit_msgs::msg::JointConstraint& joint_constraint : goal_constraint.joint_constraints)
+  //                vals[joint_constraint.joint_name] = joint_constraint.position;
+  //              goal_state->setVariablePositions(vals);
+  //              break;
+  //            }
+  //          planning_display_->setQueryGoalState(*goal_state);
+  //        }
+  //        else
+  //          RCLCPP_ERROR(LOGGER, "Failed to load planning query '%s'. Has the message format changed since the query
+  //          was saved?",
+  //                    query_name.c_str());
+  //      }
+  //    }
+  //  }
 }
 
-visualization_msgs::InteractiveMarker
+visualization_msgs::msg::InteractiveMarker
 MotionPlanningFrame::createObjectMarkerMsg(const collision_detection::CollisionEnv::ObjectConstPtr& obj)
 {
   Eigen::Vector3d center;
   double scale;
   shapes::computeShapeBoundingSphere(obj->shapes_[0].get(), center, scale);
-  geometry_msgs::PoseStamped shape_pose = tf2::toMsg(tf2::Stamped<Eigen::Isometry3d>(
-      obj->shape_poses_[0], ros::Time(), planning_display_->getRobotModel()->getModelFrame()));
+  geometry_msgs::msg::PoseStamped shape_pose = tf2::toMsg(tf2::Stamped<Eigen::Isometry3d>(
+      obj->shape_poses_[0], std::chrono::system_clock::now(), planning_display_->getRobotModel()->getModelFrame()));
   scale = (scale + center.cwiseAbs().maxCoeff()) * 2.0 * 1.2;  // add padding of 20% size
 
   // create an interactive marker msg for the given shape
-  visualization_msgs::InteractiveMarker imarker =
+  visualization_msgs::msg::InteractiveMarker imarker =
       robot_interaction::make6DOFMarker("marker_scene_object", shape_pose, scale);
   imarker.description = obj->id_;
   interactive_markers::autoComplete(imarker);
@@ -777,13 +791,14 @@ void MotionPlanningFrame::createSceneInteractiveMarker()
       ps->getWorld()->getObject(sel[0]->text().toStdString());
   if (obj && obj->shapes_.size() == 1)
   {
-    scene_marker_ = std::make_shared<rviz::InteractiveMarker>(planning_display_->getSceneNode(), context_);
+    scene_marker_ = std::make_shared<rviz_default_plugins::displays::InteractiveMarker>(
+        planning_display_->getSceneNode(), context_);
     scene_marker_->processMessage(createObjectMarkerMsg(obj));
     scene_marker_->setShowAxes(false);
 
     // Connect signals
-    connect(scene_marker_.get(), SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
-            SLOT(imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback&)));
+    connect(scene_marker_.get(), SIGNAL(userFeedback(visualization_msgs::msg::InteractiveMarkerFeedback&)), this,
+            SLOT(imProcessFeedback(visualization_msgs::msg::InteractiveMarkerFeedback&)));
   }
   else
   {
@@ -994,10 +1009,10 @@ void MotionPlanningFrame::computeExportGeometryAsText(const std::string& path)
     {
       ps->saveGeometryToStream(fout);
       fout.close();
-      ROS_INFO("Saved current scene geometry to '%s'", p.c_str());
+      RCLCPP_INFO(LOGGER, "Saved current scene geometry to '%s'", p.c_str());
     }
     else
-      ROS_WARN("Unable to save current scene geometry to '%s'", p.c_str());
+      RCLCPP_WARN(LOGGER, "Unable to save current scene geometry to '%s'", p.c_str());
   }
 }
 
@@ -1009,7 +1024,7 @@ void MotionPlanningFrame::computeImportGeometryFromText(const std::string& path)
     std::ifstream fin(path.c_str());
     if (ps->loadGeometryFromStream(fin))
     {
-      ROS_INFO("Loaded scene geometry from '%s'", path.c_str());
+      RCLCPP_INFO(LOGGER, "Loaded scene geometry from '%s'", path.c_str());
       planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populateCollisionObjectsList, this));
       planning_display_->queueRenderSceneGeometry();
       setLocalSceneEdited();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -41,7 +41,7 @@
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_state/conversions.h>
 
-#include <std_srvs/Empty.h>
+#include <std_srvs/srv/empty.hpp>
 #include <moveit_msgs/msg/robot_state.hpp>
 #include <tf2_eigen/tf2_eigen.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
@@ -50,6 +50,8 @@
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_planning");
+
 void MotionPlanningFrame::planButtonClicked()
 {
   publishSceneIfNeeded();
@@ -99,7 +101,7 @@ void MotionPlanningFrame::pathConstraintsIndexChanged(int index)
     {
       std::string c = ui_->path_constraints_combo_box->itemText(index).toStdString();
       if (!move_group_->setPathConstraints(c))
-        ROS_WARN_STREAM("Unable to set the path constraints: " << c);
+        RCLCPP_WARN_STREAM(LOGGER, "Unable to set the path constraints: " << c);
     }
     else
       move_group_->clearPathConstraints();
@@ -108,21 +110,26 @@ void MotionPlanningFrame::pathConstraintsIndexChanged(int index)
 
 void MotionPlanningFrame::onClearOctomapClicked()
 {
-  std_srvs::Empty srv;
-  clear_octomap_service_client_.call(srv);
+  auto req = std::make_shared<std_srvs::srv::Empty::Request>();
+  auto result = clear_octomap_service_client_->async_send_request(req);
+
+  if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(LOGGER, "Failed to call clear_octomap_service");
+  }
 }
 
 bool MotionPlanningFrame::computeCartesianPlan()
 {
-  ros::WallTime start = ros::WallTime::now();
+  rclcpp::Time start = rclcpp::Clock().now();
   // get goal pose
   moveit::core::RobotState goal = *planning_display_->getQueryGoalState();
-  std::vector<geometry_msgs::Pose> waypoints;
+  std::vector<geometry_msgs::msg::Pose> waypoints;
   const std::string& link_name = move_group_->getEndEffectorLink();
   const moveit::core::LinkModel* link = move_group_->getRobotModel()->getLinkModel(link_name);
   if (!link)
   {
-    ROS_ERROR_STREAM("Failed to determine unique end-effector link: " << link_name);
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to determine unique end-effector link: " << link_name);
     return false;
   }
   waypoints.push_back(tf2::toMsg(goal.getGlobalLinkTransform(link)));
@@ -139,7 +146,7 @@ bool MotionPlanningFrame::computeCartesianPlan()
 
   if (fraction >= 1.0)
   {
-    ROS_INFO("Achieved %f %% of Cartesian path", fraction * 100.);
+    RCLCPP_INFO(LOGGER, "Achieved %f %% of Cartesian path", fraction * 100.);
 
     // Compute time parameterization to also provide velocities
     // https://groups.google.com/forum/#!topic/moveit-users/MOoFxy2exT4
@@ -148,12 +155,12 @@ bool MotionPlanningFrame::computeCartesianPlan()
     trajectory_processing::IterativeParabolicTimeParameterization iptp;
     bool success =
         iptp.computeTimeStamps(rt, ui_->velocity_scaling_factor->value(), ui_->acceleration_scaling_factor->value());
-    ROS_INFO("Computing time stamps %s", success ? "SUCCEDED" : "FAILED");
+    RCLCPP_INFO(LOGGER, "Computing time stamps %s", success ? "SUCCEDED" : "FAILED");
 
     // Store trajectory in current_plan_
     current_plan_.reset(new moveit::planning_interface::MoveGroupInterface::Plan());
     rt.getRobotTrajectoryMsg(current_plan_->trajectory_);
-    current_plan_->planning_time_ = (ros::WallTime::now() - start).toSec();
+    current_plan_->planning_time_ = (rclcpp::Clock().now() - start).seconds();
     return success;
   }
   return false;
@@ -335,18 +342,19 @@ void MotionPlanningFrame::updateQueryStateHelper(moveit::core::RobotState& state
       }
       // Explain if no valid rand state found
       if (attempt_count >= MAX_ATTEMPTS)
-        ROS_WARN("Unable to find a random collision free configuration after %d attempts", MAX_ATTEMPTS);
+        RCLCPP_WARN(LOGGER, "Unable to find a random collision free configuration after %d attempts", MAX_ATTEMPTS);
     }
     else
     {
-      ROS_WARN_STREAM("Unable to get joint model group " << planning_display_->getCurrentPlanningGroup());
+      RCLCPP_WARN_STREAM(LOGGER, "Unable to get joint model group " << planning_display_->getCurrentPlanningGroup());
     }
     return;
   }
 
   if (v == "<current>")
   {
-    planning_display_->waitForCurrentRobotState();
+    rclcpp::Time t = node_->now();
+    planning_display_->waitForCurrentRobotState(t);
     const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
     if (ps)
       state = ps->getCurrentState();
@@ -379,6 +387,7 @@ void MotionPlanningFrame::updateQueryStateHelper(moveit::core::RobotState& state
 void MotionPlanningFrame::populatePlannersList(const moveit_msgs::msg::PlannerInterfaceDescription& desc)
 {
   std::string group = planning_display_->getCurrentPlanningGroup();
+  RCLCPP_INFO(LOGGER, "POPULATING PLANNERS %d grp: %s", desc.planner_ids.size(), group.c_str());
   ui_->planning_algorithm_combo_box->clear();
 
   // set the label for the planning library
@@ -390,6 +399,8 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::msg::PlannerIn
   if (!group.empty())
   {
     for (const std::string& planner_id : desc.planner_ids)
+    {
+      RCLCPP_INFO(LOGGER, "planner id: %s", planner_id.c_str());
       if (planner_id == group)
         found_group = true;
       else if (planner_id.substr(0, group.length()) == group)
@@ -404,6 +415,7 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::msg::PlannerIn
           }
         }
       }
+    }
   }
   if (ui_->planning_algorithm_combo_box->count() == 0 && !found_group)
     for (const std::string& planner_id : desc.planner_ids)
@@ -506,22 +518,22 @@ void MotionPlanningFrame::configureForPlanning()
     planning_display_->dropVisualizedTrajectory();
 }
 
-void MotionPlanningFrame::remotePlanCallback(const std_msgs::EmptyConstPtr& /*msg*/)
+void MotionPlanningFrame::remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   planButtonClicked();
 }
 
-void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::EmptyConstPtr& /*msg*/)
+void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   executeButtonClicked();
 }
 
-void MotionPlanningFrame::remoteStopCallback(const std_msgs::EmptyConstPtr& /*msg*/)
+void MotionPlanningFrame::remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   stopButtonClicked();
 }
 
-void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyConstPtr& /*msg*/)
+void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -535,7 +547,7 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
   }
 }
 
-void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyConstPtr& /*msg*/)
+void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -549,7 +561,7 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotStateConstPtr& msg)
+void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();
@@ -567,7 +579,7 @@ void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotStateConstPtr& msg)
+void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -33,10 +33,10 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan */
-
-#include <moveit/warehouse/planning_scene_storage.h>
-#include <moveit/warehouse/constraints_storage.h>
-#include <moveit/warehouse/state_storage.h>
+// TODO (ddengster): Enable when moveit_ros_warehouse is ported
+//#include <moveit/warehouse/planning_scene_storage.h>
+//#include <moveit/warehouse/constraints_storage.h>
+//#include <moveit/warehouse/state_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
@@ -44,10 +44,10 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_interaction/interactive_marker_helpers.h>
 
-#include <interactive_markers/tools.h>
+#include <interactive_markers/tools.hpp>
 
-#include <rviz/display_context.h>
-#include <rviz/window_manager_interface.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/window_manager_interface.hpp>
 
 #include <QMessageBox>
 #include <QInputDialog>
@@ -60,55 +60,61 @@
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_scenes");
+
 void MotionPlanningFrame::saveSceneButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    const std::string& name = planning_display_->getPlanningSceneRO()->getName();
-    if (name.empty() || planning_scene_storage_->hasPlanningScene(name))
-    {
-      std::unique_ptr<QMessageBox> q;
-      if (name.empty())
-        q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Scene Name",
-                                QString("The name for the planning scene should not be empty. Would you like to rename "
-                                        "the planning scene?'"),
-                                QMessageBox::Cancel, this));
-      else
-        q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Scene Overwrite",
-                                QString("A planning scene named '")
-                                    .append(name.c_str())
-                                    .append("' already exists. Do you wish to "
-                                            "overwrite that scene?"),
-                                QMessageBox::Yes | QMessageBox::No, this));
-      std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
-      if (q->exec() != QMessageBox::Yes)
-      {
-        if (q->clickedButton() == rename.get())
-        {
-          bool ok = false;
-          QString new_name = QInputDialog::getText(this, "Rename Planning Scene", "New name for the planning scene:",
-                                                   QLineEdit::Normal, QString::fromStdString(name), &ok);
-          if (ok)
-          {
-            planning_display_->getPlanningSceneRW()->setName(new_name.toStdString());
-            rviz::Property* prop = planning_display_->subProp("Scene Geometry")->subProp("Scene Name");
-            if (prop)
-            {
-              bool old = prop->blockSignals(true);
-              prop->setValue(new_name);
-              prop->blockSignals(old);
-            }
-            saveSceneButtonClicked();
-          }
-          return;
-        }
-        return;
-      }
-    }
-
-    planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
-                                        "save scene");
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    const std::string& name = planning_display_->getPlanningSceneRO()->getName();
+  //    if (name.empty() || planning_scene_storage_->hasPlanningScene(name))
+  //    {
+  //      std::unique_ptr<QMessageBox> q;
+  //      if (name.empty())
+  //        q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Scene Name",
+  //                                QString("The name for the planning scene should not be empty. Would you like to
+  //                                rename "
+  //                                        "the planning scene?'"),
+  //                                QMessageBox::Cancel, this));
+  //      else
+  //        q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Scene Overwrite",
+  //                                QString("A planning scene named '")
+  //                                    .append(name.c_str())
+  //                                    .append("' already exists. Do you wish to "
+  //                                            "overwrite that scene?"),
+  //                                QMessageBox::Yes | QMessageBox::No, this));
+  //      std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+  //      if (q->exec() != QMessageBox::Yes)
+  //      {
+  //        if (q->clickedButton() == rename.get())
+  //        {
+  //          bool ok = false;
+  //          QString new_name = QInputDialog::getText(this, "Rename Planning Scene", "New name for the planning
+  //          scene:",
+  //                                                   QLineEdit::Normal, QString::fromStdString(name), &ok);
+  //          if (ok)
+  //          {
+  //            planning_display_->getPlanningSceneRW()->setName(new_name.toStdString());
+  //            rviz_common::properties::Property* prop = planning_display_->subProp("Scene Geometry")->subProp("Scene
+  //            Name");
+  //            if (prop)
+  //            {
+  //              bool old = prop->blockSignals(true);
+  //              prop->setValue(new_name);
+  //              prop->blockSignals(old);
+  //            }
+  //            saveSceneButtonClicked();
+  //          }
+  //          return;
+  //        }
+  //        return;
+  //      }
+  //    }
+  //
+  //    planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
+  //                                        "save scene");
+  //  }
 }
 
 void MotionPlanningFrame::planningSceneItemClicked()
@@ -118,66 +124,69 @@ void MotionPlanningFrame::planningSceneItemClicked()
 
 void MotionPlanningFrame::saveQueryButtonClicked()
 {
-  if (planning_scene_storage_)
-  {
-    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-    if (!sel.empty())
-    {
-      QTreeWidgetItem* s = sel.front();
-
-      // if we have selected a PlanningScene, add the query as a new one, under that planning scene
-      if (s->type() == ITEM_TYPE_SCENE)
-      {
-        std::string scene = s->text(0).toStdString();
-        planning_display_->addBackgroundJob(
-            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
-      }
-      else
-      {
-        // if we selected a query name, then we overwrite that query
-        std::string scene = s->parent()->text(0).toStdString();
-        std::string query_name = s->text(0).toStdString();
-
-        while (query_name.empty() || planning_scene_storage_->hasPlanningQuery(scene, query_name))
-        {
-          std::unique_ptr<QMessageBox> q;
-          if (query_name.empty())
-            q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Query Name",
-                                    QString("The name for the planning query should not be empty. Would you like to "
-                                            "rename the planning query?'"),
-                                    QMessageBox::Cancel, this));
-          else
-            q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Query Overwrite",
-                                    QString("A planning query named '")
-                                        .append(query_name.c_str())
-                                        .append("' already exists. Do you wish "
-                                                "to overwrite that query?"),
-                                    QMessageBox::Yes | QMessageBox::No, this));
-          std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
-          if (q->exec() == QMessageBox::Yes)
-            break;
-          else
-          {
-            if (q->clickedButton() == rename.get())
-            {
-              bool ok = false;
-              QString new_name =
-                  QInputDialog::getText(this, "Rename Planning Query", "New name for the planning query:",
-                                        QLineEdit::Normal, QString::fromStdString(query_name), &ok);
-              if (ok)
-                query_name = new_name.toStdString();
-              else
-                return;
-            }
-            else
-              return;
-          }
-        }
-        planning_display_->addBackgroundJob(
-            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save query");
-      }
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (planning_scene_storage_)
+  //  {
+  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+  //    if (!sel.empty())
+  //    {
+  //      QTreeWidgetItem* s = sel.front();
+  //
+  //      // if we have selected a PlanningScene, add the query as a new one, under that planning scene
+  //      if (s->type() == ITEM_TYPE_SCENE)
+  //      {
+  //        std::string scene = s->text(0).toStdString();
+  //        planning_display_->addBackgroundJob(
+  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
+  //      }
+  //      else
+  //      {
+  //        // if we selected a query name, then we overwrite that query
+  //        std::string scene = s->parent()->text(0).toStdString();
+  //        std::string query_name = s->text(0).toStdString();
+  //
+  //        while (query_name.empty() || planning_scene_storage_->hasPlanningQuery(scene, query_name))
+  //        {
+  //          std::unique_ptr<QMessageBox> q;
+  //          if (query_name.empty())
+  //            q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Query Name",
+  //                                    QString("The name for the planning query should not be empty. Would you like to
+  //                                    "
+  //                                            "rename the planning query?'"),
+  //                                    QMessageBox::Cancel, this));
+  //          else
+  //            q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Query Overwrite",
+  //                                    QString("A planning query named '")
+  //                                        .append(query_name.c_str())
+  //                                        .append("' already exists. Do you wish "
+  //                                                "to overwrite that query?"),
+  //                                    QMessageBox::Yes | QMessageBox::No, this));
+  //          std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+  //          if (q->exec() == QMessageBox::Yes)
+  //            break;
+  //          else
+  //          {
+  //            if (q->clickedButton() == rename.get())
+  //            {
+  //              bool ok = false;
+  //              QString new_name =
+  //                  QInputDialog::getText(this, "Rename Planning Query", "New name for the planning query:",
+  //                                        QLineEdit::Normal, QString::fromStdString(query_name), &ok);
+  //              if (ok)
+  //                query_name = new_name.toStdString();
+  //              else
+  //                return;
+  //            }
+  //            else
+  //              return;
+  //          }
+  //        }
+  //        planning_display_->addBackgroundJob(
+  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save
+  //            query");
+  //      }
+  //    }
+  //  }
 }
 
 void MotionPlanningFrame::deleteSceneButtonClicked()
@@ -208,94 +217,96 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
 {
   if (item->text(column) == item->toolTip(column) || item->toolTip(column).length() == 0)
     return;
-  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
-  if (!planning_scene_storage)
-    return;
-
-  if (item->type() == ITEM_TYPE_SCENE)
-  {
-    std::string new_name = item->text(column).toStdString();
-
-    if (planning_scene_storage->hasPlanningScene(new_name))
-    {
-      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-      QMessageBox::warning(this, "Scene not renamed",
-                           QString("The scene name '").append(item->text(column)).append("' already exists"));
-      return;
-    }
-    else
-    {
-      std::string old_name = item->toolTip(column).toStdString();
-      planning_scene_storage->renamePlanningScene(old_name, new_name);
-      item->setToolTip(column, item->text(column));
-    }
-  }
-  else
-  {
-    std::string scene = item->parent()->text(0).toStdString();
-    std::string new_name = item->text(column).toStdString();
-    if (planning_scene_storage->hasPlanningQuery(scene, new_name))
-    {
-      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-      QMessageBox::warning(this, "Query not renamed", QString("The query name '")
-                                                          .append(item->text(column))
-                                                          .append("' already exists for scene ")
-                                                          .append(item->parent()->text(0)));
-      return;
-    }
-    else
-    {
-      std::string old_name = item->toolTip(column).toStdString();
-      planning_scene_storage->renamePlanningQuery(scene, old_name, new_name);
-      item->setToolTip(column, item->text(column));
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
+  //  if (!planning_scene_storage)
+  //    return;
+  //
+  //  if (item->type() == ITEM_TYPE_SCENE)
+  //  {
+  //    std::string new_name = item->text(column).toStdString();
+  //
+  //    if (planning_scene_storage->hasPlanningScene(new_name))
+  //    {
+  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //      QMessageBox::warning(this, "Scene not renamed",
+  //                           QString("The scene name '").append(item->text(column)).append("' already exists"));
+  //      return;
+  //    }
+  //    else
+  //    {
+  //      std::string old_name = item->toolTip(column).toStdString();
+  //      planning_scene_storage->renamePlanningScene(old_name, new_name);
+  //      item->setToolTip(column, item->text(column));
+  //    }
+  //  }
+  //  else
+  //  {
+  //    std::string scene = item->parent()->text(0).toStdString();
+  //    std::string new_name = item->text(column).toStdString();
+  //    if (planning_scene_storage->hasPlanningQuery(scene, new_name))
+  //    {
+  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  //      QMessageBox::warning(this, "Query not renamed", QString("The query name '")
+  //                                                          .append(item->text(column))
+  //                                                          .append("' already exists for scene ")
+  //                                                          .append(item->parent()->text(0)));
+  //      return;
+  //    }
+  //    else
+  //    {
+  //      std::string old_name = item->toolTip(column).toStdString();
+  //      planning_scene_storage->renamePlanningQuery(scene, old_name, new_name);
+  //      item->setToolTip(column, item->text(column));
+  //    }
+  //  }
 }
 
 void MotionPlanningFrame::populatePlanningSceneTreeView()
 {
-  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
-  if (!planning_scene_storage)
-    return;
-
-  ui_->planning_scene_tree->setUpdatesEnabled(false);
-
-  // remember which items were expanded
-  std::set<std::string> expanded;
-  for (int i = 0; i < ui_->planning_scene_tree->topLevelItemCount(); ++i)
-  {
-    QTreeWidgetItem* it = ui_->planning_scene_tree->topLevelItem(i);
-    if (it->isExpanded())
-      expanded.insert(it->text(0).toStdString());
-  }
-
-  ui_->planning_scene_tree->clear();
-  std::vector<std::string> names;
-  planning_scene_storage->getPlanningSceneNames(names);
-
-  for (const std::string& name : names)
-  {
-    std::vector<std::string> query_names;
-    planning_scene_storage->getPlanningQueriesNames(query_names, name);
-    QTreeWidgetItem* item =
-        new QTreeWidgetItem(ui_->planning_scene_tree, QStringList(QString::fromStdString(name)), ITEM_TYPE_SCENE);
-    item->setFlags(item->flags() | Qt::ItemIsEditable);
-    item->setToolTip(0, item->text(0));  // we use the tool tip as a backup of the old name when renaming
-    for (const std::string& query_name : query_names)
-    {
-      QTreeWidgetItem* subitem =
-          new QTreeWidgetItem(item, QStringList(QString::fromStdString(query_name)), ITEM_TYPE_QUERY);
-      subitem->setFlags(subitem->flags() | Qt::ItemIsEditable);
-      subitem->setToolTip(0, subitem->text(0));
-      item->addChild(subitem);
-    }
-
-    ui_->planning_scene_tree->insertTopLevelItem(ui_->planning_scene_tree->topLevelItemCount(), item);
-    if (expanded.find(name) != expanded.end())
-      ui_->planning_scene_tree->expandItem(item);
-  }
-  ui_->planning_scene_tree->sortItems(0, Qt::AscendingOrder);
-  ui_->planning_scene_tree->setUpdatesEnabled(true);
-  checkPlanningSceneTreeEnabledButtons();
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
+  //  if (!planning_scene_storage)
+  //    return;
+  //
+  //  ui_->planning_scene_tree->setUpdatesEnabled(false);
+  //
+  //  // remember which items were expanded
+  //  std::set<std::string> expanded;
+  //  for (int i = 0; i < ui_->planning_scene_tree->topLevelItemCount(); ++i)
+  //  {
+  //    QTreeWidgetItem* it = ui_->planning_scene_tree->topLevelItem(i);
+  //    if (it->isExpanded())
+  //      expanded.insert(it->text(0).toStdString());
+  //  }
+  //
+  //  ui_->planning_scene_tree->clear();
+  //  std::vector<std::string> names;
+  //  planning_scene_storage->getPlanningSceneNames(names);
+  //
+  //  for (const std::string& name : names)
+  //  {
+  //    std::vector<std::string> query_names;
+  //    planning_scene_storage->getPlanningQueriesNames(query_names, name);
+  //    QTreeWidgetItem* item =
+  //        new QTreeWidgetItem(ui_->planning_scene_tree, QStringList(QString::fromStdString(name)), ITEM_TYPE_SCENE);
+  //    item->setFlags(item->flags() | Qt::ItemIsEditable);
+  //    item->setToolTip(0, item->text(0));  // we use the tool tip as a backup of the old name when renaming
+  //    for (const std::string& query_name : query_names)
+  //    {
+  //      QTreeWidgetItem* subitem =
+  //          new QTreeWidgetItem(item, QStringList(QString::fromStdString(query_name)), ITEM_TYPE_QUERY);
+  //      subitem->setFlags(subitem->flags() | Qt::ItemIsEditable);
+  //      subitem->setToolTip(0, subitem->text(0));
+  //      item->addChild(subitem);
+  //    }
+  //
+  //    ui_->planning_scene_tree->insertTopLevelItem(ui_->planning_scene_tree->topLevelItemCount(), item);
+  //    if (expanded.find(name) != expanded.end())
+  //      ui_->planning_scene_tree->expandItem(item);
+  //  }
+  //  ui_->planning_scene_tree->sortItems(0, Qt::AscendingOrder);
+  //  ui_->planning_scene_tree->setUpdatesEnabled(true);
+  //  checkPlanningSceneTreeEnabledButtons();
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -33,8 +33,9 @@
  *********************************************************************/
 
 /* Author: Mario Prats, Ioan Sucan */
+// TODO (ddengster): Enable when moveit_ros_warehouse is ported
+// #include <moveit/warehouse/state_storage.h>
 
-#include <moveit/warehouse/state_storage.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 #include <moveit/robot_state/conversions.h>
@@ -46,10 +47,12 @@
 
 namespace moveit_rviz_plugin
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_frame_states");
+
 void MotionPlanningFrame::populateRobotStatesList()
 {
   ui_->list_states->clear();
-  for (std::pair<const std::string, moveit_msgs::RobotState>& robot_state : robot_states_)
+  for (std::pair<const std::string, moveit_msgs::msg::RobotState>& robot_state : robot_states_)
   {
     QListWidgetItem* item = new QListWidgetItem(QString(robot_state.first.c_str()));
     ui_->list_states->addItem(item);
@@ -58,18 +61,19 @@ void MotionPlanningFrame::populateRobotStatesList()
 
 void MotionPlanningFrame::loadStateButtonClicked()
 {
-  if (robot_state_storage_)
-  {
-    bool ok;
-
-    QString text =
-        QInputDialog::getText(this, tr("Robot states to load"), tr("Pattern:"), QLineEdit::Normal, ".*", &ok);
-    if (ok && !text.isEmpty())
-    {
-      loadStoredStates(text.toStdString());
-    }
-  }
-  else
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (robot_state_storage_)
+  //  {
+  //    bool ok;
+  //
+  //    QString text =
+  //        QInputDialog::getText(this, tr("Robot states to load"), tr("Pattern:"), QLineEdit::Normal, ".*", &ok);
+  //    if (ok && !text.isEmpty())
+  //    {
+  //      loadStoredStates(text.toStdString());
+  //    }
+  //  }
+  //  else
   {
     QMessageBox::warning(this, "Warning", "Not connected to a database.");
   }
@@ -77,45 +81,45 @@ void MotionPlanningFrame::loadStateButtonClicked()
 
 void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
 {
-  std::vector<std::string> names;
-  try
-  {
-    robot_state_storage_->getKnownRobotStates(pattern, names);
-  }
-  catch (std::exception& ex)
-  {
-    QMessageBox::warning(this, "Cannot query the database",
-                         QString("Wrongly formatted regular expression for robot states: ").append(ex.what()));
-    return;
-  }
-
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  // std::vector<std::string> names;
+  //  try
+  //  {
+  //    robot_state_storage_->getKnownRobotStates(pattern, names);
+  //  }
+  //  catch (std::exception& ex)
+  //  {
+  //    QMessageBox::warning(this, "Cannot query the database",
+  //                         QString("Wrongly formatted regular expression for robot states: ").append(ex.what()));
+  //    return;
+  //  }
   // Clear the current list
   clearStatesButtonClicked();
 
-  for (const std::string& name : names)
-  {
-    moveit_warehouse::RobotStateWithMetadata rs;
-    bool got_state = false;
-    try
-    {
-      got_state = robot_state_storage_->getRobotState(rs, name);
-    }
-    catch (std::exception& ex)
-    {
-      ROS_ERROR("%s", ex.what());
-    }
-    if (!got_state)
-      continue;
-
-    // Overwrite if exists.
-    if (robot_states_.find(name) != robot_states_.end())
-    {
-      robot_states_.erase(name);
-    }
-
-    // Store the current start state
-    robot_states_.insert(RobotStatePair(name, *rs));
-  }
+  //  for (const std::string& name : names)
+  //  {
+  //    moveit_warehouse::RobotStateWithMetadata rs;
+  //    bool got_state = false;
+  //    try
+  //    {
+  //      got_state = robot_state_storage_->getRobotState(rs, name);
+  //    }
+  //    catch (std::exception& ex)
+  //    {
+  //      ROS_ERROR("%s", ex.what());
+  //    }
+  //    if (!got_state)
+  //      continue;
+  //
+  //    // Overwrite if exists.
+  //    if (robot_states_.find(name) != robot_states_.end())
+  //    {
+  //      robot_states_.erase(name);
+  //    }
+  //
+  //    // Store the current start state
+  //    robot_states_.insert(RobotStatePair(name, *rs));
+  //  }
   populateRobotStatesList();
 }
 
@@ -148,22 +152,23 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const moveit::core::RobotS
         robot_states_.insert(RobotStatePair(name, msg));
 
         // Save to the database if connected
-        if (robot_state_storage_)
-        {
-          try
-          {
-            robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
-          }
-          catch (std::exception& ex)
-          {
-            ROS_ERROR("Cannot save robot state on the database: %s", ex.what());
-          }
-        }
-        else
-        {
-          QMessageBox::warning(this, "Warning",
-                               "Not connected to a database. The state will be created but not stored");
-        }
+        // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+        //        if (robot_state_storage_)
+        //        {
+        //          try
+        //          {
+        //            robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
+        //          }
+        //          catch (std::exception& ex)
+        //          {
+        //            ROS_ERROR("Cannot save robot state on the database: %s", ex.what());
+        //          }
+        //        }
+        //        else
+        //        {
+        //          QMessageBox::warning(this, "Warning",
+        //                               "Not connected to a database. The state will be created but not stored");
+        //        }
       }
     }
     else
@@ -196,50 +201,52 @@ void MotionPlanningFrame::setAsStartStateButtonClicked()
 
 void MotionPlanningFrame::setAsGoalStateButtonClicked()
 {
-  QListWidgetItem* item = ui_->list_states->currentItem();
-
-  if (item)
-  {
-    moveit::core::RobotState robot_state(*planning_display_->getQueryGoalState());
-    moveit::core::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
-    planning_display_->setQueryGoalState(robot_state);
-  }
+  // TODO (ddengster): Enable when moveit_ros_robot_interaction is ported
+  //  QListWidgetItem* item = ui_->list_states->currentItem();
+  //
+  //  if (item)
+  //  {
+  //    moveit::core::RobotState robot_state(*planning_display_->getQueryGoalState());
+  //    moveit::core::robotStateMsgToRobotState(robot_states_[item->text().toStdString()], robot_state);
+  //    planning_display_->setQueryGoalState(robot_state);
+  //  }
 }
 
 void MotionPlanningFrame::removeStateButtonClicked()
 {
-  if (robot_state_storage_)
-  {
-    // Warn the user
-    QMessageBox msg_box;
-    msg_box.setText("All the selected states will be removed from the database");
-    msg_box.setInformativeText("Do you want to continue?");
-    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-    msg_box.setDefaultButton(QMessageBox::No);
-    int ret = msg_box.exec();
-
-    switch (ret)
-    {
-      case QMessageBox::Yes:
-      {
-        QList<QListWidgetItem*> found_items = ui_->list_states->selectedItems();
-        for (QListWidgetItem* found_item : found_items)
-        {
-          const std::string& name = found_item->text().toStdString();
-          try
-          {
-            robot_state_storage_->removeRobotState(name);
-            robot_states_.erase(name);
-          }
-          catch (std::exception& ex)
-          {
-            ROS_ERROR("%s", ex.what());
-          }
-        }
-        break;
-      }
-    }
-  }
+  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
+  //  if (robot_state_storage_)
+  //  {
+  //    // Warn the user
+  //    QMessageBox msg_box;
+  //    msg_box.setText("All the selected states will be removed from the database");
+  //    msg_box.setInformativeText("Do you want to continue?");
+  //    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+  //    msg_box.setDefaultButton(QMessageBox::No);
+  //    int ret = msg_box.exec();
+  //
+  //    switch (ret)
+  //    {
+  //      case QMessageBox::Yes:
+  //      {
+  //        QList<QListWidgetItem*> found_items = ui_->list_states->selectedItems();
+  //        for (QListWidgetItem* found_item : found_items)
+  //        {
+  //          const std::string& name = found_item->text().toStdString();
+  //          try
+  //          {
+  //            robot_state_storage_->removeRobotState(name);
+  //            robot_states_.erase(name);
+  //          }
+  //          catch (std::exception& ex)
+  //          {
+  //            RCLCPP_ERROR(LOGGER, "%s", ex.what());
+  //          }
+  //        }
+  //        break;
+  //      }
+  //    }
+  //  }
   populateRobotStatesList();
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/plugin_init.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/plugin_init.cpp
@@ -37,4 +37,4 @@
 #include <class_loader/class_loader.hpp>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 
-CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::MotionPlanningDisplay, rviz::Display)
+CLASS_LOADER_REGISTER_CLASS(moveit_rviz_plugin::MotionPlanningDisplay, rviz_common::Display)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin_description.xml
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin_description.xml
@@ -1,5 +1,5 @@
-<library path="libmoveit_motion_planning_rviz_plugin">
-  <class name="moveit_rviz_plugin/MotionPlanning" type="moveit_rviz_plugin::MotionPlanningDisplay" base_class_type="rviz::Display">
+<library path="moveit_motion_planning_rviz_plugin">
+  <class name="moveit_rviz_plugin/MotionPlanning" type="moveit_rviz_plugin::MotionPlanningDisplay" base_class_type="rviz_common::Display">
     <description>
       Displays information about a planning scene and can animate solution paths within that planning scene.
     </description>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -28,8 +28,7 @@
 
   <depend>geometric_shapes</depend>
   <depend>interactive_markers</depend>
-  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_robot_interaction -->
-  <!--depend>moveit_ros_robot_interaction</depend-->
+  <depend>moveit_ros_robot_interaction</depend>
   <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_perception -->
   <!--depend>moveit_ros_perception</depend-->
   <depend>moveit_ros_planning_interface</depend>


### PR DESCRIPTION
### Description

This a port to get the Motion Planning tool working as listed [here](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html#step-4-use-motion-planning-with-the-panda). This involves the package motion_planning_rviz_plugin.

It's submodules moveit_ros_robot_interaction and fake_controller_manager have been ported and are compiling correctly, feel free to siphon changes from them. They can be ported independently as far as I know.

I'm also working off the move_group PR #187.

The other submodules like moveit_ros_perception and moveit_ros_warehouse, I don't think there's a use for them in the usage of the tool, so I will not port them.

Consider commits from 59e268c and onwards.

~~The remaining submodule that I haven't finished port is motion_planning_rviz_plugin is still a WIP. Will update when it's ready.~~

Edit: It's done!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
