### PR TITLE
WIP: Add launch_utils

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -18,6 +18,7 @@
   <url type="repository">https://github.com/ros-planning/moveit</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -37,6 +37,8 @@ if(BUILD_TESTING)
   ament_export_libraries(${MOVEIT_TEST_LIB_NAME} ${MOVEIT_LIB_NAME})
   ament_export_include_directories(include)
 
+  ament_python_install_package(${MOVEIT_LIB_NAME})
+
   install(TARGETS
     ${MOVEIT_TEST_LIB_NAME}
     LIBRARY DESTINATION lib

--- a/moveit_core/utils/moveit_utils/launch_utils.py
+++ b/moveit_core/utils/moveit_utils/launch_utils.py
@@ -1,0 +1,59 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, PickNik LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of PickNik LLC nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Sebastian Jahr
+
+import os
+import yaml
+from ament_index_python.packages import get_package_share_directory
+
+
+def load_file(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return file.read()
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def load_yaml(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return yaml.safe_load(file)
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
@@ -1,28 +1,9 @@
 import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
 
 def generate_launch_description():

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group_interface.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group_interface.launch.py
@@ -1,30 +1,7 @@
-import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 
-
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
 
 def generate_launch_description():

--- a/moveit_demo_nodes/run_move_group/package.xml
+++ b/moveit_demo_nodes/run_move_group/package.xml
@@ -11,6 +11,8 @@
 
   <depend>moveit_ros_planning_interface</depend>
 
+  <exec_depend>moveit_core</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -1,28 +1,9 @@
 import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
 
 def generate_launch_description():

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp_fake_controller.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp_fake_controller.launch.py
@@ -1,28 +1,9 @@
 import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
 
 def generate_launch_description():

--- a/moveit_demo_nodes/run_moveit_cpp/package.xml
+++ b/moveit_demo_nodes/run_moveit_cpp/package.xml
@@ -11,6 +11,8 @@
 
   <depend>moveit_ros_planning_interface</depend>
 
+  <exec_depend>moveit_core</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
@@ -1,28 +1,10 @@
 import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_launch_description():
 

--- a/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
@@ -1,28 +1,11 @@
 import os
-import yaml
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_launch_description():
     # Get parameters for the Servo node

--- a/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
@@ -1,30 +1,13 @@
 import os
-import yaml
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_launch_description():
     # Get parameters for the Servo node

--- a/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
@@ -1,30 +1,13 @@
 import os
-import yaml
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_launch_description():
     # Get parameters for the Servo node

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>moveit_core</exec_depend>
 
   <test_depend>moveit_resources</test_depend>
   <test_depend>ros_testing</test_depend>

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -1,5 +1,4 @@
 import os
-import yaml
 import launch
 from launch import LaunchDescription
 from launch.some_substitutions_type import SomeSubstitutionsType
@@ -9,25 +8,9 @@ from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
 from ament_index_python.packages import get_package_share_directory
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_servo_test_description(*args,
                                     gtest_name: SomeSubstitutionsType,

--- a/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
@@ -1,10 +1,11 @@
+from servo_launch_test_common import generate_servo_test_description
 import os
 import sys
 import unittest
 
 import launch_testing.asserts
 sys.path.append(os.path.dirname(__file__))
-from servo_launch_test_common import generate_servo_test_description 
+
 
 def generate_test_description():
     return generate_servo_test_description(gtest_name='test_servo_collision',

--- a/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
@@ -1,10 +1,11 @@
+from servo_launch_test_common import generate_servo_test_description
 import os
 import sys
 import unittest
 
 import launch_testing.asserts
 sys.path.append(os.path.dirname(__file__))
-from servo_launch_test_common import generate_servo_test_description 
+
 
 def generate_test_description():
     return generate_servo_test_description(gtest_name='test_servo_integration',

--- a/moveit_ros/moveit_servo/test/launch/test_servo_parameters.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_parameters.test.py
@@ -1,32 +1,12 @@
-import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 import unittest
 import launch_testing.asserts
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 import launch
 
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
+from moveit_utils.launch_test_utils import load_file, load_yaml
 
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        return None
 
 def generate_test_description():
     # Get (valid) parameters using the demo config file


### PR DESCRIPTION
### Description

To avoid copying and pasting common launch file functions, I added a simple python file called launch_utils.py in moveit_utils to be imported into the launch_files. Furthermore, I refactored the existing launch-files to import the functions instead of defining them.

### Checklist
- [X] Create python file with commen functions
- [ ] Migrate files in separate package
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
