### PR TITLE
Remove ROS_WS env variable from foxy-ci which is causing the overlay to be installed on top of the underlay

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -16,21 +16,3 @@ RUN apt-get -qq update && \
     #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*
-
-# Download moveit source and fetch all its dependencies
-# TODO: remove all this when the migration is finished and all dependencies are install from ci base image
-RUN mkdir src && \
-    cd $ROS_WS/src && \
-    wget -q https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos && \
-    vcs import < moveit2.repos && \
-    # Remove folders declared as COLCON_IGNORE
-    find -L . -name COLCON_IGNORE -printf "%h\0" | xargs -0 rm -rf && \
-    apt-get -qq update && \
-    rosdep update -q && \
-    rosdep install -q -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
-    # Clear apt-cache to reduce image size
-    rm -rf /var/lib/apt/lists/* && \
-    #
-    # Remove the source code from this container
-    cd $ROS_WS && \
-    rm -rf src/

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -9,9 +9,7 @@ MAINTAINER Dave Coleman dave@picknik.ai
 
 ENV TERM xterm
 
-# Setup catkin workspace
-ENV ROS_WS=/root/ws_moveit
-WORKDIR $ROS_WS
+WORKDIR /root/ws_moveit
 
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers


### PR DESCRIPTION
### Description

As you can see in https://travis-ci.com/github/ros-planning/moveit_task_constructor/jobs/489509921 having `ROS_WS` is causing the overlay ws to be installed on top of the underlay hence compiling the underlay again

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
