### PR TITLE
Enable "test_time_optimal_trajectory_generation" unit test

### DIFF
--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -45,4 +45,8 @@ if(BUILD_TESTING)
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
 
   target_link_libraries(test_time_parameterization moveit_test_utils ${MOVEIT_LIB_NAME})
+
+  ament_add_gtest(test_time_optimal_trajectory_generation test/test_time_optimal_trajectory_generation.cpp)
+
+  target_link_libraries(test_time_optimal_trajectory_generation ${MOVEIT_LIB_NAME})
 endif()


### PR DESCRIPTION
Enable missing unit test in moveit_core package as part of [#216](https://github.com/ros-planning/moveit2/issues/216)
