### PR TITLE
moveit servo: fix constructing duration from double & fix bug in insertRedundantPointsIntoTrajectory function

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -1,7 +1,7 @@
 ###############################################
 # Modify all parameters related to servoing here
 ###############################################
-use_gazebo: true # Whether the robot is started in a Gazebo simulation environment
+use_gazebo: false # Whether the robot is started in a Gazebo simulation environment
 
 ## Properties of incoming commands
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -1,7 +1,7 @@
 ###############################################
 # Modify all parameters related to servoing here
 ###############################################
-use_gazebo: true # Whether the robot is started in a Gazebo simulation environment
+use_gazebo: false # Whether the robot is started in a Gazebo simulation environment
 
 ## Properties of incoming commands
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -177,7 +177,7 @@ void ServoCalcs::start()
   initial_joint_trajectory->header.frame_id = parameters_->planning_frame;
   initial_joint_trajectory->joint_names = internal_joint_state_.name;
   trajectory_msgs::msg::JointTrajectoryPoint point;
-  point.time_from_start = rclcpp::Duration(parameters_->publish_period);
+  point.time_from_start = rclcpp::Duration::from_seconds(parameters_->publish_period);
   if (parameters_->publish_joint_positions)
     planning_scene_monitor_->getStateMonitor()->getCurrentState()->copyJointGroupPositions(joint_model_group_,
                                                                                            point.positions);
@@ -621,7 +621,7 @@ void ServoCalcs::insertRedundantPointsIntoTrajectory(trajectory_msgs::msg::Joint
   // Start from 2 because we already have the first point. End at count+1 so (total #) == count
   for (int i = 2; i < count; ++i)
   {
-    point.time_from_start = rclcpp::Duration(i * parameters_->publish_period);
+    point.time_from_start = rclcpp::Duration::from_seconds(i * parameters_->publish_period);
     joint_trajectory.points[i] = point;
   }
 }
@@ -646,7 +646,7 @@ void ServoCalcs::composeJointTrajMessage(const sensor_msgs::msg::JointState& joi
   joint_trajectory.joint_names = joint_state.name;
 
   trajectory_msgs::msg::JointTrajectoryPoint point;
-  point.time_from_start = rclcpp::Duration(parameters_->publish_period);
+  point.time_from_start = rclcpp::Duration::from_seconds(parameters_->publish_period);
   if (parameters_->publish_joint_positions)
     point.positions = joint_state.position;
   if (parameters_->publish_joint_velocities)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -610,7 +610,7 @@ bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs
 
 // Spam several redundant points into the trajectory. The first few may be skipped if the
 // time stamp is in the past when it reaches the client. Needed for gazebo simulation.
-// Start from 2 because the first point's timestamp is already 1*parameters_->publish_period
+// Start from 1 because the first point's timestamp is already 1*parameters_->publish_period
 void ServoCalcs::insertRedundantPointsIntoTrajectory(trajectory_msgs::msg::JointTrajectory& joint_trajectory,
                                                      int count) const
 {
@@ -618,10 +618,10 @@ void ServoCalcs::insertRedundantPointsIntoTrajectory(trajectory_msgs::msg::Joint
     return;
   joint_trajectory.points.resize(count);
   auto point = joint_trajectory.points[0];
-  // Start from 2 because we already have the first point. End at count+1 so (total #) == count
-  for (int i = 2; i < count; ++i)
+  // Start from 1 because we already have the first point. End at count+1 so (total #) == count
+  for (int i = 1; i < count; ++i)
   {
-    point.time_from_start = rclcpp::Duration::from_seconds(i * parameters_->publish_period);
+    point.time_from_start = rclcpp::Duration::from_seconds((i + 1) * parameters_->publish_period);
     joint_trajectory.points[i] = point;
   }
 }

--- a/moveit_ros/moveit_servo/test/test_parameter_struct.hpp
+++ b/moveit_ros/moveit_servo/test/test_parameter_struct.hpp
@@ -51,7 +51,7 @@ moveit_servo::ServoParametersPtr getTestParameters()
   auto output = std::make_shared<moveit_servo::ServoParameters>();
 
   // Populate the fields
-  output->use_gazebo = true;
+  output->use_gazebo = false;
   output->status_topic = "~/status";
   output->cartesian_command_in_topic = "~/delta_twist_cmds";
   output->joint_command_in_topic = "~/delta_joint_cmds";


### PR DESCRIPTION
### Description

Fixes two bugs:
1- Constructing a duration from a double by using `rclcpp::Duration::from_seconds` otherwise the values will cast to int
2- In `insertRedundantPointsIntoTrajectory` function we were starting from the third point, not the second one, so I fixed the index in the for-loop

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
