### PR TITLE
Fix 'start_servo' service topic in demo

### DIFF
--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -166,7 +166,7 @@ public:
     collision_pub_ = this->create_publisher<moveit_msgs::msg::PlanningScene>("/planning_scene", 10);
 
     // Create a service client to start the ServoServer
-    servo_start_client_ = this->create_client<std_srvs::srv::Trigger>("/start_servo");
+    servo_start_client_ = this->create_client<std_srvs::srv::Trigger>("/servo_server/start_servo");
     servo_start_client_->wait_for_service(std::chrono::seconds(1));
     servo_start_client_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
 

--- a/moveit_ros/moveit_servo/test/publish_fake_jog_commands.cpp
+++ b/moveit_ros/moveit_servo/test/publish_fake_jog_commands.cpp
@@ -57,12 +57,12 @@ int main(int argc, char** argv)
 
   // Call the start service to init and start the servo component
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr servo_start_client =
-      node->create_client<std_srvs::srv::Trigger>("/start_servo");
+      node->create_client<std_srvs::srv::Trigger>("/servo_server/start_servo");
   servo_start_client->wait_for_service(1s);
   servo_start_client->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
 
   // Create a publisher for publishing the jog commands
-  auto pub = node->create_publisher<geometry_msgs::msg::TwistStamped>("servo_server/delta_twist_cmds", 10);
+  auto pub = node->create_publisher<geometry_msgs::msg::TwistStamped>("/servo_server/delta_twist_cmds", 10);
   std::weak_ptr<std::remove_pointer<decltype(pub.get())>::type> captured_pub = pub;
   std::weak_ptr<std::remove_pointer<decltype(node.get())>::type> captured_node = node;
   auto callback = [captured_pub, captured_node]() -> void {


### PR DESCRIPTION
Fixes #321 by setting the right service topics in the demo clients.
