### PR TITLE
Port Ikfast kinematics solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ jobs:
     - compiler: clang  # test_ikfast_plugins takes ~10 minutes: include here to keep the main jobs shorter
       env: TEST=clang-tidy-fix
            CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-overloaded-virtual"
-           # TODO(mlautman): Enable once franka_ikfast_plugin and panda_ikfast_plugin are available
-           # BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
+           BEFORE_DOCKER_SCRIPT="source moveit_kinematics/test/test_ikfast_plugins.sh"
   allow_failures:
     - env: TEST=code-coverage
 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 add_subdirectory(kdl_kinematics_plugin)
 add_subdirectory(lma_kinematics_plugin)
 add_subdirectory(srv_kinematics_plugin)
-# add_subdirectory(ikfast_kinematics_plugin)
+add_subdirectory(ikfast_kinematics_plugin)
 add_subdirectory(cached_ik_kinematics_plugin)
 add_subdirectory(test)
 

--- a/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/CMakeLists.txt
@@ -10,12 +10,12 @@ install(
     scripts/create_ikfast_moveit_plugin.py
     scripts/round_collada_numbers.py
   DESTINATION
-    ${CATKIN_PACKAGE_BIN_DESTINATION}
+    lib/${PROJECT_NAME}
 )
 
 install(
   DIRECTORY
     templates
   DESTINATION
-    ${CATKIN_PACKAGE_SHARE_DESTINATION}/ikfast_kinematics_plugin
+    share/${PROJECT_NAME}/ikfast_kinematics_plugin
 )

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -5,35 +5,48 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(catkin REQUIRED COMPONENTS
-  moveit_core
-  pluginlib
-  roscpp
-  tf2_kdl
-  tf2_eigen
-  eigen_conversions
-)
+find_package(ament_cmake REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_kdl REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(LAPACK REQUIRED)
 
-include_directories(${catkin_INCLUDE_DIRS} include)
-
-catkin_package()
+include_directories(include)
 
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)
 add_library(${IKFAST_LIBRARY_NAME} src/_ROBOT_NAME___GROUP_NAME__ikfast_moveit_plugin.cpp)
-target_link_libraries(${IKFAST_LIBRARY_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
+ament_target_dependencies(${IKFAST_LIBRARY_NAME}
+  rclcpp
+  moveit_core
+  pluginlib
+  tf2_kdl
+  orocos_kdl
+  tf2_eigen
+)
 # suppress warnings about unused variables in OpenRave's solver code
 target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable)
 
 install(TARGETS
   ${IKFAST_LIBRARY_NAME}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
 
 install(
   FILES
   _ROBOT_NAME___GROUP_NAME__moveit_ikfast_plugin_description.xml
   DESTINATION
-  ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  share
 )
+
+pluginlib_export_plugin_description_file(moveit_core _ROBOT_NAME___GROUP_NAME__moveit_ikfast_plugin_description.xml)
+
+ament_export_libraries(${IKFAST_LIBRARY_NAME})
+ament_export_dependencies(moveit_core)
+ament_export_dependencies(pluginlib)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(tf2_kdl)
+ament_export_dependencies(tf2_eigen)
+ament_package()

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -12,6 +12,10 @@ travis_run git clone -q --depth=1 -b ros2 https://github.com/ros-planning/moveit
 fanuc=/tmp/resources/fanuc_description/urdf/fanuc.urdf
 panda=/tmp/resources/panda_description/urdf/panda.urdf
 
+# Install lxml required for create_ikfast_moveit_plugin.py
+travis_run_true sudo apt-get -qq update
+travis_run sudo apt-get -qq install -y python-lxml
+
 # Translate environment variable QUIET=[0 | 1] into actual option
 test ${QUIET:-1} -eq 0 && QUIET="" || QUIET="--quiet"
 

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -8,7 +8,7 @@
 # using the script auto_create_ikfast_moveit_plugin.sh
 
 # Clone moveit_resources for URDFs. They are not available before running docker.
-travis_run git clone -q --depth=1 https://github.com/ros-planning/moveit_resources /tmp/resources
+travis_run git clone -q --depth=1 -b ros2 https://github.com/ros-planning/moveit_resources /tmp/resources
 fanuc=/tmp/resources/fanuc_description/urdf/fanuc.urdf
 panda=/tmp/resources/panda_description/urdf/panda.urdf
 

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -21,9 +21,9 @@ test ${QUIET:-1} -eq 0 && QUIET="" || QUIET="--quiet"
 
 # Create ikfast plugins for Fanuc and Panda
 travis_run moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
-	$QUIET --name fanuc --pkg $PWD/fanuc_ikfast_plugin $fanuc manipulator base_link tool0
+	$QUIET --name fanuc --pkg $PWD/../fanuc_ikfast_plugin $fanuc manipulator base_link tool0
 
 travis_run moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh \
-	$QUIET --name panda --pkg $PWD/panda_ikfast_plugin $panda panda_arm panda_link0 panda_link8
+	$QUIET --name panda --pkg $PWD/../panda_ikfast_plugin $panda panda_arm panda_link0 panda_link8
 
 echo "Done."


### PR DESCRIPTION
### Description

eigen_conversion isn't ported yet to ROS2 so I copied the needed function and dropped its dependency

I tested it with panda robot steps are as follow [Source](https://ros-planning.github.io/moveit_tutorials/doc/ikfast/ikfast_tutorial.html)
1- clone https://github.com/JafarAbdi/panda_moveit_config/tree/ros2
2- cd moveit_resources/panda_description/urdf
3- ros2 run moveit_kinematics auto_create_ikfast_moveit_plugin.sh panda.urdf panda_arm panda_link0 panda_link8
4- now move the generated package to the main source path and recompile (the generated package name is panda_panda_arm_ikfast_plugin)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
