### PR TITLE
Fix moveit_servo test executable

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -93,7 +93,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_low_pass_filter ${LIBRARY_NAME})
 
   # Basic unit test ServoCalcs
-  ament_add_gtest(
+  ament_add_gtest_executable(
     test_servo
     test/unit_test_servo_calcs.cpp
     test/test_parameter_struct.hpp


### PR DESCRIPTION
This test keeps failing for some reason and to me it looks like this should be an executable for a launch test and not a unit test.
https://travis-ci.com/github/ros-planning/moveit2/jobs/377469134
@AdamPettinger, @tylerjw what do you think? I'm wondering why it should have passed in the first place, though.