### PR TITLE
Apply missing clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
 ---
+# TODO(henningkayser): Re-enable performance-unnecessary-value-param once #214 is resolved
 Checks:          '-*,
                   performance-*,
+                  -performance-unnecessary-value-param,
                   llvm-namespace-comment,
                   modernize-redundant-void-arg,
                   modernize-use-nullptr,

--- a/doc/MIGRATION_GUIDE.md
+++ b/doc/MIGRATION_GUIDE.md
@@ -42,4 +42,4 @@ If the source file name is the same or very similar to the library name it is su
 
 Some classes declared in header files may contain log messages, for instance to warn about not-implemented virtual functions in abstract classes.
 A logger defined in the header file would not tell us what derived class is missing the implementation, since the source name would be resolved from the header file.
-For this case, the base class should declare a private member variable `static const rclcpp::Logger logger_` which is to be defined in the implementing class using the corresponding source file name.
+For this case, the base class should declare a private member variable `static const rclcpp::Logger LOGGER` which is to be defined in the implementing class using the corresponding source file name.

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -412,7 +412,7 @@ public:
   {
     if (i >= decomp_vector_.size())
     {
-      RCLCPP_INFO(logger_, "No body decomposition");
+      RCLCPP_INFO(LOGGER, "No body decomposition");
       return empty_ptr_;
     }
     return decomp_vector_[i];
@@ -422,7 +422,7 @@ public:
   {
     if (ind >= decomp_vector_.size())
     {
-      RCLCPP_WARN(logger_, "Can't update pose");
+      RCLCPP_WARN(LOGGER, "Can't update pose");
       return;
     }
     decomp_vector_[ind]->updatePose(pose);
@@ -433,7 +433,7 @@ public:
   }
 
 private:
-  static const rclcpp::Logger logger_;
+  static const rclcpp::Logger LOGGER;
   PosedBodySphereDecompositionConstPtr empty_ptr_;
   std::vector<PosedBodySphereDecompositionPtr> decomp_vector_;
   std::vector<CollisionSphere> collision_spheres_;
@@ -475,7 +475,7 @@ public:
   {
     if (i >= decomp_vector_.size())
     {
-      RCLCPP_INFO(logger_, "No body decomposition");
+      RCLCPP_INFO(LOGGER, "No body decomposition");
       return empty_ptr_;
     }
     return decomp_vector_[i];
@@ -489,13 +489,13 @@ public:
     }
     else
     {
-      RCLCPP_WARN(logger_, "Can't update pose");
+      RCLCPP_WARN(LOGGER, "Can't update pose");
       return;
     }
   }
 
 protected:
-  static const rclcpp::Logger logger_;
+  static const rclcpp::Logger LOGGER;
 
 private:
   PosedBodyPointDecompositionPtr empty_ptr_;

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -406,11 +406,11 @@ void getCollisionSphereMarkers(const std_msgs::msg::ColorRGBA& color, const std:
 {
   unsigned int count = 0;
   rclcpp::Clock ros_clock;
-  for (unsigned int i = 0; i < posed_decompositions.size(); i++)
+  for (const auto& posed_decomposition : posed_decompositions)
   {
-    if (posed_decompositions[i])
+    if (posed_decomposition)
     {
-      for (unsigned int j = 0; j < posed_decompositions[i]->getCollisionSpheres().size(); j++)
+      for (unsigned int j = 0; j < posed_decomposition->getCollisionSpheres().size(); j++)
       {
         visualization_msgs::msg::Marker sphere;
         sphere.type = visualization_msgs::msg::Marker::SPHERE;
@@ -420,11 +420,10 @@ void getCollisionSphereMarkers(const std_msgs::msg::ColorRGBA& color, const std:
         sphere.id = count++;
         sphere.lifetime = dur;
         sphere.color = color;
-        sphere.scale.x = sphere.scale.y = sphere.scale.z =
-            posed_decompositions[i]->getCollisionSpheres()[j].radius_ * 2.0;
-        sphere.pose.position.x = posed_decompositions[i]->getSphereCenters()[j].x();
-        sphere.pose.position.y = posed_decompositions[i]->getSphereCenters()[j].y();
-        sphere.pose.position.z = posed_decompositions[i]->getSphereCenters()[j].z();
+        sphere.scale.x = sphere.scale.y = sphere.scale.z = posed_decomposition->getCollisionSpheres()[j].radius_ * 2.0;
+        sphere.pose.position.x = posed_decomposition->getSphereCenters()[j].x();
+        sphere.pose.position.y = posed_decomposition->getSphereCenters()[j].y();
+        sphere.pose.position.z = posed_decomposition->getSphereCenters()[j].z();
         arr.markers.push_back(sphere);
       }
     }

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -46,8 +46,6 @@ namespace collision_detection
 {
 static const rclcpp::Logger LOGGER =
     rclcpp::get_logger("moveit_collision_distance_field.collision_distance_field_types");
-const rclcpp::Logger PosedBodyPointDecompositionVector::logger_ = LOGGER;
-const rclcpp::Logger PosedBodySphereDecompositionVector::logger_ = LOGGER;
 
 std::vector<CollisionSphere> determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relative_transform)
 {
@@ -612,3 +610,5 @@ void getCollisionMarkers(const std::string& frame_id, const std::string& ns, con
   }
 }
 }  // namespace collision_detection
+const rclcpp::Logger collision_detection::PosedBodyPointDecompositionVector::LOGGER = collision_detection::LOGGER;
+const rclcpp::Logger collision_detection::PosedBodySphereDecompositionVector::LOGGER = collision_detection::LOGGER;

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -439,7 +439,7 @@ public:
    * @param [out] marker The marker that will contain the indicated cells.
    */
   void getIsoSurfaceMarkers(double min_distance, double max_distance, const std::string& frame_id,
-                            const rclcpp::Time stamp, visualization_msgs::msg::Marker& marker) const;
+                            const rclcpp::Time& stamp, visualization_msgs::msg::Marker& marker) const;
 
   /**
    * \brief Populates the supplied marker array with a series of
@@ -483,7 +483,7 @@ public:
    * @param [out] marker The marker that will contain the indicated cells.
    */
   void getPlaneMarkers(PlaneVisualizationType type, double length, double width, double height,
-                       const Eigen::Vector3d& origin, const std::string& frame_id, const rclcpp::Time stamp,
+                       const Eigen::Vector3d& origin, const std::string& frame_id, const rclcpp::Time& stamp,
                        visualization_msgs::msg::Marker& marker) const;
   /**
    * \brief A function that populates the marker with three planes -

--- a/moveit_core/distance_field/src/distance_field.cpp
+++ b/moveit_core/distance_field/src/distance_field.cpp
@@ -89,7 +89,7 @@ double DistanceField::getDistanceGradient(double x, double y, double z, double& 
 }
 
 void DistanceField::getIsoSurfaceMarkers(double min_distance, double max_distance, const std::string& frame_id,
-                                         const rclcpp::Time stamp, visualization_msgs::msg::Marker& inf_marker) const
+                                         const rclcpp::Time& stamp, visualization_msgs::msg::Marker& inf_marker) const
 {
   inf_marker.points.clear();
   inf_marker.header.frame_id = frame_id;
@@ -337,7 +337,7 @@ void DistanceField::removeShapeFromField(const shapes::Shape* shape, const geome
 
 void DistanceField::getPlaneMarkers(PlaneVisualizationType type, double length, double width, double height,
                                     const Eigen::Vector3d& origin, const std::string& frame_id,
-                                    const rclcpp::Time stamp, visualization_msgs::msg::Marker& plane_marker) const
+                                    const rclcpp::Time& stamp, visualization_msgs::msg::Marker& plane_marker) const
 {
   plane_marker.header.frame_id = frame_id;
   plane_marker.header.stamp = stamp;

--- a/moveit_core/exceptions/src/exceptions.cpp
+++ b/moveit_core/exceptions/src/exceptions.cpp
@@ -51,4 +51,4 @@ Exception::Exception(const std::string& what_arg) : std::runtime_error(what_arg)
 {
   RCLCPP_ERROR(LOGGER, "%s\nException thrown.", what_arg.c_str());
 }
-}
+}  // namespace moveit

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -44,10 +44,10 @@
 #include <algorithm>
 #include <map>
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.plugins.moveit_simple_controller_manager");
-
 namespace moveit_simple_controller_manager
 {
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.plugins.moveit_simple_controller_manager");
+static const std::string PARAM_BASE_NAME = "moveit_simple_controller_manager";
 class MoveItSimpleControllerManager : public moveit_controller_manager::MoveItControllerManager
 {
 public:
@@ -57,8 +57,6 @@ public:
 
   void initialize(const rclcpp::Node::SharedPtr& node) override
   {
-    // TODO(henningkayser): use flexible base
-    const std::string PARAM_BASE_NAME = "moveit_simple_controller_manager";
     node_ = node;
     if (!node_->has_parameter(PARAM_BASE_NAME + ".controller_names"))
     {

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -43,7 +43,7 @@
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.occupancy_map_server");
 
-static void publishOctomap(rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr octree_binary_pub,
+static void publishOctomap(const rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr& octree_binary_pub,
                            occupancy_map_monitor::OccupancyMapMonitor* server)
 {
   octomap_msgs::msg::Octomap map;

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -118,8 +118,8 @@ public:
     // Debug tip choices
     std::stringstream tip_debug;
     tip_debug << "Planning group '" << jmg->getName() << "' has tip(s): ";
-    for (std::size_t i = 0; i < tips.size(); ++i)
-      tip_debug << tips[i] << ", ";
+    for (const auto& tip : tips)
+      tip_debug << tip << ", ";
     RCLCPP_DEBUG(LOGGER, tip_debug.str());
 
     return tips;
@@ -354,7 +354,7 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
             rclcpp::Parameter ksolver_res_param = node_->get_parameter(ksolver_res_param_name);
             if (ksolver_res_param.get_type() == rclcpp::ParameterType::PARAMETER_STRING)
             {
-              std::string ksolver_res = ksolver_res_param.as_string();
+              const std::string& ksolver_res = ksolver_res_param.as_string();
               std::stringstream ss(ksolver_res);
               while (ss.good() && !ss.eof())
               {
@@ -384,11 +384,10 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
             if (ksolver_ik_links_param.get_type() == rclcpp::ParameterType::PARAMETER_STRING_ARRAY)
             {
               std::vector<std::string> ksolver_ik_links = ksolver_ik_links_param.as_string_array();
-              for (size_t j = 0; j < ksolver_ik_links.size(); ++j)
+              for (auto& ksolver_ik_link : ksolver_ik_links)
               {
-                RCLCPP_DEBUG(LOGGER, "found tip %s for group %s", ksolver_ik_links[j].c_str(),
-                             known_group.name_.c_str());
-                iksolver_to_tip_links[known_group.name_].push_back(ksolver_ik_links[j]);
+                RCLCPP_DEBUG(LOGGER, "found tip %s for group %s", ksolver_ik_link.c_str(), known_group.name_.c_str());
+                iksolver_to_tip_links[known_group.name_].push_back(ksolver_ik_link);
               }
             }
             else

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -78,7 +78,7 @@ public:
       \param adapter_plugins_param_name The name of the ROS parameter under which the names of the request adapter
      plugins are specified (plugin names separated by space; order matters)
   */
-  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node> node,
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node>& node,
                    const std::string& parameter_namespace,
                    const std::string& planning_plugin_param_name = "planning_plugin",
                    const std::string& adapter_plugins_param_name = "request_adapters");
@@ -90,7 +90,7 @@ public:
       \param planning_plugin_name The name of the planning plugin to load
       \param adapter_plugins_names The names of the planning request adapter plugins to load
   */
-  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node> node,
+  PlanningPipeline(const moveit::core::RobotModelConstPtr& model, const std::shared_ptr<rclcpp::Node>& node,
                    const std::string& parameter_namespace, const std::string& planning_plugin_name,
                    const std::vector<std::string>& adapter_plugin_names);
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -49,7 +49,7 @@ const std::string planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC
 const std::string planning_pipeline::PlanningPipeline::MOTION_CONTACTS_TOPIC = "display_contacts";
 
 planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
-                                                      const std::shared_ptr<rclcpp::Node> node,
+                                                      const std::shared_ptr<rclcpp::Node>& node,
                                                       const std::string& parameter_namespace,
                                                       const std::string& planner_plugin_param_name,
                                                       const std::string& adapter_plugins_param_name)
@@ -72,7 +72,7 @@ planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotM
 }
 
 planning_pipeline::PlanningPipeline::PlanningPipeline(const moveit::core::RobotModelConstPtr& model,
-                                                      const std::shared_ptr<rclcpp::Node> node,
+                                                      const std::shared_ptr<rclcpp::Node>& node,
                                                       const std::string& parameter_namespace,
                                                       const std::string& planner_plugin_name,
                                                       const std::vector<std::string>& adapter_plugin_names)

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -132,7 +132,7 @@ public:
   /** @brief Wait for at most \e wait_time seconds (default 1s) for a robot state more recent than t
    *  @return true on success, false if up-to-date robot state wasn't received within \e wait_time
   */
-  bool waitForCurrentState(const rclcpp::Time t = rclcpp::Clock().now(), double wait_time = 1.0) const;
+  bool waitForCurrentState(const rclcpp::Time& t = rclcpp::Clock().now(), double wait_time = 1.0) const;
 
   /** @brief Wait for at most \e wait_time seconds until the complete robot state is known.
       @return true if the full state is known */

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -272,7 +272,7 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(const rclcpp
   return result;
 }
 
-bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const rclcpp::Time t, double wait_time) const
+bool planning_scene_monitor::CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait_time) const
 {
   rclcpp::Time start = rclcpp::Clock().now();
   rclcpp::Duration elapsed(0, 0);

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1444,13 +1444,13 @@ void PlanningSceneMonitor::configureDefaultPadding()
   }
 
   // Ensure no leading slash creates a bad param server address
-  static const std::string robot_description =
+  static const std::string ROBOT_DESCRIPTION =
       (robot_description_[0] == '/') ? robot_description_.substr(1) : robot_description_;
 
-  node_->get_parameter_or(robot_description + "_planning/default_robot_padding", default_robot_padd_, 0.0);
-  node_->get_parameter_or(robot_description + "_planning/default_robot_scale", default_robot_scale_, 1.0);
-  node_->get_parameter_or(robot_description + "_planning/default_object_padding", default_object_padd_, 0.0);
-  node_->get_parameter_or(robot_description + "_planning/default_attached_padding", default_attached_padd_, 0.0);
+  node_->get_parameter_or(ROBOT_DESCRIPTION + "_planning/default_robot_padding", default_robot_padd_, 0.0);
+  node_->get_parameter_or(ROBOT_DESCRIPTION + "_planning/default_robot_scale", default_robot_scale_, 1.0);
+  node_->get_parameter_or(ROBOT_DESCRIPTION + "_planning/default_object_padding", default_object_padd_, 0.0);
+  node_->get_parameter_or(ROBOT_DESCRIPTION + "_planning/default_attached_padding", default_attached_padd_, 0.0);
   default_robot_link_padd_ = std::map<std::string, double>();
   default_robot_link_scale_ = std::map<std::string, double>();
   // TODO: enable parameter type support to std::map

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
@@ -73,10 +73,10 @@ public:
    * \brief Constructor
    *
    * @param scene_manager The scene manager this object is associated with
-   * @param parent_node A scene node to use as the parent of this object.  If NULL, uses the root scene node.
+   * @param parent_node A scene node to use as the parent of this object.  If nullptr, uses the root scene node.
    */
-  MeshShape(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node = NULL);
-  virtual ~MeshShape();
+  MeshShape(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node = nullptr);
+  ~MeshShape() override;
 
   /* \brief Estimate the number of vertices ahead of time. */
   void estimateVertexCount(size_t vcount);
@@ -136,6 +136,6 @@ private:
   Ogre::ManualObject* manual_object_;
 };
 
-}  // namespace rviz
+}  // namespace rviz_rendering
 
 #endif

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -59,7 +59,7 @@ MeshShape::~MeshShape()
 
 void MeshShape::estimateVertexCount(size_t vcount)
 {
-  if (entity_ == NULL && started_ == false)
+  if (entity_ == nullptr && !started_)
     manual_object_->estimateVertexCount(vcount);
 }
 
@@ -143,7 +143,7 @@ void MeshShape::clear()
     entity_->detachFromParent();
     Ogre::MeshManager::getSingleton().remove(entity_->getMesh()->getName());
     scene_manager_->destroyEntity(entity_);
-    entity_ = NULL;
+    entity_ = nullptr;
   }
   manual_object_->clear();
   started_ = false;


### PR DESCRIPTION
Applied clang-tidy-fix over the full codebase to fix master branch CI.
I disabled `performance-unnecessary-value-param` to suppress fixes for callback functions (see #214), merely adding NOLINT really clutters up the code a lot as there are many multi-line functions.
 