### PR TITLE
Update joint_state_publisher dependency

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -10,7 +10,7 @@ repositories:
   joint_state_publisher:
     type: git
     url: https://github.com/ros/joint_state_publisher
-    version: ros2-devel
+    version: ros2
   random_numbers:
     type: git
     url: https://github.com/ros-planning/random_numbers


### PR DESCRIPTION
This should fix failing CI (see #199). Apparently the `ros2-devel` branch of `joint_state_publsher` doesn't exist anymore. I switched it to `ros2`. Not sure if we might want to switch to `eloquent` with the release branch in the future.
