### PR TITLE
[Servo] Fixes to Servo tests/demos

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -67,7 +67,7 @@ public:
   /** \brief Pause or unpause processing servo commands while keeping the timers alive */
   void setPaused(bool paused);
 
-  /** \brief Returns when a joint state message has been recieved, and start() may be called */
+  /** \brief Returns when a joint state message has been received, and start() may be called */
   bool waitForInitialized(std::chrono::duration<double> wait_for = std::chrono::duration<double>(0.25));
 
   /**

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -71,7 +71,7 @@ public:
   bool start();
   void stop();
 
-  /** \brief Returns when a joint state message has been recieved, and start() may be called */
+  /** \brief Returns when a joint state message has been received, and start() may be called */
   bool waitForInitialized(std::chrono::duration<double> wait_for = std::chrono::duration<double>(0.25));
 
   /**

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -214,15 +214,15 @@ bool ServoCalcs::waitForInitialized(std::chrono::duration<double> wait_for)
     if (wait_result.kind() != rclcpp::WaitResultKind::Ready)
       return false;
 
-    sensor_msgs::msg::JointState recieved_joint_state_msg;
+    sensor_msgs::msg::JointState received_joint_state_msg;
     rclcpp::MessageInfo msg_info;
-    if (!joint_state_sub_->take(recieved_joint_state_msg, msg_info))
+    if (!joint_state_sub_->take(received_joint_state_msg, msg_info))
     {
       RCLCPP_WARN(LOGGER, "Problem receiving first joint_state message");
       return false;
     }
 
-    jointStateCB(std::make_shared<sensor_msgs::msg::JointState>(recieved_joint_state_msg));
+    jointStateCB(std::make_shared<sensor_msgs::msg::JointState>(received_joint_state_msg));
     updateJoints();
   }
   return true;

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
@@ -76,14 +76,15 @@ public:
   ServoCalcsTestFixture();
   ~ServoCalcsTestFixture() override = default;
 
-  void setUpStateController();
-
 protected:
   rclcpp::Node::SharedPtr node_;
   std::unique_ptr<FriendServoCalcs> servo_calcs_;
-  moveit_servo::ServoParametersPtr parameters_;
-  planning_scene_monitor::PlanningSceneMonitorPtr psm_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 
   sensor_msgs::msg::JointState getJointState(std::vector<double> pos, std::vector<double> vel);
 };
+
+// These are shared between each individual unit test
+std::shared_ptr<rclcpp::Node> TEST_NODE;
+std::shared_ptr<tf2_ros::Buffer> TEST_TF_BUFFER;
+std::shared_ptr<planning_scene_monitor::PlanningSceneMonitor> TEST_PSM;
+moveit_servo::ServoParametersPtr TEST_PARAMS;


### PR DESCRIPTION
### Description

Some changes to the tests to hopefully make them less flaky

1. Integration testing: remove the StaleCommandStop test, and instead add that check to the end of SendJointCommand test
2. Unit testing: Change the ServoCalcs unit test to use shared pointers for the ROS node, planning scene monitor, and Servo parameters so they are only loaded at the start of the unit tests instead of for each individual test
3. Minor change to the teleop demo to use a thread to add the collision objects instead of a future
4. Minor spelling corrections
