### PR TITLE
[fix] Add EXPORT command to plugin library installs

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -30,6 +30,7 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME}
+        EXPORT  ${PROJECT_NAME}
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin)

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -63,6 +63,7 @@ install(TARGETS move_group list_move_group_capabilities
 
 install(TARGETS moveit_move_group_capabilities_base
   moveit_move_group_default_capabilities
+  EXPORT moveit_move_group_default_capabilities
   ARCHIVE
   DESTINATION lib
   LIBRARY


### PR DESCRIPTION
### Description

When running the move_group node, I noticed that several plugins weren't being loaded correctly. I found that the plugin libraries were only being built in the "build" directory and not installed in the "install" directory. Looking at the recent changes in the git log, I saw that the EXPORT command was added to other moveit plugins, so I did the same for the missing plugins, which fixed the problem. I'm not sure why the EXPORT install is required for plugins in the MoveIt package, since it isn't required by other pluginlib libraries in other ament packages.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
