### PR TITLE
various osx/clang touchups

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -551,7 +551,9 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::random_device rng;
+        std::mt19937 urng(rng());
+        std::shuffle(permutation.begin(), permutation.end(), urng);
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)
@@ -605,7 +607,9 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::random_device rng;
+        std::mt19937 urng(rng());
+        std::shuffle(permutation.begin(), permutation.end(), urng);
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(MOVEIT_LIB_NAME moveit_ompl_interface)
 
+if (APPLE)
+  # needed to bring ode on the linker path exported by homebrew's OMPL
+  link_directories(${OMPL_LIBRARY_DIRS})
+endif()
+
 add_library(${MOVEIT_LIB_NAME} SHARED
   src/ompl_interface.cpp
   src/planning_context_manager.cpp

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(Boost REQUIRED date_time filesystem)
+find_package(Boost REQUIRED date_time filesystem regex)
 find_package(tf2_eigen REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_ros_warehouse REQUIRED)

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -46,6 +46,9 @@
 
 #include <memory>
 
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+
 namespace occupancy_map_monitor
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.perception.pointcloud_octomap_updater");

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -17,9 +17,6 @@ find_package(moveit_ros_planning REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Boost REQUIRED thread system filesystem regex date_time program_options)
-find_package(OpenSSL)
-
-include_directories(warehouse/include ${OPENSSL_INCLUDE_DIR})
 
 add_subdirectory(warehouse)
 

--- a/moveit_ros/warehouse/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/warehouse/CMakeLists.txt
@@ -9,9 +9,10 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/state_storage.cpp
   src/warehouse_connector.cpp
 )
+target_include_directories(${MOVEIT_LIB_NAME} PUBLIC include)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME} rclcpp Boost moveit_core warehouse_ros moveit_ros_planning)
-target_link_libraries(${MOVEIT_LIB_NAME} ${OPENSSL_CRYPTO_LIBRARY})
+#target_link_libraries(${MOVEIT_LIB_NAME} ${OPENSSL_CRYPTO_LIBRARY})
 
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)
 ament_target_dependencies(moveit_warehouse_broadcast rclcpp Boost warehouse_ros moveit_ros_planning)


### PR DESCRIPTION
### Description

I am not sure exactly if there's already an open issue/PR for fixes for OSX. If so, please disregard. 
I tried to give moveit2 a shot while testing the new ros2 control API with gazebo and ran into compilation issues.
The set of changes in this PR are really just various touchups, mostly a bit of cmake and some clang C++14 deprecation warnings.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
