### PR TITLE
WIP: Prevent CPU lockup in servo_cpp_interface_demo

### DIFF
--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -49,6 +49,7 @@
 using namespace std::chrono_literals;
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo_demo_node.cpp");
+static constexpr double DEFAULT_SPIN_RATE = 1000;
 
 class ServoCppDemo
 {
@@ -186,7 +187,7 @@ int main(int argc, char** argv)
 
   // Spin
   auto executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
-  rclcpp::Rate loop_rate(1000);
+  rclcpp::Rate loop_rate(DEFAULT_SPIN_RATE);
   while (rclcpp::ok())
   {
     executor->spin_node_once(node);

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -187,10 +187,11 @@ int main(int argc, char** argv)
 
   // Spin
   auto executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+  executor->add_node(node);
   rclcpp::Rate loop_rate(DEFAULT_SPIN_RATE);
   while (rclcpp::ok())
   {
-    executor->spin_node_once(node);
+    executor->spin_some();
     loop_rate.sleep();
   }
 

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -186,8 +186,12 @@ int main(int argc, char** argv)
 
   // Spin
   auto executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
-  executor->add_node(node);
-  executor->spin();
+  rclcpp::Rate loop_rate(1000);
+  while (rclcpp::ok())
+  {
+    executor->spin_node_once(node);
+    loop_rate.sleep();
+  }
 
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
This addresses issue #268 for one executable. If everybody's amenable, there are some other places this type of change might help:

- test/servo_launch_test_common.hpp
- test/test_servo_parameters.cpp
- test/test_servo_parameters_node.cpp
- test/publish_fake_jog_commands.cpp