### PR TITLE
Temporarily freeze ros2_control branches in workspace

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -30,14 +30,15 @@ repositories:
     url: https://github.com/ros/urdfdom_headers
     version: foxy
 
+# TODO(#283): Switch to master after fixing breaking changes in ros2_control
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control
-    version: master
+    version: 2c3aad1cb8ad4d23925bceeb5c26e22d6cf859ef
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: d52902538a970e792ecc604416e22ef90a57f29e
 
 # TODO(JafarAbdi): Switch to upstream once PR https://github.com/tork-a/fake_joint/pull/7 is merged
   fake_joint:


### PR DESCRIPTION
Changes the `ros2_control` workspace branches to versions before breaking changes (see #283)