### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The MoveIt Motion Planning Framework for **ROS 2**. For ROS 1, see [MoveIt 1](ht
 ## General MoveIt Documentation
 
 - [MoveIt Website](http://moveit.ros.org)
-- [Tutorials and Documentation](http://moveit.ros.org/documentation/)
+- [Tutorials and Documentation](https://ros-planning.github.io/moveit_tutorials/)
 - [How to Get Involved](http://moveit.ros.org/about/get_involved/)
 - [Future Release Dates](https://moveit.ros.org/#release-versions)
 


### PR DESCRIPTION
Fix broken link to tutorials for MoveIt 1

### Description

Like was pointing to moveit.ros.org/documentation which doesn't exist. Moveit 1 tutorial seems like the best spot for this to point to for now.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
