### PR TITLE
Porting moveit_ros_perception/pointcloud_octomap_updater

### DIFF
--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -66,12 +66,12 @@ public:
 
   /** @brief Set updater params using struct that comes from parsing a yaml string. This must be called after
    * setMonitor() */
-  // TODO rework this function
-  // virtual bool setParams(XmlRpc::XmlRpcValue& params) = 0;
+  // Rework XmlRpc param look up to ROS2 style
+  virtual bool setParams(const std::string& name_space) = 0;
 
   /** @brief Do any necessary setup (subscribe to ros topics, etc.). This call assumes setMonitor() and setParams() have
    * been previously called. */
-  virtual bool initialize() = 0;
+  virtual bool initialize(const rclcpp::Node::SharedPtr& node) = 0;
 
   virtual void start() = 0;
 

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -66,7 +66,6 @@ public:
 
   /** @brief Set updater params using struct that comes from parsing a yaml string. This must be called after
    * setMonitor() */
-  // Rework XmlRpc param look up to ROS2 style
   virtual bool setParams(const std::string& name_space) = 0;
 
   /** @brief Do any necessary setup (subscribe to ros topics, etc.). This call assumes setMonitor() and setParams() have

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -1,90 +1,88 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_perception)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
 
 option(WITH_OPENGL "Build the parts that depend on OpenGL" ON)
 
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wpedantic)
 endif()
 
 find_package(Boost REQUIRED thread)
 
-if(WITH_OPENGL)
-  # Prefer newer vendor-specific OpenGL library
-  if(POLICY CMP0072)
-    cmake_policy(SET CMP0072 NEW)
-  endif()
-  find_package(OpenGL REQUIRED)
-  find_package(GLEW REQUIRED)
-  find_package(GLUT REQUIRED)
-  set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
-  set(perception_GL_INCLUDE_DIRS "mesh_filter/include" "depth_image_octomap_updater/include")
-  set(SYSTEM_GL_INCLUDE_DIRS ${GLEW_INCLUDE_DIR} ${GLUT_INCLUDE_DIR})
-endif()
+# if(WITH_OPENGL)
+#   # Prefer newer vendor-specific OpenGL library
+#   if(POLICY CMP0072)
+#     cmake_policy(SET CMP0072 NEW)
+#   endif()
+#   find_package(OpenGL REQUIRED)
+#   find_package(GLEW REQUIRED)
+#   find_package(GLUT REQUIRED)
+#   set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
+#   set(perception_GL_INCLUDE_DIRS "mesh_filter/include" "depth_image_octomap_updater/include")
+#   set(SYSTEM_GL_INCLUDE_DIRS ${GLEW_INCLUDE_DIR} ${GLUT_INCLUDE_DIR})
+# endif()
 
 if(APPLE)
   find_package(X11 REQUIRED)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  cv_bridge
-  moveit_core
-  roscpp
-  rosconsole
-  urdf
-  message_filters
-  tf2
-  tf2_eigen
-  tf2_geometry_msgs
-  tf2_ros
-  pluginlib
-  image_transport
-  object_recognition_msgs
-  sensor_msgs
-  moveit_msgs
-  moveit_ros_occupancy_map_monitor
-)
-
+find_package(ament_cmake REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(urdf REQUIRED)
+find_package(message_filters REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(object_recognition_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_ros_occupancy_map_monitor REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(OpenCV)
 
-catkin_package(
-  INCLUDE_DIRS
-    lazy_free_space_updater/include
-    point_containment_filter/include
-    pointcloud_octomap_updater/include
-    semantic_world/include
-    ${perception_GL_INCLUDE_DIRS}
-  LIBRARIES
-    moveit_lazy_free_space_updater
-    moveit_point_containment_filter
-    moveit_pointcloud_octomap_updater_core
-    moveit_semantic_world
-  CATKIN_DEPENDS
-    image_transport
-    moveit_core
-    moveit_msgs
-    moveit_ros_occupancy_map_monitor
-    object_recognition_msgs
-    roscpp
-    sensor_msgs
-    tf2_geometry_msgs
-  DEPENDS
-    EIGEN3
-)
-
-include_directories(lazy_free_space_updater/include
+set(THIS_PACKAGE_INCLUDE_DIRS
+  # lazy_free_space_updater/include
   point_containment_filter/include
   pointcloud_octomap_updater/include
   semantic_world/include
-  ${perception_GL_INCLUDE_DIRS}
+  # ${perception_GL_INCLUDE_DIRS}
+)
+
+set(THIS_PACKAGE_LIBRARIES
+  # moveit_lazy_free_space_updater
+  moveit_point_containment_filter
+  moveit_pointcloud_octomap_updater_core
+  moveit_semantic_world
+)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  image_transport
+  moveit_core
+  moveit_msgs
+  moveit_ros_occupancy_map_monitor
+  object_recognition_msgs
+  rclcpp
+  sensor_msgs
+  tf2_geometry_msgs
+  Eigen3
+)
+
+include_directories(
+  # lazy_free_space_updater/include
+  point_containment_filter/include
+  pointcloud_octomap_updater/include
+  semantic_world/include
+  # ${perception_GL_INCLUDE_DIRS}
 )
 include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
@@ -94,20 +92,21 @@ include_directories(SYSTEM
   ${X11_INCLUDE_DIR}
 )
 
-add_subdirectory(lazy_free_space_updater)
+# add_subdirectory(lazy_free_space_updater)
 add_subdirectory(point_containment_filter)
 add_subdirectory(pointcloud_octomap_updater)
-if(WITH_OPENGL)
-  add_subdirectory(mesh_filter)
-  add_subdirectory(depth_image_octomap_updater)
-endif()
+# if(WITH_OPENGL)
+#   add_subdirectory(mesh_filter)
+#   add_subdirectory(depth_image_octomap_updater)
+# endif()
 
 add_subdirectory(semantic_world)
 
-install(
-  FILES
-    pointcloud_octomap_updater_plugin_description.xml
-    depth_image_octomap_updater_plugin_description.xml
-  DESTINATION
-    ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_export_include_directories(include)
+ament_export_libraries(${THIS_PACKAGE_LIBRARIES})
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor pointcloud_octomap_updater_plugin_description.xml)
+pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor depth_image_octomap_updater_plugin_description.xml)
+
+ament_package()

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(OpenMP REQUIRED)
 find_package(OpenCV)
 
 set(THIS_PACKAGE_INCLUDE_DIRS
-  # lazy_free_space_updater/include
+  lazy_free_space_updater/include
   point_containment_filter/include
   pointcloud_octomap_updater/include
   semantic_world/include
@@ -59,7 +59,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 )
 
 set(THIS_PACKAGE_LIBRARIES
-  # moveit_lazy_free_space_updater
+  moveit_lazy_free_space_updater
   moveit_point_containment_filter
   moveit_pointcloud_octomap_updater_core
   moveit_semantic_world
@@ -77,13 +77,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   Eigen3
 )
 
-include_directories(
-  # lazy_free_space_updater/include
-  point_containment_filter/include
-  pointcloud_octomap_updater/include
-  semantic_world/include
-  # ${perception_GL_INCLUDE_DIRS}
-)
+include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
@@ -92,7 +86,7 @@ include_directories(SYSTEM
   ${X11_INCLUDE_DIR}
 )
 
-# add_subdirectory(lazy_free_space_updater)
+add_subdirectory(lazy_free_space_updater)
 add_subdirectory(point_containment_filter)
 add_subdirectory(pointcloud_octomap_updater)
 # if(WITH_OPENGL)

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -61,7 +61,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 set(THIS_PACKAGE_LIBRARIES
   moveit_lazy_free_space_updater
   moveit_point_containment_filter
-  moveit_pointcloud_octomap_updater_core
+  moveit_pointcloud_octomap_updater
   moveit_semantic_world
 )
 
@@ -100,7 +100,7 @@ ament_export_include_directories(include)
 ament_export_libraries(${THIS_PACKAGE_LIBRARIES})
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor pointcloud_octomap_updater_plugin_description.xml)
-pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor depth_image_octomap_updater_plugin_description.xml)
+pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor "pointcloud_octomap_updater_plugin_description.xml")
+# pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor "depth_image_octomap_updater_plugin_description.xml")
 
 ament_package()

--- a/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -2,16 +2,37 @@ set(MOVEIT_LIB_NAME moveit_depth_image_octomap_updater)
 
 add_library(${MOVEIT_LIB_NAME}_core src/depth_image_octomap_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_lazy_free_space_updater moveit_mesh_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
-add_dependencies(${MOVEIT_LIB_NAME}_core ${sensor_msgs_EXPORTED_TARGETS})
+ament_target_dependencies(${MOVEIT_LIB_NAME}_core
+  rclcpp
+  moveit_core
+  image_transport
+  sensor_msgs
+  tf2
+  tf2_geometry_msgs
+  geometric_shapes
+  moveit_ros_occupancy_map_monitor
+  Boost
+)
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_lazy_free_space_updater moveit_mesh_filter)
 
 add_library(${MOVEIT_LIB_NAME} src/updater_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  image_transport
+  sensor_msgs
+  tf2
+  tf2_geometry_msgs
+  geometric_shapes
+  moveit_ros_occupancy_map_monitor
+  Boost
+  pluginlib
+)
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 
 install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/perception/depth_image_octomap_updater_plugin_description.xml
+++ b/moveit_ros/perception/depth_image_octomap_updater_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libmoveit_depth_image_octomap_updater">
+<library path="moveit_depth_image_octomap_updater">
   <class name="occupancy_map_monitor/DepthImageOctomapUpdater" type="occupancy_map_monitor::DepthImageOctomapUpdater" base_class_type="occupancy_map_monitor::OccupancyMapUpdater">
     <description>
     </description>

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_lazy_free_space_updater)
 
-add_library(${MOVEIT_LIB_NAME} src/lazy_free_space_updater.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/lazy_free_space_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -4,12 +4,16 @@ add_library(${MOVEIT_LIB_NAME} src/lazy_free_space_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_ros_occupancy_map_monitor
+  Boost
+)
 
-add_dependencies(${MOVEIT_LIB_NAME} ${sensor_msgs_EXPORTED_TARGETS})
+# add_dependencies(${MOVEIT_LIB_NAME} ${sensor_msgs_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -8,9 +8,8 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_ros_occupancy_map_monitor
   Boost
+  sensor_msgs
 )
-
-# add_dependencies(${MOVEIT_LIB_NAME} ${sensor_msgs_EXPORTED_TARGETS})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
         LIBRARY DESTINATION lib

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -8,25 +8,36 @@ add_library(${MOVEIT_LIB_NAME}
   src/gl_mesh.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  image_transport
+  cv_bridge
+  tf2_ros
+  tf2_eigen
+  geometric_shapes
+  moveit_ros_planning
+  moveit_ros_occupancy_map_monitor
+  Eigen3
+  Boost
+)
+target_link_libraries(${MOVEIT_LIB_NAME} ${gl_LIBS} GLUT::GLUT ${GLEW_LIBRARIES})
 
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} GLUT::GLUT ${GLEW_LIBRARIES})
-
-if(CATKIN_ENABLE_TESTING)
-  #catkin_lint: ignore_once env_var
-  # Can only run this test if we have a display
-  if(DEFINED ENV{DISPLAY} AND NOT $ENV{DISPLAY} STREQUAL "")
-    catkin_add_gtest(mesh_filter_test test/mesh_filter_test.cpp)
-    target_link_libraries(mesh_filter_test ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_mesh_filter)
-    # TODO: remove if transition to gtest's new API TYPED_TEST_SUITE_P is finished
-    target_compile_options(mesh_filter_test PRIVATE -Wno-deprecated-declarations)
-  else()
-    message("No display, will not configure tests for moveit_ros_perception/mesh_filter")
-  endif()
-endif()
+# TODO: enable testing
+# if(CATKIN_ENABLE_TESTING)
+#   #catkin_lint: ignore_once env_var
+#   # Can only run this test if we have a display
+#   if(DEFINED ENV{DISPLAY} AND NOT $ENV{DISPLAY} STREQUAL "")
+#     catkin_add_gtest(mesh_filter_test test/mesh_filter_test.cpp)
+#     target_link_libraries(mesh_filter_test ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_mesh_filter)
+#   else()
+#     message("No display, will not configure tests for moveit_ros_perception/mesh_filter")
+#   endif()
+# endif()
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
 )
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -21,7 +21,6 @@
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>
-  <!-- <depend>rosconsole</depend> -->
   <depend>urdf</depend>
   <depend>message_filters</depend>
   <depend version_gte="1.11.2">pluginlib</depend>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -16,11 +16,12 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
-  <depend>roscpp</depend>
-  <depend>rosconsole</depend>
+  <depend>rclcpp</depend>
+  <!-- <depend>rosconsole</depend> -->
   <depend>urdf</depend>
   <depend>message_filters</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
@@ -41,9 +42,10 @@
 
   <build_depend>eigen</build_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <!-- <test_depend>ament_cmake_gtest</test_depend> -->
 
   <export>
+    <build_type>ament_cmake</build_type>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>
     <moveit_ros_perception plugin="${prefix}/depth_image_octomap_updater_plugin_description.xml"/>
   </export>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -45,8 +45,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>
-    <moveit_ros_perception plugin="${prefix}/depth_image_octomap_updater_plugin_description.xml"/>
   </export>
 
 </package>

--- a/moveit_ros/perception/point_containment_filter/CMakeLists.txt
+++ b/moveit_ros/perception/point_containment_filter/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_point_containment_filter)
 
-add_library(${MOVEIT_LIB_NAME} src/shape_mask.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/shape_mask.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")

--- a/moveit_ros/perception/point_containment_filter/CMakeLists.txt
+++ b/moveit_ros/perception/point_containment_filter/CMakeLists.txt
@@ -4,10 +4,15 @@ add_library(${MOVEIT_LIB_NAME} src/shape_mask.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  sensor_msgs
+  geometric_shapes
+  Boost
+)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)

--- a/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/moveit_ros/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <geometric_shapes/bodies.h>
 #include <boost/function.hpp>
 #include <vector>
@@ -78,7 +78,7 @@ public:
      point
       is inside the robot. The point is outside if the mask element is OUTSIDE.
   */
-  void maskContainment(const sensor_msgs::PointCloud2& data_in, const Eigen::Vector3d& sensor_pos,
+  void maskContainment(const sensor_msgs::msg::PointCloud2& data_in, const Eigen::Vector3d& sensor_pos,
                        const double min_sensor_dist, const double max_sensor_dist, std::vector<int>& mask);
 
   /** \brief Get the containment mask (INSIDE or OUTSIDE) value for an individual point.

--- a/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
+++ b/moveit_ros/perception/point_containment_filter/src/shape_mask.cpp
@@ -36,10 +36,10 @@
 
 #include <moveit/point_containment_filter/shape_mask.h>
 #include <geometric_shapes/body_operations.h>
-#include <ros/console.h>
-#include <sensor_msgs/point_cloud2_iterator.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <rclcpp/rclcpp.hpp>
 
-static const std::string LOGNAME = "shape_mask";
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.perception.shape_mask");
 
 point_containment_filter::ShapeMask::ShapeMask(const TransformCallback& transform_callback)
   : transform_callback_(transform_callback), next_handle_(1), min_handle_(1)
@@ -80,7 +80,7 @@ point_containment_filter::ShapeHandle point_containment_filter::ShapeMask::addSh
     ss.handle = next_handle_;
     std::pair<std::set<SeeShape, SortBodies>::iterator, bool> insert_op = bodies_.insert(ss);
     if (!insert_op.second)
-      ROS_ERROR_NAMED(LOGNAME, "Internal error in management of bodies in ShapeMask. This is a serious error.");
+      RCLCPP_ERROR(LOGGER, "Internal error in management of bodies in ShapeMask. This is a serious error.");
     used_handles_[next_handle_] = insert_op.first;
   }
   else
@@ -111,10 +111,10 @@ void point_containment_filter::ShapeMask::removeShape(ShapeHandle handle)
     min_handle_ = handle;
   }
   else
-    ROS_ERROR_NAMED(LOGNAME, "Unable to remove shape handle %u", handle);
+    RCLCPP_ERROR(LOGGER, "Unable to remove shape handle %u", handle);
 }
 
-void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::PointCloud2& data_in,
+void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::msg::PointCloud2& data_in,
                                                           const Eigen::Vector3d& /*sensor_origin*/,
                                                           const double min_sensor_dist, const double max_sensor_dist,
                                                           std::vector<int>& mask)
@@ -135,10 +135,10 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
       if (!transform_callback_(it->handle, tmp))
       {
         if (!it->body)
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Missing transform for shape with handle " << it->handle << " without a body");
+          RCLCPP_ERROR_STREAM(LOGGER, "Missing transform for shape with handle " << it->handle << " without a body");
         else
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Missing transform for shape " << it->body->getType() << " with handle "
-                                                                         << it->handle);
+          RCLCPP_ERROR_STREAM(LOGGER,
+                              "Missing transform for shape " << it->body->getType() << " with handle " << it->handle);
       }
       else
       {

--- a/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_pointcloud_octomap_updater)
 
-add_library(${MOVEIT_LIB_NAME}_core src/pointcloud_octomap_updater.cpp)
+add_library(${MOVEIT_LIB_NAME}_core SHARED src/pointcloud_octomap_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME}_core
   rclcpp
@@ -17,7 +17,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_point_containment_filter)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES LINK_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
-add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
@@ -2,17 +2,40 @@ set(MOVEIT_LIB_NAME moveit_pointcloud_octomap_updater)
 
 add_library(${MOVEIT_LIB_NAME}_core src/pointcloud_octomap_updater.cpp)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_point_containment_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}_core
+  rclcpp
+  moveit_core
+  tf2_ros
+  message_filters
+  sensor_msgs
+  moveit_ros_occupancy_map_monitor
+  tf2_geometry_msgs
+  tf2
+  Boost
+)
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_point_containment_filter)
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES LINK_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  tf2_ros
+  message_filters
+  sensor_msgs
+  moveit_ros_occupancy_map_monitor
+  tf2_geometry_msgs
+  tf2
+  Boost
+  pluginlib
+)
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -41,6 +41,8 @@
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2/LinearMath/Transform.h>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <tf2_ros/create_timer_interface.h>
+#include <tf2_ros/create_timer_ros.h>
 
 #include <memory>
 
@@ -97,10 +99,7 @@ void PointCloudOctomapUpdater::start()
   if (point_cloud_subscriber_)
     return;
   /* subscribe to point cloud topic using tf filter*/
-  rmw_qos_profile_t qos;
-  qos.depth = 5;
-  point_cloud_subscriber_ =
-      new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_, qos);
+  point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_);
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(
@@ -168,7 +167,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::msg::PointClo
   if (max_update_rate_ > 0)
   {
     // ensure we are not updating the octomap representation too often
-    if (rclcpp::Clock(RCL_ROS_TIME).now() - last_update_time_ <=
+    if ((rclcpp::Clock(RCL_ROS_TIME).now() - last_update_time_) <=
         rclcpp::Duration(std::chrono::duration<double>(1.0 / max_update_rate_)))
       return;
     last_update_time_ = rclcpp::Clock(RCL_ROS_TIME).now();

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -91,6 +91,9 @@ bool PointCloudOctomapUpdater::initialize(const rclcpp::Node::SharedPtr& node)
 
 void PointCloudOctomapUpdater::start()
 {
+  if (!filtered_cloud_topic_.empty())
+    filtered_cloud_publisher_ = node_->create_publisher<sensor_msgs::msg::PointCloud2>(filtered_cloud_topic_, 10);
+
   if (point_cloud_subscriber_)
     return;
   /* subscribe to point cloud topic using tf filter*/

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -40,17 +40,15 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2/LinearMath/Transform.h>
-#include <sensor_msgs/point_cloud2_iterator.h>
-#include <XmlRpcException.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <memory>
 
 namespace occupancy_map_monitor
 {
-static const std::string LOGNAME = "occupancy_map_monitor";
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.perception.pointcloud_octomap_updater");
 PointCloudOctomapUpdater::PointCloudOctomapUpdater()
   : OccupancyMapUpdater("PointCloudUpdater")
-  , private_nh_("~")
   , scale_(1.0)
   , padding_(0.0)
   , max_range_(std::numeric_limits<double>::infinity())
@@ -66,40 +64,28 @@ PointCloudOctomapUpdater::~PointCloudOctomapUpdater()
   stopHelper();
 }
 
-bool PointCloudOctomapUpdater::setParams(XmlRpc::XmlRpcValue& params)
+bool PointCloudOctomapUpdater::setParams(const std::string& name_space)
 {
-  try
-  {
-    if (!params.hasMember("point_cloud_topic"))
-      return false;
-    point_cloud_topic_ = static_cast<const std::string&>(params["point_cloud_topic"]);
-
-    readXmlParam(params, "max_range", &max_range_);
-    readXmlParam(params, "padding_offset", &padding_);
-    readXmlParam(params, "padding_scale", &scale_);
-    readXmlParam(params, "point_subsample", &point_subsample_);
-    if (params.hasMember("max_update_rate"))
-      readXmlParam(params, "max_update_rate", &max_update_rate_);
-    if (params.hasMember("filtered_cloud_topic"))
-      filtered_cloud_topic_ = static_cast<const std::string&>(params["filtered_cloud_topic"]);
-  }
-  catch (XmlRpc::XmlRpcException& ex)
-  {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "XmlRpc Exception: " << ex.getMessage());
-    return false;
-  }
-
-  return true;
+  return node_->get_parameter(name_space + ".point_cloud_topic", point_cloud_topic_) &&
+         node_->get_parameter(name_space + ".max_range", max_range_) &&
+         node_->get_parameter(name_space + ".padding_offset", padding_) &&
+         node_->get_parameter(name_space + ".padding_scale", scale_) &&
+         node_->get_parameter(name_space + ".point_subsample", point_subsample_) &&
+         node_->get_parameter(name_space + ".max_update_rate", max_update_rate_) &&
+         node_->get_parameter(name_space + ".filtered_cloud_topic", filtered_cloud_topic_);
 }
 
-bool PointCloudOctomapUpdater::initialize()
+bool PointCloudOctomapUpdater::initialize(const rclcpp::Node::SharedPtr& node)
 {
-  tf_buffer_.reset(new tf2_ros::Buffer());
-  tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_, root_nh_));
+  node_ = node;
+  tf_buffer_.reset(new tf2_ros::Buffer(node_->get_clock()));
+  auto create_timer_interface =
+      std::make_shared<tf2_ros::CreateTimerROS>(node->get_node_base_interface(), node->get_node_timers_interface());
+  tf_buffer_->setCreateTimerInterface(create_timer_interface);
+  tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
   shape_mask_.reset(new point_containment_filter::ShapeMask());
   shape_mask_->setTransformCallback(boost::bind(&PointCloudOctomapUpdater::getShapeTransform, this, _1, _2));
-  if (!filtered_cloud_topic_.empty())
-    filtered_cloud_publisher_ = private_nh_.advertise<sensor_msgs::PointCloud2>(filtered_cloud_topic_, 10, false);
+  last_update_time_ = node_->now();
   return true;
 }
 
@@ -108,19 +94,22 @@ void PointCloudOctomapUpdater::start()
   if (point_cloud_subscriber_)
     return;
   /* subscribe to point cloud topic using tf filter*/
-  point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::PointCloud2>(root_nh_, point_cloud_topic_, 5);
+  rmw_qos_profile_t qos;
+  qos.depth = 5;
+  point_cloud_subscriber_ =
+      new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_, qos);
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
-    point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::PointCloud2>(*point_cloud_subscriber_, *tf_buffer_,
-                                                                               monitor_->getMapFrame(), 5, root_nh_);
+    point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(
+        *point_cloud_subscriber_, *tf_buffer_, monitor_->getMapFrame(), 5, node_);
     point_cloud_filter_->registerCallback(boost::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, _1));
-    ROS_INFO_NAMED(LOGNAME, "Listening to '%s' using message filter with target frame '%s'", point_cloud_topic_.c_str(),
-                   point_cloud_filter_->getTargetFramesString().c_str());
+    RCLCPP_INFO(LOGGER, "Listening to '%s' using message filter with target frame '%s'", point_cloud_topic_.c_str(),
+                point_cloud_filter_->getTargetFramesString().c_str());
   }
   else
   {
     point_cloud_subscriber_->registerCallback(boost::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, _1));
-    ROS_INFO_NAMED(LOGNAME, "Listening to '%s'", point_cloud_topic_.c_str());
+    RCLCPP_INFO(LOGGER, "Listening to '%s'", point_cloud_topic_.c_str());
   }
 }
 
@@ -143,7 +132,7 @@ ShapeHandle PointCloudOctomapUpdater::excludeShape(const shapes::ShapeConstPtr& 
   if (shape_mask_)
     h = shape_mask_->addShape(shape, scale_, padding_);
   else
-    ROS_ERROR_NAMED(LOGNAME, "Shape filter not yet initialized!");
+    RCLCPP_ERROR(LOGGER, "Shape filter not yet initialized!");
   return h;
 }
 
@@ -163,22 +152,23 @@ bool PointCloudOctomapUpdater::getShapeTransform(ShapeHandle h, Eigen::Isometry3
   return it != transform_cache_.end();
 }
 
-void PointCloudOctomapUpdater::updateMask(const sensor_msgs::PointCloud2& /*cloud*/,
+void PointCloudOctomapUpdater::updateMask(const sensor_msgs::msg::PointCloud2& /*cloud*/,
                                           const Eigen::Vector3d& /*sensor_origin*/, std::vector<int>& /*mask*/)
 {
 }
 
-void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud_msg)
 {
-  ROS_DEBUG_NAMED(LOGNAME, "Received a new point cloud message");
-  ros::WallTime start = ros::WallTime::now();
+  RCLCPP_DEBUG(LOGGER, "Received a new point cloud message");
+  rclcpp::Time start = rclcpp::Clock(RCL_ROS_TIME).now();
 
   if (max_update_rate_ > 0)
   {
     // ensure we are not updating the octomap representation too often
-    if (ros::Time::now() - last_update_time_ <= ros::Duration(1.0 / max_update_rate_))
+    if (rclcpp::Clock(RCL_ROS_TIME).now() - last_update_time_ <=
+        rclcpp::Duration(std::chrono::duration<double>(1.0 / max_update_rate_)))
       return;
-    last_update_time_ = ros::Time::now();
+    last_update_time_ = rclcpp::Clock(RCL_ROS_TIME).now();
   }
 
   if (monitor_->getMapFrame().empty())
@@ -200,7 +190,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
       }
       catch (tf2::TransformException& ex)
       {
-        ROS_ERROR_STREAM_NAMED(LOGNAME, "Transform error of sensor data: " << ex.what() << "; quitting callback");
+        RCLCPP_ERROR_STREAM(LOGGER, "Transform error of sensor data: " << ex.what() << "; quitting callback");
         return;
       }
     }
@@ -215,7 +205,8 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
 
   if (!updateTransformCache(cloud_msg->header.frame_id, cloud_msg->header.stamp))
   {
-    ROS_ERROR_THROTTLE_NAMED(1, LOGNAME, "Transform cache was not updated. Self-filtering may fail.");
+    rclcpp::Clock& clock = *node_->get_clock();
+    RCLCPP_ERROR_STREAM_THROTTLE(LOGGER, clock, 1000, "Transform cache was not updated. Self-filtering may fail.");
     return;
   }
 
@@ -224,7 +215,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   updateMask(*cloud_msg, sensor_origin_eigen, mask_);
 
   octomap::KeySet free_cells, occupied_cells, model_cells, clip_cells;
-  std::unique_ptr<sensor_msgs::PointCloud2> filtered_cloud;
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> filtered_cloud;
 
   // We only use these iterators if we are creating a filtered_cloud for
   // publishing. We cannot default construct these, so we use unique_ptr's
@@ -235,7 +226,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
 
   if (!filtered_cloud_topic_.empty())
   {
-    filtered_cloud.reset(new sensor_msgs::PointCloud2());
+    filtered_cloud.reset(new sensor_msgs::msg::PointCloud2());
     filtered_cloud->header = cloud_msg->header;
     sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
     pcd_modifier.setPointCloud2FieldsByString(1, "xyz");
@@ -347,17 +338,17 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   }
   catch (...)
   {
-    ROS_ERROR_NAMED(LOGNAME, "Internal error while updating octree");
+    RCLCPP_ERROR(LOGGER, "Internal error while updating octree");
   }
   tree_->unlockWrite();
-  ROS_DEBUG_NAMED(LOGNAME, "Processed point cloud in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
+  RCLCPP_DEBUG(LOGGER, "Processed point cloud in %lf ms", (node_->now() - start).seconds() * 1000.0);
   tree_->triggerUpdateCallback();
 
   if (filtered_cloud)
   {
     sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
     pcd_modifier.resize(filtered_cloud_size);
-    filtered_cloud_publisher_.publish(*filtered_cloud);
+    filtered_cloud_publisher_->publish(*filtered_cloud);
   }
 }
 }  // namespace occupancy_map_monitor

--- a/moveit_ros/perception/pointcloud_octomap_updater_plugin_description.xml
+++ b/moveit_ros/perception/pointcloud_octomap_updater_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libmoveit_pointcloud_octomap_updater">
+<library path="moveit_pointcloud_octomap_updater">
   <class name="occupancy_map_monitor/PointCloudOctomapUpdater" type="occupancy_map_monitor::PointCloudOctomapUpdater" base_class_type="occupancy_map_monitor::OccupancyMapUpdater">
     <description>
     </description>

--- a/moveit_ros/perception/semantic_world/CMakeLists.txt
+++ b/moveit_ros/perception/semantic_world/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_semantic_world)
 
-add_library(${MOVEIT_LIB_NAME} src/semantic_world.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/semantic_world.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_ros/perception/semantic_world/CMakeLists.txt
+++ b/moveit_ros/perception/semantic_world/CMakeLists.txt
@@ -2,12 +2,23 @@ set(MOVEIT_LIB_NAME moveit_semantic_world)
 
 add_library(${MOVEIT_LIB_NAME} src/semantic_world.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  object_recognition_msgs
+  visualization_msgs
+  geometry_msgs
+  geometric_shapes
+  moveit_msgs
+  tf2_eigen
+  Eigen3
+  Boost
+)
+target_link_libraries(${MOVEIT_LIB_NAME} ${OpenCV_LIBRARIES})
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${MOVEIT_LIB_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1169,7 +1169,7 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
     if (!octomap_monitor_)
     {
       octomap_monitor_.reset(
-          new occupancy_map_monitor::OccupancyMapMonitor(pnode_, tf_buffer_, scene_->getPlanningFrame()));
+          new occupancy_map_monitor::OccupancyMapMonitor(node_, tf_buffer_, scene_->getPlanningFrame()));
       excludeRobotLinksFromOctree();
       excludeAttachedBodiesFromOctree();
       excludeWorldObjectsFromOctree();


### PR DESCRIPTION
### Description

This PR intends to port moveit_ros_perception to ROS2.

The sensors parameter yaml file following the pattern of [this comment](https://github.com/ros-planning/moveit2/pull/148#discussion_r360469027):

```yaml
/**:
    ros__parameters:
        sensors:  ["sensor1", "sensor2"]
        sensor1:
            sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
            point_cloud_topic: /head_mount_kinect/depth_registered/points
            max_range: 5.0
            point_subsample: 1
            padding_offset: 0.1
            padding_scale: 1.0
            max_update_rate: 1.0
            filtered_cloud_topic: filtered_cloud
        sensor2:
            sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
            image_topic: /head_mount_kinect/depth_registered/image_raw
            queue_size: 5
            near_clipping_plane_distance: 0.3
            far_clipping_plane_distance: 5.0
            shadow_threshold: 0.2
            padding_scale: 4.0
            padding_offset: 0.03
            max_update_rate: 1.0
            filtered_cloud_topic: filtered_cloud
```
The perception_pipeline demo of moveit_tutorials has been [reworked](https://github.com/RoboticsYY/moveit_tutorials) to test this PR, which publishes a point cloud topic from a .pcd file:
```bash
ros2 launch moveit_tutorials obstacle_avoidance_demo.launch.py
```

<p align="center">
    <img src="https://user-images.githubusercontent.com/43195064/103007703-d825b100-456e-11eb-9cd8-abee4126e88f.png" width="500" />
</p>

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
