### PR TITLE
Server timeout set to infinity

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -148,22 +148,22 @@ public:
         (which is the default type of callback queues used in ROS)
       \param tf_buffer. Specify a TF2_ROS Buffer instance to use. If not specified,
                         one will be constructed internally along with an internal TF2_ROS TransformListener
-      \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
+      \param wait_for_servers. Timeout for connecting to action servers. -1 time means unlimited waiting.
     */
   MoveGroupInterface(const rclcpp::Node::SharedPtr& node, const Options& opt,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
-                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(0.0));
+                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(-1));
 
   /**
       \brief Construct a client for the MoveGroup action for a particular \e group.
 
       \param tf_buffer. Specify a TF2_ROS Buffer instance to use. If not specified,
                         one will be constructed internally along with an internal TF2_ROS TransformListener
-      \param wait_for_servers. Timeout for connecting to action servers. Zero time means unlimited waiting.
+      \param wait_for_servers. Timeout for connecting to action servers. -1 time means unlimited waiting.
     */
   MoveGroupInterface(const rclcpp::Node::SharedPtr& node, const std::string& group,
                      const std::shared_ptr<tf2_ros::Buffer>& tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
-                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(0.0));
+                     const rclcpp::Duration& wait_for_servers = rclcpp::Duration(-1));
 
   ~MoveGroupInterface();
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -143,12 +143,8 @@ public:
 
     current_state_monitor_ = getSharedStateMonitor(node_, robot_model_, tf_buffer_);
 
-    rclcpp::Time timeout_for_servers = pnode_->now() + wait_for_servers;
-    if (wait_for_servers == rclcpp::Duration(0.0))
-      timeout_for_servers = rclcpp::Time();  // wait for ever
-
     move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(pnode_, move_group::MOVE_ACTION);
-    move_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
+    move_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
     // TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
     // pick_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Pickup>(
     //        node_, move_group::PICKUP_ACTION);
@@ -159,7 +155,7 @@ public:
     //    place_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
     execute_action_client_ =
         rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(pnode_, move_group::EXECUTE_ACTION_NAME);
-    execute_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
+    execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
 
     query_service_ =
         pnode_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);


### PR DESCRIPTION
By setting the timeout to infinity ensures the move group interface
is will be ready to use. This change is simply a ros2 migration
change.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
