### PR TITLE
moveit2.repos: fix branch to eloquent

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -2,7 +2,7 @@ repositories:
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2
-    version: master
+    version: eloquent
   moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -22,7 +22,7 @@ repositories:
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources
-    version: ros2
+    version: 0400e1f541c143b7638041dd41a98bdd96c6e6bb
   geometric_shapes:
     type: git
     url: https://github.com/ros-planning/geometric_shapes


### PR DESCRIPTION
The [docker build for moveit/moveit2:eloquent-ci is broken](https://hub.docker.com/repository/registry-1.docker.io/moveit/moveit2/builds/ec58a1f2-d86e-4e2f-89c2-510b40f4f93a), because it was still referencing to master branch.