### PR TITLE
Add joystick to servo generic component

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -93,6 +93,13 @@ add_library(${SERVO_CONTROLLER_INPUT} SHARED src/teleop_demo/joystick_servo_exam
 ament_target_dependencies(${SERVO_CONTROLLER_INPUT} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 rclcpp_components_register_nodes(${SERVO_CONTROLLER_INPUT} "moveit_servo::JoyToServoPub")
 
+# Add executable for generic joystick to servo input
+set(JOYSTICK_TO_SERVO joystick_to_servo)
+add_library(${JOYSTICK_TO_SERVO} SHARED src/teleop_demo/joystick_to_servo.cpp)
+target_include_directories(${JOYSTICK_TO_SERVO} PRIVATE include)
+ament_target_dependencies(${JOYSTICK_TO_SERVO} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+rclcpp_components_register_nodes(${JOYSTICK_TO_SERVO} "moveit_servo::JoystickToServo")
+
 # Add executable to publish fake servo commands for testing/demo purposes
 set(FAKE_SERVO_CMDS_NAME fake_command_publisher)
 add_executable(${FAKE_SERVO_CMDS_NAME} test/publish_fake_jog_commands.cpp)
@@ -109,6 +116,7 @@ install(
     ${COMPOSABLE_NODE_NAME}
     ${SERVO_CONTROLLER_INPUT}
     ${CPP_DEMO_NAME}
+    ${JOYSTICK_TO_SERVO}
     ${FAKE_SERVO_CMDS_NAME}
     ${POSE_TRACKING}
     ${POSE_TRACKING_DEMO_NAME}

--- a/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
+++ b/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
@@ -1,9 +1,12 @@
-
 ##########################################################################
 # Modify all parameters related to joystickk to servo here
 ##########################################################################
-robot_eef_frame: tool0    # Name of the robot's end effector link defined in URDF/SRDF
-robot_base_frame: base_link  # Name of the robot's base frame used by MoveIt (usually: base_link or world)
+
+# Setup for Microsoft Xbox 360 Wired Controller
+enable_joint_commands_button: 4  # LB
+enable_twist_commands_button: 5  # RB
+switch_cartesian_command_frame_button: 1   # B
+switch_joint_axis_mode_button: 2  # X
 
 cartesian_command_frames:
   - base_link
@@ -11,24 +14,38 @@ cartesian_command_frames:
   - world
 
 joints:
-  - azimuth_joint   # joint1
-  - shoulder_joint  # joint2
-  - elbow_joint     # joint3
-  - roll_joint      # joint4
-  - pitch_joint     # joint5
-  - wrist_joint     # joint6
-  #- joint7
+  - joint1
+  - joint2
+  - joint3
+  - joint4
+  - joint5
+  - joint6
+  - joint7
 
-# Do not change this names. The joints are order as in the above list
-joint1_axis: 0  # Left/Right Axis stick left
-joint2_axis: 1  # Up/Down Axis stick left
-joint3_axis: 6  # cross key left/right
-joint4_axis: 7  # cross key up/down
-joint5_axis: 3  # Left/Right Axis stick right
-joint6_axis: 4  # Up/Down Axis stick right
-#joint7_axis: 0  # Left/Right Axis stick left
+# Do not change this names. The joints are order as in the list above
+num_joint_axis_control_modes: 2
+joint1_axis:
+  - "1": 0          # Left/Right Axis stick left
+joint2_axis:
+  - "1": 1           # Up/Down Axis stick left
+joint3_axis:
+ - 1: 6           # cross key left/right
+ - 2: 0           # Left/Right Axis stick left
+joint4_axis:
+ - 1: 7           # cross key up/down
+ - 2: 1           # Up/Down Axis stick left
+joint5_axis:
+ - 1: 3           # Left/Right Axis stick right
+joint6_axis:
+ - 1: 4           # Up/Down Axis stick right
+joint7_axis:
+ - 2: 3           # Left/Right Axis stick right
 
-# Setup for Microsoft Xbox 360 Wired Controller
-enable_joint_commands_button: 4  # LB
-enable_twist_commands_button: 5  # RB
-switch_cartesian_command_frame_button: 1   # B
+# Alternative parameters with only one control mode
+#num_joint_axis_control_modes: 1
+#joint1_axis: 0  # Left/Right Axis stick left
+#joint2_axis: 1  # Up/Down Axis stick left
+#joint3_axis: 6  # cross key left/right
+#joint4_axis: 7  # cross key up/down
+#joint5_axis: 3  # Left/Right Axis stick right
+#joint6_axis: 4  # Up/Down Axis stick right

--- a/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
+++ b/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
@@ -1,0 +1,34 @@
+
+##########################################################################
+# Modify all parameters related to joystickk to servo here
+##########################################################################
+robot_eef_frame: tool0    # Name of the robot's end effector link defined in URDF/SRDF
+robot_base_frame: base_link  # Name of the robot's base frame used by MoveIt (usually: base_link or world)
+
+cartesian_command_frames:
+  - base_link
+  - tool0
+  - world
+
+joints:
+  - azimuth_joint   # joint1
+  - shoulder_joint  # joint2
+  - elbow_joint     # joint3
+  - roll_joint      # joint4
+  - pitch_joint     # joint5
+  - wrist_joint     # joint6
+  #- joint7
+
+# Do not change this names. The joints are order as in the above list
+joint1_axis: 0  # Left/Right Axis stick left
+joint2_axis: 1  # Up/Down Axis stick left
+joint3_axis: 6  # cross key left/right
+joint4_axis: 7  # cross key up/down
+joint5_axis: 3  # Left/Right Axis stick right
+joint6_axis: 4  # Up/Down Axis stick right
+#joint7_axis: 0  # Left/Right Axis stick left
+
+# Setup for Microsoft Xbox 360 Wired Controller
+enable_joint_commands_button: 4  # LB
+enable_twist_commands_button: 5  # RB
+switch_cartesian_command_frame_button: 1   # B

--- a/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
+++ b/moveit_ros/moveit_servo/config/joystick_to_servo.yaml
@@ -23,7 +23,8 @@ joints:
   - joint7
 
 # Do not change this names. The joints are order as in the list above
-num_joint_axis_control_modes: 2
+# Each joystick axis has up to 2 different behaviors, depending on the control mode
+num_joint_axis_control_modes: 2 
 joint1_axis:
   - "1": 0          # Left/Right Axis stick left
 joint2_axis:

--- a/moveit_ros/moveit_servo/config/xbox360_wired.yaml
+++ b/moveit_ros/moveit_servo/config/xbox360_wired.yaml
@@ -1,0 +1,28 @@
+axis_linear:
+  x: 1       # Up/Down Axis stick left
+  y: 0       # Left/Right Axis stick left
+  z: 4       # Up/Down Axis stick right
+scale_linear:
+  x: 0.7
+  y: 0.7
+  z: 0.7
+scale_linear_turbo:
+  x: 1.5
+  y: 1.5
+  z: 1.5
+
+axis_angular:
+  yaw: 3      # Left/Right Axis stick right
+  pitch: 6    # cross key left/right
+  roll: 7     # cross key up/down
+scale_angular:
+  yaw: 0.4
+  pitch: 0.4
+  roll: 0.4
+scale_angluar_turbo:
+  yaw: 1
+  pitch: 1
+  roll: 1
+
+enable_button: 5  # RB
+enable_turbo_button: 1  # B

--- a/moveit_ros/moveit_servo/doc/servo_tutorial.md
+++ b/moveit_ros/moveit_servo/doc/servo_tutorial.md
@@ -206,3 +206,27 @@ joint_pub->publish(std::move(msg));
 ```
 
 Notice that the topic to publish to is the Servo parameters `cartesian_command_in_topic` and `joint_command_in_topic`.
+
+
+## Using generic "Joystick to Servo" components
+
+joystick_to_servo component simplifies start and testing of servo functionality.
+In combination with [ros2/teleop_twist_joy](https://github.com/ros2/teleop_twist_joy) enables cartesian and joint-based servoing with a manipulator.
+The component subscribes to `sensors_msgs/msg/Joy` messages from joystick driver and `geometry_msgs/msg/Twist` from a node/component providing cartesian commands, i.e., teleop_twist_joy.
+The example provides a configuration for [Xbox 360 Wired](https://wiki.ros.org/joy#Microsoft_Xbox_360_Wired_Controller_for_Linux) joystick in [xbox360_wired.yaml](../config/xbox360_wired.yaml) file.
+For details about configuration and available parameters check the [ros2/teleop_twist_joy](https://github.com/ros2/teleop_twist_joy) repository.
+If cartesian commands are enabled, the input twist is wrapped into the `geometry_msgs/msg/TwistStamped` message and send to the servo server.
+If joint commands are enabled, the `joystick_to_servo` component maps them to joint velocities as defined in the configuration file.
+
+Configuration file [joystick_to_servo.yaml](../config/joystick_to_servo.yaml) provides following options for this component:
+
+  * `cartesian_command_frames`: cartesian frames in which the `TwistStamped` commands can be published. E.g., base_link, tool0, world.
+  * `enable_joint_commands_button`: joystick button to enable joint-commands mode.
+  * `enable_twist_commands_button`: joystick button to enable cartesian mode, i.e., proxy input twist messages to servo server.
+  * `switch_cartesian_command_frame_button`: joystick button to switch cartesian command frame.
+  * `switch_joint_axis_mode_button`: joysitck_button to switch joint to joystick axis mapping mode.
+  * `joints`: list of manipulators joints (usually 6 or 7) used for joint-space servoing
+  * `num_joint_axis_control_modes`: number of modes for joint-control. It enables the reuse of the joystick axis for different manipulator joints if needed.
+  * `joint<X>_axis`: joystick axis configuration for each manipulator's joint. `<X>` should be replaced with the joint number (starts with 1) in the joint list. If the number of joint-control modes is larger than 1, then a map with `<control_mode>: <joystick_axis>` is expected. The control mode numbering starts with 1.
+
+

--- a/moveit_ros/moveit_servo/doc/servo_tutorial.md
+++ b/moveit_ros/moveit_servo/doc/servo_tutorial.md
@@ -220,11 +220,11 @@ If joint commands are enabled, the `joystick_to_servo` component maps them to jo
 
 Configuration file [joystick_to_servo.yaml](../config/joystick_to_servo.yaml) provides following options for this component:
 
-  * `cartesian_command_frames`: cartesian frames in which the `TwistStamped` commands can be published. E.g., base_link, tool0, world.
   * `enable_joint_commands_button`: joystick button to enable joint-commands mode.
   * `enable_twist_commands_button`: joystick button to enable cartesian mode, i.e., proxy input twist messages to servo server.
   * `switch_cartesian_command_frame_button`: joystick button to switch cartesian command frame.
   * `switch_joint_axis_mode_button`: joysitck_button to switch joint to joystick axis mapping mode.
+  * `cartesian_command_frames`: cartesian frames in which the `TwistStamped` commands can be published. E.g., base_link, tool0, world.
   * `joints`: list of manipulators joints (usually 6 or 7) used for joint-space servoing
   * `num_joint_axis_control_modes`: number of modes for joint-control. It enables the reuse of the joystick axis for different manipulator joints if needed.
   * `joint<X>_axis`: joystick axis configuration for each manipulator's joint. `<X>` should be replaced with the joint number (starts with 1) in the joint list. If the number of joint-control modes is larger than 1, then a map with `<control_mode>: <joystick_axis>` is expected. The control mode numbering starts with 1.

--- a/moveit_ros/moveit_servo/include/moveit_servo/joystick_to_servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/joystick_to_servo.hpp
@@ -59,9 +59,8 @@ public:
 
   ~JoystickToServo() = default;
 
-  // To change controls or setup a new controller, all you should to do is change the above enums and the follow 2
-  // functions
-  /** \brief // This converts a joystick axes and buttons array to a TwistStamped or JointJog message
+  /**
+   * @brief // This converts a joystick axes and buttons array to a TwistStamped or JointJog message
    * @param axes The vector of continuous controller joystick axes
    * @param buttons The vector of discrete controller button values
    */
@@ -83,12 +82,14 @@ protected:
   int enable_joint_commands_button_ = -1;
   int enable_twist_commands_button_ = -1;
   int switch_cartesian_command_frame_button_ = -1;
+  int switch_joint_axis_mode_button_ = -1;
 
   std::vector<std::string> cartesian_command_frames_;
   std::vector<std::string> joint_names_;
-  std::vector<int> joint_axes_;
+  std::vector<std::vector<int>> joint_to_joystick_axes_;
 
   int command_frame_index_ = 0;
+  int joint_axis_mode_index_ = 0;
 
   geometry_msgs::msg::Twist::SharedPtr input_twist_;
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/joystick_to_servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/joystick_to_servo.hpp
@@ -1,0 +1,98 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : joystick_to_servo.hpp
+ *      Project   : moveit_servo
+ *      Created   : 18/02/2021
+ *      Author    : Denis Stogl
+ */
+
+#include <memory>
+#include <string>
+#include <mutex>
+#include <vector>
+
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+namespace moveit_servo
+{
+class JoystickToServo : public rclcpp::Node
+{
+public:
+  JoystickToServo(const rclcpp::NodeOptions& options);
+
+  ~JoystickToServo() = default;
+
+  // To change controls or setup a new controller, all you should to do is change the above enums and the follow 2
+  // functions
+  /** \brief // This converts a joystick axes and buttons array to a TwistStamped or JointJog message
+   * @param axes The vector of continuous controller joystick axes
+   * @param buttons The vector of discrete controller button values
+   */
+  void convertJoyToCmd(const std::vector<float> & axes, const std::vector<int> & buttons);
+
+  // Callbacks
+
+  void inputTwistCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+
+  void joystickCallback(const sensor_msgs::msg::Joy::SharedPtr msg);
+
+protected:
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+  rclcpp::Publisher<control_msgs::msg::JointJog>::SharedPtr joint_pub_;
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr servo_start_client_;
+
+  int enable_joint_commands_button_ = -1;
+  int enable_twist_commands_button_ = -1;
+  int switch_cartesian_command_frame_button_ = -1;
+
+  std::vector<std::string> cartesian_command_frames_;
+  std::vector<std::string> joint_names_;
+  std::vector<int> joint_axes_;
+
+  int command_frame_index_ = 0;
+
+  geometry_msgs::msg::Twist::SharedPtr input_twist_;
+
+  std::recursive_mutex twist_update_lock_;
+};  // class JoystickToServo
+
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/launch/servo_teleop_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_teleop_demo.launch.py
@@ -1,0 +1,106 @@
+import os
+import yaml
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def load_file(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return file.read()
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def load_yaml(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return yaml.safe_load(file)
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def generate_launch_description():
+    # Get parameters for the Servo node
+    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
+    servo_params = {'moveit_servo': servo_yaml}
+
+    # Get URDF and SRDF
+    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
+    robot_description = {'robot_description': robot_description_config}
+
+    robot_description_semantic_config = load_file(
+        'moveit_resources_panda_moveit_config', 'config/panda.srdf')
+    robot_description_semantic = {'robot_description_semantic': robot_description_semantic_config}
+
+    panda_controllers_config = os.path.join(
+        get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml")
+
+    panda_start_positions = os.path.join(
+        get_package_share_directory("moveit_servo"), "config", "start_positions.yaml")
+
+    # RViz
+    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_config.rviz"
+    rviz_node = Node(package='rviz2',
+                     executable='rviz2',
+                     name='rviz2',
+                     output='log',
+                     arguments=['-d', rviz_config_file],
+                     parameters=[robot_description, robot_description_semantic])
+
+    # Is a perfect controller without dynamics
+    fake_joint_driver_node = Node(package='fake_joint_driver',
+                                  executable='fake_joint_driver_node',
+                                  parameters=[
+                                    {'controller_name': 'fake_joint_trajectory_controller'},
+                                    panda_controllers_config,
+                                    panda_start_positions,
+                                    robot_description])
+
+    # Launch as much as possible in components
+    container = ComposableNodeContainer(
+            name='moveit_servo_demo_container',
+            namespace='/',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='robot_state_publisher',
+                    plugin='robot_state_publisher::RobotStatePublisher',
+                    name='robot_state_publisher',
+                    parameters=[robot_description]),
+                ComposableNode(
+                    package='tf2_ros',
+                    plugin='tf2_ros::StaticTransformBroadcasterNode',
+                    name='static_tf2_broadcaster',
+                    parameters=[{'/child_frame_id': 'panda_link0', '/frame_id': 'world'}]),
+                ComposableNode(
+                    package='moveit_servo',
+                    plugin='moveit_servo::ServoServer',
+                    name='servo_server',
+                    parameters=[servo_params, robot_description, robot_description_semantic],
+                    extra_arguments=[{'use_intra_process_comms': True}]),
+                ComposableNode(
+                    package='moveit_servo',
+                    plugin='moveit_servo::JoyToServoPub',
+                    name='controller_to_servo_node',
+                    extra_arguments=[{'use_intra_process_comms': True}]),
+                ComposableNode(
+                    package='joy',
+                    plugin='joy::Joy',
+                    name='joy_node',
+                    extra_arguments=[{'use_intra_process_comms': True}])
+            ],
+            output='screen',
+    )
+    
+    return LaunchDescription([rviz_node, fake_joint_driver_node, container])

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_to_servo.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_to_servo.cpp
@@ -1,0 +1,170 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : joystick_to_servo.cpp
+ *      Project   : moveit_servo
+ *      Created   : 18/02/2021
+ *      Author    : Denis Stogl
+ */
+
+#include <moveit_servo/joystick_to_servo.hpp>
+
+#include <mutex>
+#include <utility>
+#include <thread>
+
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+const size_t ROS_QUEUE_SIZE = 10;
+
+namespace moveit_servo
+{
+
+JoystickToServo::JoystickToServo(const rclcpp::NodeOptions& options)
+: rclcpp::Node("joystick_to_servo", options)
+{
+  // Declare parameters
+  this->declare_parameter<std::vector<std::string>>(
+    "cartesian_command_frames", cartesian_command_frames_);
+  this->declare_parameter<std::vector<std::string>>("joints", joint_names_);
+  this->declare_parameter<int>("enable_joint_commands_button", enable_joint_commands_button_);
+  this->declare_parameter<int>("enable_twist_commands_button", enable_twist_commands_button_);
+  this->declare_parameter<int>(
+    "switch_cartesian_command_frame_button", switch_cartesian_command_frame_button_);
+
+  //TODO(denis): add info output regarding parameters
+  // Read parameters
+  cartesian_command_frames_ = this->get_parameter("cartesian_command_frames").as_string_array();
+  joint_names_ = this->get_parameter("joints").as_string_array();
+  enable_joint_commands_button_ = this->get_parameter("enable_joint_commands_button").as_int();
+  enable_twist_commands_button_ = this->get_parameter("enable_twist_commands_button").as_int();
+  switch_cartesian_command_frame_button_ = this->get_parameter("switch_cartesian_command_frame_button").as_int();
+
+  RCLCPP_INFO(this->get_logger(),
+              "Defined %d cartesian command frames.", cartesian_command_frames_.size());
+  RCLCPP_INFO(this->get_logger(), "Enable button for joint commands: %d", enable_joint_commands_button_);
+  RCLCPP_INFO(this->get_logger(), "Enable button for twist commands: %d", enable_twist_commands_button_);
+  RCLCPP_INFO(this->get_logger(),
+              "Button to switch command frame: %d", switch_cartesian_command_frame_button_);
+
+  if (joint_names_.empty()) {
+    RCLCPP_WARN(this->get_logger(),
+                "No joint names specified. Only cartesian/twist control is available.");
+  } else {
+    RCLCPP_INFO(this->get_logger(), "Got list with %d joints.", joint_names_.size());
+    joint_axes_.resize(joint_names_.size(), -1);
+    for (uint i = 0; i < joint_names_.size(); ++i) {
+      // Declare and read joint axis parameters
+      this->declare_parameter<int>("joint" + std::to_string(i+1) + "_axis", joint_axes_[i]);
+      // TODO: Maybe it will not work so fast...
+      joint_axes_[i] = this->get_parameter("joint" + std::to_string(i+1) + "_axis").as_int();
+      RCLCPP_INFO(this->get_logger(), "Joint '" + joint_names_[i] + "' using axis: " +
+        std::to_string(joint_axes_[i]));
+    }
+  }
+
+  // Setup pub/sub
+  joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
+      "/joy", ROS_QUEUE_SIZE, std::bind(&JoystickToServo::joystickCallback, this, std::placeholders::_1));
+  twist_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+    "~/input_twist", ROS_QUEUE_SIZE, std::bind(
+      &JoystickToServo::inputTwistCallback, this, std::placeholders::_1));
+
+  joint_pub_ = this->create_publisher<control_msgs::msg::JointJog>(
+    "~/servo_joint_commands", ROS_QUEUE_SIZE);
+  twist_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "~/servo_twist_commands", ROS_QUEUE_SIZE);
+
+  // Create a service client to start the ServoServer
+  servo_start_client_ = this->create_client<std_srvs::srv::Trigger>("/servo_server/start_servo");
+  servo_start_client_->wait_for_service(std::chrono::seconds(1));
+  servo_start_client_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
+}
+
+
+void JoystickToServo::convertJoyToCmd(
+  const std::vector<float> & axes, const std::vector<int> & buttons)
+{
+  if (buttons[switch_cartesian_command_frame_button_]) {
+    command_frame_index_ = (command_frame_index_ + 1) % cartesian_command_frames_.size();
+  }
+
+  if (buttons[enable_joint_commands_button_] && buttons[enable_twist_commands_button_]) {
+    RCLCPP_DEBUG(this->get_logger(), "Both enalble buttons are pressed. Not moving!");
+    return;
+  }
+
+  if (buttons[enable_joint_commands_button_]) {
+    auto joint_msg = control_msgs::msg::JointJog();
+    joint_msg.header.stamp = this->now();
+
+    for (uint i = 0; i < joint_names_.size(); ++i) {
+      joint_msg.joint_names.push_back(joint_names_[i]);
+      joint_msg.velocities.push_back(axes[joint_axes_[i]]);
+    }
+
+    joint_pub_->publish(joint_msg);
+  }
+
+  if (buttons[enable_twist_commands_button_]) {
+    auto twist_msg = geometry_msgs::msg::TwistStamped();
+    twist_msg.header.frame_id = cartesian_command_frames_[command_frame_index_];
+    twist_msg.header.stamp = this->now();
+
+    std::lock_guard<std::recursive_mutex> guard(twist_update_lock_);
+    twist_msg.twist = *input_twist_;
+    twist_pub_->publish(twist_msg);
+  }
+}
+
+void JoystickToServo::inputTwistCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  if (twist_update_lock_.try_lock()) {
+    input_twist_ = msg;
+  }
+}
+
+void JoystickToServo::joystickCallback(const sensor_msgs::msg::Joy::SharedPtr msg)
+{
+  // This call updates the frame for twist commands
+  convertJoyToCmd(msg->axes, msg->buttons);
+}
+
+}  // namespace moveit_servo
+
+// Register the component with class_loader
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(moveit_servo::JoystickToServo)


### PR DESCRIPTION
### Description

The current demonstration component `JoyToServo` is tailor-made for the Panda manipulator, going so far that the joint names are hard-coded. It also does not provide control of all joints and all cartesian directions.

So in this PR, I propose a solution using a coupling with [ros2/teleop_twist_joy](https://github.com/ros2/teleop_twist_joy) package for the cartesian control and implementing only joint-based control using a joystick. The implementation is currently tested with a non-public manipulator using FakeSystem (#361) implementation in ros2_control. I added only a configuration file for the [Xbox 360 Wired](https://wiki.ros.org/joy?distro=noetic#Microsoft_Xbox_360_Wired_Controller_for_Linux) joystick since this is the one currently available to me.

For now, this PR draft to share my work, which could be useful for someone. Before making it a proper PR, the following need to be done:

- [ ] Add a section about this node in the documentation
- [ ] Add support for FakeSystem in Panda URDF - partially from (#361)
- [ ] Update example launch file
- [ ] Test example
- [ ] Update documentation

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
