### PR TITLE
Port moveit_ros_warehouse

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -36,8 +36,13 @@ repositories:
     url: https://github.com/JafarAbdi/fake_joint
     version: foxy
 
-# TODO(YuYan): Switch to upstream once PR https://github.com/ros-planning/warehouse_ros/pull/48 is merged
   warehouse_ros:
     type: git
-    url: https://github.com/RoboticsYY/warehouse_ros
-    version: pr-ros2
+    url: https://github.com/ros-planning/warehouse_ros
+    version: ros2
+
+# TODO(YuYan): Switch to upstream once PR https://github.com/ros-planning/warehouse_ros_mongo/pull/38 is merged
+  warehouse_ros_mongo:
+    type: git
+    url: https://github.com/RoboticsYY/warehouse_ros_mongo
+    version: pr-porting_to_ros2

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -41,8 +41,7 @@ repositories:
     url: https://github.com/ros-planning/warehouse_ros
     version: ros2
 
-# TODO(YuYan): Switch to upstream once PR https://github.com/ros-planning/warehouse_ros_mongo/pull/38 is merged
   warehouse_ros_mongo:
     type: git
-    url: https://github.com/RoboticsYY/warehouse_ros_mongo
-    version: pr-porting_to_ros2
+    url: https://github.com/ros-planning/warehouse_ros_mongo
+    version: ros2

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -35,3 +35,9 @@ repositories:
     type: git
     url: https://github.com/JafarAbdi/fake_joint
     version: foxy
+
+# TODO(YuYan): Switch to upstream once PR https://github.com/ros-planning/warehouse_ros/pull/48 is merged
+  warehouse_ros:
+    type: git
+    url: https://github.com/RoboticsYY/warehouse_ros
+    version: pr-ros2

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
@@ -107,4 +107,12 @@ def generate_launch_description():
                                               robot_description]
                                   )
 
-    return LaunchDescription([ rviz_node, static_tf, robot_state_publisher, run_move_group_node, fake_joint_driver_node ])
+    # Warehouse mongodb server
+    mongodb_server_node = Node(package='warehouse_ros_mongo',
+                               executable='mongo_wrapper_ros.py',
+                               parameters=[{'warehouse_port': 33829},
+                                           {'warehouse_host': 'localhost'},
+                                           {'warehouse_plugin': 'warehouse_ros_mongo::MongoDatabaseConnection'}],
+                               output='screen')
+
+    return LaunchDescription([ rviz_node, static_tf, robot_state_publisher, run_move_group_node, fake_joint_driver_node, mongodb_server_node ])

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(moveit_ros_planning_interface REQUIRED)
 # TODO(JafarAbdi): Uncomment when porting each package
 # find_package(moveit_ros_perception REQUIRED)
 find_package(moveit_ros_robot_interaction REQUIRED)
-# find_package(moveit_ros_warehouse REQUIRED)
+find_package(moveit_ros_warehouse REQUIRED)
 find_package(object_recognition_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -34,6 +34,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}_core
   Boost
   moveit_ros_robot_interaction
   moveit_ros_planning_interface
+  moveit_ros_warehouse
   rviz2
   rviz_ogre_vendor
   Qt5
@@ -48,6 +49,7 @@ target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
   moveit_ros_robot_interaction
+  moveit_ros_warehouse
   pluginlib
   rviz_ogre_vendor
 )

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -137,10 +137,9 @@ protected:
   //  moveit::semantic_world::SemanticWorldPtr semantic_world_;
 
   moveit::planning_interface::MoveGroupInterface::PlanPtr current_plan_;
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  // moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage_;
-  // moveit_warehouse::ConstraintsStoragePtr constraints_storage_;
-  // moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
+  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage_;
+  moveit_warehouse::ConstraintsStoragePtr constraints_storage_;
+  moveit_warehouse::RobotStateStoragePtr robot_state_storage_;
 
   std::shared_ptr<rviz_default_plugins::displays::InteractiveMarker> scene_marker_;
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -392,7 +392,6 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       std::shared_ptr<tf2_ros::Buffer> tf_buffer = moveit::planning_interface::getSharedTF();
 #endif
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(node_, opt, tf_buffer, rclcpp::Duration(30)));
-      // TODO (ddengster): Enable when moveit_ros_warehouse is ported
       if (planning_scene_storage_)
         move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -393,9 +393,8 @@ void MotionPlanningFrame::changePlanningGroupHelper()
 #endif
       move_group_.reset(new moveit::planning_interface::MoveGroupInterface(node_, opt, tf_buffer, rclcpp::Duration(30)));
       // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-      //      if (planning_scene_storage_)
-      //        move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(),
-      //        ui_->database_port->value());
+      if (planning_scene_storage_)
+        move_group_->setConstraintsDatabase(ui_->database_host->text().toStdString(), ui_->database_port->value());
     }
     catch (std::exception& ex)
     {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -34,9 +34,9 @@
 
 /* Author: Ioan Sucan */
 // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-// #include <moveit/warehouse/planning_scene_storage.h>
-// #include <moveit/warehouse/constraints_storage.h>
-// #include <moveit/warehouse/state_storage.h>
+#include <moveit/warehouse/planning_scene_storage.h>
+#include <moveit/warehouse/constraints_storage.h>
+#include <moveit/warehouse/state_storage.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
 
@@ -100,47 +100,48 @@ void MotionPlanningFrame::resetDbButtonClicked()
 
 void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
 {
-  RCLCPP_WARN(LOGGER, "compute database functionality isn't supported yet");
+  RCLCPP_INFO(LOGGER, "Connect to database: {host: %s, port: %d}", ui_->database_host->text().toStdString().c_str(),
+              ui_->database_port->value());
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    planning_scene_storage_.reset();
-  //    robot_state_storage_.reset();
-  //    constraints_storage_.reset();
-  //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
-  //  }
-  //  else
-  //  {
-  //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
-  //    try
-  //    {
-  //      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
-  //      conn->setParams(ui_->database_host->text().toStdString(), ui_->database_port->value(), 5.0);
-  //      if (conn->connect())
-  //      {
-  //        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
-  //        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
-  //        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
-  //      }
-  //      else
-  //      {
-  //        planning_display_->addMainLoopJob(
-  //            boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
-  //        return;
-  //      }
-  //    }
-  //    catch (std::exception& ex)
-  //    {
-  //      planning_display_->addMainLoopJob(
-  //          boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
-  //      ROS_ERROR("%s", ex.what());
-  //      return;
-  //    }
-  //    planning_display_->addMainLoopJob(
-  //        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
-  //  }
+  if (planning_scene_storage_)
+  {
+    planning_scene_storage_.reset();
+    robot_state_storage_.reset();
+    constraints_storage_.reset();
+    planning_display_->addMainLoopJob(
+        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 1));
+  }
+  else
+  {
+    planning_display_->addMainLoopJob(
+        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
+    try
+    {
+      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase(node_);
+      conn->setParams(ui_->database_host->text().toStdString(), ui_->database_port->value(), 5.0);
+      if (conn->connect())
+      {
+        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
+        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
+        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+      }
+      else
+      {
+        planning_display_->addMainLoopJob(
+            boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+        return;
+      }
+    }
+    catch (std::exception& ex)
+    {
+      planning_display_->addMainLoopJob(
+          boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+      return;
+    }
+    planning_display_->addMainLoopJob(
+        boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 4));
+  }
 }
 
 void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
@@ -202,11 +203,11 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
 void MotionPlanningFrame::computeResetDbButtonClicked(const std::string& db)
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (db == "Constraints" && constraints_storage_)
-  //    constraints_storage_->reset();
-  //  else if (db == "Robot States" && robot_state_storage_)
-  //    robot_state_storage_->reset();
-  //  else if (db == "Planning Scenes")
-  //    planning_scene_storage_->reset();
+  if (db == "Constraints" && constraints_storage_)
+    constraints_storage_->reset();
+  else if (db == "Robot States" && robot_state_storage_)
+    robot_state_storage_->reset();
+  else if (db == "Planning Scenes")
+    planning_scene_storage_->reset();
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -33,7 +33,6 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan */
-// TODO (ddengster): Enable when moveit_ros_warehouse is ported
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/warehouse/state_storage.h>
@@ -102,7 +101,6 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
 {
   RCLCPP_INFO(LOGGER, "Connect to database: {host: %s, port: %d}", ui_->database_host->text().toStdString().c_str(),
               ui_->database_port->value());
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     planning_scene_storage_.reset();
@@ -202,7 +200,6 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper(int mode)
 
 void MotionPlanningFrame::computeResetDbButtonClicked(const std::string& db)
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (db == "Constraints" && constraints_storage_)
     constraints_storage_->reset();
   else if (db == "Robot States" && robot_state_storage_)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -33,7 +33,6 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan, Mario Prats */
-// TODO (ddengster): Enable when moveit_ros_warehouse is ported
 #include <moveit/warehouse/planning_scene_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
@@ -496,7 +495,6 @@ void MotionPlanningFrame::copySelectedCollisionObject()
 
 void MotionPlanningFrame::computeSaveSceneButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     moveit_msgs::msg::PlanningScene msg;
@@ -519,7 +517,6 @@ void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene
 {
   moveit_msgs::msg::MotionPlanRequest mreq;
   constructPlanningRequest(mreq);
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     try
@@ -539,7 +536,6 @@ void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene
 
 void MotionPlanningFrame::computeDeleteSceneButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
@@ -578,7 +574,6 @@ void MotionPlanningFrame::computeDeleteSceneButtonClicked()
 
 void MotionPlanningFrame::computeDeleteQueryButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
@@ -649,7 +644,6 @@ void MotionPlanningFrame::checkPlanningSceneTreeEnabledButtons()
 
 void MotionPlanningFrame::computeLoadSceneButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
@@ -706,7 +700,6 @@ void MotionPlanningFrame::computeLoadSceneButtonClicked()
 
 void MotionPlanningFrame::computeLoadQueryButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Ioan Sucan, Mario Prats */
 // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-// #include <moveit/warehouse/planning_scene_storage.h>
+#include <moveit/warehouse/planning_scene_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
@@ -497,22 +497,22 @@ void MotionPlanningFrame::copySelectedCollisionObject()
 void MotionPlanningFrame::computeSaveSceneButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    moveit_msgs::msg::PlanningScene msg;
-  //    planning_display_->getPlanningSceneRO()->getPlanningSceneMsg(msg);
-  //    try
-  //    {
-  //      planning_scene_storage_->removePlanningScene(msg.name);
-  //      planning_scene_storage_->addPlanningScene(msg);
-  //    }
-  //    catch (std::exception& ex)
-  //    {
-  //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //    }
-  //
-  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  //  }
+  if (planning_scene_storage_)
+  {
+    moveit_msgs::msg::PlanningScene msg;
+    planning_display_->getPlanningSceneRO()->getPlanningSceneMsg(msg);
+    try
+    {
+      planning_scene_storage_->removePlanningScene(msg.name);
+      planning_scene_storage_->addPlanningScene(msg);
+    }
+    catch (std::exception& ex)
+    {
+      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+    }
+
+    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  }
 }
 
 void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene, const std::string& query_name)
@@ -520,88 +520,88 @@ void MotionPlanningFrame::computeSaveQueryButtonClicked(const std::string& scene
   moveit_msgs::msg::MotionPlanRequest mreq;
   constructPlanningRequest(mreq);
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    try
-  //    {
-  //      if (!query_name.empty())
-  //        planning_scene_storage_->removePlanningQuery(scene, query_name);
-  //      planning_scene_storage_->addPlanningQuery(mreq, scene, query_name);
-  //    }
-  //    catch (std::exception& ex)
-  //    {
-  //      RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //    }
-  //
-  //    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  //  }
+  if (planning_scene_storage_)
+  {
+    try
+    {
+      if (!query_name.empty())
+        planning_scene_storage_->removePlanningQuery(scene, query_name);
+      planning_scene_storage_->addPlanningQuery(mreq, scene, query_name);
+    }
+    catch (std::exception& ex)
+    {
+      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+    }
+
+    planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+  }
 }
 
 void MotionPlanningFrame::computeDeleteSceneButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-  //    if (!sel.empty())
-  //    {
-  //      QTreeWidgetItem* s = sel.front();
-  //      if (s->type() == ITEM_TYPE_SCENE)
-  //      {
-  //        std::string scene = s->text(0).toStdString();
-  //        try
-  //        {
-  //          planning_scene_storage_->removePlanningScene(scene);
-  //        }
-  //        catch (std::exception& ex)
-  //        {
-  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //        }
-  //      }
-  //      else
-  //      {
-  //        // if we selected a query name, then we overwrite that query
-  //        std::string scene = s->parent()->text(0).toStdString();
-  //        try
-  //        {
-  //          planning_scene_storage_->removePlanningScene(scene);
-  //        }
-  //        catch (std::exception& ex)
-  //        {
-  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //        }
-  //      }
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  //    }
-  //  }
+  if (planning_scene_storage_)
+  {
+    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+    if (!sel.empty())
+    {
+      QTreeWidgetItem* s = sel.front();
+      if (s->type() == ITEM_TYPE_SCENE)
+      {
+        std::string scene = s->text(0).toStdString();
+        try
+        {
+          planning_scene_storage_->removePlanningScene(scene);
+        }
+        catch (std::exception& ex)
+        {
+          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+        }
+      }
+      else
+      {
+        // if we selected a query name, then we overwrite that query
+        std::string scene = s->parent()->text(0).toStdString();
+        try
+        {
+          planning_scene_storage_->removePlanningScene(scene);
+        }
+        catch (std::exception& ex)
+        {
+          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+        }
+      }
+      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+    }
+  }
 }
 
 void MotionPlanningFrame::computeDeleteQueryButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-  //    if (!sel.empty())
-  //    {
-  //      QTreeWidgetItem* s = sel.front();
-  //      if (s->type() == ITEM_TYPE_QUERY)
-  //      {
-  //        std::string scene = s->parent()->text(0).toStdString();
-  //        std::string query_name = s->text(0).toStdString();
-  //        try
-  //        {
-  //          planning_scene_storage_->removePlanningQuery(scene, query_name);
-  //        }
-  //        catch (std::exception& ex)
-  //        {
-  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //        }
-  //        planning_display_->addMainLoopJob(
-  //            boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
-  //      }
-  //    }
-  //  }
+  if (planning_scene_storage_)
+  {
+    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+    if (!sel.empty())
+    {
+      QTreeWidgetItem* s = sel.front();
+      if (s->type() == ITEM_TYPE_QUERY)
+      {
+        std::string scene = s->parent()->text(0).toStdString();
+        std::string query_name = s->text(0).toStdString();
+        try
+        {
+          planning_scene_storage_->removePlanningQuery(scene, query_name);
+        }
+        catch (std::exception& ex)
+        {
+          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+        }
+        planning_display_->addMainLoopJob(
+            boost::bind(&MotionPlanningFrame::computeDeleteQueryButtonClickedHelper, this, s));
+      }
+    }
+  }
 }
 
 void MotionPlanningFrame::computeDeleteQueryButtonClickedHelper(QTreeWidgetItem* s)
@@ -650,114 +650,112 @@ void MotionPlanningFrame::checkPlanningSceneTreeEnabledButtons()
 void MotionPlanningFrame::computeLoadSceneButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-  //    if (!sel.empty())
-  //    {
-  //      QTreeWidgetItem* s = sel.front();
-  //      if (s->type() == ITEM_TYPE_SCENE)
-  //      {
-  //        std::string scene = s->text(0).toStdString();
-  //        RCLCPP_DEBUG(LOGGER, "Attempting to load scene '%s'", scene.c_str());
-  //
-  //        moveit_warehouse::PlanningSceneWithMetadata scene_m;
-  //        bool got_ps = false;
-  //        try
-  //        {
-  //          got_ps = planning_scene_storage_->getPlanningScene(scene_m, scene);
-  //        }
-  //        catch (std::exception& ex)
-  //        {
-  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //        }
-  //
-  //        if (got_ps)
-  //        {
-  //          RCLCPP_INFO(LOGGER, "Loaded scene '%s'", scene.c_str());
-  //          if (planning_display_->getPlanningSceneMonitor())
-  //          {
-  //            if (scene_m->robot_model_name != planning_display_->getRobotModel()->getName())
-  //            {
-  //              RCLCPP_INFO(LOGGER, "Scene '%s' was saved for robot '%s' but we are using robot '%s'. Using scene
-  //              geometry only",
-  //                       scene.c_str(), scene_m->robot_model_name.c_str(),
-  //                       planning_display_->getRobotModel()->getName().c_str());
-  //              planning_scene_world_publisher_.publish(scene_m->world);
-  //              // publish the parts that are not in the world
-  //              moveit_msgs::msg::PlanningScene diff;
-  //              diff.is_diff = true;
-  //              diff.name = scene_m->name;
-  //              planning_scene_publisher_.publish(diff);
-  //            }
-  //            else
-  //              planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
-  //          }
-  //          else
-  //            planning_scene_publisher_.publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
-  //        }
-  //        else
-  //          RCLCPP_WARN(LOGGER, "Failed to load scene '%s'. Has the message format changed since the scene was
-  //          saved?",
-  //                   scene.c_str());
-  //      }
-  //    }
-  //  }
+  if (planning_scene_storage_)
+  {
+    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+    if (!sel.empty())
+    {
+      QTreeWidgetItem* s = sel.front();
+      if (s->type() == ITEM_TYPE_SCENE)
+      {
+        std::string scene = s->text(0).toStdString();
+        RCLCPP_DEBUG(LOGGER, "Attempting to load scene '%s'", scene.c_str());
+
+        moveit_warehouse::PlanningSceneWithMetadata scene_m;
+        bool got_ps = false;
+        try
+        {
+          got_ps = planning_scene_storage_->getPlanningScene(scene_m, scene);
+        }
+        catch (std::exception& ex)
+        {
+          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+        }
+
+        if (got_ps)
+        {
+          RCLCPP_INFO(LOGGER, "Loaded scene '%s'", scene.c_str());
+          if (planning_display_->getPlanningSceneMonitor())
+          {
+            if (scene_m->robot_model_name != planning_display_->getRobotModel()->getName())
+            {
+              RCLCPP_INFO(LOGGER,
+                          "Scene '%s' was saved for robot '%s' but we are using robot '%s'. Using scene geometry only",
+                          scene.c_str(), scene_m->robot_model_name.c_str(),
+                          planning_display_->getRobotModel()->getName().c_str());
+              planning_scene_world_publisher_->publish(scene_m->world);
+              // publish the parts that are not in the world
+              moveit_msgs::msg::PlanningScene diff;
+              diff.is_diff = true;
+              diff.name = scene_m->name;
+              planning_scene_publisher_->publish(diff);
+            }
+            else
+              planning_scene_publisher_->publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
+          }
+          else
+            planning_scene_publisher_->publish(static_cast<const moveit_msgs::msg::PlanningScene&>(*scene_m));
+        }
+        else
+          RCLCPP_WARN(LOGGER, "Failed to load scene '%s'. Has the message format changed since the scene was saved?",
+                      scene.c_str());
+      }
+    }
+  }
 }
 
 void MotionPlanningFrame::computeLoadQueryButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-  //    if (!sel.empty())
-  //    {
-  //      QTreeWidgetItem* s = sel.front();
-  //      if (s->type() == ITEM_TYPE_QUERY)
-  //      {
-  //        std::string scene = s->parent()->text(0).toStdString();
-  //        std::string query_name = s->text(0).toStdString();
-  //
-  //        moveit_warehouse::MotionPlanRequestWithMetadata mp;
-  //        bool got_q = false;
-  //        try
-  //        {
-  //          got_q = planning_scene_storage_->getPlanningQuery(mp, scene, query_name);
-  //        }
-  //        catch (std::exception& ex)
-  //        {
-  //          RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //        }
-  //
-  //        if (got_q)
-  //        {
-  //          moveit::core::RobotStatePtr start_state(
-  //              new moveit::core::RobotState(*planning_display_->getQueryStartState()));
-  //          moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
-  //                                                  mp->start_state, *start_state);
-  //          planning_display_->setQueryStartState(*start_state);
-  //
-  //          moveit::core::RobotStatePtr goal_state(new
-  //          moveit::core::RobotState(*planning_display_->getQueryGoalState()));
-  //          for (const moveit_msgs::msg::Constraints& goal_constraint : mp->goal_constraints)
-  //            if (!goal_constraint.joint_constraints.empty())
-  //            {
-  //              std::map<std::string, double> vals;
-  //              for (const moveit_msgs::msg::JointConstraint& joint_constraint : goal_constraint.joint_constraints)
-  //                vals[joint_constraint.joint_name] = joint_constraint.position;
-  //              goal_state->setVariablePositions(vals);
-  //              break;
-  //            }
-  //          planning_display_->setQueryGoalState(*goal_state);
-  //        }
-  //        else
-  //          RCLCPP_ERROR(LOGGER, "Failed to load planning query '%s'. Has the message format changed since the query
-  //          was saved?",
-  //                    query_name.c_str());
-  //      }
-  //    }
-  //  }
+  if (planning_scene_storage_)
+  {
+    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+    if (!sel.empty())
+    {
+      QTreeWidgetItem* s = sel.front();
+      if (s->type() == ITEM_TYPE_QUERY)
+      {
+        std::string scene = s->parent()->text(0).toStdString();
+        std::string query_name = s->text(0).toStdString();
+
+        moveit_warehouse::MotionPlanRequestWithMetadata mp;
+        bool got_q = false;
+        try
+        {
+          got_q = planning_scene_storage_->getPlanningQuery(mp, scene, query_name);
+        }
+        catch (std::exception& ex)
+        {
+          RCLCPP_ERROR(LOGGER, "%s", ex.what());
+        }
+
+        if (got_q)
+        {
+          moveit::core::RobotStatePtr start_state(
+              new moveit::core::RobotState(*planning_display_->getQueryStartState()));
+          moveit::core::robotStateMsgToRobotState(planning_display_->getPlanningSceneRO()->getTransforms(),
+                                                  mp->start_state, *start_state);
+          planning_display_->setQueryStartState(*start_state);
+
+          moveit::core::RobotStatePtr goal_state(new moveit::core::RobotState(*planning_display_->getQueryGoalState()));
+          for (const moveit_msgs::msg::Constraints& goal_constraint : mp->goal_constraints)
+            if (!goal_constraint.joint_constraints.empty())
+            {
+              std::map<std::string, double> vals;
+              for (const moveit_msgs::msg::JointConstraint& joint_constraint : goal_constraint.joint_constraints)
+                vals[joint_constraint.joint_name] = joint_constraint.position;
+              goal_state->setVariablePositions(vals);
+              break;
+            }
+          planning_display_->setQueryGoalState(*goal_state);
+        }
+        else
+          RCLCPP_ERROR(LOGGER,
+                       "Failed to load planning query '%s'. Has the message format changed since the query was saved?",
+                       query_name.c_str());
+      }
+    }
+  }
 }
 
 visualization_msgs::msg::InteractiveMarker

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -33,7 +33,6 @@
  *********************************************************************/
 
 /* Author: Ioan Sucan */
-// TODO (ddengster): Enable when moveit_ros_warehouse is ported
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/warehouse/state_storage.h>
@@ -64,7 +63,6 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualizatio
 
 void MotionPlanningFrame::saveSceneButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     const std::string& name = planning_display_->getPlanningSceneRO()->getName();
@@ -123,7 +121,6 @@ void MotionPlanningFrame::planningSceneItemClicked()
 
 void MotionPlanningFrame::saveQueryButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (planning_scene_storage_)
   {
     QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
@@ -214,7 +211,6 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
 {
   if (item->text(column) == item->toolTip(column) || item->toolTip(column).length() == 0)
     return;
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
   if (!planning_scene_storage)
     return;
@@ -262,7 +258,6 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
 
 void MotionPlanningFrame::populatePlanningSceneTreeView()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
   if (!planning_scene_storage)
     return;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -34,9 +34,9 @@
 
 /* Author: Ioan Sucan */
 // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-//#include <moveit/warehouse/planning_scene_storage.h>
-//#include <moveit/warehouse/constraints_storage.h>
-//#include <moveit/warehouse/state_storage.h>
+#include <moveit/warehouse/planning_scene_storage.h>
+#include <moveit/warehouse/constraints_storage.h>
+#include <moveit/warehouse/state_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
@@ -65,56 +65,55 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualizatio
 void MotionPlanningFrame::saveSceneButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    const std::string& name = planning_display_->getPlanningSceneRO()->getName();
-  //    if (name.empty() || planning_scene_storage_->hasPlanningScene(name))
-  //    {
-  //      std::unique_ptr<QMessageBox> q;
-  //      if (name.empty())
-  //        q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Scene Name",
-  //                                QString("The name for the planning scene should not be empty. Would you like to
-  //                                rename "
-  //                                        "the planning scene?'"),
-  //                                QMessageBox::Cancel, this));
-  //      else
-  //        q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Scene Overwrite",
-  //                                QString("A planning scene named '")
-  //                                    .append(name.c_str())
-  //                                    .append("' already exists. Do you wish to "
-  //                                            "overwrite that scene?"),
-  //                                QMessageBox::Yes | QMessageBox::No, this));
-  //      std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
-  //      if (q->exec() != QMessageBox::Yes)
-  //      {
-  //        if (q->clickedButton() == rename.get())
-  //        {
-  //          bool ok = false;
-  //          QString new_name = QInputDialog::getText(this, "Rename Planning Scene", "New name for the planning
-  //          scene:",
-  //                                                   QLineEdit::Normal, QString::fromStdString(name), &ok);
-  //          if (ok)
-  //          {
-  //            planning_display_->getPlanningSceneRW()->setName(new_name.toStdString());
-  //            rviz_common::properties::Property* prop = planning_display_->subProp("Scene Geometry")->subProp("Scene
-  //            Name");
-  //            if (prop)
-  //            {
-  //              bool old = prop->blockSignals(true);
-  //              prop->setValue(new_name);
-  //              prop->blockSignals(old);
-  //            }
-  //            saveSceneButtonClicked();
-  //          }
-  //          return;
-  //        }
-  //        return;
-  //      }
-  //    }
-  //
-  //    planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
-  //                                        "save scene");
-  //  }
+  if (planning_scene_storage_)
+  {
+    const std::string& name = planning_display_->getPlanningSceneRO()->getName();
+    if (name.empty() || planning_scene_storage_->hasPlanningScene(name))
+    {
+      std::unique_ptr<QMessageBox> q;
+      if (name.empty())
+        q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Scene Name",
+                                QString("The name for the planning scene should not be empty. Would you like to rename "
+                                        "the planning scene?'"),
+                                QMessageBox::Cancel, this));
+      else
+        q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Scene Overwrite",
+                                QString("A planning scene named '")
+                                    .append(name.c_str())
+                                    .append("' already exists. Do you wish to "
+                                            "overwrite that scene?"),
+                                QMessageBox::Yes | QMessageBox::No, this));
+      std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+      if (q->exec() != QMessageBox::Yes)
+      {
+        if (q->clickedButton() == rename.get())
+        {
+          bool ok = false;
+          QString new_name = QInputDialog::getText(this, "Rename Planning Scene",
+                                                   "New name for the planning scene:", QLineEdit::Normal,
+                                                   QString::fromStdString(name), &ok);
+          if (ok)
+          {
+            planning_display_->getPlanningSceneRW()->setName(new_name.toStdString());
+            rviz_common::properties::Property* prop =
+                planning_display_->subProp("Scene Geometry")->subProp("Scene Name");
+            if (prop)
+            {
+              bool old = prop->blockSignals(true);
+              prop->setValue(new_name);
+              prop->blockSignals(old);
+            }
+            saveSceneButtonClicked();
+          }
+          return;
+        }
+        return;
+      }
+    }
+
+    planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeSaveSceneButtonClicked, this),
+                                        "save scene");
+  }
 }
 
 void MotionPlanningFrame::planningSceneItemClicked()
@@ -125,68 +124,66 @@ void MotionPlanningFrame::planningSceneItemClicked()
 void MotionPlanningFrame::saveQueryButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (planning_scene_storage_)
-  //  {
-  //    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
-  //    if (!sel.empty())
-  //    {
-  //      QTreeWidgetItem* s = sel.front();
-  //
-  //      // if we have selected a PlanningScene, add the query as a new one, under that planning scene
-  //      if (s->type() == ITEM_TYPE_SCENE)
-  //      {
-  //        std::string scene = s->text(0).toStdString();
-  //        planning_display_->addBackgroundJob(
-  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
-  //      }
-  //      else
-  //      {
-  //        // if we selected a query name, then we overwrite that query
-  //        std::string scene = s->parent()->text(0).toStdString();
-  //        std::string query_name = s->text(0).toStdString();
-  //
-  //        while (query_name.empty() || planning_scene_storage_->hasPlanningQuery(scene, query_name))
-  //        {
-  //          std::unique_ptr<QMessageBox> q;
-  //          if (query_name.empty())
-  //            q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Query Name",
-  //                                    QString("The name for the planning query should not be empty. Would you like to
-  //                                    "
-  //                                            "rename the planning query?'"),
-  //                                    QMessageBox::Cancel, this));
-  //          else
-  //            q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Query Overwrite",
-  //                                    QString("A planning query named '")
-  //                                        .append(query_name.c_str())
-  //                                        .append("' already exists. Do you wish "
-  //                                                "to overwrite that query?"),
-  //                                    QMessageBox::Yes | QMessageBox::No, this));
-  //          std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
-  //          if (q->exec() == QMessageBox::Yes)
-  //            break;
-  //          else
-  //          {
-  //            if (q->clickedButton() == rename.get())
-  //            {
-  //              bool ok = false;
-  //              QString new_name =
-  //                  QInputDialog::getText(this, "Rename Planning Query", "New name for the planning query:",
-  //                                        QLineEdit::Normal, QString::fromStdString(query_name), &ok);
-  //              if (ok)
-  //                query_name = new_name.toStdString();
-  //              else
-  //                return;
-  //            }
-  //            else
-  //              return;
-  //          }
-  //        }
-  //        planning_display_->addBackgroundJob(
-  //            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save
-  //            query");
-  //      }
-  //    }
-  //  }
+  if (planning_scene_storage_)
+  {
+    QList<QTreeWidgetItem*> sel = ui_->planning_scene_tree->selectedItems();
+    if (!sel.empty())
+    {
+      QTreeWidgetItem* s = sel.front();
+
+      // if we have selected a PlanningScene, add the query as a new one, under that planning scene
+      if (s->type() == ITEM_TYPE_SCENE)
+      {
+        std::string scene = s->text(0).toStdString();
+        planning_display_->addBackgroundJob(
+            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, ""), "save query");
+      }
+      else
+      {
+        // if we selected a query name, then we overwrite that query
+        std::string scene = s->parent()->text(0).toStdString();
+        std::string query_name = s->text(0).toStdString();
+
+        while (query_name.empty() || planning_scene_storage_->hasPlanningQuery(scene, query_name))
+        {
+          std::unique_ptr<QMessageBox> q;
+          if (query_name.empty())
+            q.reset(new QMessageBox(QMessageBox::Question, "Change Planning Query Name",
+                                    QString("The name for the planning query should not be empty. Would you like to"
+                                            "rename the planning query?'"),
+                                    QMessageBox::Cancel, this));
+          else
+            q.reset(new QMessageBox(QMessageBox::Question, "Confirm Planning Query Overwrite",
+                                    QString("A planning query named '")
+                                        .append(query_name.c_str())
+                                        .append("' already exists. Do you wish "
+                                                "to overwrite that query?"),
+                                    QMessageBox::Yes | QMessageBox::No, this));
+          std::unique_ptr<QPushButton> rename(q->addButton("&Rename", QMessageBox::AcceptRole));
+          if (q->exec() == QMessageBox::Yes)
+            break;
+          else
+          {
+            if (q->clickedButton() == rename.get())
+            {
+              bool ok = false;
+              QString new_name = QInputDialog::getText(this, "Rename Planning Query",
+                                                       "New name for the planning query:", QLineEdit::Normal,
+                                                       QString::fromStdString(query_name), &ok);
+              if (ok)
+                query_name = new_name.toStdString();
+              else
+                return;
+            }
+            else
+              return;
+          }
+        }
+        planning_display_->addBackgroundJob(
+            boost::bind(&MotionPlanningFrame::computeSaveQueryButtonClicked, this, scene, query_name), "save query");
+      }
+    }
+  }
 }
 
 void MotionPlanningFrame::deleteSceneButtonClicked()
@@ -218,95 +215,96 @@ void MotionPlanningFrame::warehouseItemNameChanged(QTreeWidgetItem* item, int co
   if (item->text(column) == item->toolTip(column) || item->toolTip(column).length() == 0)
     return;
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
-  //  if (!planning_scene_storage)
-  //    return;
-  //
-  //  if (item->type() == ITEM_TYPE_SCENE)
-  //  {
-  //    std::string new_name = item->text(column).toStdString();
-  //
-  //    if (planning_scene_storage->hasPlanningScene(new_name))
-  //    {
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  //      QMessageBox::warning(this, "Scene not renamed",
-  //                           QString("The scene name '").append(item->text(column)).append("' already exists"));
-  //      return;
-  //    }
-  //    else
-  //    {
-  //      std::string old_name = item->toolTip(column).toStdString();
-  //      planning_scene_storage->renamePlanningScene(old_name, new_name);
-  //      item->setToolTip(column, item->text(column));
-  //    }
-  //  }
-  //  else
-  //  {
-  //    std::string scene = item->parent()->text(0).toStdString();
-  //    std::string new_name = item->text(column).toStdString();
-  //    if (planning_scene_storage->hasPlanningQuery(scene, new_name))
-  //    {
-  //      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
-  //      QMessageBox::warning(this, "Query not renamed", QString("The query name '")
-  //                                                          .append(item->text(column))
-  //                                                          .append("' already exists for scene ")
-  //                                                          .append(item->parent()->text(0)));
-  //      return;
-  //    }
-  //    else
-  //    {
-  //      std::string old_name = item->toolTip(column).toStdString();
-  //      planning_scene_storage->renamePlanningQuery(scene, old_name, new_name);
-  //      item->setToolTip(column, item->text(column));
-  //    }
-  //  }
+  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
+  if (!planning_scene_storage)
+    return;
+
+  if (item->type() == ITEM_TYPE_SCENE)
+  {
+    std::string new_name = item->text(column).toStdString();
+
+    if (planning_scene_storage->hasPlanningScene(new_name))
+    {
+      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+      QMessageBox::warning(this, "Scene not renamed",
+                           QString("The scene name '").append(item->text(column)).append("' already exists"));
+      return;
+    }
+    else
+    {
+      std::string old_name = item->toolTip(column).toStdString();
+      planning_scene_storage->renamePlanningScene(old_name, new_name);
+      item->setToolTip(column, item->text(column));
+    }
+  }
+  else
+  {
+    std::string scene = item->parent()->text(0).toStdString();
+    std::string new_name = item->text(column).toStdString();
+    if (planning_scene_storage->hasPlanningQuery(scene, new_name))
+    {
+      planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::populatePlanningSceneTreeView, this));
+      QMessageBox::warning(this, "Query not renamed",
+                           QString("The query name '")
+                               .append(item->text(column))
+                               .append("' already exists for scene ")
+                               .append(item->parent()->text(0)));
+      return;
+    }
+    else
+    {
+      std::string old_name = item->toolTip(column).toStdString();
+      planning_scene_storage->renamePlanningQuery(scene, old_name, new_name);
+      item->setToolTip(column, item->text(column));
+    }
+  }
 }
 
 void MotionPlanningFrame::populatePlanningSceneTreeView()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
-  //  if (!planning_scene_storage)
-  //    return;
-  //
-  //  ui_->planning_scene_tree->setUpdatesEnabled(false);
-  //
-  //  // remember which items were expanded
-  //  std::set<std::string> expanded;
-  //  for (int i = 0; i < ui_->planning_scene_tree->topLevelItemCount(); ++i)
-  //  {
-  //    QTreeWidgetItem* it = ui_->planning_scene_tree->topLevelItem(i);
-  //    if (it->isExpanded())
-  //      expanded.insert(it->text(0).toStdString());
-  //  }
-  //
-  //  ui_->planning_scene_tree->clear();
-  //  std::vector<std::string> names;
-  //  planning_scene_storage->getPlanningSceneNames(names);
-  //
-  //  for (const std::string& name : names)
-  //  {
-  //    std::vector<std::string> query_names;
-  //    planning_scene_storage->getPlanningQueriesNames(query_names, name);
-  //    QTreeWidgetItem* item =
-  //        new QTreeWidgetItem(ui_->planning_scene_tree, QStringList(QString::fromStdString(name)), ITEM_TYPE_SCENE);
-  //    item->setFlags(item->flags() | Qt::ItemIsEditable);
-  //    item->setToolTip(0, item->text(0));  // we use the tool tip as a backup of the old name when renaming
-  //    for (const std::string& query_name : query_names)
-  //    {
-  //      QTreeWidgetItem* subitem =
-  //          new QTreeWidgetItem(item, QStringList(QString::fromStdString(query_name)), ITEM_TYPE_QUERY);
-  //      subitem->setFlags(subitem->flags() | Qt::ItemIsEditable);
-  //      subitem->setToolTip(0, subitem->text(0));
-  //      item->addChild(subitem);
-  //    }
-  //
-  //    ui_->planning_scene_tree->insertTopLevelItem(ui_->planning_scene_tree->topLevelItemCount(), item);
-  //    if (expanded.find(name) != expanded.end())
-  //      ui_->planning_scene_tree->expandItem(item);
-  //  }
-  //  ui_->planning_scene_tree->sortItems(0, Qt::AscendingOrder);
-  //  ui_->planning_scene_tree->setUpdatesEnabled(true);
-  //  checkPlanningSceneTreeEnabledButtons();
+  moveit_warehouse::PlanningSceneStoragePtr planning_scene_storage = planning_scene_storage_;
+  if (!planning_scene_storage)
+    return;
+
+  ui_->planning_scene_tree->setUpdatesEnabled(false);
+
+  // remember which items were expanded
+  std::set<std::string> expanded;
+  for (int i = 0; i < ui_->planning_scene_tree->topLevelItemCount(); ++i)
+  {
+    QTreeWidgetItem* it = ui_->planning_scene_tree->topLevelItem(i);
+    if (it->isExpanded())
+      expanded.insert(it->text(0).toStdString());
+  }
+
+  ui_->planning_scene_tree->clear();
+  std::vector<std::string> names;
+  planning_scene_storage->getPlanningSceneNames(names);
+
+  for (const std::string& name : names)
+  {
+    std::vector<std::string> query_names;
+    planning_scene_storage->getPlanningQueriesNames(query_names, name);
+    QTreeWidgetItem* item =
+        new QTreeWidgetItem(ui_->planning_scene_tree, QStringList(QString::fromStdString(name)), ITEM_TYPE_SCENE);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
+    item->setToolTip(0, item->text(0));  // we use the tool tip as a backup of the old name when renaming
+    for (const std::string& query_name : query_names)
+    {
+      QTreeWidgetItem* subitem =
+          new QTreeWidgetItem(item, QStringList(QString::fromStdString(query_name)), ITEM_TYPE_QUERY);
+      subitem->setFlags(subitem->flags() | Qt::ItemIsEditable);
+      subitem->setToolTip(0, subitem->text(0));
+      item->addChild(subitem);
+    }
+
+    ui_->planning_scene_tree->insertTopLevelItem(ui_->planning_scene_tree->topLevelItemCount(), item);
+    if (expanded.find(name) != expanded.end())
+      ui_->planning_scene_tree->expandItem(item);
+  }
+  ui_->planning_scene_tree->sortItems(0, Qt::AscendingOrder);
+  ui_->planning_scene_tree->setUpdatesEnabled(true);
+  checkPlanningSceneTreeEnabledButtons();
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -33,7 +33,6 @@
  *********************************************************************/
 
 /* Author: Mario Prats, Ioan Sucan */
-// TODO (ddengster): Enable when moveit_ros_warehouse is ported
 #include <moveit/warehouse/state_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
@@ -61,7 +60,6 @@ void MotionPlanningFrame::populateRobotStatesList()
 
 void MotionPlanningFrame::loadStateButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (robot_state_storage_)
   {
     bool ok;
@@ -81,7 +79,6 @@ void MotionPlanningFrame::loadStateButtonClicked()
 
 void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   std::vector<std::string> names;
   try
   {
@@ -151,7 +148,6 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const moveit::core::RobotS
         robot_states_.insert(RobotStatePair(name, msg));
 
         // Save to the database if connected
-        // TODO (ddengster): Enable when moveit_ros_warehouse is ported
         if (robot_state_storage_)
         {
           try
@@ -211,7 +207,6 @@ void MotionPlanningFrame::setAsGoalStateButtonClicked()
 
 void MotionPlanningFrame::removeStateButtonClicked()
 {
-  // TODO (ddengster): Enable when moveit_ros_warehouse is ported
   if (robot_state_storage_)
   {
     // Warn the user

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Mario Prats, Ioan Sucan */
 // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-// #include <moveit/warehouse/state_storage.h>
+#include <moveit/warehouse/state_storage.h>
 
 #include <moveit/motion_planning_rviz_plugin/motion_planning_frame.h>
 #include <moveit/motion_planning_rviz_plugin/motion_planning_display.h>
@@ -62,18 +62,18 @@ void MotionPlanningFrame::populateRobotStatesList()
 void MotionPlanningFrame::loadStateButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (robot_state_storage_)
-  //  {
-  //    bool ok;
-  //
-  //    QString text =
-  //        QInputDialog::getText(this, tr("Robot states to load"), tr("Pattern:"), QLineEdit::Normal, ".*", &ok);
-  //    if (ok && !text.isEmpty())
-  //    {
-  //      loadStoredStates(text.toStdString());
-  //    }
-  //  }
-  //  else
+  if (robot_state_storage_)
+  {
+    bool ok;
+
+    QString text =
+        QInputDialog::getText(this, tr("Robot states to load"), tr("Pattern:"), QLineEdit::Normal, ".*", &ok);
+    if (ok && !text.isEmpty())
+    {
+      loadStoredStates(text.toStdString());
+    }
+  }
+  else
   {
     QMessageBox::warning(this, "Warning", "Not connected to a database.");
   }
@@ -82,44 +82,44 @@ void MotionPlanningFrame::loadStateButtonClicked()
 void MotionPlanningFrame::loadStoredStates(const std::string& pattern)
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  // std::vector<std::string> names;
-  //  try
-  //  {
-  //    robot_state_storage_->getKnownRobotStates(pattern, names);
-  //  }
-  //  catch (std::exception& ex)
-  //  {
-  //    QMessageBox::warning(this, "Cannot query the database",
-  //                         QString("Wrongly formatted regular expression for robot states: ").append(ex.what()));
-  //    return;
-  //  }
+  std::vector<std::string> names;
+  try
+  {
+    robot_state_storage_->getKnownRobotStates(pattern, names);
+  }
+  catch (std::exception& ex)
+  {
+    QMessageBox::warning(this, "Cannot query the database",
+                         QString("Wrongly formatted regular expression for robot states: ").append(ex.what()));
+    return;
+  }
   // Clear the current list
   clearStatesButtonClicked();
 
-  //  for (const std::string& name : names)
-  //  {
-  //    moveit_warehouse::RobotStateWithMetadata rs;
-  //    bool got_state = false;
-  //    try
-  //    {
-  //      got_state = robot_state_storage_->getRobotState(rs, name);
-  //    }
-  //    catch (std::exception& ex)
-  //    {
-  //      ROS_ERROR("%s", ex.what());
-  //    }
-  //    if (!got_state)
-  //      continue;
-  //
-  //    // Overwrite if exists.
-  //    if (robot_states_.find(name) != robot_states_.end())
-  //    {
-  //      robot_states_.erase(name);
-  //    }
-  //
-  //    // Store the current start state
-  //    robot_states_.insert(RobotStatePair(name, *rs));
-  //  }
+  for (const std::string& name : names)
+  {
+    moveit_warehouse::RobotStateWithMetadata rs;
+    bool got_state = false;
+    try
+    {
+      got_state = robot_state_storage_->getRobotState(rs, name);
+    }
+    catch (std::exception& ex)
+    {
+      RCLCPP_ERROR(LOGGER, "%s", ex.what());
+    }
+    if (!got_state)
+      continue;
+
+    // Overwrite if exists.
+    if (robot_states_.find(name) != robot_states_.end())
+    {
+      robot_states_.erase(name);
+    }
+
+    // Store the current start state
+    robot_states_.insert(RobotStatePair(name, *rs));
+  }
   populateRobotStatesList();
 }
 
@@ -152,22 +152,21 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const moveit::core::RobotS
 
         // Save to the database if connected
         // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-        //        if (robot_state_storage_)
-        //        {
-        //          try
-        //          {
-        //            robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
-        //          }
-        //          catch (std::exception& ex)
-        //          {
-        //            ROS_ERROR("Cannot save robot state on the database: %s", ex.what());
-        //          }
-        //        }
-        //        else
-        //        {
-        //          QMessageBox::warning(this, "Warning",
-        //                               "Not connected to a database. The state will be created but not stored");
-        //        }
+        if (robot_state_storage_)
+        {
+          try
+          {
+            robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
+          }
+          catch (std::exception& ex)
+          {
+            RCLCPP_ERROR(LOGGER, "Cannot save robot state on the database: %s", ex.what());
+          }
+        }
+        else
+        {
+          QMessageBox::warning(this, "Warning", "Not connected to a database. The state will be created but not stored");
+        }
       }
     }
     else
@@ -213,38 +212,38 @@ void MotionPlanningFrame::setAsGoalStateButtonClicked()
 void MotionPlanningFrame::removeStateButtonClicked()
 {
   // TODO (ddengster): Enable when moveit_ros_warehouse is ported
-  //  if (robot_state_storage_)
-  //  {
-  //    // Warn the user
-  //    QMessageBox msg_box;
-  //    msg_box.setText("All the selected states will be removed from the database");
-  //    msg_box.setInformativeText("Do you want to continue?");
-  //    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-  //    msg_box.setDefaultButton(QMessageBox::No);
-  //    int ret = msg_box.exec();
-  //
-  //    switch (ret)
-  //    {
-  //      case QMessageBox::Yes:
-  //      {
-  //        QList<QListWidgetItem*> found_items = ui_->list_states->selectedItems();
-  //        for (QListWidgetItem* found_item : found_items)
-  //        {
-  //          const std::string& name = found_item->text().toStdString();
-  //          try
-  //          {
-  //            robot_state_storage_->removeRobotState(name);
-  //            robot_states_.erase(name);
-  //          }
-  //          catch (std::exception& ex)
-  //          {
-  //            RCLCPP_ERROR(LOGGER, "%s", ex.what());
-  //          }
-  //        }
-  //        break;
-  //      }
-  //    }
-  //  }
+  if (robot_state_storage_)
+  {
+    // Warn the user
+    QMessageBox msg_box;
+    msg_box.setText("All the selected states will be removed from the database");
+    msg_box.setInformativeText("Do you want to continue?");
+    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+    msg_box.setDefaultButton(QMessageBox::No);
+    int ret = msg_box.exec();
+
+    switch (ret)
+    {
+      case QMessageBox::Yes:
+      {
+        QList<QListWidgetItem*> found_items = ui_->list_states->selectedItems();
+        for (QListWidgetItem* found_item : found_items)
+        {
+          const std::string& name = found_item->text().toStdString();
+          try
+          {
+            robot_state_storage_->removeRobotState(name);
+            robot_states_.erase(name);
+          }
+          catch (std::exception& ex)
+          {
+            RCLCPP_ERROR(LOGGER, "%s", ex.what());
+          }
+        }
+        break;
+      }
+    }
+  }
   populateRobotStatesList();
 }
 

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -33,8 +33,7 @@
   <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_perception -->
   <!--depend>moveit_ros_perception</depend-->
   <depend>moveit_ros_planning_interface</depend>
-  <!-- TODO(JafarAbdi): uncomment after porting moveit_ros_warehouse -->
-  <!--depend>moveit_ros_warehouse</depend-->
+  <depend>moveit_ros_warehouse</depend>
   <depend>object_recognition_msgs</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -1,18 +1,12 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_warehouse)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -11,29 +11,32 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(warehouse_ros REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_ros REQUIRED)
 find_package(Boost REQUIRED thread system filesystem regex date_time program_options)
+find_package(OpenSSL)
 
-find_package(catkin REQUIRED COMPONENTS
-  moveit_ros_planning
-  roscpp
-  rosconsole
-  warehouse_ros
-  tf2_eigen
-  tf2_ros
-)
-
-catkin_package(
-  LIBRARIES
-    moveit_warehouse
-  INCLUDE_DIRS
-    warehouse/include
-  CATKIN_DEPENDS
-    moveit_ros_planning
-    warehouse_ros
-    roscpp
-)
-
-include_directories(warehouse/include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(warehouse/include ${OPENSSL_INCLUDE_DIR})
 
 add_subdirectory(warehouse)
+
+ament_export_include_directories(include)
+ament_export_libraries(moveit_warehouse)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(moveit_core)
+ament_export_dependencies(warehouse_ros)
+ament_export_dependencies(moveit_ros_planning)
+ament_export_dependencies(tf2_eigen)
+ament_export_dependencies(tf2_ros)
+ament_export_dependencies(Boost)
+
+ament_package()

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -14,13 +14,17 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>moveit_core</depend>
   <depend>warehouse_ros</depend>
   <depend>moveit_ros_planning</depend>
-  <depend>roscpp</depend>
-  <depend>rosconsole</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -15,7 +15,8 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <build_depend>moveit_common</build_depend>
+  
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>
   <depend>warehouse_ros</depend>

--- a/moveit_ros/warehouse/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/warehouse/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_warehouse)
 
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/moveit_message_storage.cpp
   src/planning_scene_storage.cpp
   src/planning_scene_world_storage.cpp
@@ -10,32 +10,38 @@ add_library(${MOVEIT_LIB_NAME}
   src/warehouse_connector.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME} rclcpp Boost moveit_core warehouse_ros moveit_ros_planning)
+target_link_libraries(${MOVEIT_LIB_NAME} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)
-target_link_libraries(moveit_warehouse_broadcast ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_warehouse_broadcast rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_warehouse_broadcast ${MOVEIT_LIB_NAME})
 
 add_executable(moveit_save_to_warehouse src/save_to_warehouse.cpp)
-target_link_libraries(moveit_save_to_warehouse ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_save_to_warehouse rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_save_to_warehouse ${MOVEIT_LIB_NAME})
 
 add_executable(moveit_warehouse_import_from_text src/import_from_text.cpp)
-target_link_libraries(moveit_warehouse_import_from_text ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_warehouse_import_from_text rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_warehouse_import_from_text ${MOVEIT_LIB_NAME})
 
 add_executable(moveit_warehouse_save_as_text src/save_as_text.cpp)
-target_link_libraries(moveit_warehouse_save_as_text ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_warehouse_save_as_text rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_warehouse_save_as_text ${MOVEIT_LIB_NAME})
 
 add_executable(moveit_init_demo_warehouse src/initialize_demo_db.cpp)
-target_link_libraries(moveit_init_demo_warehouse ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_init_demo_warehouse rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_init_demo_warehouse ${MOVEIT_LIB_NAME})
 
 add_executable(moveit_warehouse_services src/warehouse_services.cpp)
-target_link_libraries(moveit_warehouse_services ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+ament_target_dependencies(moveit_warehouse_services rclcpp Boost warehouse_ros moveit_ros_planning)
+target_link_libraries(moveit_warehouse_services ${MOVEIT_LIB_NAME})
 
 install(
-  TARGETS
-    ${MOVEIT_LIB_NAME}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  TARGETS ${MOVEIT_LIB_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(
@@ -46,6 +52,6 @@ install(
     moveit_warehouse_save_as_text
     moveit_init_demo_warehouse
     moveit_warehouse_services
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/warehouse/warehouse/include/moveit/warehouse/moveit_message_storage.h
+++ b/moveit_ros/warehouse/warehouse/include/moveit/warehouse/moveit_message_storage.h
@@ -63,5 +63,5 @@ protected:
 };
 
 /// \brief Load a database connection
-typename warehouse_ros::DatabaseConnection::Ptr loadDatabase();
+typename warehouse_ros::DatabaseConnection::Ptr loadDatabase(const rclcpp::Node::SharedPtr& node);
 }  // namespace moveit_warehouse

--- a/moveit_ros/warehouse/warehouse/src/constraints_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/constraints_storage.cpp
@@ -44,6 +44,8 @@ const std::string moveit_warehouse::ConstraintsStorage::CONSTRAINTS_ID_NAME = "c
 const std::string moveit_warehouse::ConstraintsStorage::CONSTRAINTS_GROUP_NAME = "group_id";
 const std::string moveit_warehouse::ConstraintsStorage::ROBOT_NAME = "robot_id";
 
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.constraints_storage");
+
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
 
@@ -79,7 +81,7 @@ void moveit_warehouse::ConstraintsStorage::addConstraints(const moveit_msgs::msg
   metadata->append(ROBOT_NAME, robot);
   metadata->append(CONSTRAINTS_GROUP_NAME, group);
   constraints_collection_->insert(msg, metadata);
-  ROS_DEBUG("%s constraints '%s'", replace ? "Replaced" : "Added", msg.name.c_str());
+  RCLCPP_DEBUG(LOGGER, "%s constraints '%s'", replace ? "Replaced" : "Added", msg.name.c_str());
 }
 
 bool moveit_warehouse::ConstraintsStorage::hasConstraints(const std::string& name, const std::string& robot,
@@ -152,7 +154,7 @@ void moveit_warehouse::ConstraintsStorage::renameConstraints(const std::string& 
   Metadata::Ptr m = constraints_collection_->createMetadata();
   m->append(CONSTRAINTS_ID_NAME, new_name);
   constraints_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed constraints from '%s' to '%s'", old_name.c_str(), new_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed constraints from '%s' to '%s'", old_name.c_str(), new_name.c_str());
 }
 
 void moveit_warehouse::ConstraintsStorage::removeConstraints(const std::string& name, const std::string& robot,
@@ -165,5 +167,5 @@ void moveit_warehouse::ConstraintsStorage::removeConstraints(const std::string& 
   if (!group.empty())
     q->append(CONSTRAINTS_GROUP_NAME, group);
   unsigned int rem = constraints_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u Constraints messages (named '%s')", rem, name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u Constraints messages (named '%s')", rem, name.c_str());
 }

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -45,7 +45,7 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 

--- a/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
@@ -67,11 +67,11 @@ void moveit_warehouse::MoveItMessageStorage::filterNames(const std::string& rege
 
 static std::unique_ptr<warehouse_ros::DatabaseLoader> DBLOADER;
 
-typename warehouse_ros::DatabaseConnection::Ptr moveit_warehouse::loadDatabase()
+typename warehouse_ros::DatabaseConnection::Ptr moveit_warehouse::loadDatabase(const rclcpp::Node::SharedPtr& node)
 {
   if (!DBLOADER)
   {
-    DBLOADER.reset(new warehouse_ros::DatabaseLoader());
+    DBLOADER.reset(new warehouse_ros::DatabaseLoader(node));
   }
   return DBLOADER->loadDatabase();
   // return typename warehouse_ros::DatabaseConnection::Ptr(new warehouse_ros_mongo::MongoDatabaseConnection());

--- a/moveit_ros/warehouse/warehouse/src/planning_scene_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/planning_scene_storage.cpp
@@ -37,6 +37,7 @@
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <boost/regex.hpp>
 #include <utility>
+#include <rclcpp/serialization.hpp>
 
 const std::string moveit_warehouse::PlanningSceneStorage::DATABASE_NAME = "moveit_planning_scenes";
 
@@ -45,6 +46,8 @@ const std::string moveit_warehouse::PlanningSceneStorage::MOTION_PLAN_REQUEST_ID
 
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
+
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.planning_scene_storage");
 
 moveit_warehouse::PlanningSceneStorage::PlanningSceneStorage(warehouse_ros::DatabaseConnection::Ptr conn)
   : MoveItMessageStorage(std::move(conn))
@@ -82,7 +85,7 @@ void moveit_warehouse::PlanningSceneStorage::addPlanningScene(const moveit_msgs:
   Metadata::Ptr metadata = planning_scene_collection_->createMetadata();
   metadata->append(PLANNING_SCENE_ID_NAME, scene.name);
   planning_scene_collection_->insert(scene, metadata);
-  ROS_DEBUG("%s scene '%s'", replace ? "Replaced" : "Added", scene.name.c_str());
+  RCLCPP_DEBUG(LOGGER, "%s scene '%s'", replace ? "Replaced" : "Added", scene.name.c_str());
 }
 
 bool moveit_warehouse::PlanningSceneStorage::hasPlanningScene(const std::string& name) const
@@ -106,22 +109,22 @@ std::string moveit_warehouse::PlanningSceneStorage::getMotionPlanRequestName(
     return "";
 
   // compute the serialization of the message passed as argument
-  const size_t serial_size_arg = ros::serialization::serializationLength(planning_query);
-  boost::shared_array<uint8_t> buffer_arg(new uint8_t[serial_size_arg]);
-  ros::serialization::OStream stream_arg(buffer_arg.get(), serial_size_arg);
-  ros::serialization::serialize(stream_arg, planning_query);
-  const void* data_arg = buffer_arg.get();
+  rclcpp::Serialization<moveit_msgs::msg::MotionPlanRequest> serializer;
+  rclcpp::SerializedMessage serialized_msg_arg;
+  serializer.serialize_message(&planning_query, &serialized_msg_arg);
+  const size_t serial_size_arg = serialized_msg_arg.size();
+  const void* data_arg = serialized_msg_arg.get_rcl_serialized_message().buffer;
 
   for (MotionPlanRequestWithMetadata& existing_request : existing_requests)
   {
-    const size_t serial_size = ros::serialization::serializationLength(
-        static_cast<const moveit_msgs::msg::MotionPlanRequest&>(*existing_request));
+    auto msg = static_cast<const moveit_msgs::msg::MotionPlanRequest&>(*existing_request);
+    rclcpp::SerializedMessage serialized_msg;
+    serializer.serialize_message(&msg, &serialized_msg);
+    const size_t serial_size = serialized_msg.size();
+    const void* data = serialized_msg.get_rcl_serialized_message().buffer;
+
     if (serial_size != serial_size_arg)
       continue;
-    boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
-    ros::serialization::OStream stream(buffer.get(), serial_size);
-    ros::serialization::serialize(stream, static_cast<const moveit_msgs::msg::MotionPlanRequest&>(*existing_request));
-    const void* data = buffer.get();
     if (memcmp(data_arg, data, serial_size) == 0)
       // we found the same message twice
       return existing_request->lookupString(MOTION_PLAN_REQUEST_ID_NAME);
@@ -160,7 +163,7 @@ moveit_warehouse::PlanningSceneStorage::addNewPlanningRequest(const moveit_msgs:
     std::size_t index = existing_requests.size();
     do
     {
-      id = "Motion Plan Request " + boost::lexical_cast<std::string>(index);
+      id = "Motion Plan Request " + std::to_string(index);
       index++;
     } while (used.find(id) != used.end());
   }
@@ -168,7 +171,7 @@ moveit_warehouse::PlanningSceneStorage::addNewPlanningRequest(const moveit_msgs:
   metadata->append(PLANNING_SCENE_ID_NAME, scene_name);
   metadata->append(MOTION_PLAN_REQUEST_ID_NAME, id);
   motion_plan_request_collection_->insert(planning_query, metadata);
-  ROS_DEBUG("Saved planning query '%s' for scene '%s'", id.c_str(), scene_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Saved planning query '%s' for scene '%s'", id.c_str(), scene_name.c_str());
   return id;
 }
 
@@ -224,7 +227,7 @@ bool moveit_warehouse::PlanningSceneStorage::getPlanningScene(PlanningSceneWithM
   std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->queryList(q, false);
   if (planning_scenes.empty())
   {
-    ROS_WARN("Planning scene '%s' was not found in the database", scene_name.c_str());
+    RCLCPP_WARN(LOGGER, "Planning scene '%s' was not found in the database", scene_name.c_str());
     return false;
   }
   scene_m = planning_scenes.back();
@@ -244,7 +247,7 @@ bool moveit_warehouse::PlanningSceneStorage::getPlanningQuery(MotionPlanRequestW
   std::vector<MotionPlanRequestWithMetadata> planning_queries = motion_plan_request_collection_->queryList(q, false);
   if (planning_queries.empty())
   {
-    ROS_ERROR("Planning query '%s' not found for scene '%s'", query_name.c_str(), scene_name.c_str());
+    RCLCPP_ERROR(LOGGER, "Planning query '%s' not found for scene '%s'", query_name.c_str(), scene_name.c_str());
     return false;
   }
   else
@@ -350,7 +353,7 @@ void moveit_warehouse::PlanningSceneStorage::renamePlanningScene(const std::stri
   Metadata::Ptr m = planning_scene_collection_->createMetadata();
   m->append(PLANNING_SCENE_ID_NAME, new_scene_name);
   planning_scene_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed planning scene from '%s' to '%s'", old_scene_name.c_str(), new_scene_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed planning scene from '%s' to '%s'", old_scene_name.c_str(), new_scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::renamePlanningQuery(const std::string& scene_name,
@@ -363,8 +366,8 @@ void moveit_warehouse::PlanningSceneStorage::renamePlanningQuery(const std::stri
   Metadata::Ptr m = motion_plan_request_collection_->createMetadata();
   m->append(MOTION_PLAN_REQUEST_ID_NAME, new_query_name);
   motion_plan_request_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed planning query for scene '%s' from '%s' to '%s'", scene_name.c_str(), old_query_name.c_str(),
-            new_query_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed planning query for scene '%s' from '%s' to '%s'", scene_name.c_str(),
+               old_query_name.c_str(), new_query_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningScene(const std::string& scene_name)
@@ -373,7 +376,7 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningScene(const std::stri
   Query::Ptr q = planning_scene_collection_->createQuery();
   q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = planning_scene_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u PlanningScene messages (named '%s')", rem, scene_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u PlanningScene messages (named '%s')", rem, scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningQueries(const std::string& scene_name)
@@ -382,7 +385,7 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningQueries(const std::st
   Query::Ptr q = motion_plan_request_collection_->createQuery();
   q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = motion_plan_request_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u MotionPlanRequest messages for scene '%s'", rem, scene_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u MotionPlanRequest messages for scene '%s'", rem, scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningQuery(const std::string& scene_name,
@@ -393,8 +396,8 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningQuery(const std::stri
   q->append(PLANNING_SCENE_ID_NAME, scene_name);
   q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
   unsigned int rem = motion_plan_request_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u MotionPlanRequest messages for scene '%s', query '%s'", rem, scene_name.c_str(),
-            query_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u MotionPlanRequest messages for scene '%s', query '%s'", rem, scene_name.c_str(),
+               query_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::string& scene_name)
@@ -402,7 +405,7 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::st
   Query::Ptr q = robot_trajectory_collection_->createQuery();
   q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = robot_trajectory_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u RobotTrajectory messages for scene '%s'", rem, scene_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u RobotTrajectory messages for scene '%s'", rem, scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::string& scene_name,
@@ -412,6 +415,6 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::st
   q->append(PLANNING_SCENE_ID_NAME, scene_name);
   q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
   unsigned int rem = robot_trajectory_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u RobotTrajectory messages for scene '%s', query '%s'", rem, scene_name.c_str(),
-            query_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u RobotTrajectory messages for scene '%s', query '%s'", rem, scene_name.c_str(),
+               query_name.c_str());
 }

--- a/moveit_ros/warehouse/warehouse/src/planning_scene_world_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/planning_scene_world_storage.cpp
@@ -41,6 +41,8 @@
 const std::string moveit_warehouse::PlanningSceneWorldStorage::DATABASE_NAME = "moveit_planning_scene_worlds";
 const std::string moveit_warehouse::PlanningSceneWorldStorage::PLANNING_SCENE_WORLD_ID_NAME = "world_id";
 
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.planning_scene_world_storage");
+
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
 
@@ -75,7 +77,7 @@ void moveit_warehouse::PlanningSceneWorldStorage::addPlanningSceneWorld(const mo
   Metadata::Ptr metadata = planning_scene_world_collection_->createMetadata();
   metadata->append(PLANNING_SCENE_WORLD_ID_NAME, name);
   planning_scene_world_collection_->insert(msg, metadata);
-  ROS_DEBUG("%s planning scene world '%s'", replace ? "Replaced" : "Added", name.c_str());
+  RCLCPP_DEBUG(LOGGER, "%s planning scene world '%s'", replace ? "Replaced" : "Added", name.c_str());
 }
 
 bool moveit_warehouse::PlanningSceneWorldStorage::hasPlanningSceneWorld(const std::string& name) const
@@ -127,7 +129,7 @@ void moveit_warehouse::PlanningSceneWorldStorage::renamePlanningSceneWorld(const
   Metadata::Ptr m = planning_scene_world_collection_->createMetadata();
   m->append(PLANNING_SCENE_WORLD_ID_NAME, new_name);
   planning_scene_world_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed planning scene world from '%s' to '%s'", old_name.c_str(), new_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed planning scene world from '%s' to '%s'", old_name.c_str(), new_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneWorldStorage::removePlanningSceneWorld(const std::string& name)
@@ -135,5 +137,5 @@ void moveit_warehouse::PlanningSceneWorldStorage::removePlanningSceneWorld(const
   Query::Ptr q = planning_scene_world_collection_->createQuery();
   q->append(PLANNING_SCENE_WORLD_ID_NAME, name);
   unsigned int rem = planning_scene_world_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u PlanningSceneWorld messages (named '%s')", rem, name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u PlanningSceneWorld messages (named '%s')", rem, name.c_str());
 }

--- a/moveit_ros/warehouse/warehouse/src/state_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/state_storage.cpp
@@ -43,6 +43,8 @@ const std::string moveit_warehouse::RobotStateStorage::DATABASE_NAME = "moveit_r
 const std::string moveit_warehouse::RobotStateStorage::STATE_NAME = "state_id";
 const std::string moveit_warehouse::RobotStateStorage::ROBOT_NAME = "robot_id";
 
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.state_storage");
+
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
 
@@ -77,7 +79,7 @@ void moveit_warehouse::RobotStateStorage::addRobotState(const moveit_msgs::msg::
   metadata->append(STATE_NAME, name);
   metadata->append(ROBOT_NAME, robot);
   state_collection_->insert(msg, metadata);
-  ROS_DEBUG("%s robot state '%s'", replace ? "Replaced" : "Added", name.c_str());
+  RCLCPP_DEBUG(LOGGER, "%s robot state '%s'", replace ? "Replaced" : "Added", name.c_str());
 }
 
 bool moveit_warehouse::RobotStateStorage::hasRobotState(const std::string& name, const std::string& robot) const
@@ -137,7 +139,7 @@ void moveit_warehouse::RobotStateStorage::renameRobotState(const std::string& ol
   Metadata::Ptr m = state_collection_->createMetadata();
   m->append(STATE_NAME, new_name);
   state_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed robot state from '%s' to '%s'", old_name.c_str(), new_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed robot state from '%s' to '%s'", old_name.c_str(), new_name.c_str());
 }
 
 void moveit_warehouse::RobotStateStorage::removeRobotState(const std::string& name, const std::string& robot)
@@ -147,5 +149,5 @@ void moveit_warehouse::RobotStateStorage::removeRobotState(const std::string& na
   if (!robot.empty())
     q->append(ROBOT_NAME, robot);
   unsigned int rem = state_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u RobotState messages (named '%s')", rem, name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u RobotState messages (named '%s')", rem, name.c_str());
 }

--- a/moveit_ros/warehouse/warehouse/src/trajectory_constraints_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/trajectory_constraints_storage.cpp
@@ -44,6 +44,8 @@ const std::string moveit_warehouse::TrajectoryConstraintsStorage::CONSTRAINTS_ID
 const std::string moveit_warehouse::TrajectoryConstraintsStorage::CONSTRAINTS_GROUP_NAME = "group_id";
 const std::string moveit_warehouse::TrajectoryConstraintsStorage::ROBOT_NAME = "robot_id";
 
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.trajectory_constraints_storage");
+
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
 
@@ -81,7 +83,7 @@ void moveit_warehouse::TrajectoryConstraintsStorage::addTrajectoryConstraints(
   metadata->append(ROBOT_NAME, robot);
   metadata->append(CONSTRAINTS_GROUP_NAME, group);
   constraints_collection_->insert(msg, metadata);
-  ROS_DEBUG("%s constraints '%s'", replace ? "Replaced" : "Added", name.c_str());
+  RCLCPP_DEBUG(LOGGER, "%s constraints '%s'", replace ? "Replaced" : "Added", name.c_str());
 }
 
 bool moveit_warehouse::TrajectoryConstraintsStorage::hasTrajectoryConstraints(const std::string& name,
@@ -159,7 +161,7 @@ void moveit_warehouse::TrajectoryConstraintsStorage::renameTrajectoryConstraints
   Metadata::Ptr m = constraints_collection_->createMetadata();
   m->append(CONSTRAINTS_ID_NAME, new_name);
   constraints_collection_->modifyMetadata(q, m);
-  ROS_DEBUG("Renamed constraints from '%s' to '%s'", old_name.c_str(), new_name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Renamed constraints from '%s' to '%s'", old_name.c_str(), new_name.c_str());
 }
 
 void moveit_warehouse::TrajectoryConstraintsStorage::removeTrajectoryConstraints(const std::string& name,
@@ -173,5 +175,5 @@ void moveit_warehouse::TrajectoryConstraintsStorage::removeTrajectoryConstraints
   if (!group.empty())
     q->append(CONSTRAINTS_GROUP_NAME, group);
   unsigned int rem = constraints_collection_->removeMessages(q);
-  ROS_DEBUG("Removed %u TrajectoryConstraints messages (named '%s')", rem, name.c_str());
+  RCLCPP_DEBUG(LOGGER, "Removed %u TrajectoryConstraints messages (named '%s')", rem, name.c_str());
 }

--- a/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_connector.cpp
@@ -37,8 +37,10 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <unistd.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/warehouse/warehouse_connector.h>
+
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.warehouse_connector");
 
 namespace moveit_warehouse
 {
@@ -60,7 +62,7 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
   child_pid_ = fork();
   if (child_pid_ == -1)
   {
-    ROS_ERROR("Error forking process.");
+    RCLCPP_ERROR(LOGGER, "Error forking process.");
     child_pid_ = 0;
     return false;
   }
@@ -88,14 +90,16 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
       delete[] argv[1];
       delete[] argv[2];
       delete[] argv;
-      ROS_ERROR_STREAM("execv() returned " << code << ", errno=" << errno << " string errno = " << strerror(errno));
+      RCLCPP_ERROR_STREAM(LOGGER,
+                          "execv() returned " << code << ", errno=" << errno << " string errno = " << strerror(errno));
     }
     return false;
   }
   else
   {
     // sleep so mongod has time to come up
-    ros::WallDuration(1.0).sleep();
+    using namespace std::chrono_literals;
+    rclcpp::sleep_for(1s);
   }
   return true;
 }


### PR DESCRIPTION
### Description

This PR intends to port moveit_ros_warehouse to ROS2.

- Depends on [warehouse_ros PR#48](https://github.com/ros-planning/warehouse_ros/pull/48) and [warehouse_ros_mongo PR#38](https://github.com/ros-planning/warehouse_ros_mongo/pull/38).

- Run tests:
  - `ros2 launch run_move_group run_move_group.launch.py`
  - On `Context` tab of motion planning rviz panel, click `connect` button to connect to the mongodb server.
  - Please try save robot states or planning scene to the database in their own rviz tabs.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
