### PR TITLE
Fix Servo runtime issues

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -38,7 +38,7 @@ repositories:
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: d52902538a970e792ecc604416e22ef90a57f29e
+    version: 8587e079490acdd0fabeb2742a3bec3bf551bbc5
 
 # TODO(JafarAbdi): Switch to upstream once PR https://github.com/tork-a/fake_joint/pull/7 is merged
   fake_joint:

--- a/moveit_ros/moveit_servo/doc/servo_tutorial.md
+++ b/moveit_ros/moveit_servo/doc/servo_tutorial.md
@@ -120,7 +120,7 @@ If using the composable node, you will need to load the parameters into the "mov
 servo_params = { 'moveit_servo' : servo_yaml }
 container = ComposableNodeContainer(
             name='moveit_servo_demo_container',
-            namespace='',
+            namespace='/',
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[

--- a/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
     # Launch as much as possible in components
     container = ComposableNodeContainer(
             name='moveit_servo_demo_container',
-            namespace='',
+            namespace='/',
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[

--- a/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
     # Launch as much as possible in components
     container = ComposableNodeContainer(
             name='moveit_servo_demo_container',
-            namespace='',
+            namespace='/',
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -55,7 +55,7 @@ def generate_servo_test_description(*args,
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(
             name='test_servo_integration_container',
-            namespace='',
+            namespace='/',
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[


### PR DESCRIPTION
This resets `ros2_controllers` to the last version that worked with FakeJoint and Servo. We'll switch to the latest versions once there are stable APIs. Also, since the last ros2 package sync, running the component nodes in Servo would throw an InvalidServiceNameException becaues the namespace parameter in the launch files were undefined. Setting them to root "/" fixes this. @AdamPettinger 