### PR TITLE
Mk/fix moveit servo linkerr

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(${SERVO_LIB_NAME} SHARED
   src/servo_calcs.cpp
   src/collision_check.cpp
   src/low_pass_filter.cpp
-  include/moveit_servo/servo_parameters.cpp
+  src/servo_parameters.cpp
 )
 set_target_properties(${SERVO_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${SERVO_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
@@ -140,7 +140,8 @@ if(BUILD_TESTING)
   # Servo parameters launch test
   add_executable(test_servo_parameters_node
     test/test_servo_parameters_node.cpp
-    test/test_parameter_struct.hpp)
+    test/test_parameter_struct.hpp
+    src/servo_parameters.cpp)
   ament_target_dependencies(test_servo_parameters_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
   ament_add_gtest_executable(test_servo_parameters test/test_servo_parameters.cpp)

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -89,4 +89,46 @@ struct ServoParameters
 
 using ServoParametersPtr = std::shared_ptr<ServoParameters>;
 
+template <typename T>
+void declareOrGetParam(T& output_value, const std::string& param_name, const rclcpp::Node::SharedPtr& node,
+                       const rclcpp::Logger& logger)
+{
+  try
+  {
+    if (node->has_parameter(param_name))
+      node->get_parameter<T>(param_name, output_value);
+    else
+      output_value = node->declare_parameter<T>(param_name, T{});
+  }
+  catch (const rclcpp::exceptions::InvalidParameterTypeException& e)
+  {
+    // Catch a <double> parameter written in the yaml as "1" being considered an <int>
+    if (std::is_same<T, double>::value)
+    {
+      node->undeclare_parameter(param_name);
+      output_value = node->declare_parameter<int>(param_name, 0);
+    }
+    else
+    {
+      RCLCPP_ERROR_STREAM(logger, "Error getting parameter \'" << param_name << "\', check parameter type in YAML file");
+      throw e;
+    }
+  }
+  RCLCPP_INFO_STREAM(logger, "Found parameter - " << param_name << ": " << output_value);
+}
+
+/**
+ * Declares, reads, and validates parameters used for moveit_servo
+ * @param node Shared ptr to node that will the parameters will be declared in. Params should be defined in
+ * launch/config files
+ * @param logger Logger for outputting warnings about the parameters
+ * @param parameters The set up parameters that will be updated. After this call, they can be used to start a Servo
+ * instance
+ * @param ns Parameter namespace (as loaded in launch files). Defaults to "moveit_servo" but can be changed to allow
+ * multiple arms/instances
+ * @return true if all parameters were loaded and verified successfully, false otherwise
+ */
+bool readParameters(ServoParametersPtr& parameters, const rclcpp::Node::SharedPtr& node, const rclcpp::Logger& logger,
+                    std::string ns = "moveit_servo");
+
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -42,7 +42,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 // Servo
-#include <moveit_servo/servo_parameters.cpp>
+#include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/servo.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -47,47 +47,8 @@
 
 namespace moveit_servo
 {
-template <typename T>
-void declareOrGetParam(T& output_value, const std::string& param_name, const rclcpp::Node::SharedPtr& node,
-                       const rclcpp::Logger& logger)
-{
-  try
-  {
-    if (node->has_parameter(param_name))
-      node->get_parameter<T>(param_name, output_value);
-    else
-      output_value = node->declare_parameter<T>(param_name, T{});
-  }
-  catch (const rclcpp::exceptions::InvalidParameterTypeException& e)
-  {
-    // Catch a <double> parameter written in the yaml as "1" being considered an <int>
-    if (std::is_same<T, double>::value)
-    {
-      node->undeclare_parameter(param_name);
-      output_value = node->declare_parameter<int>(param_name, 0);
-    }
-    else
-    {
-      RCLCPP_ERROR_STREAM(logger, "Error getting parameter \'" << param_name << "\', check parameter type in YAML file");
-      throw e;
-    }
-  }
-  RCLCPP_INFO_STREAM(logger, "Found parameter - " << param_name << ": " << output_value);
-}
-
-/**
- * Declares, reads, and validates parameters used for moveit_servo
- * @param node Shared ptr to node that will the parameters will be declared in. Params should be defined in
- * launch/config files
- * @param logger Logger for outputting warnings about the parameters
- * @param parameters The set up parameters that will be updated. After this call, they can be used to start a Servo
- * instance
- * @param ns Parameter namespace (as loaded in launch files). Defaults to "moveit_servo" but can be changed to allow
- * multiple arms/instances
- * @return true if all parameters were loaded and verified successfully, false otherwise
- */
 bool readParameters(ServoParametersPtr& parameters, const rclcpp::Node::SharedPtr& node, const rclcpp::Logger& logger,
-                    std::string ns = "moveit_servo")
+                    std::string ns)
 {
   // Get the parameters (organized same order as YAML file)
   declareOrGetParam<bool>(parameters->use_gazebo, ns + ".use_gazebo", node, logger);

--- a/moveit_ros/moveit_servo/src/servo_server.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server.cpp
@@ -38,7 +38,7 @@
  */
 
 #include <moveit_servo/servo_server.h>
-#include <moveit_servo/servo_parameters.cpp>
+#include <moveit_servo/servo_parameters.h>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo_server");
 

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -58,7 +58,7 @@
 #include <gtest/gtest.h>
 
 // Servo
-#include <moveit_servo/servo_parameters.cpp>
+#include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/status_codes.h>
 #include "test_parameter_struct.hpp"
 

--- a/moveit_ros/moveit_servo/test/test_servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_parameters.cpp
@@ -41,7 +41,7 @@
 
 #include <gtest/gtest.h>
 #include <rclcpp/rclcpp.hpp>
-#include <moveit_servo/servo_parameters.cpp>
+#include <moveit_servo/servo_parameters.h>
 #include <std_srvs/srv/trigger.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.test_servo_parameters.cpp");

--- a/moveit_ros/moveit_servo/test/test_servo_parameters_node.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_parameters_node.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <rclcpp/rclcpp.hpp>
-#include <moveit_servo/servo_parameters.cpp>
+#include <moveit_servo/servo_parameters.h>
 #include <std_srvs/srv/trigger.hpp>
 #include "test_parameter_struct.hpp"
 


### PR DESCRIPTION
### Description
When I tried to use moveit_servo from a self created package outside from this repository, by including the related hedders as follows:

```cpp
#include <moveit_servo/servo_parameters.cpp>
#include <moveit_servo/servo.h>
```

the following link error due to multiple definition of `moveit_servo::readParameters` did not stop.

```bash
--- stderr: self_created_pkg                                                                                                                                                           
self_created_pkg: You did not request a specific build type: Choosing 'Release' for maximum performance
/usr/bin/ld: CMakeFiles/self_created_code.dir/src/self_created_code_node.cpp.o: in function `moveit_servo::readParameters(std::shared_ptr<moveit_servo::ServoParameters>&, std::shared_ptr<rclcpp::Node> const&, rclcpp::Logger const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
self_created_code_node.cpp:(.text+0xc0): multiple definition of `moveit_servo::readParameters(std::shared_ptr<moveit_servo::ServoParameters>&, std::shared_ptr<rclcpp::Node> const&, rclcpp::Logger const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'; CMakeFiles/self_created_code.dir/src/self_created_code.cpp.self_created_code.cpp:(.text+0x970): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/self_created_code.dir/build.make:358: self_created_code] Error 1
make[1]: *** [CMakeFiles/Makefile2:80: CMakeFiles/self_created_code.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< self_created_pkg [43.3s, exited with code 2]
```
I'm pretty sure that directly including `servo_parameters.cpp` containing the definition of `moveit_servo::readParameters` causes this link error.

Thus I modified the structure of `servo_parameters` and updated the related demo codes to include `servo_parameters.h` instead of `servo_parameters.cpp`.

After applying this modification, the following demo script still works fine.

```bash
$  ros2 launch moveit_servo servo_cpp_interface_demo.launch.py
```

In addition, our original code became to also include `servo_parameters.h` and confirmed the servo have properly worked.

Please have a check of the codes. I carefully changed the codes so that the differences should be minimum.

Thank you in advance.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers