### PR TITLE
Add black formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+
   - repo: local
     hooks:
       - id: clang-format

--- a/moveit/scripts/create_maintainer_table.py
+++ b/moveit/scripts/create_maintainer_table.py
@@ -39,22 +39,22 @@ import webbrowser
 from catkin_pkg.packages import find_packages
 
 maintainers_dict = {
-    'Ioan Sucan': 'isucan',
-    'Michael Ferguson': 'mikeferguson',
-    'Sachin Chitta': 'sachinchitta',
-    'G.A. vd. Hoorn': 'gavanderhoorn',
-    'Dave Coleman': 'davetcoleman',
-    'Acorn Pooley': 'acorn',
-    'Jon Binney': 'jonbinney',
-    'Matei Ciocarlie': 'mateiciocarlie',
-    'Michael Görner'.decode('utf8'): 'v4hn',
-    'Robert Haschke': 'rhaschke',
-    'Ian McMahon': 'IanTheEngineer',
-    'Isaac I. Y. Saito': '130s',
-    'Mathias Lüdtke'.decode('utf8'): 'ipa-mdl',
-    'Ryan Luna': 'ryanluna',
-    'Chittaranjan Srinivas Swaminathan': 'ksatyaki',
-    'Chittaranjan S Srinivas': 'ksatyaki'
+    "Ioan Sucan": "isucan",
+    "Michael Ferguson": "mikeferguson",
+    "Sachin Chitta": "sachinchitta",
+    "G.A. vd. Hoorn": "gavanderhoorn",
+    "Dave Coleman": "davetcoleman",
+    "Acorn Pooley": "acorn",
+    "Jon Binney": "jonbinney",
+    "Matei Ciocarlie": "mateiciocarlie",
+    "Michael Görner".decode("utf8"): "v4hn",
+    "Robert Haschke": "rhaschke",
+    "Ian McMahon": "IanTheEngineer",
+    "Isaac I. Y. Saito": "130s",
+    "Mathias Lüdtke".decode("utf8"): "ipa-mdl",
+    "Ryan Luna": "ryanluna",
+    "Chittaranjan Srinivas Swaminathan": "ksatyaki",
+    "Chittaranjan S Srinivas": "ksatyaki",
 }
 
 
@@ -66,87 +66,87 @@ def author_to_github(maintainer):
     try:
         name = maintainers_dict[maintainer.name]
     except KeyError:
-        eprint('Missing maintainer: ',  maintainer.name)
+        eprint("Missing maintainer: ", maintainer.name)
         name = maintainer.email
     return name
 
 
 def template_file(src, dst, subs):
     print("++ Templating '{0}'".format(src))
-    with open(src, 'r') as f:
+    with open(src, "r") as f:
         data = f.read()
     for k, v in subs.items():
         data = data.replace(k, v)
-    with open(dst, 'w+') as f:
+    with open(dst, "w+") as f:
         f.write(data)
     print("++ Webpage ready at '{0}'".format(dst))
     webbrowser.open(dst)
 
 
 def create_travis_badge(package_name):
-    output = ''
+    output = ""
     # Indigo
-    output += '<td>'
+    output += "<td>"
     output += (
-        "<a href='http://build.ros.org/view/Isrc_uT/job/Isrc_uT__" +
-        package_name +
-        "__ubuntu_trusty__source/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Isrc_uT__" +
-        package_name +
-        "__ubuntu_trusty__source'></a>"
+        "<a href='http://build.ros.org/view/Isrc_uT/job/Isrc_uT__"
+        + package_name
+        + "__ubuntu_trusty__source/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Isrc_uT__"
+        + package_name
+        + "__ubuntu_trusty__source'></a>"
     )
-    output += '</td><td>'
+    output += "</td><td>"
     output += (
-        "<a href='http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__" +
-        package_name +
-        "__ubuntu_trusty_amd64__binary/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Ibin_uT64__" +
-        package_name +
-        "__ubuntu_trusty_amd64__binary'></a>"
+        "<a href='http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__"
+        + package_name
+        + "__ubuntu_trusty_amd64__binary/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Ibin_uT64__"
+        + package_name
+        + "__ubuntu_trusty_amd64__binary'></a>"
     )
-    output += '</td>'
+    output += "</td>"
 
     # Jade
-    output += '<td>'
+    output += "<td>"
     output += (
-        "<a href='http://build.ros.org/view/Jsrc_uT/job/Jsrc_uT__" +
-        package_name +
-        "__ubuntu_trusty__source/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Jsrc_uT__" +
-        package_name +
-        "__ubuntu_trusty__source'></a>"
+        "<a href='http://build.ros.org/view/Jsrc_uT/job/Jsrc_uT__"
+        + package_name
+        + "__ubuntu_trusty__source/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Jsrc_uT__"
+        + package_name
+        + "__ubuntu_trusty__source'></a>"
     )
-    output += '</td><td>'
+    output += "</td><td>"
     output += (
-        "<a href='http://build.ros.org/view/Jbin_uT64/job/Jbin_uT64__" +
-        package_name +
-        "__ubuntu_trusty_amd64__binary/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Jbin_uT64__" +
-        package_name +
-        "__ubuntu_trusty_amd64__binary'></a>"
+        "<a href='http://build.ros.org/view/Jbin_uT64/job/Jbin_uT64__"
+        + package_name
+        + "__ubuntu_trusty_amd64__binary/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Jbin_uT64__"
+        + package_name
+        + "__ubuntu_trusty_amd64__binary'></a>"
     )
-    output += '</td>'
+    output += "</td>"
 
     # Kinetic
-    output += '<td>'
+    output += "<td>"
     output += (
-        "<a href='http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__" +
-        package_name +
-        "__ubuntu_xenial__source/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Ksrc_uX__" +
-        package_name +
-        "__ubuntu_xenial__source'></a>"
+        "<a href='http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__"
+        + package_name
+        + "__ubuntu_xenial__source/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Ksrc_uX__"
+        + package_name
+        + "__ubuntu_xenial__source'></a>"
     )
-    output += '</td><td>'
+    output += "</td><td>"
     output += (
-        "<a href='http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__" +
-        package_name +
-        "__ubuntu_xenial_amd64__binary/'>"
-        "<img src='http://build.ros.org/buildStatus/icon?job=Kbin_uX64__" +
-        package_name +
-        "__ubuntu_xenial_amd64__binary'></a>"
+        "<a href='http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__"
+        + package_name
+        + "__ubuntu_xenial_amd64__binary/'>"
+        "<img src='http://build.ros.org/buildStatus/icon?job=Kbin_uX64__"
+        + package_name
+        + "__ubuntu_xenial_amd64__binary'></a>"
     )
-    output += '</td>'
+    output += "</td>"
     return output
 
 
@@ -161,43 +161,45 @@ def get_first_folder(path):
 
 def populate_package_data(path, package):
     output = (
-        "<td><a href='https://github.com/ros-planning/" +
-        get_first_folder(path) +
-        "'>" +
-        package.name +
-        '</a></td>'
+        "<td><a href='https://github.com/ros-planning/"
+        + get_first_folder(path)
+        + "'>"
+        + package.name
+        + "</a></td>"
     )
-    output += '<td>' + package.version + '</td>'
-    output += '<td>'
+    output += "<td>" + package.version + "</td>"
+    output += "<td>"
     first = True
     for maintainer in package.maintainers:
         author = author_to_github(maintainer)
         if first:
             first = False
         else:
-            output += ', '
-        output += "<a href='https://github.com/" + author + "'>" + author + '</a>'
-    output += '</td>'
+            output += ", "
+        output += "<a href='https://github.com/" + author + "'>" + author + "</a>"
+    output += "</td>"
     output += create_travis_badge(package.name)
     return output
 
 
 def list_moveit_packages():
     """Create list of MoveIt packages."""
-    output = ''
+    output = ""
     packages = find_packages(os.getcwd())
 
     for path, package in packages.items():
-        output += '<tr>'
+        output += "<tr>"
         output += populate_package_data(path, package)
-        output += '</tr>'
+        output += "</tr>"
 
     # Save to file
     basepath = os.path.dirname(os.path.realpath(__file__))
-    template_file(os.path.join(basepath, 'maintainer_table_template.html'),
-                  os.path.join(basepath, 'index.html'),
-                  {'CONTENTS': output})
+    template_file(
+        os.path.join(basepath, "maintainer_table_template.html"),
+        os.path.join(basepath, "index.html"),
+        {"CONTENTS": output},
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(list_moveit_packages())

--- a/moveit/scripts/create_readme_table.py
+++ b/moveit/scripts/create_readme_table.py
@@ -41,50 +41,56 @@ import requests
 
 def create_header(ros_ubuntu_dict):
     ros_distros = sorted(ros_ubuntu_dict.keys())
-    section_header = '### ROS Buildfarm\n'
-    header = 'MoveIt Package'
-    header_lines = '-'*len(header)
+    section_header = "### ROS Buildfarm\n"
+    header = "MoveIt Package"
+    header_lines = "-" * len(header)
     for ros in ros_distros:
-        source = ' '.join([ros.capitalize(), 'Source'])
-        debian = ' '.join([ros.capitalize(), 'Debian'])
-        header = ' | '.join([header, source, debian])
-        header_lines = ' | '.join([header_lines, '-'*len(source), '-'*len(debian)])
-    return '\n'.join([section_header, header, header_lines])
+        source = " ".join([ros.capitalize(), "Source"])
+        debian = " ".join([ros.capitalize(), "Debian"])
+        header = " | ".join([header, source, debian])
+        header_lines = " | ".join([header_lines, "-" * len(source), "-" * len(debian)])
+    return "\n".join([section_header, header, header_lines])
 
 
 def define_urls(target, params):
-    if target == 'src':
-        params['job'] = '{R}src_u{U}__{package}__ubuntu_{ubuntu}__source'.format(**params)
-        params['url'] = '{base_url}/view/{R}src_u{U}/job/{job}'.format(**params)
-    elif target == 'bin':
-        params['job'] = '{R}bin_u{U}64__{package}__ubuntu_{ubuntu}_amd64__binary'.format(**params)
-        params['url'] = '{base_url}/view/{R}bin_u{U}64/job/{job}'.format(**params)
+    if target == "src":
+        params["job"] = "{R}src_u{U}__{package}__ubuntu_{ubuntu}__source".format(
+            **params
+        )
+        params["url"] = "{base_url}/view/{R}src_u{U}/job/{job}".format(**params)
+    elif target == "bin":
+        params[
+            "job"
+        ] = "{R}bin_u{U}64__{package}__ubuntu_{ubuntu}_amd64__binary".format(**params)
+        params["url"] = "{base_url}/view/{R}bin_u{U}64/job/{job}".format(**params)
 
 
 def create_line(package, ros_ubuntu_dict):
     ros_distros = sorted(ros_ubuntu_dict.keys())
-    line_format = ' | [![Build Status]({base_url}/buildStatus/icon?job={job})]({url})'
-    line = '\n' + package
+    line_format = " | [![Build Status]({base_url}/buildStatus/icon?job={job})]({url})"
+    line = "\n" + package
     print(package, file=sys.stderr)
     for ros in ros_distros:
         ubuntu = ros_ubuntu_dict[ros]
         params = {
-            'R': ros[0].upper(),
-            'U': ubuntu[0].upper(),
-            'ubuntu': ubuntu.lower(),
-            'package': package,
-            'base_url': 'http://build.ros.org'
+            "R": ros[0].upper(),
+            "U": ubuntu[0].upper(),
+            "ubuntu": ubuntu.lower(),
+            "package": package,
+            "base_url": "http://build.ros.org",
         }
-        for target in ['src', 'bin']:
+        for target in ["src", "bin"]:
             define_urls(target, params)
-            response = requests.get(params['url']).status_code
+            response = requests.get(params["url"]).status_code
             # we want to show a particular OS's badges to indicate they are not
             # released / working yet
-            if response < 400 or ubuntu == 'focal':  # success
+            if response < 400 or ubuntu == "focal":  # success
                 line += line_format.format(**params)
             else:  # error
-                line += ' | '
-                print('  {}: {} {}'.format(ros, response, params['url']), file=sys.stderr)
+                line += " | "
+                print(
+                    "  {}: {} {}".format(ros, response, params["url"]), file=sys.stderr
+                )
 
     return line
 
@@ -96,16 +102,18 @@ def create_moveit_buildfarm_table():
     # remove {"indigo":"trusty"} and add {"noetic":"fbuntu"} with "fbuntu"
     # being whatever the 20.04 distro is named
     supported_distro_ubuntu_dict = {
-        'kinetic': 'xenial',
-        'melodic': 'bionic',
-        'noetic': 'focal'
+        "kinetic": "xenial",
+        "melodic": "bionic",
+        "noetic": "focal",
     }
 
-    all_packages = sorted(package.name for _, package in find_packages(os.getcwd()).items())
+    all_packages = sorted(
+        package.name for _, package in find_packages(os.getcwd()).items()
+    )
     moveit_packages = []
     other_packages = []
     for package in all_packages:
-        if package.startswith('moveit'):
+        if package.startswith("moveit"):
             moveit_packages.append(package)
         else:
             other_packages.append(package)
@@ -117,5 +125,5 @@ def create_moveit_buildfarm_table():
     print(buildfarm_table)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(create_moveit_buildfarm_table())

--- a/moveit_commander/bin/moveit_commander_cmdline.py
+++ b/moveit_commander/bin/moveit_commander_cmdline.py
@@ -4,35 +4,43 @@ from __future__ import print_function
 
 import roslib
 import rospy
+
 try:
     import readline
 except ImportError:
-    import pyreadline as readline # for Windows
+    import pyreadline as readline  # for Windows
 import sys
 import os
 import signal
 
 import argparse
-from moveit_commander import MoveGroupCommandInterpreter, MoveGroupInfoLevel, roscpp_initialize, roscpp_shutdown
+from moveit_commander import (
+    MoveGroupCommandInterpreter,
+    MoveGroupInfoLevel,
+    roscpp_initialize,
+    roscpp_shutdown,
+)
 
 # python3 has renamed raw_input to input: https://www.python.org/dev/peps/pep-3111
 # Here, we use the new input(). Hence, for python2, we redirect raw_input to input
 try:
     import __builtin__  # This is named builtin in python3
-    input = getattr(__builtin__, 'raw_input')
+
+    input = getattr(__builtin__, "raw_input")
 except (ImportError, AttributeError):
     pass
 
+
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+
 
 class SimpleCompleter(object):
-
     def __init__(self, options):
         self.options = options
 
@@ -52,13 +60,13 @@ class SimpleCompleter(object):
             # This is the first time for this text, so build a match list.
             if text:
                 if len(prefix) == 0:
-                    self.matches = sorted([s
-                                           for s in self.options.keys()
-                                           if s and s.startswith(text)])
+                    self.matches = sorted(
+                        [s for s in self.options.keys() if s and s.startswith(text)]
+                    )
                 else:
-                    self.matches = sorted([s
-                                           for s in self.options[prefix]
-                                           if s and s.startswith(text)])
+                    self.matches = sorted(
+                        [s for s in self.options[prefix] if s and s.startswith(text)]
+                    )
             else:
                 if len(prefix) == 0:
                     self.matches = sorted(self.options.keys())
@@ -73,6 +81,7 @@ class SimpleCompleter(object):
             response = None
         return response
 
+
 def print_message(level, msg):
     if level == MoveGroupInfoLevel.FAIL:
         print(bcolors.FAIL + msg + bcolors.ENDC)
@@ -85,10 +94,12 @@ def print_message(level, msg):
     else:
         print(msg)
 
+
 def get_context_keywords(interpreter):
     kw = interpreter.get_keywords()
     kw["quit"] = []
     return kw
+
 
 def run_interactive(group_name):
     c = MoveGroupCommandInterpreter()
@@ -98,9 +109,13 @@ def run_interactive(group_name):
     readline.set_completer(completer.complete)
 
     print()
-    print(bcolors.HEADER + "Waiting for commands. Type 'help' to get a list of known commands." + bcolors.ENDC)
+    print(
+        bcolors.HEADER
+        + "Waiting for commands. Type 'help' to get a list of known commands."
+        + bcolors.ENDC
+    )
     print()
-    readline.parse_and_bind('tab: complete')
+    readline.parse_and_bind("tab: complete")
 
     while not rospy.is_shutdown():
         cmd = ""
@@ -109,7 +124,7 @@ def run_interactive(group_name):
             ag = c.get_active_group()
             if ag != None:
                 name = ag.get_name()
-            cmd = input(bcolors.OKBLUE + name + '> ' + bcolors.ENDC)
+            cmd = input(bcolors.OKBLUE + name + "> " + bcolors.ENDC)
         except:
             break
         cmdorig = cmd.strip()
@@ -120,13 +135,17 @@ def run_interactive(group_name):
         if cmd == "q" or cmd == "quit" or cmd == "exit":
             break
         if cmd == "host":
-            print_message(MoveGroupInfoLevel.INFO, "Master is '" + os.environ['ROS_MASTER_URI'] + "'")
+            print_message(
+                MoveGroupInfoLevel.INFO,
+                "Master is '" + os.environ["ROS_MASTER_URI"] + "'",
+            )
             continue
 
         (level, msg) = c.execute(cmdorig)
         print_message(level, msg)
         # update the set of keywords
         completer.set_options(get_context_keywords(c))
+
 
 def run_service(group_name):
     c = MoveGroupCommandInterpreter()
@@ -136,30 +155,55 @@ def run_service(group_name):
     print("Running ROS service")
     rospy.spin()
 
+
 def stop_ros(reason):
     rospy.signal_shutdown(reason)
     roscpp_shutdown()
+
 
 def sigint_handler(signal, frame):
     stop_ros("Ctrl+C pressed")
     # this won't actually exit, but trigger an exception to terminate input
     sys.exit(0)
 
-if __name__=='__main__':
+
+if __name__ == "__main__":
 
     signal.signal(signal.SIGINT, sigint_handler)
 
     roscpp_initialize(sys.argv)
 
-    rospy.init_node('move_group_interface_cmdline', anonymous=True, disable_signals=True)
+    rospy.init_node(
+        "move_group_interface_cmdline", anonymous=True, disable_signals=True
+    )
 
-    parser = argparse.ArgumentParser(usage = """%(prog)s [options] [<group_name>]""",
-                                     description = "Command Line Interface to MoveIt")
-    parser.add_argument("-i", "--interactive", action="store_true", dest="interactive", default=True,
-                        help="Run the command processing script in interactive mode (default)")
-    parser.add_argument("-s", "--service", action="store_true", dest="service", default=False,
-                        help="Run the command processing script as a ROS service")
-    parser.add_argument("group_name", type=str, default="", nargs='?', help="Group name to initialize the CLI for.")
+    parser = argparse.ArgumentParser(
+        usage="""%(prog)s [options] [<group_name>]""",
+        description="Command Line Interface to MoveIt",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        dest="interactive",
+        default=True,
+        help="Run the command processing script in interactive mode (default)",
+    )
+    parser.add_argument(
+        "-s",
+        "--service",
+        action="store_true",
+        dest="service",
+        default=False,
+        help="Run the command processing script as a ROS service",
+    )
+    parser.add_argument(
+        "group_name",
+        type=str,
+        default="",
+        nargs="?",
+        help="Group name to initialize the CLI for.",
+    )
 
     opt = parser.parse_args(rospy.myargv()[1:])
 

--- a/moveit_commander/demos/pick.py
+++ b/moveit_commander/demos/pick.py
@@ -36,13 +36,18 @@
 
 import sys
 import rospy
-from moveit_commander import RobotCommander, PlanningSceneInterface, roscpp_initialize, roscpp_shutdown
+from moveit_commander import (
+    RobotCommander,
+    PlanningSceneInterface,
+    roscpp_initialize,
+    roscpp_shutdown,
+)
 from geometry_msgs.msg import PoseStamped
 
-if __name__=='__main__':
+if __name__ == "__main__":
 
     roscpp_initialize(sys.argv)
-    rospy.init_node('moveit_py_demo', anonymous=True)
+    rospy.init_node("moveit_py_demo", anonymous=True)
 
     scene = PlanningSceneInterface()
     robot = RobotCommander()

--- a/moveit_commander/demos/plan.py
+++ b/moveit_commander/demos/plan.py
@@ -39,10 +39,10 @@ import rospy
 from moveit_commander import RobotCommander, roscpp_initialize, roscpp_shutdown
 from moveit_msgs.msg import RobotState
 
-if __name__=='__main__':
+if __name__ == "__main__":
 
     roscpp_initialize(sys.argv)
-    rospy.init_node('moveit_py_demo', anonymous=True)
+    rospy.init_node("moveit_py_demo", anonymous=True)
 
     robot = RobotCommander()
     rospy.sleep(1)

--- a/moveit_commander/demos/plan_with_constraints.py
+++ b/moveit_commander/demos/plan_with_constraints.py
@@ -40,10 +40,10 @@ from moveit_commander import RobotCommander, roscpp_initialize, roscpp_shutdown
 from moveit_msgs.msg import RobotState, Constraints
 from geometry_msgs.msg import Pose
 
-if __name__=='__main__':
+if __name__ == "__main__":
 
     roscpp_initialize(sys.argv)
-    rospy.init_node('moveit_py_demo', anonymous=True)
+    rospy.init_node("moveit_py_demo", anonymous=True)
 
     robot = RobotCommander()
     rospy.sleep(1)
@@ -72,4 +72,4 @@ if __name__=='__main__':
     waypoints.append(wpose)
 
     plan, fraction = a.compute_cartesian_path(waypoints, 0.01, 0.0, path_constraints=c)
-    print('Plan success percent: ', fraction)
+    print("Plan success percent: ", fraction)

--- a/moveit_commander/setup.py
+++ b/moveit_commander/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
-d['packages'] = ['moveit_commander']
-d['package_dir'] = {'': 'src'}
+d["packages"] = ["moveit_commander"]
+d["package_dir"] = {"": "src"}
 
 setup(**d)

--- a/moveit_commander/src/moveit_commander/conversions.py
+++ b/moveit_commander/src/moveit_commander/conversions.py
@@ -44,13 +44,16 @@ from geometry_msgs.msg import Pose, PoseStamped, Transform
 import rospy
 import tf
 
+
 def msg_to_string(msg):
     buf = StringIO()
     msg.serialize(buf)
     return buf.getvalue()
 
+
 def msg_from_string(msg, data):
     msg.deserialize(data)
+
 
 def pose_to_list(pose_msg):
     pose = []
@@ -62,6 +65,7 @@ def pose_to_list(pose_msg):
     pose.append(pose_msg.orientation.z)
     pose.append(pose_msg.orientation.w)
     return pose
+
 
 def list_to_pose(pose_list):
     pose_msg = Pose()
@@ -77,14 +81,19 @@ def list_to_pose(pose_list):
         pose_msg.position.x = pose_list[0]
         pose_msg.position.y = pose_list[1]
         pose_msg.position.z = pose_list[2]
-        q = tf.transformations.quaternion_from_euler(pose_list[3], pose_list[4], pose_list[5])
+        q = tf.transformations.quaternion_from_euler(
+            pose_list[3], pose_list[4], pose_list[5]
+        )
         pose_msg.orientation.x = q[0]
         pose_msg.orientation.y = q[1]
         pose_msg.orientation.z = q[2]
         pose_msg.orientation.w = q[3]
     else:
-        raise MoveItCommanderException("Expected either 6 or 7 elements in list: (x,y,z,r,p,y) or (x,y,z,qx,qy,qz,qw)")
+        raise MoveItCommanderException(
+            "Expected either 6 or 7 elements in list: (x,y,z,r,p,y) or (x,y,z,qx,qy,qz,qw)"
+        )
     return pose_msg
+
 
 def list_to_pose_stamped(pose_list, target_frame):
     pose_msg = PoseStamped()
@@ -92,6 +101,7 @@ def list_to_pose_stamped(pose_list, target_frame):
     pose_msg.header.frame_id = target_frame
     pose_msg.header.stamp = rospy.Time.now()
     return pose_msg
+
 
 def transform_to_list(trf_msg):
     trf = []
@@ -103,6 +113,7 @@ def transform_to_list(trf_msg):
     trf.append(trf_msg.rotation.z)
     trf.append(trf_msg.rotation.w)
     return trf
+
 
 def list_to_transform(trf_list):
     trf_msg = Transform()

--- a/moveit_commander/src/moveit_commander/exception.py
+++ b/moveit_commander/src/moveit_commander/exception.py
@@ -32,4 +32,6 @@
 #
 # Author: Ioan Sucan
 
-class MoveItCommanderException(Exception): pass
+
+class MoveItCommanderException(Exception):
+    pass

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -33,12 +33,18 @@
 # Author: Ioan Sucan
 
 import rospy
-from moveit_commander import RobotCommander, MoveGroupCommander, PlanningSceneInterface, MoveItCommanderException
+from moveit_commander import (
+    RobotCommander,
+    MoveGroupCommander,
+    PlanningSceneInterface,
+    MoveItCommanderException,
+)
 from geometry_msgs.msg import Pose, PoseStamped
 import tf
 import re
 import time
 import os.path
+
 
 class MoveGroupInfoLevel:
     FAIL = 1
@@ -47,15 +53,25 @@ class MoveGroupInfoLevel:
     INFO = 4
     DEBUG = 5
 
+
 class MoveGroupCommandInterpreter(object):
     """
     Interpreter for simple commands
     """
 
     DEFAULT_FILENAME = "move_group.cfg"
-    GO_DIRS = {"up" : (2,1), "down" : (2, -1), "z" : (2, 1),
-               "left" : (1, 1), "right" : (1, -1), "y" : (1, 1),
-               "forward" : (0, 1), "backward" : (0, -1), "back" : (0, -1), "x" : (0, 1) }
+    GO_DIRS = {
+        "up": (2, 1),
+        "down": (2, -1),
+        "z": (2, 1),
+        "left": (1, 1),
+        "right": (1, -1),
+        "y": (1, 1),
+        "forward": (0, 1),
+        "backward": (0, -1),
+        "back": (0, -1),
+        "x": (0, 1),
+    }
 
     def __init__(self):
         self._gdict = {}
@@ -86,7 +102,11 @@ class MoveGroupCommandInterpreter(object):
             if len(self._group_name) > 0:
                 return self.execute_group_command(self._gdict[self._group_name], cmd)
             else:
-                return (MoveGroupInfoLevel.INFO, self.get_help() + "\n\nNo groups initialized yet. You must call the 'use' or the 'load' command first.\n")
+                return (
+                    MoveGroupInfoLevel.INFO,
+                    self.get_help()
+                    + "\n\nNo groups initialized yet. You must call the 'use' or the 'load' command first.\n",
+                )
 
     def execute_generic_command(self, cmd):
         if os.path.isfile("cmd/" + cmd):
@@ -114,12 +134,21 @@ class MoveGroupCommandInterpreter(object):
                             self._group_name = clist[1]
                             return (MoveGroupInfoLevel.DEBUG, "OK")
                         except MoveItCommanderException as e:
-                            return (MoveGroupInfoLevel.FAIL, "Initializing " + clist[1] + ": " + str(e))
+                            return (
+                                MoveGroupInfoLevel.FAIL,
+                                "Initializing " + clist[1] + ": " + str(e),
+                            )
                         except:
-                            return (MoveGroupInfoLevel.FAIL, "Unable to initialize " + clist[1])
+                            return (
+                                MoveGroupInfoLevel.FAIL,
+                                "Unable to initialize " + clist[1],
+                            )
         elif cmdlow.startswith("trace"):
             if cmdlow == "trace":
-                return (MoveGroupInfoLevel.INFO, "trace is on" if self._trace else "trace is off")
+                return (
+                    MoveGroupInfoLevel.INFO,
+                    "trace is on" if self._trace else "trace is off",
+                )
             clist = cmdlow.split()
             if clist[0] == "trace" and clist[1] == "on":
                 self._trace = True
@@ -139,28 +168,38 @@ class MoveGroupCommandInterpreter(object):
             line_num = 0
             line_content = ""
             try:
-                f = open(filename, 'r')
+                f = open(filename, "r")
                 for line in f:
                     line_num += 1
                     line = line.rstrip()
                     line_content = line
                     if self._trace:
-                        print ("%s:%d:  %s" % (filename, line_num, line_content))
+                        print("%s:%d:  %s" % (filename, line_num, line_content))
                     comment = line.find("#")
                     if comment != -1:
-                      line = line[0:comment].rstrip()
+                        line = line[0:comment].rstrip()
                     if line != "":
-                      self.execute(line.rstrip())
+                        self.execute(line.rstrip())
                     line_content = ""
                 return (MoveGroupInfoLevel.DEBUG, "OK")
             except MoveItCommanderException as e:
                 if line_num > 0:
-                    return (MoveGroupInfoLevel.WARN, "Error at %s:%d:  %s\n%s" % (filename, line_num, line_content, str(e)))
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Error at %s:%d:  %s\n%s"
+                        % (filename, line_num, line_content, str(e)),
+                    )
                 else:
-                    return (MoveGroupInfoLevel.WARN, "Processing " + filename + ": " + str(e))
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Processing " + filename + ": " + str(e),
+                    )
             except:
                 if line_num > 0:
-                    return (MoveGroupInfoLevel.WARN, "Error at %s:%d:  %s" % (filename, line_num, line_content))
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Error at %s:%d:  %s" % (filename, line_num, line_content),
+                    )
                 else:
                     return (MoveGroupInfoLevel.WARN, "Unable to load " + filename)
         elif cmdlow.startswith("save"):
@@ -171,14 +210,18 @@ class MoveGroupCommandInterpreter(object):
             if len(clist) == 2:
                 filename = clist[1]
             try:
-                f = open(filename, 'w')
+                f = open(filename, "w")
                 for gr in self._gdict.keys():
                     f.write("use " + gr + "\n")
                     known = self._gdict[gr].get_remembered_joint_values()
                     for v in known.keys():
-                        f.write(v + " = [" + " ".join([str(x) for x in known[v]]) + "]\n")
+                        f.write(
+                            v + " = [" + " ".join([str(x) for x in known[v]]) + "]\n"
+                        )
                 if self._db_host != None:
-                    f.write("database " + self._db_host + " " + str(self._db_port) + "\n")
+                    f.write(
+                        "database " + self._db_host + " " + str(self._db_port) + "\n"
+                    )
                 return (MoveGroupInfoLevel.DEBUG, "OK")
             except:
                 return (MoveGroupInfoLevel.WARN, "Unable to save " + filename)
@@ -204,7 +247,12 @@ class MoveGroupCommandInterpreter(object):
 
         if cmd == "joints":
             joints = g.get_joints()
-            return (MoveGroupInfoLevel.INFO, "\n" + "\n".join([str(i) + " = " + joints[i] for i in range(len(joints))]) + "\n")
+            return (
+                MoveGroupInfoLevel.INFO,
+                "\n"
+                + "\n".join([str(i) + " = " + joints[i] for i in range(len(joints))])
+                + "\n",
+            )
 
         if cmd == "show":
             return self.command_show(g)
@@ -224,7 +272,9 @@ class MoveGroupCommandInterpreter(object):
             pose.pose.orientation.w = 1
             pose.header.stamp = rospy.get_rostime()
             pose.header.frame_id = self._robot.get_root_link()
-            self._planning_scene_interface.attach_box(self._robot.get_root_link(), "ground", pose, (3, 3, 0.1))
+            self._planning_scene_interface.attach_box(
+                self._robot.get_root_link(), "ground", pose, (3, 3, 0.1)
+            )
             return (MoveGroupInfoLevel.INFO, "Added ground")
 
         if cmd == "eef":
@@ -237,7 +287,10 @@ class MoveGroupCommandInterpreter(object):
             if self._db_host == None:
                 return (MoveGroupInfoLevel.INFO, "Not connected to a database")
             else:
-                return (MoveGroupInfoLevel.INFO, "Connected to " + self._db_host + ":" + str(self._db_port))
+                return (
+                    MoveGroupInfoLevel.INFO,
+                    "Connected to " + self._db_host + ":" + str(self._db_port),
+                )
         if cmd == "plan":
             if self._last_plan != None:
                 return (MoveGroupInfoLevel.INFO, str(self._last_plan))
@@ -249,7 +302,11 @@ class MoveGroupCommandInterpreter(object):
             return (MoveGroupInfoLevel.SUCCESS, "Cleared path constraints")
 
         if cmd == "tol" or cmd == "tolerance":
-            return (MoveGroupInfoLevel.INFO, "Joint = %0.6g, Position = %0.6g, Orientation = %0.6g" % g.get_goal_tolerance())
+            return (
+                MoveGroupInfoLevel.INFO,
+                "Joint = %0.6g, Position = %0.6g, Orientation = %0.6g"
+                % g.get_goal_tolerance(),
+            )
 
         if cmd == "time":
             return (MoveGroupInfoLevel.INFO, str(g.get_planning_time()))
@@ -259,7 +316,10 @@ class MoveGroupCommandInterpreter(object):
                 if g.execute(self._last_plan):
                     return (MoveGroupInfoLevel.SUCCESS, "Plan submitted for execution")
                 else:
-                    return (MoveGroupInfoLevel.WARN, "Failed to submit plan for execution")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Failed to submit plan for execution",
+                    )
             else:
                 return (MoveGroupInfoLevel.WARN, "No motion plan computed")
 
@@ -268,8 +328,15 @@ class MoveGroupCommandInterpreter(object):
         if assign_match:
             known = g.get_remembered_joint_values()
             if assign_match.group(2) in known:
-                g.remember_joint_values(assign_match.group(1), known[assign_match.group(2)])
-                return (MoveGroupInfoLevel.SUCCESS, assign_match.group(1) + " is now the same as " + assign_match.group(2))
+                g.remember_joint_values(
+                    assign_match.group(1), known[assign_match.group(2)]
+                )
+                return (
+                    MoveGroupInfoLevel.SUCCESS,
+                    assign_match.group(1)
+                    + " is now the same as "
+                    + assign_match.group(2),
+                )
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
@@ -277,13 +344,26 @@ class MoveGroupCommandInterpreter(object):
         set_match = re.match(r"^(\w+)\s*=\s*\[([\d\.e\-\+\s]+)\]$", cmd)
         if set_match:
             try:
-                g.remember_joint_values(set_match.group(1), [float(x) for x in set_match.group(2).split()])
-                return (MoveGroupInfoLevel.SUCCESS, "Remembered joint values [" + set_match.group(2) + "] under the name " + set_match.group(1))
+                g.remember_joint_values(
+                    set_match.group(1), [float(x) for x in set_match.group(2).split()]
+                )
+                return (
+                    MoveGroupInfoLevel.SUCCESS,
+                    "Remembered joint values ["
+                    + set_match.group(2)
+                    + "] under the name "
+                    + set_match.group(1),
+                )
             except:
-                return (MoveGroupInfoLevel.WARN, "Unable to parse joint value [" + set_match.group(2) + "]")
+                return (
+                    MoveGroupInfoLevel.WARN,
+                    "Unable to parse joint value [" + set_match.group(2) + "]",
+                )
 
         # see if we have assignment of matlab-like element update
-        component_match = re.match(r"^(\w+)\s*\[\s*(\d+)\s*\]\s*=\s*([\d\.e\-\+]+)$", cmd)
+        component_match = re.match(
+            r"^(\w+)\s*\[\s*(\d+)\s*\]\s*=\s*([\d\.e\-\+]+)$", cmd
+        )
         if component_match:
             known = g.get_remembered_joint_values()
             if component_match.group(1) in known:
@@ -291,9 +371,19 @@ class MoveGroupCommandInterpreter(object):
                     val = known[component_match.group(1)]
                     val[int(component_match.group(2))] = float(component_match.group(3))
                     g.remember_joint_values(component_match.group(1), val)
-                    return (MoveGroupInfoLevel.SUCCESS, "Updated " + component_match.group(1) + "[" + component_match.group(2) + "]")
+                    return (
+                        MoveGroupInfoLevel.SUCCESS,
+                        "Updated "
+                        + component_match.group(1)
+                        + "["
+                        + component_match.group(2)
+                        + "]",
+                    )
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse index or value in '" + cmd +"'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse index or value in '" + cmd + "'",
+                    )
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
@@ -304,7 +394,10 @@ class MoveGroupCommandInterpreter(object):
         if len(clist) == 1:
             known = g.get_remembered_joint_values()
             if cmd in known:
-                return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[cmd]]) + "]")
+                return (
+                    MoveGroupInfoLevel.INFO,
+                    "[" + " ".join([str(x) for x in known[cmd]]) + "]",
+                )
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
@@ -316,18 +409,34 @@ class MoveGroupCommandInterpreter(object):
                     vals = g.get_random_joint_values()
                     g.set_joint_value_target(vals)
                     if g.go():
-                        return (MoveGroupInfoLevel.SUCCESS, "Moved to random target [" + " ".join([str(x) for x in vals]) + "]")
+                        return (
+                            MoveGroupInfoLevel.SUCCESS,
+                            "Moved to random target ["
+                            + " ".join([str(x) for x in vals])
+                            + "]",
+                        )
                     else:
-                        return (MoveGroupInfoLevel.FAIL, "Failed while moving to random target [" + " ".join([str(x) for x in vals]) + "]")
+                        return (
+                            MoveGroupInfoLevel.FAIL,
+                            "Failed while moving to random target ["
+                            + " ".join([str(x) for x in vals])
+                            + "]",
+                        )
                 else:
                     try:
                         g.set_named_target(clist[1])
                         if g.go():
                             return (MoveGroupInfoLevel.SUCCESS, "Moved to " + clist[1])
                         else:
-                            return (MoveGroupInfoLevel.FAIL, "Failed while moving to " + clist[1])
+                            return (
+                                MoveGroupInfoLevel.FAIL,
+                                "Failed while moving to " + clist[1],
+                            )
                     except MoveItCommanderException as e:
-                        return (MoveGroupInfoLevel.WARN, "Going to " + clist[1] + ": " + str(e))
+                        return (
+                            MoveGroupInfoLevel.WARN,
+                            "Going to " + clist[1] + ": " + str(e),
+                        )
                     except:
                         return (MoveGroupInfoLevel.WARN, clist[1] + " is unknown")
             if clist[0] == "plan":
@@ -336,17 +445,23 @@ class MoveGroupCommandInterpreter(object):
                 if clist[1] == "rand" or clist[1] == "random":
                     vals = g.get_random_joint_values()
                     g.set_joint_value_target(vals)
-                    self._last_plan = g.plan()[1] # The trajectory msg
+                    self._last_plan = g.plan()[1]  # The trajectory msg
                 else:
                     try:
                         g.set_named_target(clist[1])
-                        self._last_plan = g.plan()[1] # The trajectory msg
+                        self._last_plan = g.plan()[1]  # The trajectory msg
                     except MoveItCommanderException as e:
-                        return (MoveGroupInfoLevel.WARN, "Planning to " + clist[1] + ": " + str(e))
+                        return (
+                            MoveGroupInfoLevel.WARN,
+                            "Planning to " + clist[1] + ": " + str(e),
+                        )
                     except:
                         return (MoveGroupInfoLevel.WARN, clist[1] + " is unknown")
                 if self._last_plan != None:
-                    if len(self._last_plan.joint_trajectory.points) == 0 and len(self._last_plan.multi_dof_joint_trajectory.points) == 0:
+                    if (
+                        len(self._last_plan.joint_trajectory.points) == 0
+                        and len(self._last_plan.multi_dof_joint_trajectory.points) == 0
+                    ):
                         self._last_plan = None
                 dest_str = clist[1]
                 if vals != None:
@@ -354,56 +469,89 @@ class MoveGroupCommandInterpreter(object):
                 if self._last_plan != None:
                     return (MoveGroupInfoLevel.SUCCESS, "Planned to " + dest_str)
                 else:
-                    return (MoveGroupInfoLevel.FAIL, "Failed while planning to " + dest_str)
+                    return (
+                        MoveGroupInfoLevel.FAIL,
+                        "Failed while planning to " + dest_str,
+                    )
             elif clist[0] == "pick":
                 self._last_plan = None
                 if g.pick(clist[1]):
                     return (MoveGroupInfoLevel.SUCCESS, "Picked object " + clist[1])
                 else:
-                    return (MoveGroupInfoLevel.FAIL, "Failed while trying to pick object " + clist[1])
+                    return (
+                        MoveGroupInfoLevel.FAIL,
+                        "Failed while trying to pick object " + clist[1],
+                    )
             elif clist[0] == "place":
                 self._last_plan = None
                 if g.place(clist[1]):
                     return (MoveGroupInfoLevel.SUCCESS, "Placed object " + clist[1])
                 else:
-                    return (MoveGroupInfoLevel.FAIL, "Failed while trying to place object " + clist[1])
+                    return (
+                        MoveGroupInfoLevel.FAIL,
+                        "Failed while trying to place object " + clist[1],
+                    )
             elif clist[0] == "planner":
                 g.set_planner_id(clist[1])
                 return (MoveGroupInfoLevel.SUCCESS, "Planner is now " + clist[1])
             elif clist[0] == "record" or clist[0] == "rec":
                 g.remember_joint_values(clist[1])
-                return (MoveGroupInfoLevel.SUCCESS, "Remembered current joint values under the name " + clist[1])
+                return (
+                    MoveGroupInfoLevel.SUCCESS,
+                    "Remembered current joint values under the name " + clist[1],
+                )
             elif clist[0] == "rand" or clist[0] == "random":
                 g.remember_joint_values(clist[1], g.get_random_joint_values())
-                return (MoveGroupInfoLevel.SUCCESS, "Remembered random joint values under the name " + clist[1])
+                return (
+                    MoveGroupInfoLevel.SUCCESS,
+                    "Remembered random joint values under the name " + clist[1],
+                )
             elif clist[0] == "del" or clist[0] == "delete":
                 g.forget_joint_values(clist[1])
-                return (MoveGroupInfoLevel.SUCCESS, "Forgot joint values under the name " + clist[1])
+                return (
+                    MoveGroupInfoLevel.SUCCESS,
+                    "Forgot joint values under the name " + clist[1],
+                )
             elif clist[0] == "show":
                 known = g.get_remembered_joint_values()
                 if clist[1] in known:
-                    return (MoveGroupInfoLevel.INFO, "[" + " ".join([str(x) for x in known[clist[1]]]) + "]")
+                    return (
+                        MoveGroupInfoLevel.INFO,
+                        "[" + " ".join([str(x) for x in known[clist[1]]]) + "]",
+                    )
                 else:
-                    return (MoveGroupInfoLevel.WARN, "Joint values for " + clist[1] + " are not known")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Joint values for " + clist[1] + " are not known",
+                    )
             elif clist[0] == "tol" or clist[0] == "tolerance":
                 try:
                     g.set_goal_tolerance(float(clist[1]))
                     return (MoveGroupInfoLevel.SUCCESS, "OK")
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse tolerance value '" + clist[1] + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse tolerance value '" + clist[1] + "'",
+                    )
             elif clist[0] == "time":
                 try:
                     g.set_planning_time(float(clist[1]))
                     return (MoveGroupInfoLevel.SUCCESS, "OK")
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse planning duration value '" + clist[1] + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse planning duration value '" + clist[1] + "'",
+                    )
             elif clist[0] == "constrain":
                 try:
                     g.set_path_constraints(clist[1])
                     return (MoveGroupInfoLevel.SUCCESS, "OK")
                 except:
                     if self._db_host != None:
-                        return (MoveGroupInfoLevel.WARN, "Constraint " + clist[1] + " is not known.")
+                        return (
+                            MoveGroupInfoLevel.WARN,
+                            "Constraint " + clist[1] + " is not known.",
+                        )
                     else:
                         return (MoveGroupInfoLevel.WARN, "Not connected to a database.")
             elif clist[0] == "wait":
@@ -411,14 +559,27 @@ class MoveGroupCommandInterpreter(object):
                     time.sleep(float(clist[1]))
                     return (MoveGroupInfoLevel.SUCCESS, clist[1] + " seconds passed")
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to wait '" + clist[1] + "' seconds")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to wait '" + clist[1] + "' seconds",
+                    )
             elif clist[0] == "database":
                 try:
                     g.set_constraints_database(clist[1], self._db_port)
                     self._db_host = clist[1]
-                    return (MoveGroupInfoLevel.SUCCESS, "Connected to " + self._db_host + ":" + str(self._db_port))
+                    return (
+                        MoveGroupInfoLevel.SUCCESS,
+                        "Connected to " + self._db_host + ":" + str(self._db_port),
+                    )
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to connect to '" + clist[1] + ":" + str(self._db_port) + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to connect to '"
+                        + clist[1]
+                        + ":"
+                        + str(self._db_port)
+                        + "'",
+                    )
             else:
                 return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
@@ -430,17 +591,35 @@ class MoveGroupCommandInterpreter(object):
                     (axis, factor) = self.GO_DIRS[clist[1]]
                     return self.command_go_offset(g, offset, factor, axis, clist[1])
                 except MoveItCommanderException as e:
-                    return (MoveGroupInfoLevel.WARN, "Going " + clist[1] + ": " + str(e))
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Going " + clist[1] + ": " + str(e),
+                    )
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse distance '" + clist[2] + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse distance '" + clist[2] + "'",
+                    )
             elif clist[0] == "allow" and (clist[1] == "look" or clist[1] == "looking"):
-                if clist[2] == "1" or clist[2] == "true" or clist[2] == "T" or clist[2] == "True":
+                if (
+                    clist[2] == "1"
+                    or clist[2] == "true"
+                    or clist[2] == "T"
+                    or clist[2] == "True"
+                ):
                     g.allow_looking(True)
                 else:
                     g.allow_looking(False)
                 return (MoveGroupInfoLevel.DEBUG, "OK")
-            elif clist[0] == "allow" and (clist[1] == "replan" or clist[1] == "replanning"):
-                if clist[2] == "1" or clist[2] == "true" or clist[2] == "T" or clist[2] == "True":
+            elif clist[0] == "allow" and (
+                clist[1] == "replan" or clist[1] == "replanning"
+            ):
+                if (
+                    clist[2] == "1"
+                    or clist[2] == "true"
+                    or clist[2] == "T"
+                    or clist[2] == "True"
+                ):
                     g.allow_replanning(True)
                 else:
                     g.allow_replanning(False)
@@ -450,10 +629,16 @@ class MoveGroupCommandInterpreter(object):
                     g.set_constraints_database(clist[1], int(clist[2]))
                     self._db_host = clist[1]
                     self._db_port = int(clist[2])
-                    return (MoveGroupInfoLevel.SUCCESS, "Connected to " + self._db_host + ":" + str(self._db_port))
+                    return (
+                        MoveGroupInfoLevel.SUCCESS,
+                        "Connected to " + self._db_host + ":" + str(self._db_port),
+                    )
                 except:
                     self._db_host = None
-                    return (MoveGroupInfoLevel.WARN, "Unable to connect to '" + clist[1] + ":" + clist[2] + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to connect to '" + clist[1] + ":" + clist[2] + "'",
+                    )
         if len(clist) == 4:
             if clist[0] == "rotate":
                 try:
@@ -461,24 +646,34 @@ class MoveGroupCommandInterpreter(object):
                     if g.go():
                         return (MoveGroupInfoLevel.SUCCESS, "Rotation complete")
                     else:
-                        return (MoveGroupInfoLevel.FAIL, "Failed while rotating to " + " ".join(clist[1:]))
+                        return (
+                            MoveGroupInfoLevel.FAIL,
+                            "Failed while rotating to " + " ".join(clist[1:]),
+                        )
                 except MoveItCommanderException as e:
                     return (MoveGroupInfoLevel.WARN, str(e))
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse X-Y-Z rotation  values '" + " ".join(clist[1:]) + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse X-Y-Z rotation  values '"
+                        + " ".join(clist[1:])
+                        + "'",
+                    )
         if len(clist) >= 7:
             if clist[0] == "go":
                 self._last_plan = None
                 approx = False
-                if (len(clist) > 7):
-                    if (clist[7] == "approx" or clist[7] == "approximate"):
+                if len(clist) > 7:
+                    if clist[7] == "approx" or clist[7] == "approximate":
                         approx = True
                 try:
                     p = Pose()
                     p.position.x = float(clist[1])
                     p.position.y = float(clist[2])
                     p.position.z = float(clist[3])
-                    q = tf.transformations.quaternion_from_euler(float(clist[4]), float(clist[5]), float(clist[6]))
+                    q = tf.transformations.quaternion_from_euler(
+                        float(clist[4]), float(clist[5]), float(clist[6])
+                    )
                     p.orientation.x = q[0]
                     p.orientation.y = q[1]
                     p.orientation.z = q[2]
@@ -488,13 +683,25 @@ class MoveGroupCommandInterpreter(object):
                     else:
                         g.set_pose_target(p)
                     if g.go():
-                        return (MoveGroupInfoLevel.SUCCESS, "Moved to pose target\n%s\n" % (str(p)))
+                        return (
+                            MoveGroupInfoLevel.SUCCESS,
+                            "Moved to pose target\n%s\n" % (str(p)),
+                        )
                     else:
-                        return (MoveGroupInfoLevel.FAIL, "Failed while moving to pose \n%s\n" % (str(p)))
+                        return (
+                            MoveGroupInfoLevel.FAIL,
+                            "Failed while moving to pose \n%s\n" % (str(p)),
+                        )
                 except MoveItCommanderException as e:
-                    return (MoveGroupInfoLevel.WARN, "Going to pose target: %s" % (str(e)))
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Going to pose target: %s" % (str(e)),
+                    )
                 except:
-                    return (MoveGroupInfoLevel.WARN, "Unable to parse pose '" + " ".join(clist[1:]) + "'")
+                    return (
+                        MoveGroupInfoLevel.WARN,
+                        "Unable to parse pose '" + " ".join(clist[1:]) + "'",
+                    )
 
         return (MoveGroupInfoLevel.WARN, "Unknown command: '" + cmd + "'")
 
@@ -506,10 +713,27 @@ class MoveGroupCommandInterpreter(object):
         return (MoveGroupInfoLevel.INFO, "\n".join(res))
 
     def command_current(self, g):
-        res = "joints = [" + " ".join([str(x) for x in g.get_current_joint_values()]) + "]"
+        res = (
+            "joints = ["
+            + " ".join([str(x) for x in g.get_current_joint_values()])
+            + "]"
+        )
         if len(g.get_end_effector_link()) > 0:
-            res = res + "\n" + g.get_end_effector_link() + " pose = [\n" + str(g.get_current_pose()) + " ]"
-            res = res + "\n" + g.get_end_effector_link() + " RPY = " + str(g.get_current_rpy())
+            res = (
+                res
+                + "\n"
+                + g.get_end_effector_link()
+                + " pose = [\n"
+                + str(g.get_current_pose())
+                + " ]"
+            )
+            res = (
+                res
+                + "\n"
+                + g.get_end_effector_link()
+                + " RPY = "
+                + str(g.get_current_rpy())
+            )
         return (MoveGroupInfoLevel.INFO, res)
 
     def command_go_offset(self, g, offset, factor, dimension_index, direction_name):
@@ -517,15 +741,24 @@ class MoveGroupCommandInterpreter(object):
             try:
                 g.shift_pose_target(dimension_index, factor * offset)
                 if g.go():
-                    return (MoveGroupInfoLevel.SUCCESS, "Moved " + direction_name + " by " + str(offset) + " m")
+                    return (
+                        MoveGroupInfoLevel.SUCCESS,
+                        "Moved " + direction_name + " by " + str(offset) + " m",
+                    )
                 else:
-                    return (MoveGroupInfoLevel.FAIL, "Failed while moving " + direction_name)
+                    return (
+                        MoveGroupInfoLevel.FAIL,
+                        "Failed while moving " + direction_name,
+                    )
             except MoveItCommanderException as e:
                 return (MoveGroupInfoLevel.WARN, str(e))
             except:
                 return (MoveGroupInfoLevel.WARN, "Unable to process pose update")
         else:
-            return (MoveGroupInfoLevel.WARN, "No known end effector. Cannot move " + direction_name)
+            return (
+                MoveGroupInfoLevel.WARN,
+                "No known end effector. Cannot move " + direction_name,
+            )
 
     def resolve_command_alias(self, cmdorig):
         cmd = cmdorig.lower()
@@ -542,36 +775,68 @@ class MoveGroupCommandInterpreter(object):
         res.append("  allow looking <true|false>       enable/disable looking around")
         res.append("  allow replanning <true|false>    enable/disable replanning")
         res.append("  constrain           clear path constraints")
-        res.append("  constrain <name>    use the constraint <name> as a path constraint")
+        res.append(
+            "  constrain <name>    use the constraint <name> as a path constraint"
+        )
         res.append("  current             show the current state of the active group")
-        res.append("  database            display the current database connection (if any)")
-        res.append("  delete <name>       forget the joint values under the name <name>")
-        res.append("  eef                 print the name of the end effector attached to the current group")
+        res.append(
+            "  database            display the current database connection (if any)"
+        )
+        res.append(
+            "  delete <name>       forget the joint values under the name <name>"
+        )
+        res.append(
+            "  eef                 print the name of the end effector attached to the current group"
+        )
         res.append("  execute             execute a previously computed motion plan")
-        res.append("  go <name>           plan and execute a motion to the state <name>")
+        res.append(
+            "  go <name>           plan and execute a motion to the state <name>"
+        )
         res.append("  go rand             plan and execute a motion to a random state")
-        res.append("  go <dir> <dx>|      plan and execute a motion in direction up|down|left|right|forward|backward for distance <dx>")
+        res.append(
+            "  go <dir> <dx>|      plan and execute a motion in direction up|down|left|right|forward|backward for distance <dx>"
+        )
         res.append("  ground              add a ground plane to the planning scene")
-        res.append("  id|which            display the name of the group that is operated on")
-        res.append("  joints              display names of the joints in the active group")
-        res.append("  load [<file>]       load a set of interpreted commands from a file")
+        res.append(
+            "  id|which            display the name of the group that is operated on"
+        )
+        res.append(
+            "  joints              display names of the joints in the active group"
+        )
+        res.append(
+            "  load [<file>]       load a set of interpreted commands from a file"
+        )
         res.append("  pick <name>         pick up object <name>")
         res.append("  place <name>        place object <name>")
         res.append("  plan <name>         plan a motion to the state <name>")
         res.append("  plan rand           plan a motion to a random state")
         res.append("  planner <name>      use planner <name> to plan next motion")
-        res.append("  record <name>       record the current joint values under the name <name>")
-        res.append("  rotate <x> <y> <z>  plan and execute a motion to a specified orientation (about the X,Y,Z axes)")
-        res.append("  save [<file>]       save the currently known variables as a set of commands")
-        res.append("  show                display the names and values of the known states")
+        res.append(
+            "  record <name>       record the current joint values under the name <name>"
+        )
+        res.append(
+            "  rotate <x> <y> <z>  plan and execute a motion to a specified orientation (about the X,Y,Z axes)"
+        )
+        res.append(
+            "  save [<file>]       save the currently known variables as a set of commands"
+        )
+        res.append(
+            "  show                display the names and values of the known states"
+        )
         res.append("  show <name>         display the value of a state")
         res.append("  stop                stop the active group")
         res.append("  time                show the configured allowed planning time")
         res.append("  time <val>          set the allowed planning time")
-        res.append("  tolerance           show the tolerance for reaching the goal region")
-        res.append("  tolerance <val>     set the tolerance for reaching the goal region")
+        res.append(
+            "  tolerance           show the tolerance for reaching the goal region"
+        )
+        res.append(
+            "  tolerance <val>     set the tolerance for reaching the goal region"
+        )
         res.append("  trace <on|off>      enable/disable replanning or looking around")
-        res.append("  use <name>          switch to using the group named <name> (and load it if necessary)")
+        res.append(
+            "  use <name>          switch to using the group named <name> (and load it if necessary)"
+        )
         res.append("  use|groups          show the group names that are already loaded")
         res.append("  vars                display the names of the known states")
         res.append("  wait <dt>           sleep for <dt> seconds")
@@ -587,27 +852,30 @@ class MoveGroupCommandInterpreter(object):
             known_vars = self.get_active_group().get_remembered_joint_values().keys()
             known_constr = self.get_active_group().get_known_constraints()
         groups = self._robot.get_group_names()
-        return {'go':['up', 'down', 'left', 'right', 'backward', 'forward', 'random'] + list(known_vars),
-                'help':[],
-                'record':known_vars,
-                'show':known_vars,
-                'wait':[],
-                'delete':known_vars,
-                'database': [],
-                'current':[],
-                'use':groups,
-                'load':[],
-                'save':[],
-                'pick':[],
-                'place':[],
-                'plan':known_vars,
-                'allow':['replanning', 'looking'],
-                'constrain':known_constr,
-                'vars':[],
-                'joints':[],
-                'tolerance':[],
-                'time':[],
-                'eef':[],
-                'execute':[],
-                'ground':[],
-                'id':[]}
+        return {
+            "go": ["up", "down", "left", "right", "backward", "forward", "random"]
+            + list(known_vars),
+            "help": [],
+            "record": known_vars,
+            "show": known_vars,
+            "wait": [],
+            "delete": known_vars,
+            "database": [],
+            "current": [],
+            "use": groups,
+            "load": [],
+            "save": [],
+            "pick": [],
+            "place": [],
+            "plan": known_vars,
+            "allow": ["replanning", "looking"],
+            "constrain": known_constr,
+            "vars": [],
+            "joints": [],
+            "tolerance": [],
+            "time": [],
+            "eef": [],
+            "execute": [],
+            "ground": [],
+            "id": [],
+        }

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -33,8 +33,18 @@
 # Author: Ioan Sucan, William Baker
 
 from geometry_msgs.msg import Pose, PoseStamped
-from moveit_msgs.msg import RobotTrajectory, Grasp, PlaceLocation, Constraints, RobotState
-from moveit_msgs.msg import MoveItErrorCodes, TrajectoryConstraints, PlannerInterfaceDescription
+from moveit_msgs.msg import (
+    RobotTrajectory,
+    Grasp,
+    PlaceLocation,
+    Constraints,
+    RobotState,
+)
+from moveit_msgs.msg import (
+    MoveItErrorCodes,
+    TrajectoryConstraints,
+    PlannerInterfaceDescription,
+)
 from sensor_msgs.msg import JointState
 import rospy
 import tf
@@ -48,9 +58,13 @@ class MoveGroupCommander(object):
     Execution of simple commands for a particular group
     """
 
-    def __init__(self, name, robot_description="robot_description", ns="", wait_for_servers=5.0):
+    def __init__(
+        self, name, robot_description="robot_description", ns="", wait_for_servers=5.0
+    ):
         """ Specify the group name for which to construct this commander instance. Throws an exception if there is an initialization error. """
-        self._g = _moveit_move_group_interface.MoveGroupInterface(name, robot_description, ns, wait_for_servers)
+        self._g = _moveit_move_group_interface.MoveGroupInterface(
+            name, robot_description, ns, wait_for_servers
+        )
 
     def get_name(self):
         """ Get the name of the group this instance was initialized for """
@@ -110,9 +124,13 @@ class MoveGroupCommander(object):
     def get_current_pose(self, end_effector_link=""):
         """ Get the current pose of the end-effector of the group. Throws an exception if there is not end-effector. """
         if len(end_effector_link) > 0 or self.has_end_effector_link():
-            return conversions.list_to_pose_stamped(self._g.get_current_pose(end_effector_link), self.get_planning_frame())
+            return conversions.list_to_pose_stamped(
+                self._g.get_current_pose(end_effector_link), self.get_planning_frame()
+            )
         else:
-            raise MoveItCommanderException("There is no end effector to get the pose of")
+            raise MoveItCommanderException(
+                "There is no end effector to get the pose of"
+            )
 
     def get_current_rpy(self, end_effector_link=""):
         """ Get a list of 3 elements defining the [roll, pitch, yaw] of the end-effector. Throws an exception if there is not end-effector. """
@@ -126,9 +144,13 @@ class MoveGroupCommander(object):
 
     def get_random_pose(self, end_effector_link=""):
         if len(end_effector_link) > 0 or self.has_end_effector_link():
-            return conversions.list_to_pose_stamped(self._g.get_random_pose(end_effector_link), self.get_planning_frame())
+            return conversions.list_to_pose_stamped(
+                self._g.get_random_pose(end_effector_link), self.get_planning_frame()
+            )
         else:
-            raise MoveItCommanderException("There is no end effector to get the pose of")
+            raise MoveItCommanderException(
+                "There is no end effector to get the pose of"
+            )
 
     def set_start_state_to_current_state(self):
         self._g.set_start_state_to_current_state()
@@ -189,26 +211,36 @@ class MoveGroupCommander(object):
         """
         if isinstance(arg1, RobotState):
             if not self._g.set_state_value_target(conversions.msg_to_string(arg1)):
-                raise MoveItCommanderException("Error setting state target. Is the target state within bounds?")
+                raise MoveItCommanderException(
+                    "Error setting state target. Is the target state within bounds?"
+                )
 
         elif isinstance(arg1, JointState):
-            if (arg2 is not None or arg3 is not None):
+            if arg2 is not None or arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
-            if not self._g.set_joint_value_target_from_joint_state_message(conversions.msg_to_string(arg1)):
-                raise MoveItCommanderException("Error setting joint target. Is the target within bounds?")
+            if not self._g.set_joint_value_target_from_joint_state_message(
+                conversions.msg_to_string(arg1)
+            ):
+                raise MoveItCommanderException(
+                    "Error setting joint target. Is the target within bounds?"
+                )
 
         elif isinstance(arg1, str):
-            if (arg2 is None):
-                raise MoveItCommanderException("Joint value expected when joint name specified")
-            if (arg3 is not None):
+            if arg2 is None:
+                raise MoveItCommanderException(
+                    "Joint value expected when joint name specified"
+                )
+            if arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
             if not self._g.set_joint_value_target(arg1, arg2):
-                raise MoveItCommanderException("Error setting joint target. Is the target within bounds?")
+                raise MoveItCommanderException(
+                    "Error setting joint target. Is the target within bounds?"
+                )
 
         elif isinstance(arg1, (Pose, PoseStamped)):
             approx = False
             eef = ""
-            if (arg2 is not None):
+            if arg2 is not None:
                 if type(arg2) is str:
                     eef = arg2
                 else:
@@ -216,7 +248,7 @@ class MoveGroupCommander(object):
                         approx = arg2
                     else:
                         raise MoveItCommanderException("Unexpected type")
-            if (arg3 is not None):
+            if arg3 is not None:
                 if type(arg3) is str:
                     eef = arg3
                 else:
@@ -226,53 +258,77 @@ class MoveGroupCommander(object):
                         raise MoveItCommanderException("Unexpected type")
             r = False
             if type(arg1) is PoseStamped:
-                r = self._g.set_joint_value_target_from_pose_stamped(conversions.msg_to_string(arg1), eef, approx)
+                r = self._g.set_joint_value_target_from_pose_stamped(
+                    conversions.msg_to_string(arg1), eef, approx
+                )
             else:
-                r = self._g.set_joint_value_target_from_pose(conversions.msg_to_string(arg1), eef, approx)
+                r = self._g.set_joint_value_target_from_pose(
+                    conversions.msg_to_string(arg1), eef, approx
+                )
             if not r:
                 if approx:
-                    raise MoveItCommanderException("Error setting joint target. Does your IK solver support approximate IK?")
+                    raise MoveItCommanderException(
+                        "Error setting joint target. Does your IK solver support approximate IK?"
+                    )
                 else:
-                    raise MoveItCommanderException("Error setting joint target. Is the IK solver functional?")
+                    raise MoveItCommanderException(
+                        "Error setting joint target. Is the IK solver functional?"
+                    )
 
-        elif (hasattr(arg1, '__iter__')):
-            if (arg2 is not None or arg3 is not None):
+        elif hasattr(arg1, "__iter__"):
+            if arg2 is not None or arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
             if not self._g.set_joint_value_target(arg1):
-                raise MoveItCommanderException("Error setting joint target. Is the target within bounds?")
+                raise MoveItCommanderException(
+                    "Error setting joint target. Is the target within bounds?"
+                )
 
         else:
-            raise MoveItCommanderException("Unsupported argument of type %s" % type(arg1))
+            raise MoveItCommanderException(
+                "Unsupported argument of type %s" % type(arg1)
+            )
 
     def set_rpy_target(self, rpy, end_effector_link=""):
         """ Specify a target orientation for the end-effector. Any position of the end-effector is acceptable."""
         if len(end_effector_link) > 0 or self.has_end_effector_link():
             if len(rpy) == 3:
-                if not self._g.set_rpy_target(rpy[0], rpy[1], rpy[2], end_effector_link):
+                if not self._g.set_rpy_target(
+                    rpy[0], rpy[1], rpy[2], end_effector_link
+                ):
                     raise MoveItCommanderException("Unable to set orientation target")
             else:
                 raise MoveItCommanderException("Expected [roll, pitch, yaw]")
         else:
-            raise MoveItCommanderException("There is no end effector to set the pose for")
+            raise MoveItCommanderException(
+                "There is no end effector to set the pose for"
+            )
 
     def set_orientation_target(self, q, end_effector_link=""):
         """ Specify a target orientation for the end-effector. Any position of the end-effector is acceptable."""
         if len(end_effector_link) > 0 or self.has_end_effector_link():
             if len(q) == 4:
-                if not self._g.set_orientation_target(q[0], q[1], q[2], q[3], end_effector_link):
+                if not self._g.set_orientation_target(
+                    q[0], q[1], q[2], q[3], end_effector_link
+                ):
                     raise MoveItCommanderException("Unable to set orientation target")
             else:
                 raise MoveItCommanderException("Expected [qx, qy, qz, qw]")
         else:
-            raise MoveItCommanderException("There is no end effector to set the pose for")
+            raise MoveItCommanderException(
+                "There is no end effector to set the pose for"
+            )
 
     def set_position_target(self, xyz, end_effector_link=""):
         """ Specify a target position for the end-effector. Any orientation of the end-effector is acceptable."""
         if len(end_effector_link) > 0 or self.has_end_effector_link():
-            if not self._g.set_position_target(xyz[0], xyz[1], xyz[2], end_effector_link):
+            if not self._g.set_position_target(
+                xyz[0], xyz[1], xyz[2], end_effector_link
+            ):
                 raise MoveItCommanderException("Unable to set position target")
         else:
-            raise MoveItCommanderException("There is no end effector to set the pose for")
+            raise MoveItCommanderException(
+                "There is no end effector to set the pose for"
+            )
 
     def set_pose_target(self, pose, end_effector_link=""):
         """ Set the pose of the end-effector, if one is available. The expected input is a Pose message, a PoseStamped message or a list of 6 floats:"""
@@ -282,21 +338,30 @@ class MoveGroupCommander(object):
             if type(pose) is PoseStamped:
                 old = self.get_pose_reference_frame()
                 self.set_pose_reference_frame(pose.header.frame_id)
-                ok = self._g.set_pose_target(conversions.pose_to_list(pose.pose), end_effector_link)
+                ok = self._g.set_pose_target(
+                    conversions.pose_to_list(pose.pose), end_effector_link
+                )
                 self.set_pose_reference_frame(old)
             elif type(pose) is Pose:
-                ok = self._g.set_pose_target(conversions.pose_to_list(pose), end_effector_link)
+                ok = self._g.set_pose_target(
+                    conversions.pose_to_list(pose), end_effector_link
+                )
             else:
                 ok = self._g.set_pose_target(pose, end_effector_link)
             if not ok:
                 raise MoveItCommanderException("Unable to set target pose")
         else:
-            raise MoveItCommanderException("There is no end effector to set the pose for")
+            raise MoveItCommanderException(
+                "There is no end effector to set the pose for"
+            )
 
     def set_pose_targets(self, poses, end_effector_link=""):
         """ Set the pose of the end-effector, if one is available. The expected input is a list of poses. Each pose can be a Pose message, a list of 6 floats: [x, y, z, rot_x, rot_y, rot_z] or a list of 7 floats [x, y, z, qx, qy, qz, qw] """
         if len(end_effector_link) > 0 or self.has_end_effector_link():
-            if not self._g.set_pose_targets([conversions.pose_to_list(p) if type(p) is Pose else p for p in poses], end_effector_link):
+            if not self._g.set_pose_targets(
+                [conversions.pose_to_list(p) if type(p) is Pose else p for p in poses],
+                end_effector_link,
+            ):
                 raise MoveItCommanderException("Unable to set target poses")
         else:
             raise MoveItCommanderException("There is no end effector to set poses for")
@@ -337,7 +402,9 @@ class MoveGroupCommander(object):
     def set_named_target(self, name):
         """ Set a joint configuration by name. The name can be a name previlusy remembered with remember_joint_values() or a configuration specified in the SRDF. """
         if not self._g.set_named_target(name):
-            raise MoveItCommanderException("Unable to set target %s. Is the target within bounds?" % name)
+            raise MoveItCommanderException(
+                "Unable to set target %s. Is the target within bounds?" % name
+            )
 
     def get_named_target_values(self, target):
         """Get a dictionary of joint values of a named target"""
@@ -359,7 +426,11 @@ class MoveGroupCommander(object):
 
     def get_goal_tolerance(self):
         """ Return a tuple of goal tolerances: joint, position and orientation. """
-        return (self.get_goal_joint_tolerance(), self.get_goal_position_tolerance(), self.get_goal_orientation_tolerance())
+        return (
+            self.get_goal_joint_tolerance(),
+            self.get_goal_position_tolerance(),
+            self.get_goal_orientation_tolerance(),
+        )
 
     def get_goal_joint_tolerance(self):
         """ Get the tolerance for achieving a joint goal (distance for each joint variable) """
@@ -416,7 +487,9 @@ class MoveGroupCommander(object):
             if type(value) is Constraints:
                 self._g.set_path_constraints_from_msg(conversions.msg_to_string(value))
             elif not self._g.set_path_constraints(value):
-                raise MoveItCommanderException("Unable to set path constraints " + value)
+                raise MoveItCommanderException(
+                    "Unable to set path constraints " + value
+                )
 
     def clear_path_constraints(self):
         """ Specify that no path constraints are to be used during motion planning """
@@ -435,9 +508,13 @@ class MoveGroupCommander(object):
             self.clear_trajectory_constraints()
         else:
             if type(value) is TrajectoryConstraints:
-                self._g.set_trajectory_constraints_from_msg(conversions.msg_to_string(value))
+                self._g.set_trajectory_constraints_from_msg(
+                    conversions.msg_to_string(value)
+                )
             elif not self._g.set_trajectory_constraints(value):
-                raise MoveItCommanderException("Unable to set trajectory constraints " + value)
+                raise MoveItCommanderException(
+                    "Unable to set trajectory constraints " + value
+                )
 
     def clear_trajectory_constraints(self):
         """ Specify that no trajectory constraints are to be used during motion planning """
@@ -478,23 +555,29 @@ class MoveGroupCommander(object):
                 if len(ws) == 6:
                     self._g.set_workspace(ws[0], ws[1], ws[2], ws[3], ws[4], ws[5])
                 else:
-                    raise MoveItCommanderException("Expected 0, 4 or 6 values in list specifying workspace")
+                    raise MoveItCommanderException(
+                        "Expected 0, 4 or 6 values in list specifying workspace"
+                    )
 
     def set_max_velocity_scaling_factor(self, value):
-        """ Set a scaling factor to reduce the maximum joint velocities. Allowed values are in (0,1].
-            The default value is set in the joint_limits.yaml of the moveit_config package. """
+        """Set a scaling factor to reduce the maximum joint velocities. Allowed values are in (0,1].
+        The default value is set in the joint_limits.yaml of the moveit_config package."""
         if value > 0 and value <= 1:
             self._g.set_max_velocity_scaling_factor(value)
         else:
-            raise MoveItCommanderException("Expected value in the range from 0 to 1 for scaling factor")
+            raise MoveItCommanderException(
+                "Expected value in the range from 0 to 1 for scaling factor"
+            )
 
     def set_max_acceleration_scaling_factor(self, value):
-        """ Set a scaling factor to reduce the maximum joint accelerations. Allowed values are in (0,1].
-            The default value is set in the joint_limits.yaml of the moveit_config package. """
+        """Set a scaling factor to reduce the maximum joint accelerations. Allowed values are in (0,1].
+        The default value is set in the joint_limits.yaml of the moveit_config package."""
         if value > 0 and value <= 1:
             self._g.set_max_acceleration_scaling_factor(value)
         else:
-            raise MoveItCommanderException("Expected value in the range from 0 to 1 for scaling factor")
+            raise MoveItCommanderException(
+                "Expected value in the range from 0 to 1 for scaling factor"
+            )
 
     def go(self, joints=None, wait=True):
         """ Set the target of the group and then move the group to the specified target """
@@ -519,9 +602,9 @@ class MoveGroupCommander(object):
             return self._g.async_move()
 
     def plan(self, joints=None):
-        """ Return a tuple of the motion planning results such as
-            (success flag : boolean, trajectory message : RobotTrajectory,
-             planning time : float, error code : MoveitErrorCodes) """
+        """Return a tuple of the motion planning results such as
+        (success flag : boolean, trajectory message : RobotTrajectory,
+         planning time : float, error code : MoveitErrorCodes)"""
         if type(joints) is JointState:
             self.set_joint_value_target(joints)
 
@@ -539,21 +622,44 @@ class MoveGroupCommander(object):
         error_code = MoveItErrorCodes()
         error_code.deserialize(error_code_msg)
         plan = RobotTrajectory()
-        return (error_code.val == MoveItErrorCodes.SUCCESS,
-                plan.deserialize(trajectory_msg),
-                planning_time,
-                error_code)
+        return (
+            error_code.val == MoveItErrorCodes.SUCCESS,
+            plan.deserialize(trajectory_msg),
+            planning_time,
+            error_code,
+        )
 
-    def compute_cartesian_path(self, waypoints, eef_step, jump_threshold, avoid_collisions=True, path_constraints=None):
+    def compute_cartesian_path(
+        self,
+        waypoints,
+        eef_step,
+        jump_threshold,
+        avoid_collisions=True,
+        path_constraints=None,
+    ):
         """ Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory. """
         if path_constraints:
             if type(path_constraints) is Constraints:
                 constraints_str = conversions.msg_to_string(path_constraints)
             else:
-                raise MoveItCommanderException("Unable to set path constraints, unknown constraint type " + type(path_constraints))
-            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions, constraints_str)
+                raise MoveItCommanderException(
+                    "Unable to set path constraints, unknown constraint type "
+                    + type(path_constraints)
+                )
+            (ser_path, fraction) = self._g.compute_cartesian_path(
+                [conversions.pose_to_list(p) for p in waypoints],
+                eef_step,
+                jump_threshold,
+                avoid_collisions,
+                constraints_str,
+            )
         else:
-            (ser_path, fraction) = self._g.compute_cartesian_path([conversions.pose_to_list(p) for p in waypoints], eef_step, jump_threshold, avoid_collisions)
+            (ser_path, fraction) = self._g.compute_cartesian_path(
+                [conversions.pose_to_list(p) for p in waypoints],
+                eef_step,
+                jump_threshold,
+                avoid_collisions,
+            )
 
         path = RobotTrajectory()
         path.deserialize(ser_path)
@@ -577,9 +683,13 @@ class MoveGroupCommander(object):
     def pick(self, object_name, grasp=[], plan_only=False):
         """Pick the named object. A grasp message, or a list of Grasp messages can also be specified as argument."""
         if type(grasp) is Grasp:
-            return self._g.pick(object_name, conversions.msg_to_string(grasp), plan_only)
+            return self._g.pick(
+                object_name, conversions.msg_to_string(grasp), plan_only
+            )
         else:
-            return self._g.pick(object_name, [conversions.msg_to_string(x) for x in grasp], plan_only)
+            return self._g.pick(
+                object_name, [conversions.msg_to_string(x) for x in grasp], plan_only
+            )
 
     def place(self, object_name, location=None, plan_only=False):
         """Place the named object at a particular location in the environment or somewhere safe in the world if location is not provided"""
@@ -589,39 +699,73 @@ class MoveGroupCommander(object):
         elif type(location) is PoseStamped:
             old = self.get_pose_reference_frame()
             self.set_pose_reference_frame(location.header.frame_id)
-            result = self._g.place(object_name, conversions.pose_to_list(location.pose), plan_only)
+            result = self._g.place(
+                object_name, conversions.pose_to_list(location.pose), plan_only
+            )
             self.set_pose_reference_frame(old)
         elif type(location) is Pose:
-            result = self._g.place(object_name, conversions.pose_to_list(location), plan_only)
+            result = self._g.place(
+                object_name, conversions.pose_to_list(location), plan_only
+            )
         elif type(location) is PlaceLocation:
-            result = self._g.place(object_name, conversions.msg_to_string(location), plan_only)
+            result = self._g.place(
+                object_name, conversions.msg_to_string(location), plan_only
+            )
         elif type(location) is list:
             if location:
                 if type(location[0]) is PlaceLocation:
-                    result = self._g.place_locations_list(object_name, [conversions.msg_to_string(x) for x in location], plan_only)
+                    result = self._g.place_locations_list(
+                        object_name,
+                        [conversions.msg_to_string(x) for x in location],
+                        plan_only,
+                    )
                 elif type(location[0]) is PoseStamped:
-                    result = self._g.place_poses_list(object_name, [conversions.msg_to_string(x) for x in location], plan_only)
+                    result = self._g.place_poses_list(
+                        object_name,
+                        [conversions.msg_to_string(x) for x in location],
+                        plan_only,
+                    )
                 else:
-                    raise MoveItCommanderException("Parameter location must be a Pose, PoseStamped, PlaceLocation, list of PoseStamped or list of PlaceLocation object")
+                    raise MoveItCommanderException(
+                        "Parameter location must be a Pose, PoseStamped, PlaceLocation, list of PoseStamped or list of PlaceLocation object"
+                    )
         else:
-            raise MoveItCommanderException("Parameter location must be a Pose, PoseStamped, PlaceLocation, list of PoseStamped or list of PlaceLocation object")
+            raise MoveItCommanderException(
+                "Parameter location must be a Pose, PoseStamped, PlaceLocation, list of PoseStamped or list of PlaceLocation object"
+            )
         return result
 
     def set_support_surface_name(self, value):
         """ Set the support surface name for a place operation """
         self._g.set_support_surface_name(value)
 
-    def retime_trajectory(self, ref_state_in, traj_in, velocity_scaling_factor=1.0, acceleration_scaling_factor=1.0, algorithm="iterative_time_parameterization"):
+    def retime_trajectory(
+        self,
+        ref_state_in,
+        traj_in,
+        velocity_scaling_factor=1.0,
+        acceleration_scaling_factor=1.0,
+        algorithm="iterative_time_parameterization",
+    ):
         ser_ref_state_in = conversions.msg_to_string(ref_state_in)
         ser_traj_in = conversions.msg_to_string(traj_in)
-        ser_traj_out = self._g.retime_trajectory(ser_ref_state_in, ser_traj_in, velocity_scaling_factor, acceleration_scaling_factor, algorithm)
+        ser_traj_out = self._g.retime_trajectory(
+            ser_ref_state_in,
+            ser_traj_in,
+            velocity_scaling_factor,
+            acceleration_scaling_factor,
+            algorithm,
+        )
         traj_out = RobotTrajectory()
         traj_out.deserialize(ser_traj_out)
         return traj_out
 
     def get_jacobian_matrix(self, joint_values, reference_point=None):
         """ Get the jacobian matrix of the group as a list"""
-        return self._g.get_jacobian_matrix(joint_values, [0.0, 0.0, 0.0] if reference_point is None else reference_point)
+        return self._g.get_jacobian_matrix(
+            joint_values,
+            [0.0, 0.0, 0.0] if reference_point is None else reference_point,
+        )
 
     def enforce_bounds(self, robot_state_msg):
         """ Takes a moveit_msgs RobotState and enforces the state bounds, based on the C++ RobotState enforceBounds() """

--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -51,21 +51,31 @@ except:
         import pyassimp
     except:
         pyassimp = False
-        print("Failed to import pyassimp, see https://github.com/ros-planning/moveit/issues/86 for more info")
+        print(
+            "Failed to import pyassimp, see https://github.com/ros-planning/moveit/issues/86 for more info"
+        )
 
 
 class PlanningSceneInterface(object):
     """ Simple interface to making updates to a planning scene """
 
-    def __init__(self, ns='', synchronous=False, service_timeout=5.0):
+    def __init__(self, ns="", synchronous=False, service_timeout=5.0):
         """ Create a planning scene interface; it uses both C++ wrapped methods and scene manipulation topics. """
         self._psi = _moveit_planning_scene_interface.PlanningSceneInterface(ns)
 
-        self._pub_co = rospy.Publisher(ns_join(ns, 'collision_object'), CollisionObject, queue_size=100)
-        self._pub_aco = rospy.Publisher(ns_join(ns, 'attached_collision_object'), AttachedCollisionObject, queue_size=100)
+        self._pub_co = rospy.Publisher(
+            ns_join(ns, "collision_object"), CollisionObject, queue_size=100
+        )
+        self._pub_aco = rospy.Publisher(
+            ns_join(ns, "attached_collision_object"),
+            AttachedCollisionObject,
+            queue_size=100,
+        )
         self.__synchronous = synchronous
         if self.__synchronous:
-            self._apply_planning_scene_diff = rospy.ServiceProxy(ns_join(ns, 'apply_planning_scene'), ApplyPlanningScene)
+            self._apply_planning_scene_diff = rospy.ServiceProxy(
+                ns_join(ns, "apply_planning_scene"), ApplyPlanningScene
+            )
             self._apply_planning_scene_diff.wait_for_service(service_timeout)
 
     def __submit(self, collision_object, attach=False):
@@ -119,7 +129,9 @@ class PlanningSceneInterface(object):
         co.plane_poses = [pose.pose]
         self.__submit(co, attach=False)
 
-    def attach_mesh(self, link, name, pose=None, filename='', size=(1, 1, 1), touch_links=[]):
+    def attach_mesh(
+        self, link, name, pose=None, filename="", size=(1, 1, 1), touch_links=[]
+    ):
         aco = AttachedCollisionObject()
         if (pose is not None) and filename:
             aco.object = self.__make_mesh(name, pose, filename, size)
@@ -171,12 +183,16 @@ class PlanningSceneInterface(object):
         """
         return self._psi.get_known_object_names(with_type)
 
-    def get_known_object_names_in_roi(self, minx, miny, minz, maxx, maxy, maxz, with_type=False):
+    def get_known_object_names_in_roi(
+        self, minx, miny, minz, maxx, maxy, maxz, with_type=False
+    ):
         """
         Get the names of known objects in the world that are located within a bounding region (specified in the frame reported by
         get_planning_frame()). If with_type is set to true, only return objects that have a known type.
         """
-        return self._psi.get_known_object_names_in_roi(minx, miny, minz, maxx, maxy, maxz, with_type)
+        return self._psi.get_known_object_names_in_roi(
+            minx, miny, minz, maxx, maxy, maxz, with_type
+        )
 
     def get_object_poses(self, object_ids):
         """
@@ -241,7 +257,8 @@ class PlanningSceneInterface(object):
         co = CollisionObject()
         if pyassimp is False:
             raise MoveItCommanderException(
-                "Pyassimp needs patch https://launchpadlibrarian.net/319496602/patchPyassim.txt")
+                "Pyassimp needs patch https://launchpadlibrarian.net/319496602/patchPyassim.txt"
+            )
         scene = pyassimp.load(filename)
         if not scene.meshes or len(scene.meshes) == 0:
             raise MoveItCommanderException("There are no meshes in the file")
@@ -253,22 +270,26 @@ class PlanningSceneInterface(object):
 
         mesh = Mesh()
         first_face = scene.meshes[0].faces[0]
-        if hasattr(first_face, '__len__'):
+        if hasattr(first_face, "__len__"):
             for face in scene.meshes[0].faces:
                 if len(face) == 3:
                     triangle = MeshTriangle()
                     triangle.vertex_indices = [face[0], face[1], face[2]]
                     mesh.triangles.append(triangle)
-        elif hasattr(first_face, 'indices'):
+        elif hasattr(first_face, "indices"):
             for face in scene.meshes[0].faces:
                 if len(face.indices) == 3:
                     triangle = MeshTriangle()
-                    triangle.vertex_indices = [face.indices[0],
-                                               face.indices[1],
-                                               face.indices[2]]
+                    triangle.vertex_indices = [
+                        face.indices[0],
+                        face.indices[1],
+                        face.indices[2],
+                    ]
                     mesh.triangles.append(triangle)
         else:
-            raise MoveItCommanderException("Unable to build triangles from mesh due to mesh object structure")
+            raise MoveItCommanderException(
+                "Unable to build triangles from mesh due to mesh object structure"
+            )
         for vertex in scene.meshes[0].vertices:
             point = Point()
             point.x = vertex[0] * scale[0]

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -40,7 +40,6 @@ import moveit_commander.conversions as conversions
 
 
 class RobotCommander(object):
-
     class Joint(object):
         def __init__(self, robot, name):
             self._robot = robot
@@ -116,7 +115,10 @@ class RobotCommander(object):
             """
             group = self._robot.get_default_owner_group(self.name())
             if group is None:
-                raise MoveItCommanderException("There is no known group containing joint %s. Cannot move." % self._name)
+                raise MoveItCommanderException(
+                    "There is no known group containing joint %s. Cannot move."
+                    % self._name
+                )
             gc = self._robot.get_group(group)
             if gc is not None:
                 gc.set_joint_value_target(gc.get_current_joint_values())
@@ -143,7 +145,10 @@ class RobotCommander(object):
             """
             @rtype: geometry_msgs.Pose
             """
-            return conversions.list_to_pose_stamped(self._robot._r.get_link_pose(self._name), self._robot.get_planning_frame())
+            return conversions.list_to_pose_stamped(
+                self._robot._r.get_link_pose(self._name),
+                self._robot.get_planning_frame(),
+            )
 
     def __init__(self, robot_description="robot_description", ns=""):
         self._robot_description = robot_description
@@ -264,7 +269,9 @@ class RobotCommander(object):
         if not name in self._groups:
             if not self.has_group(name):
                 raise MoveItCommanderException("There is no group named %s" % name)
-            self._groups[name] = MoveGroupCommander(name, self._robot_description, self._ns)
+            self._groups[name] = MoveGroupCommander(
+                name, self._robot_description, self._ns
+            )
         return self._groups[name]
 
     def has_group(self, name):
@@ -286,7 +293,9 @@ class RobotCommander(object):
                     if group is None:
                         group = g
                     else:
-                        if len(self.get_link_names(g)) < len(self.get_link_names(group)):
+                        if len(self.get_link_names(g)) < len(
+                            self.get_link_names(group)
+                        ):
                             group = g
             self._joint_owner_groups[joint_name] = group
         return self._joint_owner_groups[joint_name]

--- a/moveit_commander/src/moveit_commander/roscpp_initializer.py
+++ b/moveit_commander/src/moveit_commander/roscpp_initializer.py
@@ -34,10 +34,12 @@
 
 from moveit_ros_planning_interface import _moveit_roscpp_initializer
 
+
 def roscpp_initialize(args):
     # remove __name:= argument
-    args2 = [ a for a in args if not a.startswith("__name:=") ]
+    args2 = [a for a in args if not a.startswith("__name:=")]
     _moveit_roscpp_initializer.roscpp_init("move_group_commander_wrappers", args2)
+
 
 def roscpp_shutdown():
     _moveit_roscpp_initializer.roscpp_shutdown()

--- a/moveit_commander/test/python_moveit_commander.py
+++ b/moveit_commander/test/python_moveit_commander.py
@@ -66,8 +66,15 @@ class PythonMoveitCommanderTest(unittest.TestCase):
 
     def test_enforce_bounds(self):
         in_msg = RobotState()
-        in_msg.joint_state.header.frame_id = 'base_link'
-        in_msg.joint_state.name = ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']
+        in_msg.joint_state.header.frame_id = "base_link"
+        in_msg.joint_state.name = [
+            "joint_1",
+            "joint_2",
+            "joint_3",
+            "joint_4",
+            "joint_5",
+            "joint_6",
+        ]
         in_msg.joint_state.position = [0] * 6
         in_msg.joint_state.position[0] = 1000
 
@@ -78,9 +85,16 @@ class PythonMoveitCommanderTest(unittest.TestCase):
 
     def test_get_current_state(self):
         expected_state = RobotState()
-        expected_state.joint_state.header.frame_id = 'base_link'
-        expected_state.multi_dof_joint_state.header.frame_id = 'base_link'
-        expected_state.joint_state.name = ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']
+        expected_state.joint_state.header.frame_id = "base_link"
+        expected_state.multi_dof_joint_state.header.frame_id = "base_link"
+        expected_state.joint_state.name = [
+            "joint_1",
+            "joint_2",
+            "joint_3",
+            "joint_4",
+            "joint_5",
+            "joint_6",
+        ]
         expected_state.joint_state.position = [0] * 6
         self.assertEqual(self.group.get_current_state(), expected_state)
 
@@ -89,15 +103,19 @@ class PythonMoveitCommanderTest(unittest.TestCase):
             args = [expect]
         self.group.set_joint_value_target(*args)
         res = self.group.get_joint_value_target()
-        self.assertTrue(np.all(np.asarray(res) == np.asarray(expect)),
-                        "Setting failed for %s, values: %s" % (type(args[0]), res))
+        self.assertTrue(
+            np.all(np.asarray(res) == np.asarray(expect)),
+            "Setting failed for %s, values: %s" % (type(args[0]), res),
+        )
 
     def test_target_setting(self):
         n = self.group.get_variable_count()
         self.check_target_setting([0.1] * n)
         self.check_target_setting((0.2,) * n)
         self.check_target_setting(np.zeros(n))
-        self.check_target_setting([0.3] * n, {name: 0.3 for name in self.group.get_active_joints()})
+        self.check_target_setting(
+            [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
+        )
         self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
 
     def plan(self, target):
@@ -127,9 +145,9 @@ class PythonMoveitCommanderTest(unittest.TestCase):
         planning_scene = PlanningSceneInterface()
 
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_moveit_commander'
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_moveit_commander"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveitCommanderTest)
 

--- a/moveit_commander/test/python_moveit_commander_ns.py
+++ b/moveit_commander/test/python_moveit_commander_ns.py
@@ -52,7 +52,9 @@ class PythonMoveitCommanderNsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.commander = RobotCommander("%srobot_description" % self.PLANNING_NS, self.PLANNING_NS)
+        self.commander = RobotCommander(
+            "%srobot_description" % self.PLANNING_NS, self.PLANNING_NS
+        )
         self.group = self.commander.get_group(self.PLANNING_GROUP)
 
     @classmethod
@@ -64,15 +66,19 @@ class PythonMoveitCommanderNsTest(unittest.TestCase):
             args = [expect]
         self.group.set_joint_value_target(*args)
         res = self.group.get_joint_value_target()
-        self.assertTrue(np.all(np.asarray(res) == np.asarray(expect)),
-                        "Setting failed for %s, values: %s" % (type(args[0]), res))
+        self.assertTrue(
+            np.all(np.asarray(res) == np.asarray(expect)),
+            "Setting failed for %s, values: %s" % (type(args[0]), res),
+        )
 
     def test_target_setting(self):
         n = self.group.get_variable_count()
         self.check_target_setting([0.1] * n)
         self.check_target_setting((0.2,) * n)
         self.check_target_setting(np.zeros(n))
-        self.check_target_setting([0.3] * n, {name: 0.3 for name in self.group.get_active_joints()})
+        self.check_target_setting(
+            [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
+        )
         self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
 
     def plan(self, target):
@@ -99,9 +105,9 @@ class PythonMoveitCommanderNsTest(unittest.TestCase):
         self.assertTrue(self.group.execute(plan3))
 
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_moveit_commander_ns'
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_moveit_commander_ns"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveitCommanderNsTest)
 

--- a/moveit_commander/test/python_moveit_commander_ros_namespace.py
+++ b/moveit_commander/test/python_moveit_commander_ros_namespace.py
@@ -46,7 +46,6 @@ from moveit_commander import PlanningSceneInterface
 
 
 class PythonMoveitCommanderRosNamespaceTest(unittest.TestCase):
-
     def test_namespace(self):
         self.scene = PlanningSceneInterface()
         expected_resolved_co_name = "/test_ros_namespace/collision_object"
@@ -57,12 +56,15 @@ class PythonMoveitCommanderRosNamespaceTest(unittest.TestCase):
     def test_namespace_synchronous(self):
         self.scene = PlanningSceneInterface(synchronous=True)
         expected_resolved_apply_diff_name = "/test_ros_namespace/apply_planning_scene"
-        self.assertEqual(self.scene._apply_planning_scene_diff.resolved_name, expected_resolved_apply_diff_name)
+        self.assertEqual(
+            self.scene._apply_planning_scene_diff.resolved_name,
+            expected_resolved_apply_diff_name,
+        )
 
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_moveit_commander_ros_namespace'
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_moveit_commander_ros_namespace"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveitCommanderRosNamespaceTest)
 

--- a/moveit_commander/test/python_time_parameterization.py
+++ b/moveit_commander/test/python_time_parameterization.py
@@ -59,34 +59,52 @@ class PythonTimeParameterizationTest(unittest.TestCase):
         start_pose = self.group.get_current_pose().pose
         goal_pose = self.group.get_current_pose().pose
         goal_pose.position.z -= 0.1
-        (plan, fraction) = self.group.compute_cartesian_path([start_pose, goal_pose], 0.005, 0.0)
+        (plan, fraction) = self.group.compute_cartesian_path(
+            [start_pose, goal_pose], 0.005, 0.0
+        )
         self.assertEqual(fraction, 1.0, "Cartesian path plan failed")
         return plan
 
     def time_parameterization(self, plan, algorithm):
         ref_state = self.commander.get_current_state()
         retimed_plan = self.group.retime_trajectory(
-            ref_state, plan,
+            ref_state,
+            plan,
             velocity_scaling_factor=0.1,
             acceleration_scaling_factor=0.1,
-            algorithm=algorithm)
+            algorithm=algorithm,
+        )
         return retimed_plan
-
 
     def test_plan_and_time_parameterization(self):
         plan = self.plan()
-        retimed_plan = self.time_parameterization(plan, "iterative_time_parameterization")
-        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
-        retimed_plan = self.time_parameterization(plan, "iterative_spline_parameterization")
-        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
-        retimed_plan = self.time_parameterization(plan, "time_optimal_trajectory_generation")
-        self.assertTrue(len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid")
+        retimed_plan = self.time_parameterization(
+            plan, "iterative_time_parameterization"
+        )
+        self.assertTrue(
+            len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid"
+        )
+        retimed_plan = self.time_parameterization(
+            plan, "iterative_spline_parameterization"
+        )
+        self.assertTrue(
+            len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid"
+        )
+        retimed_plan = self.time_parameterization(
+            plan, "time_optimal_trajectory_generation"
+        )
+        self.assertTrue(
+            len(retimed_plan.joint_trajectory.points) > 0, "Retimed plan is invalid"
+        )
         retimed_plan = self.time_parameterization(plan, "")
-        self.assertTrue(len(retimed_plan.joint_trajectory.points) == 0, "Invalid retime algorithm")
+        self.assertTrue(
+            len(retimed_plan.joint_trajectory.points) == 0, "Invalid retime algorithm"
+        )
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_time_parameterization'
+
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_time_parameterization"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonTimeParameterizationTest)
 

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
@@ -4,115 +4,174 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
 
     # planning_context
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
     # Planning Functionality
-    ompl_planning_pipeline_config = { 'move_group' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config = {
+        "move_group": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Functionality
-    controllers_yaml = load_yaml('run_move_group', 'config/controllers.yaml')
-    moveit_controllers = { 'moveit_simple_controller_manager' : controllers_yaml,
-                           'moveit_controller_manager': 'moveit_simple_controller_manager/MoveItSimpleControllerManager'}
+    controllers_yaml = load_yaml("run_move_group", "config/controllers.yaml")
+    moveit_controllers = {
+        "moveit_simple_controller_manager": controllers_yaml,
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
+    }
 
-    trajectory_execution = {'moveit_manage_controllers': True,
-                            'trajectory_execution.allowed_execution_duration_scaling': 1.2,
-                            'trajectory_execution.allowed_goal_duration_margin': 0.5,
-                            'trajectory_execution.allowed_start_tolerance': 0.01}
+    trajectory_execution = {
+        "moveit_manage_controllers": True,
+        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
+        "trajectory_execution.allowed_goal_duration_margin": 0.5,
+        "trajectory_execution.allowed_start_tolerance": 0.01,
+    }
 
-    planning_scene_monitor_parameters = {"publish_planning_scene": True,
-                 "publish_geometry_updates": True,
-                 "publish_state_updates": True,
-                 "publish_transforms_updates": True}
+    planning_scene_monitor_parameters = {
+        "publish_planning_scene": True,
+        "publish_geometry_updates": True,
+        "publish_state_updates": True,
+        "publish_transforms_updates": True,
+    }
 
     # Start the actual move_group node/action server
-    run_move_group_node = Node(package='moveit_ros_move_group',
-                               executable='move_group',
-                               output='screen',
-                               parameters=[robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml,
-                                           ompl_planning_pipeline_config,
-                                           trajectory_execution,
-                                           moveit_controllers,
-                                           planning_scene_monitor_parameters])
+    run_move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            ompl_planning_pipeline_config,
+            trajectory_execution,
+            moveit_controllers,
+            planning_scene_monitor_parameters,
+        ],
+    )
 
     # RViz
-    rviz_config_file = get_package_share_directory('run_move_group') + "/launch/run_move_group.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description,
-                                 robot_description_semantic,
-                                 ompl_planning_pipeline_config,
-                                 kinematics_yaml])
+    rviz_config_file = (
+        get_package_share_directory("run_move_group") + "/launch/run_move_group.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            ompl_planning_pipeline_config,
+            kinematics_yaml,
+        ],
+    )
 
     # Static TF
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # Publish TF
-    robot_state_publisher = Node(package='robot_state_publisher',
-                                 executable='robot_state_publisher',
-                                 name='robot_state_publisher',
-                                 output='both',
-                                 parameters=[robot_description])
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'panda_arm_controller'},
-                                              os.path.join(get_package_share_directory("run_move_group"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("run_move_group"), "config", "start_positions.yaml"),
-                                              robot_description]
-                                  )
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "panda_arm_controller"},
+            os.path.join(
+                get_package_share_directory("run_move_group"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("run_move_group"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
     # Warehouse mongodb server
-    mongodb_server_node = Node(package='warehouse_ros_mongo',
-                               executable='mongo_wrapper_ros.py',
-                               parameters=[{'warehouse_port': 33829},
-                                           {'warehouse_host': 'localhost'},
-                                           {'warehouse_plugin': 'warehouse_ros_mongo::MongoDatabaseConnection'}],
-                               output='screen')
+    mongodb_server_node = Node(
+        package="warehouse_ros_mongo",
+        executable="mongo_wrapper_ros.py",
+        parameters=[
+            {"warehouse_port": 33829},
+            {"warehouse_host": "localhost"},
+            {"warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"},
+        ],
+        output="screen",
+    )
 
-    return LaunchDescription([ rviz_node, static_tf, robot_state_publisher, run_move_group_node, fake_joint_driver_node, mongodb_server_node ])
+    return LaunchDescription(
+        [
+            rviz_node,
+            static_tf,
+            robot_state_publisher,
+            run_move_group_node,
+            fake_joint_driver_node,
+            mongodb_server_node,
+        ]
+    )

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group_interface.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group_interface.launch.py
@@ -10,7 +10,7 @@ def load_file(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
@@ -21,7 +21,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
@@ -29,22 +29,30 @@ def load_yaml(package_name, file_path):
 
 def generate_launch_description():
     # planning_context
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description': robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic': robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
 
     # MoveGroupInterface demo executable
-    run_move_group_demo = Node(name='run_move_group',
-                               package='run_move_group',
-                               executable='run_move_group',
-                               prefix='xterm -e',
-                               output='screen',
-                               parameters=[robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml])
+    run_move_group_demo = Node(
+        name="run_move_group",
+        package="run_move_group",
+        executable="run_move_group",
+        prefix="xterm -e",
+        output="screen",
+        parameters=[robot_description, robot_description_semantic, kinematics_yaml],
+    )
 
     return LaunchDescription([run_move_group_demo])

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -4,99 +4,148 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
     # moveit_cpp.yaml is passed by filename for now since it's node specific
-    moveit_cpp_yaml_file_name = get_package_share_directory('run_moveit_cpp') + "/config/moveit_cpp.yaml"
+    moveit_cpp_yaml_file_name = (
+        get_package_share_directory("run_moveit_cpp") + "/config/moveit_cpp.yaml"
+    )
 
     # Component yaml files are grouped in separate namespaces
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
-    controllers_yaml = load_yaml('run_moveit_cpp', 'config/controllers.yaml')
-    moveit_controllers = { 'moveit_simple_controller_manager' : controllers_yaml,
-                           'moveit_controller_manager': 'moveit_simple_controller_manager/MoveItSimpleControllerManager'}
+    controllers_yaml = load_yaml("run_moveit_cpp", "config/controllers.yaml")
+    moveit_controllers = {
+        "moveit_simple_controller_manager": controllers_yaml,
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
+    }
 
-    ompl_planning_pipeline_config = { 'ompl' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config = {
+        "ompl": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     # MoveItCpp demo executable
-    run_moveit_cpp_node = Node(name='run_moveit_cpp',
-                               package='run_moveit_cpp',
-                               # TODO(henningkayser): add debug argument
-                               # prefix='xterm -e gdb --args',
-                               executable='run_moveit_cpp',
-                               output='screen',
-                               parameters=[moveit_cpp_yaml_file_name,
-                                           robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml,
-                                           ompl_planning_pipeline_config,
-                                           moveit_controllers])
+    run_moveit_cpp_node = Node(
+        name="run_moveit_cpp",
+        package="run_moveit_cpp",
+        # TODO(henningkayser): add debug argument
+        # prefix='xterm -e gdb --args',
+        executable="run_moveit_cpp",
+        output="screen",
+        parameters=[
+            moveit_cpp_yaml_file_name,
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            ompl_planning_pipeline_config,
+            moveit_controllers,
+        ],
+    )
 
     # RViz
-    rviz_config_file = get_package_share_directory('run_moveit_cpp') + "/launch/run_moveit_cpp.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description,
-                                 robot_description_semantic])
+    rviz_config_file = (
+        get_package_share_directory("run_moveit_cpp") + "/launch/run_moveit_cpp.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic],
+    )
 
     # Static TF
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # Publish TF
-    robot_state_publisher = Node(package='robot_state_publisher',
-                                 executable='robot_state_publisher',
-                                 name='robot_state_publisher',
-                                 output='both',
-                                 parameters=[robot_description])
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  # TODO(JafarAbdi): Why this launch the two nodes (controller manager and the fake joint driver) with the same name!
-                                  # name='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'panda_arm_controller'},
-                                              os.path.join(get_package_share_directory("run_moveit_cpp"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("run_moveit_cpp"), "config", "start_positions.yaml"),
-                                              robot_description]
-                                  )
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        # TODO(JafarAbdi): Why this launch the two nodes (controller manager and the fake joint driver) with the same name!
+        # name='fake_joint_driver_node',
+        parameters=[
+            {"controller_name": "panda_arm_controller"},
+            os.path.join(
+                get_package_share_directory("run_moveit_cpp"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("run_moveit_cpp"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
-    return LaunchDescription([ static_tf, robot_state_publisher, rviz_node, run_moveit_cpp_node, fake_joint_driver_node ])
+    return LaunchDescription(
+        [
+            static_tf,
+            robot_state_publisher,
+            rviz_node,
+            run_moveit_cpp_node,
+            fake_joint_driver_node,
+        ]
+    )

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp_fake_controller.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp_fake_controller.launch.py
@@ -4,103 +4,149 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
     # moveit_cpp.yaml is passed by filename for now since it's node specific
-    moveit_cpp_yaml_file_name = get_package_share_directory('run_moveit_cpp') + "/config/moveit_cpp.yaml"
+    moveit_cpp_yaml_file_name = (
+        get_package_share_directory("run_moveit_cpp") + "/config/moveit_cpp.yaml"
+    )
 
     # Component yaml files are grouped in separate namespaces
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
-    ompl_planning_pipeline_config = { 'ompl' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config = {
+        "ompl": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
-    trajectory_execution = {'moveit_manage_controllers': True,
-                            'trajectory_execution.allowed_execution_duration_scaling': 1.2,
-                            'trajectory_execution.allowed_goal_duration_margin': 0.5,
-                            'trajectory_execution.allowed_start_tolerance': 0.01}
+    trajectory_execution = {
+        "moveit_manage_controllers": True,
+        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
+        "trajectory_execution.allowed_goal_duration_margin": 0.5,
+        "trajectory_execution.allowed_start_tolerance": 0.01,
+    }
 
-    controllers_yaml = load_yaml('run_moveit_cpp', 'config/fake_controllers.yaml')
-    fake_controller = {'moveit_fake_controller_manager': controllers_yaml,
-                       'moveit_controller_manager': 'moveit_fake_controller_manager/MoveItFakeControllerManager'}
+    controllers_yaml = load_yaml("run_moveit_cpp", "config/fake_controllers.yaml")
+    fake_controller = {
+        "moveit_fake_controller_manager": controllers_yaml,
+        "moveit_controller_manager": "moveit_fake_controller_manager/MoveItFakeControllerManager",
+    }
 
     # MoveItCpp demo executable
-    run_moveit_cpp_node = Node(name='run_moveit_cpp',
-                               package='run_moveit_cpp',
-                               # TODO(henningkayser): add debug argument
-                               # prefix='xterm -e gdb --args',
-                               executable='run_moveit_cpp',
-                               output='screen',
-                               parameters=[moveit_cpp_yaml_file_name,
-                                           robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml,
-                                           ompl_planning_pipeline_config,
-                                           trajectory_execution,
-                                           fake_controller])
+    run_moveit_cpp_node = Node(
+        name="run_moveit_cpp",
+        package="run_moveit_cpp",
+        # TODO(henningkayser): add debug argument
+        # prefix='xterm -e gdb --args',
+        executable="run_moveit_cpp",
+        output="screen",
+        parameters=[
+            moveit_cpp_yaml_file_name,
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            ompl_planning_pipeline_config,
+            trajectory_execution,
+            fake_controller,
+        ],
+    )
 
     # RViz
-    rviz_config_file = get_package_share_directory('run_moveit_cpp') + "/launch/run_moveit_cpp.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description,
-                                 robot_description_semantic])
+    rviz_config_file = (
+        get_package_share_directory("run_moveit_cpp") + "/launch/run_moveit_cpp.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic],
+    )
 
     # Static TF
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # Publish TF
-    robot_state_publisher = Node(package='robot_state_publisher',
-                                 executable='robot_state_publisher',
-                                 name='robot_state_publisher',
-                                 output='both',
-                                 parameters=[robot_description])
-
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
 
     # Joint state publisher
-    joint_state_publisher = Node(package='joint_state_publisher',
-                                 executable='joint_state_publisher',
-                                 name='joint_state_publisher',
-                                 arguments=[os.path.join(get_package_share_directory('moveit_resources_panda_description'), 'urdf/panda.urdf')],
-                                 output='log',
-                                 parameters=[{'source_list': ["/fake_controller_joint_states"]}])
+    joint_state_publisher = Node(
+        package="joint_state_publisher",
+        executable="joint_state_publisher",
+        name="joint_state_publisher",
+        arguments=[
+            os.path.join(
+                get_package_share_directory("moveit_resources_panda_description"),
+                "urdf/panda.urdf",
+            )
+        ],
+        output="log",
+        parameters=[{"source_list": ["/fake_controller_joint_states"]}],
+    )
 
-    return LaunchDescription([ static_tf, robot_state_publisher, rviz_node, joint_state_publisher, run_moveit_cpp_node ])
+    return LaunchDescription(
+        [
+            static_tf,
+            robot_state_publisher,
+            rviz_node,
+            joint_state_publisher,
+            run_moveit_cpp_node,
+        ]
+    )

--- a/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
@@ -4,117 +4,179 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
 
     # planning_context
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
     # Planning Functionality
-    ompl_planning_pipeline_config = { 'move_group' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
+    ompl_planning_pipeline_config = {
+        "move_group": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
 
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Functionality
-    controllers_yaml = load_yaml('run_ompl_constrained_planning', 'config/controllers.yaml')
-    moveit_controllers = { 'moveit_simple_controller_manager' : controllers_yaml,
-                           'moveit_controller_manager': 'moveit_simple_controller_manager/MoveItSimpleControllerManager'}
+    controllers_yaml = load_yaml(
+        "run_ompl_constrained_planning", "config/controllers.yaml"
+    )
+    moveit_controllers = {
+        "moveit_simple_controller_manager": controllers_yaml,
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
+    }
 
-    trajectory_execution = {'moveit_manage_controllers': True,
-                            'trajectory_execution.allowed_execution_duration_scaling': 1.2,
-                            'trajectory_execution.allowed_goal_duration_margin': 0.5,
-                            'trajectory_execution.allowed_start_tolerance': 0.01}
+    trajectory_execution = {
+        "moveit_manage_controllers": True,
+        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
+        "trajectory_execution.allowed_goal_duration_margin": 0.5,
+        "trajectory_execution.allowed_start_tolerance": 0.01,
+    }
 
-    planning_scene_monitor_parameters = {"publish_planning_scene": True,
-                 "publish_geometry_updates": True,
-                 "publish_state_updates": True,
-                 "publish_transforms_updates": True}
+    planning_scene_monitor_parameters = {
+        "publish_planning_scene": True,
+        "publish_geometry_updates": True,
+        "publish_state_updates": True,
+        "publish_transforms_updates": True,
+    }
 
     # Start the actual move_group node/action server
-    run_move_group_node = Node(package='moveit_ros_move_group',
-                               executable='move_group',
-                               output='screen',
-                            #    prefix='kitty -e gdb -e run --args',
-                               parameters=[robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml,
-                                           ompl_planning_pipeline_config,
-                                           trajectory_execution,
-                                           moveit_controllers,
-                                           planning_scene_monitor_parameters])
+    run_move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        #    prefix='kitty -e gdb -e run --args',
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            ompl_planning_pipeline_config,
+            trajectory_execution,
+            moveit_controllers,
+            planning_scene_monitor_parameters,
+        ],
+    )
 
     # RViz
-    rviz_config_file = get_package_share_directory('run_ompl_constrained_planning') + "/config/run_move_group.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description,
-                                 robot_description_semantic,
-                                 ompl_planning_pipeline_config,
-                                 kinematics_yaml])
+    rviz_config_file = (
+        get_package_share_directory("run_ompl_constrained_planning")
+        + "/config/run_move_group.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            ompl_planning_pipeline_config,
+            kinematics_yaml,
+        ],
+    )
 
     # Static TF
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # Publish TF
-    robot_state_publisher = Node(package='robot_state_publisher',
-                                 executable='robot_state_publisher',
-                                 name='robot_state_publisher',
-                                 output='both',
-                                 parameters=[robot_description])
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'panda_arm_controller'},
-                                              os.path.join(get_package_share_directory("run_ompl_constrained_planning"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("run_ompl_constrained_planning"), "config", "start_positions.yaml"),
-                                              robot_description]
-                                  )
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "panda_arm_controller"},
+            os.path.join(
+                get_package_share_directory("run_ompl_constrained_planning"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("run_ompl_constrained_planning"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
     # Warehouse mongodb server
-    mongodb_server_node = Node(package='warehouse_ros_mongo',
-                               executable='mongo_wrapper_ros.py',
-                               parameters=[{'warehouse_port': 33829},
-                                           {'warehouse_host': 'localhost'},
-                                           {'warehouse_plugin': 'warehouse_ros_mongo::MongoDatabaseConnection'}],
-                               output='screen')
+    mongodb_server_node = Node(
+        package="warehouse_ros_mongo",
+        executable="mongo_wrapper_ros.py",
+        parameters=[
+            {"warehouse_port": 33829},
+            {"warehouse_host": "localhost"},
+            {"warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"},
+        ],
+        output="screen",
+    )
 
-    return LaunchDescription([ rviz_node, static_tf, robot_state_publisher, run_move_group_node, fake_joint_driver_node, mongodb_server_node ])
+    return LaunchDescription(
+        [
+            rviz_node,
+            static_tf,
+            robot_state_publisher,
+            run_move_group_node,
+            fake_joint_driver_node,
+            mongodb_server_node,
+        ]
+    )

--- a/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_ompl_demo.launch.py
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_ompl_demo.launch.py
@@ -10,7 +10,7 @@ def load_file(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
@@ -21,7 +21,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
@@ -29,22 +29,30 @@ def load_yaml(package_name, file_path):
 
 def generate_launch_description():
     # planning_context
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description': robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic': robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
 
     # MoveGroupInterface demo executable
-    run_move_group_demo = Node(name='run_ompl_constrained_planning',
-                               package='run_ompl_constrained_planning',
-                               executable='run_ompl_constrained_planning',
-                               output='screen',
-                            #    prefix='kitty -e gdb -e run --args',
-                               parameters=[robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml])
+    run_move_group_demo = Node(
+        name="run_ompl_constrained_planning",
+        package="run_ompl_constrained_planning",
+        executable="run_ompl_constrained_planning",
+        output="screen",
+        #    prefix='kitty -e gdb -e run --args',
+        parameters=[robot_description, robot_description_semantic, kinematics_yaml],
+    )
 
     return LaunchDescription([run_move_group_demo])

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 from __future__ import print_function
-'''
+
+"""
 IKFast Plugin Generator for MoveIt
 
 Creates a kinematics plugin using the output of IKFast from OpenRAVE.
@@ -15,8 +16,8 @@ Author: Dave Coleman, PickNik Robotics
 
 Date: March 2013
 
-'''
-'''
+"""
+"""
 Copyright (c) 2013, Jeremy Zoss, SwRI
 All rights reserved.
 
@@ -43,7 +44,7 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
-'''
+"""
 
 import re
 import os
@@ -54,252 +55,363 @@ import shutil
 import argparse
 
 try:
-  from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
+    from ament_index_python.packages import (
+        get_package_share_directory,
+        PackageNotFoundError,
+    )
 except ImportError:
-  print("Failed to import ament_index_python. No ROS2 environment available? Trying without.")
-  # define stubs
-  class PackageNotFoundError(Exception):
-    pass
-  def get_package_share_directory(pkg_name):
-    raise PackageNotFoundError
+    print(
+        "Failed to import ament_index_python. No ROS2 environment available? Trying without."
+    )
+    # define stubs
+    class PackageNotFoundError(Exception):
+        pass
+
+    def get_package_share_directory(pkg_name):
+        raise PackageNotFoundError
+
 
 # Package containing this file
-plugin_gen_pkg = 'moveit_kinematics'
+plugin_gen_pkg = "moveit_kinematics"
 # Allowed search modes, see SEARCH_MODE enum in template file
-search_modes = ['OPTIMIZE_MAX_JOINT', 'OPTIMIZE_FREE_JOINT']
+search_modes = ["OPTIMIZE_MAX_JOINT", "OPTIMIZE_FREE_JOINT"]
 
 
 def create_parser():
-  parser = argparse.ArgumentParser(
-      description="Generate an IKFast MoveIt kinematic plugin")
-  parser.add_argument("robot_name",
-                      help="The name of your robot")
-  parser.add_argument("planning_group_name",
-                      help="The name of the planning group for which your IKFast solution was generated")
-  parser.add_argument("ikfast_plugin_pkg",
-                      help="The name of the MoveIt IKFast Kinematics Plugin to be created/updated")
-  parser.add_argument("base_link_name",
-                      help="The name of the base link that was used when generating your IKFast solution")
-  parser.add_argument("eef_link_name",
-                      help="The name of the end effector link that was used when generating your IKFast solution")
-  parser.add_argument("ikfast_output_path",
-                      help="The full path to the analytic IK solution output by IKFast")
-  parser.add_argument("--search_mode",
-                      default=search_modes[0],
-                      help="The search mode used to solve IK for robots with more than 6DOF")
-  parser.add_argument("--srdf_filename",
-                      help="The name of your robot. Defaults to <robot_name>.srdf")
-  parser.add_argument("--robot_name_in_srdf",
-                      help="The name of your robot as defined in the srdf. Defaults to <robot_name>")
-  parser.add_argument("--moveit_config_pkg",
-                      help="The robot moveit_config package. Defaults to <robot_name>_moveit_config")
-  return parser
+    parser = argparse.ArgumentParser(
+        description="Generate an IKFast MoveIt kinematic plugin"
+    )
+    parser.add_argument("robot_name", help="The name of your robot")
+    parser.add_argument(
+        "planning_group_name",
+        help="The name of the planning group for which your IKFast solution was generated",
+    )
+    parser.add_argument(
+        "ikfast_plugin_pkg",
+        help="The name of the MoveIt IKFast Kinematics Plugin to be created/updated",
+    )
+    parser.add_argument(
+        "base_link_name",
+        help="The name of the base link that was used when generating your IKFast solution",
+    )
+    parser.add_argument(
+        "eef_link_name",
+        help="The name of the end effector link that was used when generating your IKFast solution",
+    )
+    parser.add_argument(
+        "ikfast_output_path",
+        help="The full path to the analytic IK solution output by IKFast",
+    )
+    parser.add_argument(
+        "--search_mode",
+        default=search_modes[0],
+        help="The search mode used to solve IK for robots with more than 6DOF",
+    )
+    parser.add_argument(
+        "--srdf_filename", help="The name of your robot. Defaults to <robot_name>.srdf"
+    )
+    parser.add_argument(
+        "--robot_name_in_srdf",
+        help="The name of your robot as defined in the srdf. Defaults to <robot_name>",
+    )
+    parser.add_argument(
+        "--moveit_config_pkg",
+        help="The robot moveit_config package. Defaults to <robot_name>_moveit_config",
+    )
+    return parser
 
 
 def populate_optional(args):
-  if args.srdf_filename is None:
-    args.srdf_filename = args.robot_name + ".srdf"
-  if args.robot_name_in_srdf is None:
-    args.robot_name_in_srdf = args.robot_name
-  if args.moveit_config_pkg is None:
-    args.moveit_config_pkg = args.robot_name + "_moveit_config"
+    if args.srdf_filename is None:
+        args.srdf_filename = args.robot_name + ".srdf"
+    if args.robot_name_in_srdf is None:
+        args.robot_name_in_srdf = args.robot_name
+    if args.moveit_config_pkg is None:
+        args.moveit_config_pkg = args.robot_name + "_moveit_config"
 
 
 def print_args(args):
-  print("Creating IKFastKinematicsPlugin with parameters: ")
-  print(" robot_name:           %s" % args.robot_name)
-  print(" base_link_name:       %s" % args.base_link_name)
-  print(" eef_link_name:        %s" % args.eef_link_name)
-  print(" planning_group_name:  %s" % args.planning_group_name)
-  print(" ikfast_plugin_pkg:    %s" % args.ikfast_plugin_pkg)
-  print(" ikfast_output_path:   %s" % args.ikfast_output_path)
-  print(" search_mode:          %s" % args.search_mode)
-  print(" srdf_filename:        %s" % args.srdf_filename)
-  print(" robot_name_in_srdf:   %s" % args.robot_name_in_srdf)
-  print(" moveit_config_pkg:    %s" % args.moveit_config_pkg)
-  print("")
+    print("Creating IKFastKinematicsPlugin with parameters: ")
+    print(" robot_name:           %s" % args.robot_name)
+    print(" base_link_name:       %s" % args.base_link_name)
+    print(" eef_link_name:        %s" % args.eef_link_name)
+    print(" planning_group_name:  %s" % args.planning_group_name)
+    print(" ikfast_plugin_pkg:    %s" % args.ikfast_plugin_pkg)
+    print(" ikfast_output_path:   %s" % args.ikfast_output_path)
+    print(" search_mode:          %s" % args.search_mode)
+    print(" srdf_filename:        %s" % args.srdf_filename)
+    print(" robot_name_in_srdf:   %s" % args.robot_name_in_srdf)
+    print(" moveit_config_pkg:    %s" % args.moveit_config_pkg)
+    print("")
 
 
 def update_deps(reqd_deps, req_type, e_parent):
-  curr_deps = [e.text for e in e_parent.findall(req_type)]
-  missing_deps = set(reqd_deps) - set(curr_deps)
-  for dep in missing_deps:
-     etree.SubElement(e_parent, req_type).text = dep
+    curr_deps = [e.text for e in e_parent.findall(req_type)]
+    missing_deps = set(reqd_deps) - set(curr_deps)
+    for dep in missing_deps:
+        etree.SubElement(e_parent, req_type).text = dep
 
 
 def validate_openrave_version(args):
-  if not os.path.exists(args.ikfast_output_path):
-    raise Exception("Can't find IKFast source code at " + args.ikfast_output_path)
+    if not os.path.exists(args.ikfast_output_path):
+        raise Exception("Can't find IKFast source code at " + args.ikfast_output_path)
 
-  # Detect version of IKFast used to generate solver code
-  solver_version = 0
-  with open(args.ikfast_output_path, 'r') as src:
-    for line in src:
-       if line.startswith('/// ikfast version'):
-          line_search = re.search('ikfast version (.*) generated', line)
-          if line_search:
-             solver_version = int(line_search.group(1), 0) & ~0x10000000
-          break
-  print('Found source code generated by IKFast version %s' % str(solver_version))
+    # Detect version of IKFast used to generate solver code
+    solver_version = 0
+    with open(args.ikfast_output_path, "r") as src:
+        for line in src:
+            if line.startswith("/// ikfast version"):
+                line_search = re.search("ikfast version (.*) generated", line)
+                if line_search:
+                    solver_version = int(line_search.group(1), 0) & ~0x10000000
+                break
+    print("Found source code generated by IKFast version %s" % str(solver_version))
 
-  # Chose template depending on IKFast version
-  if solver_version >= 56:
-    setattr(args, 'template_version', 61)
-  else:
-    raise Exception('This converter requires IKFast 0.5.6 or newer.')
+    # Chose template depending on IKFast version
+    if solver_version >= 56:
+        setattr(args, "template_version", 61)
+    else:
+        raise Exception("This converter requires IKFast 0.5.6 or newer.")
+
 
 def xmlElement(name, text=None, **attributes):
-   e = etree.Element(name, **attributes)
-   e.text = text
-   return e
+    e = etree.Element(name, **attributes)
+    e.text = text
+    return e
+
 
 def create_ikfast_package(args):
-  try:
-    setattr(args, 'ikfast_plugin_pkg_path', get_package_share_directory(args.ikfast_plugin_pkg))
-  except PackageNotFoundError:
-    args.ikfast_plugin_pkg_path = os.path.abspath(args.ikfast_plugin_pkg)
-    print("Failed to find package: %s. Will create it in %s." %
-          (args.ikfast_plugin_pkg, args.ikfast_plugin_pkg_path))
-    # update pkg name to basename of path
-    args.ikfast_plugin_pkg=os.path.basename(args.ikfast_plugin_pkg_path)
+    try:
+        setattr(
+            args,
+            "ikfast_plugin_pkg_path",
+            get_package_share_directory(args.ikfast_plugin_pkg),
+        )
+    except PackageNotFoundError:
+        args.ikfast_plugin_pkg_path = os.path.abspath(args.ikfast_plugin_pkg)
+        print(
+            "Failed to find package: %s. Will create it in %s."
+            % (args.ikfast_plugin_pkg, args.ikfast_plugin_pkg_path)
+        )
+        # update pkg name to basename of path
+        args.ikfast_plugin_pkg = os.path.basename(args.ikfast_plugin_pkg_path)
 
-  src_path = args.ikfast_plugin_pkg_path + '/src/'
-  if not os.path.exists(src_path):
-     os.makedirs(src_path)
+    src_path = args.ikfast_plugin_pkg_path + "/src/"
+    if not os.path.exists(src_path):
+        os.makedirs(src_path)
 
-  include_path = args.ikfast_plugin_pkg_path + '/include/'
-  if not os.path.exists(include_path):
-     os.makedirs(include_path)
+    include_path = args.ikfast_plugin_pkg_path + "/include/"
+    if not os.path.exists(include_path):
+        os.makedirs(include_path)
 
-  # Create package.xml
-  pkg_xml_path = args.ikfast_plugin_pkg_path + '/package.xml'
-  if not os.path.exists(pkg_xml_path):
-    root = xmlElement("package", format="2")
-    root.append(xmlElement("name", text=args.ikfast_plugin_pkg))
-    root.append(xmlElement("version", text="0.0.0"))
-    root.append(xmlElement("description", text="IKFast plugin for " + args.robot_name))
-    root.append(xmlElement("license", text="BSD"))
-    user_name = getuser()
-    root.append(xmlElement("maintainer", email="%s@todo.todo" % user_name, text=user_name))
-    root.append(xmlElement("buildtool_depend", text="ament_cmake"))
-    etree.ElementTree(root).write(pkg_xml_path, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-    print("Created package.xml at: '%s'" % pkg_xml_path)
+    # Create package.xml
+    pkg_xml_path = args.ikfast_plugin_pkg_path + "/package.xml"
+    if not os.path.exists(pkg_xml_path):
+        root = xmlElement("package", format="2")
+        root.append(xmlElement("name", text=args.ikfast_plugin_pkg))
+        root.append(xmlElement("version", text="0.0.0"))
+        root.append(
+            xmlElement("description", text="IKFast plugin for " + args.robot_name)
+        )
+        root.append(xmlElement("license", text="BSD"))
+        user_name = getuser()
+        root.append(
+            xmlElement("maintainer", email="%s@todo.todo" % user_name, text=user_name)
+        )
+        root.append(xmlElement("buildtool_depend", text="ament_cmake"))
+        etree.ElementTree(root).write(
+            pkg_xml_path, xml_declaration=True, pretty_print=True, encoding="UTF-8"
+        )
+        print("Created package.xml at: '%s'" % pkg_xml_path)
 
 
 def find_template_dir():
-  for candidate in [os.path.dirname(__file__) + '/../templates']:
-    if os.path.exists(candidate) and os.path.exists(candidate + '/ikfast.h'):
-      return os.path.realpath(candidate)
-  try:
-    return os.path.join(get_package_share_directory(plugin_gen_pkg), 'ikfast_kinematics_plugin/templates')
-  except PackageNotFoundError:
-    raise Exception("Can't find package %s" % plugin_gen_pkg)
+    for candidate in [os.path.dirname(__file__) + "/../templates"]:
+        if os.path.exists(candidate) and os.path.exists(candidate + "/ikfast.h"):
+            return os.path.realpath(candidate)
+    try:
+        return os.path.join(
+            get_package_share_directory(plugin_gen_pkg),
+            "ikfast_kinematics_plugin/templates",
+        )
+    except PackageNotFoundError:
+        raise Exception("Can't find package %s" % plugin_gen_pkg)
 
 
 def update_ikfast_package(args):
-  # Copy the source code generated by IKFast into our src folder
-  src_path = args.ikfast_plugin_pkg_path + '/src/'
-  solver_file_path = src_path + args.robot_name + '_' + args.planning_group_name + '_ikfast_solver.cpp'
-  if not os.path.exists(solver_file_path) or not os.path.samefile(args.ikfast_output_path, solver_file_path):
-    shutil.copy2(args.ikfast_output_path, solver_file_path)
+    # Copy the source code generated by IKFast into our src folder
+    src_path = args.ikfast_plugin_pkg_path + "/src/"
+    solver_file_path = (
+        src_path
+        + args.robot_name
+        + "_"
+        + args.planning_group_name
+        + "_ikfast_solver.cpp"
+    )
+    if not os.path.exists(solver_file_path) or not os.path.samefile(
+        args.ikfast_output_path, solver_file_path
+    ):
+        shutil.copy2(args.ikfast_output_path, solver_file_path)
 
-  if not os.path.exists(solver_file_path):
-    raise Exception("Failed to copy IKFast source code from '%s' to '%s'\n"
-                    "Manually copy the source file generated by IKFast to this location and re-run" %
-                    (args.ikfast_output_path, solver_file_path))
-  # Remember ikfast solver file for update of MoveIt package
-  args.ikfast_output_path = solver_file_path
+    if not os.path.exists(solver_file_path):
+        raise Exception(
+            "Failed to copy IKFast source code from '%s' to '%s'\n"
+            "Manually copy the source file generated by IKFast to this location and re-run"
+            % (args.ikfast_output_path, solver_file_path)
+        )
+    # Remember ikfast solver file for update of MoveIt package
+    args.ikfast_output_path = solver_file_path
 
-  # Get template folder location
-  template_dir = find_template_dir()
+    # Get template folder location
+    template_dir = find_template_dir()
 
-  # namespace for the plugin
-  setattr(args, 'namespace', args.robot_name + "_" + args.planning_group_name)
-  replacements = dict(_ROBOT_NAME_= args.robot_name,
-                      _GROUP_NAME_ = args.planning_group_name,
-                      _SEARCH_MODE_ = args.search_mode,
-                      _EEF_LINK_ = args.eef_link_name,
-                      _BASE_LINK_ = args.base_link_name,
-                      _PACKAGE_NAME_ = args.ikfast_plugin_pkg,
-                      _NAMESPACE_ = args.namespace
-  )
+    # namespace for the plugin
+    setattr(args, "namespace", args.robot_name + "_" + args.planning_group_name)
+    replacements = dict(
+        _ROBOT_NAME_=args.robot_name,
+        _GROUP_NAME_=args.planning_group_name,
+        _SEARCH_MODE_=args.search_mode,
+        _EEF_LINK_=args.eef_link_name,
+        _BASE_LINK_=args.base_link_name,
+        _PACKAGE_NAME_=args.ikfast_plugin_pkg,
+        _NAMESPACE_=args.namespace,
+    )
 
-  # Copy ikfast header file
-  copy_file(template_dir + '/ikfast.h', args.ikfast_plugin_pkg_path + "/include/ikfast.h",
-            "ikfast header file")
-  # Create ikfast plugin template
-  copy_file(template_dir + '/ikfast' + str(args.template_version) + '_moveit_plugin_template.cpp',
-            args.ikfast_plugin_pkg_path + "/src/" + args.robot_name + '_' + args.planning_group_name + "_ikfast_moveit_plugin.cpp",
-            "ikfast plugin file", replacements)
+    # Copy ikfast header file
+    copy_file(
+        template_dir + "/ikfast.h",
+        args.ikfast_plugin_pkg_path + "/include/ikfast.h",
+        "ikfast header file",
+    )
+    # Create ikfast plugin template
+    copy_file(
+        template_dir
+        + "/ikfast"
+        + str(args.template_version)
+        + "_moveit_plugin_template.cpp",
+        args.ikfast_plugin_pkg_path
+        + "/src/"
+        + args.robot_name
+        + "_"
+        + args.planning_group_name
+        + "_ikfast_moveit_plugin.cpp",
+        "ikfast plugin file",
+        replacements,
+    )
 
-  # Create plugin definition .xml file
-  ik_library_name = args.namespace + "_moveit_ikfast_plugin"
-  plugin_def = etree.Element("library", path="lib/lib" + ik_library_name)
-  setattr(args, 'plugin_name', args.namespace + '/IKFastKinematicsPlugin')
-  cl = etree.SubElement(plugin_def, "class", name=args.plugin_name,
-                        type=args.namespace + "::IKFastKinematicsPlugin",
-                        base_class_type="kinematics::KinematicsBase")
-  desc = etree.SubElement(cl, "description")
-  desc.text = 'IKFast{template} plugin for closed-form kinematics of {robot} {group}' \
-      .format(template=args.template_version, robot=args.robot_name, group=args.planning_group_name)
+    # Create plugin definition .xml file
+    ik_library_name = args.namespace + "_moveit_ikfast_plugin"
+    plugin_def = etree.Element("library", path="lib/lib" + ik_library_name)
+    setattr(args, "plugin_name", args.namespace + "/IKFastKinematicsPlugin")
+    cl = etree.SubElement(
+        plugin_def,
+        "class",
+        name=args.plugin_name,
+        type=args.namespace + "::IKFastKinematicsPlugin",
+        base_class_type="kinematics::KinematicsBase",
+    )
+    desc = etree.SubElement(cl, "description")
+    desc.text = (
+        "IKFast{template} plugin for closed-form kinematics of {robot} {group}".format(
+            template=args.template_version,
+            robot=args.robot_name,
+            group=args.planning_group_name,
+        )
+    )
 
-  # Write plugin definition to file
-  plugin_file_name = ik_library_name + "_description.xml"
-  plugin_file_path = args.ikfast_plugin_pkg_path + "/" + plugin_file_name
-  etree.ElementTree(plugin_def).write(plugin_file_path, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-  print("Created plugin definition at  '%s'" % plugin_file_path)
+    # Write plugin definition to file
+    plugin_file_name = ik_library_name + "_description.xml"
+    plugin_file_path = args.ikfast_plugin_pkg_path + "/" + plugin_file_name
+    etree.ElementTree(plugin_def).write(
+        plugin_file_path, xml_declaration=True, pretty_print=True, encoding="UTF-8"
+    )
+    print("Created plugin definition at  '%s'" % plugin_file_path)
 
-  # Create CMakeLists file
-  replacements.update(dict(_LIBRARY_NAME_ = ik_library_name))
-  copy_file(template_dir + "/CMakeLists.txt", args.ikfast_plugin_pkg_path + '/CMakeLists.txt',
-            "cmake file", replacements)
+    # Create CMakeLists file
+    replacements.update(dict(_LIBRARY_NAME_=ik_library_name))
+    copy_file(
+        template_dir + "/CMakeLists.txt",
+        args.ikfast_plugin_pkg_path + "/CMakeLists.txt",
+        "cmake file",
+        replacements,
+    )
 
-  # Add plugin export to package manifest
-  parser = etree.XMLParser(remove_blank_text=True)
-  package_file_name = args.ikfast_plugin_pkg_path + "/package.xml"
-  package_xml = etree.parse(package_file_name, parser).getroot()
+    # Add plugin export to package manifest
+    parser = etree.XMLParser(remove_blank_text=True)
+    package_file_name = args.ikfast_plugin_pkg_path + "/package.xml"
+    package_xml = etree.parse(package_file_name, parser).getroot()
 
-  # Make sure at least all required dependencies are in the depends lists
-  build_deps = ["liblapack-dev", "moveit_core", "pluginlib", "rclcpp", "tf2_kdl", "tf2_eigen"]
-  run_deps = ["liblapack-dev", "moveit_core", "pluginlib", "rclcpp"]
+    # Make sure at least all required dependencies are in the depends lists
+    build_deps = [
+        "liblapack-dev",
+        "moveit_core",
+        "pluginlib",
+        "rclcpp",
+        "tf2_kdl",
+        "tf2_eigen",
+    ]
+    run_deps = ["liblapack-dev", "moveit_core", "pluginlib", "rclcpp"]
 
-  update_deps(build_deps, "build_depend", package_xml)
-  update_deps(run_deps, "exec_depend", package_xml)
+    update_deps(build_deps, "build_depend", package_xml)
+    update_deps(run_deps, "exec_depend", package_xml)
 
-  # Check that plugin definition file is in the export list
-  new_export = etree.Element("moveit_core", plugin="${prefix}/" + plugin_file_name)
+    # Check that plugin definition file is in the export list
+    new_export = etree.Element("moveit_core", plugin="${prefix}/" + plugin_file_name)
 
-  export_element = package_xml.find("export")
-  if export_element is None:
-    export_element = etree.SubElement(package_xml, "export")
+    export_element = package_xml.find("export")
+    if export_element is None:
+        export_element = etree.SubElement(package_xml, "export")
 
-  found = False
-  for el in export_element.findall("moveit_core"):
-    found = (etree.tostring(new_export) == etree.tostring(el))
-    if found:
-      break
+    found = False
+    for el in export_element.findall("moveit_core"):
+        found = etree.tostring(new_export) == etree.tostring(el)
+        if found:
+            break
 
-  if not found:
-    export_element.append(new_export)
+    if not found:
+        export_element.append(new_export)
 
-  # Always write the package xml file, even if there are no changes, to ensure
-  # proper encodings are used in the future (UTF-8)
-  etree.ElementTree(package_xml).write(package_file_name, xml_declaration=True, pretty_print=True, encoding="UTF-8")
-  print("Wrote package.xml at  '%s'" % package_file_name)
+    # Always write the package xml file, even if there are no changes, to ensure
+    # proper encodings are used in the future (UTF-8)
+    etree.ElementTree(package_xml).write(
+        package_file_name, xml_declaration=True, pretty_print=True, encoding="UTF-8"
+    )
+    print("Wrote package.xml at  '%s'" % package_file_name)
 
-  # Create a script for easily updating the plugin in the future in case the plugin needs to be updated
-  easy_script_file_path = args.ikfast_plugin_pkg_path + "/update_ikfast_plugin.sh"
-  with open(easy_script_file_path, 'w') as f:
-    f.write("search_mode=" + args.search_mode + "\n"
-            + "srdf_filename=" + args.srdf_filename + "\n"
-            + "robot_name_in_srdf=" + args.robot_name_in_srdf + "\n"
-            + "moveit_config_pkg=" + args.moveit_config_pkg + "\n"
-            + "robot_name=" + args.robot_name + "\n"
-            + "planning_group_name=" + args.planning_group_name + "\n"
-            + "ikfast_plugin_pkg=" + args.ikfast_plugin_pkg + "\n"
-            + "base_link_name=" + args.base_link_name + "\n"
-            + "eef_link_name=" + args.eef_link_name + "\n"
-            + "ikfast_output_path=" + args.ikfast_output_path + "\n\n"
+    # Create a script for easily updating the plugin in the future in case the plugin needs to be updated
+    easy_script_file_path = args.ikfast_plugin_pkg_path + "/update_ikfast_plugin.sh"
+    with open(easy_script_file_path, "w") as f:
+        f.write(
+            "search_mode="
+            + args.search_mode
+            + "\n"
+            + "srdf_filename="
+            + args.srdf_filename
+            + "\n"
+            + "robot_name_in_srdf="
+            + args.robot_name_in_srdf
+            + "\n"
+            + "moveit_config_pkg="
+            + args.moveit_config_pkg
+            + "\n"
+            + "robot_name="
+            + args.robot_name
+            + "\n"
+            + "planning_group_name="
+            + args.planning_group_name
+            + "\n"
+            + "ikfast_plugin_pkg="
+            + args.ikfast_plugin_pkg
+            + "\n"
+            + "base_link_name="
+            + args.base_link_name
+            + "\n"
+            + "eef_link_name="
+            + args.eef_link_name
+            + "\n"
+            + "ikfast_output_path="
+            + args.ikfast_output_path
+            + "\n\n"
             + "rosrun moveit_kinematics create_ikfast_moveit_plugin.py\\\n"
             + "  --search_mode=$search_mode\\\n"
             + "  --srdf_filename=$srdf_filename\\\n"
@@ -310,87 +422,97 @@ def update_ikfast_package(args):
             + "  $ikfast_plugin_pkg\\\n"
             + "  $base_link_name\\\n"
             + "  $eef_link_name\\\n"
-            + "  $ikfast_output_path\n")
+            + "  $ikfast_output_path\n"
+        )
 
-  print("Created update plugin script at '%s'" % easy_script_file_path)
+    print("Created update plugin script at '%s'" % easy_script_file_path)
 
 
 def update_moveit_package(args):
-  try:
-    moveit_config_pkg_path = get_package_share_directory(args.moveit_config_pkg)
-  except PackageNotFoundError:
-    raise Exception("Failed to find package: " + args.moveit_config_pkg)
+    try:
+        moveit_config_pkg_path = get_package_share_directory(args.moveit_config_pkg)
+    except PackageNotFoundError:
+        raise Exception("Failed to find package: " + args.moveit_config_pkg)
 
-  try:
-    srdf_file_name = moveit_config_pkg_path + '/config/' + args.srdf_filename
-    srdf = etree.parse(srdf_file_name).getroot()
-  except IOError:
-    raise Exception("Failed to find SRDF file: " + srdf_file_name)
-  except etree.XMLSyntaxError as err:
-    raise Exception("Failed to parse xml in file: %s\n%s" % (srdf_file_name, err.msg))
+    try:
+        srdf_file_name = moveit_config_pkg_path + "/config/" + args.srdf_filename
+        srdf = etree.parse(srdf_file_name).getroot()
+    except IOError:
+        raise Exception("Failed to find SRDF file: " + srdf_file_name)
+    except etree.XMLSyntaxError as err:
+        raise Exception(
+            "Failed to parse xml in file: %s\n%s" % (srdf_file_name, err.msg)
+        )
 
-  if args.robot_name_in_srdf != srdf.get('name'):
-    raise Exception("Robot name in srdf ('%s') doesn't match expected name ('%s')" %
-                    (srdf.get('name'), args.robot_name_in_srdf))
+    if args.robot_name_in_srdf != srdf.get("name"):
+        raise Exception(
+            "Robot name in srdf ('%s') doesn't match expected name ('%s')"
+            % (srdf.get("name"), args.robot_name_in_srdf)
+        )
 
-  groups = srdf.findall('group')
-  if len(groups) < 1:
-    raise Exception("No planning groups are defined in the SRDF")
+    groups = srdf.findall("group")
+    if len(groups) < 1:
+        raise Exception("No planning groups are defined in the SRDF")
 
-  planning_group = None
-  for group in groups:
-    if group.get('name').lower() == args.planning_group_name.lower():
-      planning_group = group
+    planning_group = None
+    for group in groups:
+        if group.get("name").lower() == args.planning_group_name.lower():
+            planning_group = group
 
-  if planning_group is None:
-    raise Exception("Planning group '%s' not defined in the SRDF. Available groups: \n%s" % (
-        args.planning_group_name, ", ".join([group_name.get('name') for group_name in groups])))
+    if planning_group is None:
+        raise Exception(
+            "Planning group '%s' not defined in the SRDF. Available groups: \n%s"
+            % (
+                args.planning_group_name,
+                ", ".join([group_name.get("name") for group_name in groups]),
+            )
+        )
 
-  # Modify kinematics.yaml file
-  kin_yaml_file_name = moveit_config_pkg_path + "/config/kinematics.yaml"
-  with open(kin_yaml_file_name, 'r') as f:
-    kin_yaml_data = yaml.safe_load(f)
+    # Modify kinematics.yaml file
+    kin_yaml_file_name = moveit_config_pkg_path + "/config/kinematics.yaml"
+    with open(kin_yaml_file_name, "r") as f:
+        kin_yaml_data = yaml.safe_load(f)
 
-  kin_yaml_data[args.planning_group_name]["kinematics_solver"] = args.plugin_name
-  with open(kin_yaml_file_name, 'w') as f:
-    yaml.dump(kin_yaml_data, f, default_flow_style=False)
+    kin_yaml_data[args.planning_group_name]["kinematics_solver"] = args.plugin_name
+    with open(kin_yaml_file_name, "w") as f:
+        yaml.dump(kin_yaml_data, f, default_flow_style=False)
 
-  print("Modified kinematics.yaml at '%s'" % kin_yaml_file_name)
+    print("Modified kinematics.yaml at '%s'" % kin_yaml_file_name)
 
 
 def copy_file(src_path, dest_path, description, replacements=None):
-  if not os.path.exists(src_path):
-    raise Exception("Can't find %s at '%s'" % (description, src_path))
+    if not os.path.exists(src_path):
+        raise Exception("Can't find %s at '%s'" % (description, src_path))
 
-  if replacements is None:
-    replacements = dict()
+    if replacements is None:
+        replacements = dict()
 
-  with open(src_path, 'r') as f:
-    content = f.read()
+    with open(src_path, "r") as f:
+        content = f.read()
 
-  # replace templates
-  for key, value in replacements.items():
-    content = re.sub(key, value, content)
+    # replace templates
+    for key, value in replacements.items():
+        content = re.sub(key, value, content)
 
-  with open(dest_path, 'w') as f:
-    f.write(content)
-  print("Created %s at '%s'" % (description, dest_path))
+    with open(dest_path, "w") as f:
+        f.write(content)
+    print("Created %s at '%s'" % (description, dest_path))
 
 
 def main():
-  parser = create_parser()
-  args = parser.parse_args()
+    parser = create_parser()
+    args = parser.parse_args()
 
-  populate_optional(args)
-  print_args(args)
-  validate_openrave_version(args)
-  create_ikfast_package(args)
-  update_ikfast_package(args)
-  try:
-    update_moveit_package(args)
-  except Exception as e:
-    print("Failed to update MoveIt package:\n" + str(e))
+    populate_optional(args)
+    print_args(args)
+    validate_openrave_version(args)
+    create_ikfast_package(args)
+    update_ikfast_package(args)
+    try:
+        update_moveit_package(args)
+    except Exception as e:
+        print("Failed to update MoveIt package:\n" + str(e))
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/round_collada_numbers.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/round_collada_numbers.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-'''
+"""
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -35,7 +35,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-'''
+"""
 # Author: Dave Coleman
 # Desc:   Rounds all the numbers to <decimal places> places
 
@@ -46,78 +46,82 @@ import shlex
 import sys
 import io
 
-def doRound(values,decimal_places):
+
+def doRound(values, decimal_places):
     num_vector = shlex.split(values)
     new_vector = []
 
     for num in num_vector:
-        new_num = round(float(num),decimal_places)
-        print("Old:",num,"New:",new_num)
+        new_num = round(float(num), decimal_places)
+        print("Old:", num, "New:", new_num)
         new_vector.append(str(new_num))
 
     new = " ".join(new_vector)
-    #print('Original:', values, '  Updated: ', new)
+    # print('Original:', values, '  Updated: ', new)
 
     return new
 
+
 # -----------------------------------------------------------------------------
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Check input arguments
     try:
         input_file = sys.argv[1]
         output_file = sys.argv[2]
         decimal_places = int(sys.argv[3])
-        assert( len(sys.argv) < 5 )   # invalid num-arguments
+        assert len(sys.argv) < 5  # invalid num-arguments
     except:
-        print('\nUsage: round_collada_numbers.py <input_dae> <output_dae> <decimal places>')
-        print('Rounds all the numbers to <decimal places> places\n')
+        print(
+            "\nUsage: round_collada_numbers.py <input_dae> <output_dae> <decimal places>"
+        )
+        print("Rounds all the numbers to <decimal places> places\n")
         sys.exit(-1)
 
-    print('\nCollada Number Rounder')
-    print('Rounding numbers to', decimal_places, 'decimal places\n')
+    print("\nCollada Number Rounder")
+    print("Rounding numbers to", decimal_places, "decimal places\n")
 
     # Read string from file
-    f = open(input_file,'r')
-    xml = f.read();
+    f = open(input_file, "r")
+    xml = f.read()
 
     # Parse XML
-    #doc = etree.fromstring(xml)
-    #print(doc.tag)
-    #doc = etree.parse(io.BytesIO(xml))
-    #element=doc.xpath('//ns:asset',namespaces={'ns','http://www.collada.org/2008/03/COLLADASchema'})
-    #print(element)
+    # doc = etree.fromstring(xml)
+    # print(doc.tag)
+    # doc = etree.parse(io.BytesIO(xml))
+    # element=doc.xpath('//ns:asset',namespaces={'ns','http://www.collada.org/2008/03/COLLADASchema'})
+    # print(element)
 
-    namespace = 'http://www.collada.org/2008/03/COLLADASchema'
+    namespace = "http://www.collada.org/2008/03/COLLADASchema"
     dom = etree.parse(io.BytesIO(xml))
 
     # find elements of particular name
-    elements=dom.xpath('//ns:translate',namespaces={'ns':namespace})
+    elements = dom.xpath("//ns:translate", namespaces={"ns": namespace})
     for i in range(len(elements)):
-        elements[i].text = doRound(elements[i].text,decimal_places)
+        elements[i].text = doRound(elements[i].text, decimal_places)
 
     # find elements of particular name
-    elements=dom.xpath('//ns:rotate',namespaces={'ns':namespace})
+    elements = dom.xpath("//ns:rotate", namespaces={"ns": namespace})
     for i in range(len(elements)):
-        elements[i].text = doRound(elements[i].text,decimal_places)
+        elements[i].text = doRound(elements[i].text, decimal_places)
 
     # find elements of particular name
-    elements=dom.xpath('//ns:min',namespaces={'ns':namespace})
+    elements = dom.xpath("//ns:min", namespaces={"ns": namespace})
     for i in range(len(elements)):
-        elements[i].text = doRound(elements[i].text,decimal_places)
+        elements[i].text = doRound(elements[i].text, decimal_places)
 
     # find elements of particular name
-    elements=dom.xpath('//ns:max',namespaces={'ns':namespace})
+    elements = dom.xpath("//ns:max", namespaces={"ns": namespace})
     for i in range(len(elements)):
-        elements[i].text = doRound(elements[i].text,decimal_places)
+        elements[i].text = doRound(elements[i].text, decimal_places)
 
     # find elements of particular name
-    elements=dom.xpath('//ns:float',namespaces={'ns':namespace})
+    elements = dom.xpath("//ns:float", namespaces={"ns": namespace})
     for i in range(len(elements)):
-        elements[i].text = doRound(elements[i].text,decimal_places)
+        elements[i].text = doRound(elements[i].text, decimal_places)
 
     # save changes
-    f = open(output_file,'w')
+    f = open(output_file, "w")
     f.write(etree.tostring(dom))
     f.close()

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/testpoints.py
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/testpoints.py
@@ -40,27 +40,27 @@ import rospy
 __REQUIRED_API_VERSION__ = "1"
 
 robot_configs = {}
-robot_configs['prbt'] = {
-        'initJointPose': [0.0, 0.0, math.radians(-25), 0.0, -1.57, 0],
-        'L': 0.2,
-        'M': 0.1,
-        'planning_group': 'manipulator',
-        'target_link': 'prbt_tcp',
-        'reference_frame': 'prbt_base',
-        'default_or': from_euler(0, math.radians(180), math.radians(90)),
-        'P1_position': Point(0.3, 0.0, 0.5),
-        'P1_orientation': from_euler(0, math.radians(180), math.radians(135))
+robot_configs["prbt"] = {
+    "initJointPose": [0.0, 0.0, math.radians(-25), 0.0, -1.57, 0],
+    "L": 0.2,
+    "M": 0.1,
+    "planning_group": "manipulator",
+    "target_link": "prbt_tcp",
+    "reference_frame": "prbt_base",
+    "default_or": from_euler(0, math.radians(180), math.radians(90)),
+    "P1_position": Point(0.3, 0.0, 0.5),
+    "P1_orientation": from_euler(0, math.radians(180), math.radians(135)),
 }
 
-robot_configs['panda'] = {
-        'initJointPose': [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785],
-        'L': 0.2,
-        'M': 0.1,
-        'planning_group': 'panda_arm',
-        'target_link': 'panda_link8',
-        'reference_frame': 'panda_link0',
-        'default_or': Quaternion(0.924, -0.382, 0.000, 0.000),
-        'P1_position': Point(0.2, 0.0, 0.8)
+robot_configs["panda"] = {
+    "initJointPose": [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785],
+    "L": 0.2,
+    "M": 0.1,
+    "planning_group": "panda_arm",
+    "target_link": "panda_link8",
+    "reference_frame": "panda_link0",
+    "default_or": Quaternion(0.924, -0.382, 0.000, 0.000),
+    "P1_position": Point(0.2, 0.0, 0.8),
 }
 
 
@@ -69,41 +69,122 @@ def start_program(robot_name):
 
     test_sequence(**robot_configs[robot_name])
 
-def test_sequence(initJointPose, L, M, planning_group, target_link, reference_frame, default_or, P1_position, P1_orientation):
+
+def test_sequence(
+    initJointPose,
+    L,
+    M,
+    planning_group,
+    target_link,
+    reference_frame,
+    default_or,
+    P1_position,
+    P1_orientation,
+):
     r = Robot(__REQUIRED_API_VERSION__)
 
     r.move(Ptp(goal=initJointPose, planning_group=planning_group))
 
     P1 = Pose(position=P1_position, orientation=P1_orientation)
 
+    P2 = Pose(
+        position=Point(P1.position.x + L, P1.position.y + L, P1.position.z - M),
+        orientation=default_or,
+    )
+    P3 = Pose(
+        position=Point(P1.position.x, P1.position.y + 2 * L, P1.position.z - 2 * M),
+        orientation=default_or,
+    )
+    P4 = Pose(
+        position=Point(P1.position.x, P1.position.y + L, P1.position.z - M),
+        orientation=default_or,
+    )
 
-    P2 = Pose(position=Point(P1.position.x+L, P1.position.y+L, P1.position.z-M), orientation=default_or)
-    P3 = Pose(position=Point(P1.position.x, P1.position.y+2*L, P1.position.z-2*M), orientation=default_or)
-    P4 = Pose(position=Point(P1.position.x, P1.position.y+L, P1.position.z-M), orientation=default_or)
+    ptp1 = Ptp(
+        goal=P1,
+        acc_scale=0.3,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    ptp2 = Ptp(
+        goal=P2,
+        acc_scale=0.3,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    ptp3 = Ptp(
+        goal=P3,
+        acc_scale=0.3,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    ptp4 = Ptp(
+        goal=P4,
+        acc_scale=0.3,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    lin1 = Lin(
+        goal=P1,
+        acc_scale=0.1,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    lin2 = Lin(
+        goal=P2,
+        acc_scale=0.1,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    lin3 = Lin(
+        goal=P3,
+        acc_scale=0.1,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    lin4 = Lin(
+        goal=P4,
+        acc_scale=0.1,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
 
-    ptp1 = Ptp(goal=P1, acc_scale=0.3, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    ptp2 = Ptp(goal=P2, acc_scale=0.3, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    ptp3 = Ptp(goal=P3, acc_scale=0.3, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    ptp4 = Ptp(goal=P4, acc_scale=0.3, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    lin1 = Lin(goal=P1, acc_scale=0.1, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    lin2 = Lin(goal=P2, acc_scale=0.1, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    lin3 = Lin(goal=P3, acc_scale=0.1, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    lin4 = Lin(goal=P4, acc_scale=0.1, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-
-    r.move(ptp1) #PTP_12 test
-    r.move(ptp2) #PTP_23
-    r.move(ptp3) #PTP_34
-    r.move(ptp4) #PTP_41
+    r.move(ptp1)  # PTP_12 test
+    r.move(ptp2)  # PTP_23
+    r.move(ptp3)  # PTP_34
+    r.move(ptp4)  # PTP_41
     r.move(ptp1)
 
-    r.move(lin1) #LIN_12
-    r.move(lin2) #LIN_23
-    r.move(lin3) #LIN_34
-    r.move(lin4) #LIN_41
+    r.move(lin1)  # LIN_12
+    r.move(lin2)  # LIN_23
+    r.move(lin3)  # LIN_34
+    r.move(lin4)  # LIN_41
     r.move(lin1)
 
-    circ3_interim_2 = Circ(goal=P3, interim=P2.position, acc_scale=0.2, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
-    circ1_center_2 = Circ(goal=P1, center=P2.position, acc_scale=0.2, planning_group=planning_group, target_link=target_link, reference_frame=reference_frame)
+    circ3_interim_2 = Circ(
+        goal=P3,
+        interim=P2.position,
+        acc_scale=0.2,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
+    circ1_center_2 = Circ(
+        goal=P1,
+        center=P2.position,
+        acc_scale=0.2,
+        planning_group=planning_group,
+        target_link=target_link,
+        reference_frame=reference_frame,
+    )
 
     for radius in [0, 0.1]:
         r.move(Ptp(goal=initJointPose, planning_group=planning_group))
@@ -119,22 +200,29 @@ def test_sequence(initJointPose, L, M, planning_group, target_link, reference_fr
 
         r.move(seq)
 
+
 if __name__ == "__main__":
     # Init a ros node
-    rospy.init_node('robot_program_node')
+    rospy.init_node("robot_program_node")
 
     import sys
 
     robots = list(robot_configs.keys())
 
-    if(len(sys.argv) < 2):
-        print("Please specify the robot you want to use." + ', '.join('"{0}"'.format(r) for r in robots))
+    if len(sys.argv) < 2:
+        print(
+            "Please specify the robot you want to use."
+            + ", ".join('"{0}"'.format(r) for r in robots)
+        )
         sys.exit()
 
-
-    if(sys.argv[1] not in robots):
-        print("Robot " + sys.argv[1] + " not available. Use one of " + ', '.join('"{0}"'.format(r) for r in robots))
+    if sys.argv[1] not in robots:
+        print(
+            "Robot "
+            + sys.argv[1]
+            + " not available. Use one of "
+            + ", ".join('"{0}"'.format(r) for r in robots)
+        )
         sys.exit()
-
 
     start_program(sys.argv[1])

--- a/moveit_ros/benchmarks/examples/demo_panda.launch.py
+++ b/moveit_ros/benchmarks/examples/demo_panda.launch.py
@@ -4,66 +4,90 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def generate_launch_description():
 
-    moveit_ros_benchmarks_yaml = load_yaml('moveit_ros_benchmarks', 'demo1.yaml')
-    moveit_ros_benchmarks_config = { 'benchmark_config' : moveit_ros_benchmarks_yaml }
+    moveit_ros_benchmarks_yaml = load_yaml("moveit_ros_benchmarks", "demo1.yaml")
+    moveit_ros_benchmarks_config = {"benchmark_config": moveit_ros_benchmarks_yaml}
 
     # Component yaml files are grouped in separate namespaces
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config }
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
-    ompl_planning_pipeline_config = { 'ompl' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config = {
+        "ompl": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     # moveit_ros_benchmark demo executable
-    moveit_ros_benchmarks_node = Node(name='moveit_run_benchmark',
-                                      package='moveit_ros_benchmarks',
-                                      # prefix='xterm -e gdb --ex=run --args',
-                                      executable='moveit_run_benchmark',
-                                      output='screen',
-                                      parameters=[moveit_ros_benchmarks_config,
-                                                  robot_description,
-                                                  robot_description_semantic,
-                                                  robot_description_kinematics,
-                                                  ompl_planning_pipeline_config])
+    moveit_ros_benchmarks_node = Node(
+        name="moveit_run_benchmark",
+        package="moveit_ros_benchmarks",
+        # prefix='xterm -e gdb --ex=run --args',
+        executable="moveit_run_benchmark",
+        output="screen",
+        parameters=[
+            moveit_ros_benchmarks_config,
+            robot_description,
+            robot_description_semantic,
+            robot_description_kinematics,
+            ompl_planning_pipeline_config,
+        ],
+    )
 
     # Warehouse mongodb server
-    mongodb_server_node = Node(package='warehouse_ros_mongo',
-                               executable='mongo_wrapper_ros.py',
-                               parameters=[{'warehouse_port': 33829},
-                                           {'warehouse_host': 'localhost'},
-                                           {'warehouse_plugin': 'warehouse_ros_mongo::MongoDatabaseConnection'}],
-                               output='screen')
+    mongodb_server_node = Node(
+        package="warehouse_ros_mongo",
+        executable="mongo_wrapper_ros.py",
+        parameters=[
+            {"warehouse_port": 33829},
+            {"warehouse_host": "localhost"},
+            {"warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"},
+        ],
+        output="screen",
+    )
 
     return LaunchDescription([moveit_ros_benchmarks_node, mongodb_server_node])

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
@@ -4,58 +4,80 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def generate_launch_description():
 
-    moveit_ros_benchmarks_yaml = load_yaml('moveit_ros_benchmarks', 'demo_panda_predefined_poses.yaml')
-    moveit_ros_benchmarks_config = { 'benchmark_config' : moveit_ros_benchmarks_yaml }
+    moveit_ros_benchmarks_yaml = load_yaml(
+        "moveit_ros_benchmarks", "demo_panda_predefined_poses.yaml"
+    )
+    moveit_ros_benchmarks_config = {"benchmark_config": moveit_ros_benchmarks_yaml}
 
     # Component yaml files are grouped in separate namespaces
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
-    ompl_planning_pipeline_config = { 'ompl' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config = {
+        "ompl": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     # moveit_ros_benchmark demo executable
-    moveit_ros_benchmarks_node = Node(node_name='moveit_run_benchmark',
-                                      package='moveit_ros_benchmarks',
-                                    #   prefix='xterm -e gdb --ex=run --args',
-                                      node_executable='moveit_combine_predefined_poses_benchmark',
-                                      output='screen',
-                                      parameters=[moveit_ros_benchmarks_config,
-                                                  robot_description,
-                                                  robot_description_semantic,
-                                                  robot_description_kinematics,
-                                                  ompl_planning_pipeline_config])
+    moveit_ros_benchmarks_node = Node(
+        node_name="moveit_run_benchmark",
+        package="moveit_ros_benchmarks",
+        #   prefix='xterm -e gdb --ex=run --args',
+        node_executable="moveit_combine_predefined_poses_benchmark",
+        output="screen",
+        parameters=[
+            moveit_ros_benchmarks_config,
+            robot_description,
+            robot_description_semantic,
+            robot_description_kinematics,
+            ompl_planning_pipeline_config,
+        ],
+    )
 
     return LaunchDescription([moveit_ros_benchmarks_node])

--- a/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
+++ b/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
@@ -41,7 +41,8 @@ from os.path import basename, splitext
 import sqlite3
 import datetime
 import matplotlib
-matplotlib.use('pdf')
+
+matplotlib.use("pdf")
 from matplotlib import __version__ as matplotlibversion
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
@@ -52,7 +53,7 @@ from optparse import OptionParser, OptionGroup
 # Given a text line, split it into tokens (by space) and return the token
 # at the desired index. Additionally, test that some expected tokens exist.
 # Return None if they do not.
-def readLogValue(filevar, desired_token_index, expected_tokens) :
+def readLogValue(filevar, desired_token_index, expected_tokens):
     start_pos = filevar.tell()
     tokens = filevar.readline().split()
     for token_index in expected_tokens:
@@ -62,19 +63,23 @@ def readLogValue(filevar, desired_token_index, expected_tokens) :
             return None
     return tokens[desired_token_index]
 
-def readOptionalLogValue(filevar, desired_token_index, expected_tokens = {}) :
+
+def readOptionalLogValue(filevar, desired_token_index, expected_tokens={}):
     return readLogValue(filevar, desired_token_index, expected_tokens)
 
-def readRequiredLogValue(name, filevar, desired_token_index, expected_tokens = {}) :
+
+def readRequiredLogValue(name, filevar, desired_token_index, expected_tokens={}):
     result = readLogValue(filevar, desired_token_index, expected_tokens)
     if result == None:
         raise Exception("Unable to read " + name)
     return result
 
+
 def ensurePrefix(line, prefix):
     if not line.startswith(prefix):
         raise Exception("Expected prefix " + prefix + " was not found")
     return line
+
 
 def readOptionalMultilineValue(filevar):
     start_pos = filevar.tell()
@@ -82,20 +87,21 @@ def readOptionalMultilineValue(filevar):
     if not line.startswith("<<<|"):
         filevar.seek(start_pos)
         return None
-    value = ''
+    value = ""
     line = filevar.readline()
-    while not line.startswith('|>>>'):
+    while not line.startswith("|>>>"):
         value = value + line
         line = filevar.readline()
         if line == None:
             raise Exception("Expected token |>>> missing")
     return value
 
+
 def readRequiredMultilineValue(filevar):
     ensurePrefix(filevar.readline(), "<<<|")
-    value = ''
+    value = ""
     line = filevar.readline()
-    while not line.startswith('|>>>'):
+    while not line.startswith("|>>>"):
         value = value + line
         line = filevar.readline()
         if line == None:
@@ -108,10 +114,11 @@ def readBenchmarkLog(dbname, filenames):
 
     conn = sqlite3.connect(dbname)
     c = conn.cursor()
-    c.execute('PRAGMA FOREIGN_KEYS = ON')
+    c.execute("PRAGMA FOREIGN_KEYS = ON")
 
     # create all tables if they don't already exist
-    c.executescript("""CREATE TABLE IF NOT EXISTS experiments
+    c.executescript(
+        """CREATE TABLE IF NOT EXISTS experiments
         (id INTEGER PRIMARY KEY ON CONFLICT REPLACE AUTOINCREMENT, name VARCHAR(512),
         totaltime REAL, timelimit REAL, memorylimit REAL, runcount INTEGER,
         version VARCHAR(128), hostname VARCHAR(1024), cpuinfo TEXT,
@@ -128,117 +135,187 @@ def readBenchmarkLog(dbname, filenames):
         FOREIGN KEY (plannerid) REFERENCES plannerConfigs(id) ON DELETE CASCADE);
         CREATE TABLE IF NOT EXISTS progress
         (runid INTEGER, time REAL, PRIMARY KEY (runid, time),
-        FOREIGN KEY (runid) REFERENCES runs(id) ON DELETE CASCADE)""")
+        FOREIGN KEY (runid) REFERENCES runs(id) ON DELETE CASCADE)"""
+    )
 
     # add placeholder entry for all_experiments
     allExperimentsName = "all_experiments"
     allExperimentsValues = {
-        "totaltime": 0.0, "timelimit": 0.0, "memorylimit": 0.0, "runcount": 0, "version": "0.0.0",
-        "hostname": "",   "cpuinfo": "",    "date": 0,          "seed": 0,     "setup": ""
+        "totaltime": 0.0,
+        "timelimit": 0.0,
+        "memorylimit": 0.0,
+        "runcount": 0,
+        "version": "0.0.0",
+        "hostname": "",
+        "cpuinfo": "",
+        "date": 0,
+        "seed": 0,
+        "setup": "",
     }
     addAllExperiments = len(filenames) > 0
     if addAllExperiments:
-        c.execute('INSERT INTO experiments VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-                  (None, allExperimentsName) + tuple(allExperimentsValues.values()))
+        c.execute(
+            "INSERT INTO experiments VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (None, allExperimentsName) + tuple(allExperimentsValues.values()),
+        )
         allExperimentsId = c.lastrowid
 
     for i, filename in enumerate(filenames):
-        print('Processing ' + filename)
-        logfile = open(filename,'r')
+        print("Processing " + filename)
+        logfile = open(filename, "r")
         start_pos = logfile.tell()
-        libname = readOptionalLogValue(logfile, 0, {1 : "version"})
+        libname = readOptionalLogValue(logfile, 0, {1: "version"})
         if libname == None:
             libname = "OMPL"
         logfile.seek(start_pos)
-        version = readOptionalLogValue(logfile, -1, {1 : "version"})
+        version = readOptionalLogValue(logfile, -1, {1: "version"})
         if version == None:
             # set the version number to make Planner Arena happy
             version = "0.0.0"
-        version = ' '.join([libname, version])
-        expname = readRequiredLogValue("experiment name", logfile, -1, {0 : "Experiment"})
-        hostname = readRequiredLogValue("hostname", logfile, -1, {0 : "Running"})
-        date = ' '.join(ensurePrefix(logfile.readline(), "Starting").split()[2:])
+        version = " ".join([libname, version])
+        expname = readRequiredLogValue(
+            "experiment name", logfile, -1, {0: "Experiment"}
+        )
+        hostname = readRequiredLogValue("hostname", logfile, -1, {0: "Running"})
+        date = " ".join(ensurePrefix(logfile.readline(), "Starting").split()[2:])
         expsetup = readRequiredMultilineValue(logfile)
         cpuinfo = readOptionalMultilineValue(logfile)
-        rseed = int(readRequiredLogValue("random seed", logfile, 0, {-2 : "random", -1 : "seed"}))
-        timelimit = float(readRequiredLogValue("time limit", logfile, 0, {-3 : "seconds", -2 : "per", -1 : "run"}))
-        memorylimit = float(readRequiredLogValue("memory limit", logfile, 0, {-3 : "MB", -2 : "per", -1 : "run"}))
-        nrrunsOrNone = readOptionalLogValue(logfile, 0, {-3 : "runs", -2 : "per", -1 : "planner"})
+        rseed = int(
+            readRequiredLogValue("random seed", logfile, 0, {-2: "random", -1: "seed"})
+        )
+        timelimit = float(
+            readRequiredLogValue(
+                "time limit", logfile, 0, {-3: "seconds", -2: "per", -1: "run"}
+            )
+        )
+        memorylimit = float(
+            readRequiredLogValue(
+                "memory limit", logfile, 0, {-3: "MB", -2: "per", -1: "run"}
+            )
+        )
+        nrrunsOrNone = readOptionalLogValue(
+            logfile, 0, {-3: "runs", -2: "per", -1: "planner"}
+        )
         nrruns = -1
         if nrrunsOrNone != None:
             nrruns = int(nrrunsOrNone)
-            allExperimentsValues['runcount'] += nrruns
-        totaltime = float(readRequiredLogValue("total time", logfile, 0, {-3 : "collect", -2 : "the", -1 : "data"}))
+            allExperimentsValues["runcount"] += nrruns
+        totaltime = float(
+            readRequiredLogValue(
+                "total time", logfile, 0, {-3: "collect", -2: "the", -1: "data"}
+            )
+        )
         # fill in fields of all_experiments
-        allExperimentsValues['totaltime'] += totaltime
-        allExperimentsValues['memorylimit'] = max(allExperimentsValues['memorylimit'], totaltime)
-        allExperimentsValues['timelimit'] = max(allExperimentsValues['timelimit'], totaltime)
+        allExperimentsValues["totaltime"] += totaltime
+        allExperimentsValues["memorylimit"] = max(
+            allExperimentsValues["memorylimit"], totaltime
+        )
+        allExperimentsValues["timelimit"] = max(
+            allExperimentsValues["timelimit"], totaltime
+        )
         # copy the fields of the first file to all_experiments so that they are not empty
-        if (i==0):
-            allExperimentsValues['version'] = version
-            allExperimentsValues['date'] = date
-            allExperimentsValues['setup'] = expsetup
-            allExperimentsValues['hostname'] = hostname
-            allExperimentsValues['cpuinfo'] = cpuinfo
+        if i == 0:
+            allExperimentsValues["version"] = version
+            allExperimentsValues["date"] = date
+            allExperimentsValues["setup"] = expsetup
+            allExperimentsValues["hostname"] = hostname
+            allExperimentsValues["cpuinfo"] = cpuinfo
         numEnums = 0
-        numEnumsOrNone = readOptionalLogValue(logfile, 0, {-2 : "enum"})
+        numEnumsOrNone = readOptionalLogValue(logfile, 0, {-2: "enum"})
         if numEnumsOrNone != None:
             numEnums = int(numEnumsOrNone)
         for i in range(numEnums):
-            enum = logfile.readline()[:-1].split('|')
+            enum = logfile.readline()[:-1].split("|")
             c.execute('SELECT * FROM enums WHERE name IS "%s"' % enum[0])
             if c.fetchone() == None:
-                for j in range(len(enum)-1):
-                    c.execute('INSERT INTO enums VALUES (?,?,?)',
-                        (enum[0],j,enum[j+1]))
-        c.execute('INSERT INTO experiments VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-              (None, expname, totaltime, timelimit, memorylimit, nrruns,
-              version, hostname, cpuinfo, date, rseed, expsetup) )
+                for j in range(len(enum) - 1):
+                    c.execute(
+                        "INSERT INTO enums VALUES (?,?,?)", (enum[0], j, enum[j + 1])
+                    )
+        c.execute(
+            "INSERT INTO experiments VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                None,
+                expname,
+                totaltime,
+                timelimit,
+                memorylimit,
+                nrruns,
+                version,
+                hostname,
+                cpuinfo,
+                date,
+                rseed,
+                expsetup,
+            ),
+        )
         experimentId = c.lastrowid
-        numPlanners = int(readRequiredLogValue("planner count", logfile, 0, {-1 : "planners"}))
+        numPlanners = int(
+            readRequiredLogValue("planner count", logfile, 0, {-1: "planners"})
+        )
         for i in range(numPlanners):
             plannerName = logfile.readline()[:-1]
-            print('Parsing data for ' + plannerName)
+            print("Parsing data for " + plannerName)
 
             # read common data for planner
             numCommon = int(logfile.readline().split()[0])
-            settings = ''
+            settings = ""
             for j in range(numCommon):
-                settings = settings + logfile.readline() + ';'
+                settings = settings + logfile.readline() + ";"
 
             # find planner id
-            c.execute('SELECT id FROM plannerConfigs WHERE (name=? AND settings=?)',
-                (plannerName, settings,))
+            c.execute(
+                "SELECT id FROM plannerConfigs WHERE (name=? AND settings=?)",
+                (
+                    plannerName,
+                    settings,
+                ),
+            )
             p = c.fetchone()
-            if p==None:
-                c.execute('INSERT INTO plannerConfigs VALUES (?,?,?)',
-                    (None, plannerName, settings,))
+            if p == None:
+                c.execute(
+                    "INSERT INTO plannerConfigs VALUES (?,?,?)",
+                    (
+                        None,
+                        plannerName,
+                        settings,
+                    ),
+                )
                 plannerId = c.lastrowid
             else:
                 plannerId = p[0]
 
             # get current column names
-            c.execute('PRAGMA table_info(runs)')
+            c.execute("PRAGMA table_info(runs)")
             columnNames = [col[1] for col in c.fetchall()]
 
             # read properties and add columns as necessary
             numProperties = int(logfile.readline().split()[0])
-            propertyNames = ['experimentid', 'plannerid']
+            propertyNames = ["experimentid", "plannerid"]
             for j in range(numProperties):
                 field = logfile.readline().split()
                 propertyType = field[-1]
-                propertyName = '_'.join(field[:-1])
+                propertyName = "_".join(field[:-1])
                 if propertyName not in columnNames:
-                    c.execute('ALTER TABLE runs ADD %s %s' % (propertyName, propertyType))
+                    c.execute(
+                        "ALTER TABLE runs ADD %s %s" % (propertyName, propertyType)
+                    )
                 propertyNames.append(propertyName)
             # read measurements
-            insertFmtStr = 'INSERT INTO runs (' + ','.join(propertyNames) + \
-                ') VALUES (' + ','.join('?'*len(propertyNames)) + ')'
+            insertFmtStr = (
+                "INSERT INTO runs ("
+                + ",".join(propertyNames)
+                + ") VALUES ("
+                + ",".join("?" * len(propertyNames))
+                + ")"
+            )
             numRuns = int(logfile.readline().split()[0])
             runIds = []
             for j in range(numRuns):
-                runValues = [None if len(x) == 0 or x == 'nan' or x == 'inf' else x
-                    for x in logfile.readline().split('; ')[:-1]]
+                runValues = [
+                    None if len(x) == 0 or x == "nan" or x == "inf" else x
+                    for x in logfile.readline().split("; ")[:-1]
+                ]
                 values = tuple([experimentId, plannerId] + runValues)
                 c.execute(insertFmtStr, values)
                 # extract primary key of each run row so we can reference them
@@ -252,37 +329,49 @@ def readBenchmarkLog(dbname, filenames):
             nextLine = logfile.readline().strip()
 
             # read planner progress data if it's supplied
-            if nextLine != '.':
+            if nextLine != ".":
                 # get current column names
-                c.execute('PRAGMA table_info(progress)')
+                c.execute("PRAGMA table_info(progress)")
                 columnNames = [col[1] for col in c.fetchall()]
 
                 # read progress properties and add columns as necesary
                 numProgressProperties = int(nextLine.split()[0])
-                progressPropertyNames = ['runid']
+                progressPropertyNames = ["runid"]
                 for i in range(numProgressProperties):
                     field = logfile.readline().split()
                     progressPropertyType = field[-1]
                     progressPropertyName = "_".join(field[:-1])
                     if progressPropertyName not in columnNames:
-                        c.execute('ALTER TABLE progress ADD %s %s' %
-                            (progressPropertyName, progressPropertyType))
+                        c.execute(
+                            "ALTER TABLE progress ADD %s %s"
+                            % (progressPropertyName, progressPropertyType)
+                        )
                     progressPropertyNames.append(progressPropertyName)
                 # read progress measurements
-                insertFmtStr = 'INSERT INTO progress (' + \
-                    ','.join(progressPropertyNames) + ') VALUES (' + \
-                    ','.join('?'*len(progressPropertyNames)) + ')'
+                insertFmtStr = (
+                    "INSERT INTO progress ("
+                    + ",".join(progressPropertyNames)
+                    + ") VALUES ("
+                    + ",".join("?" * len(progressPropertyNames))
+                    + ")"
+                )
                 numRuns = int(logfile.readline().split()[0])
                 for j in range(numRuns):
-                    dataSeries = logfile.readline().split(';')[:-1]
+                    dataSeries = logfile.readline().split(";")[:-1]
                     for dataSample in dataSeries:
-                        values = tuple([runIds[j]] + \
-                            [None if len(x) == 0 or x == 'nan' or x == 'inf' else x
-                            for x in dataSample.split(',')[:-1]])
+                        values = tuple(
+                            [runIds[j]]
+                            + [
+                                None if len(x) == 0 or x == "nan" or x == "inf" else x
+                                for x in dataSample.split(",")[:-1]
+                            ]
+                        )
                         try:
                             c.execute(insertFmtStr, values)
                         except sqlite3.IntegrityError:
-                            print('Ignoring duplicate progress data. Consider increasing ompl::tools::Benchmark::Request::timeBetweenUpdates.')
+                            print(
+                                "Ignoring duplicate progress data. Consider increasing ompl::tools::Benchmark::Request::timeBetweenUpdates."
+                            )
                             pass
 
                 logfile.readline()
@@ -299,125 +388,158 @@ def readBenchmarkLog(dbname, filenames):
     conn.commit()
     c.close()
 
+
 def plotAttribute(cur, planners, attribute, typename):
     """Create a plot for a particular attribute. It will include data for
     all planners that have data for this attribute."""
     labels = []
     measurements = []
     nanCounts = []
-    if typename == 'ENUM':
+    if typename == "ENUM":
         cur.execute('SELECT description FROM enums where name IS "%s"' % attribute)
-        descriptions = [ t[0] for t in cur.fetchall() ]
+        descriptions = [t[0] for t in cur.fetchall()]
         numValues = len(descriptions)
     for planner in planners:
-        cur.execute('SELECT %s FROM runs WHERE plannerid = %s AND %s IS NOT NULL' \
-            % (attribute, planner[0], attribute))
-        measurement = [ t[0] for t in cur.fetchall() if t[0] != None ]
+        cur.execute(
+            "SELECT %s FROM runs WHERE plannerid = %s AND %s IS NOT NULL"
+            % (attribute, planner[0], attribute)
+        )
+        measurement = [t[0] for t in cur.fetchall() if t[0] != None]
         if len(measurement) > 0:
-            cur.execute('SELECT count(*) FROM runs WHERE plannerid = %s AND %s IS NULL' \
-                % (planner[0], attribute))
+            cur.execute(
+                "SELECT count(*) FROM runs WHERE plannerid = %s AND %s IS NULL"
+                % (planner[0], attribute)
+            )
             nanCounts.append(cur.fetchone()[0])
             labels.append(planner[1])
-            if typename == 'ENUM':
-                scale = 100. / len(measurement)
-                measurements.append([measurement.count(i)*scale for i in range(numValues)])
+            if typename == "ENUM":
+                scale = 100.0 / len(measurement)
+                measurements.append(
+                    [measurement.count(i) * scale for i in range(numValues)]
+                )
             else:
                 measurements.append(measurement)
 
-    if len(measurements)==0:
+    if len(measurements) == 0:
         print('Skipping "%s": no available measurements' % attribute)
         return
 
     plt.clf()
     ax = plt.gca()
-    if typename == 'ENUM':
-        width = .5
+    if typename == "ENUM":
+        width = 0.5
         measurements = np.transpose(np.vstack(measurements))
         colsum = np.sum(measurements, axis=1)
         rows = np.where(colsum != 0)[0]
-        heights = np.zeros((1,measurements.shape[1]))
+        heights = np.zeros((1, measurements.shape[1]))
         ind = range(measurements.shape[1])
         legend_labels = []
         for i in rows:
-            plt.bar(ind, measurements[i], width, bottom=heights[0],
-                color=matplotlib.cm.hot(int(floor(i*256/numValues))),
-                label=descriptions[i])
+            plt.bar(
+                ind,
+                measurements[i],
+                width,
+                bottom=heights[0],
+                color=matplotlib.cm.hot(int(floor(i * 256 / numValues))),
+                label=descriptions[i],
+            )
             heights = heights + measurements[i]
-        xtickNames = plt.xticks([x + width / 2. for x in ind], labels, rotation=30, fontsize=8, ha='right')
-        ax.set_ylabel(attribute.replace('_',' ') + ' (%)')
+        xtickNames = plt.xticks(
+            [x + width / 2.0 for x in ind], labels, rotation=30, fontsize=8, ha="right"
+        )
+        ax.set_ylabel(attribute.replace("_", " ") + " (%)")
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         props = matplotlib.font_manager.FontProperties()
-        props.set_size('small')
-        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5), prop = props)
-    elif typename == 'BOOLEAN':
-        width = .5
-        measurementsPercentage = [sum(m) * 100. / len(m) for m in measurements]
+        props.set_size("small")
+        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5), prop=props)
+    elif typename == "BOOLEAN":
+        width = 0.5
+        measurementsPercentage = [sum(m) * 100.0 / len(m) for m in measurements]
         ind = range(len(measurements))
         plt.bar(ind, measurementsPercentage, width)
         ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers.
         ### Fits situations where you need more control in the plot, such as in an academic publication for example
-        #labels = [l.replace('kConfigDefault', '') for l in labels]
+        # labels = [l.replace('kConfigDefault', '') for l in labels]
 
-        xtickNames = plt.xticks([x + width / 2. for x in ind], labels, rotation=30, fontsize=8, ha='right')
-        ax.set_ylabel(attribute.replace('_',' ') + ' (%)')
-        plt.subplots_adjust(bottom=0.3) # Squish the plot into the upper 2/3 of the page.  Leave room for labels
+        xtickNames = plt.xticks(
+            [x + width / 2.0 for x in ind], labels, rotation=30, fontsize=8, ha="right"
+        )
+        ax.set_ylabel(attribute.replace("_", " ") + " (%)")
+        plt.subplots_adjust(
+            bottom=0.3
+        )  # Squish the plot into the upper 2/3 of the page.  Leave room for labels
     else:
-        if int(matplotlibversion.split('.')[0])<1:
-            plt.boxplot(measurements, notch=0, sym='k+', vert=1, whis=1.5)
+        if int(matplotlibversion.split(".")[0]) < 1:
+            plt.boxplot(measurements, notch=0, sym="k+", vert=1, whis=1.5)
         else:
-            plt.boxplot(measurements, notch=0, sym='k+', vert=1, whis=1.5, bootstrap=1000)
-        ax.set_ylabel(attribute.replace('_',' '))
+            plt.boxplot(
+                measurements, notch=0, sym="k+", vert=1, whis=1.5, bootstrap=1000
+            )
+        ax.set_ylabel(attribute.replace("_", " "))
 
-        #xtickNames = plt.xticks(labels, rotation=30, fontsize=10)
-        #plt.subplots_adjust(bottom=0.3) # Squish the plot into the upper 2/3 of the page.  Leave room for labels
+        # xtickNames = plt.xticks(labels, rotation=30, fontsize=10)
+        # plt.subplots_adjust(bottom=0.3) # Squish the plot into the upper 2/3 of the page.  Leave room for labels
 
         ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers.
         ### Fits situations where you need more control in the plot, such as in an academic publication for example
-        #labels = [l.replace('kConfigDefault', '') for l in labels]
+        # labels = [l.replace('kConfigDefault', '') for l in labels]
 
-        xtickNames = plt.setp(ax,xticklabels=labels)
-        plt.setp(xtickNames, rotation=30, fontsize=8, ha='right')
-        for tick in ax.xaxis.get_major_ticks(): # shrink the font size of the x tick labels
+        xtickNames = plt.setp(ax, xticklabels=labels)
+        plt.setp(xtickNames, rotation=30, fontsize=8, ha="right")
+        for (
+            tick
+        ) in ax.xaxis.get_major_ticks():  # shrink the font size of the x tick labels
             tick.label.set_fontsize(8)
-        plt.subplots_adjust(bottom=0.3) # Squish the plot into the upper 2/3 of the page.  Leave room for labels
-    ax.set_xlabel('Motion planning algorithm', fontsize=12)
-    ax.yaxis.grid(True, linestyle='-', which='major', color='lightgrey', alpha=0.5)
-    if max(nanCounts)>0:
+        plt.subplots_adjust(
+            bottom=0.3
+        )  # Squish the plot into the upper 2/3 of the page.  Leave room for labels
+    ax.set_xlabel("Motion planning algorithm", fontsize=12)
+    ax.yaxis.grid(True, linestyle="-", which="major", color="lightgrey", alpha=0.5)
+    if max(nanCounts) > 0:
         maxy = max([max(y) for y in measurements])
         for i in range(len(labels)):
-            x = i+width/2 if typename=='BOOLEAN' else i+1
+            x = i + width / 2 if typename == "BOOLEAN" else i + 1
         ### uncommenting the next line, the number of failed planning attempts will be added to each bar
         # ax.text(x, .95*maxy, str(nanCounts[i]), horizontalalignment='center', size='small')
     plt.show()
 
+
 def plotProgressAttribute(cur, planners, attribute):
     """Plot data for a single planner progress attribute. Will create an
-average time-plot with error bars of the attribute over all runs for
-each planner."""
+    average time-plot with error bars of the attribute over all runs for
+    each planner."""
 
     import numpy.ma as ma
 
     plt.clf()
     ax = plt.gca()
-    ax.set_xlabel('time (s)')
-    ax.set_ylabel(attribute.replace('_',' '))
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel(attribute.replace("_", " "))
     plannerNames = []
     for planner in planners:
-        cur.execute("""SELECT count(progress.%s) FROM progress INNER JOIN runs
+        cur.execute(
+            """SELECT count(progress.%s) FROM progress INNER JOIN runs
             ON progress.runid = runs.id AND runs.plannerid=%s
-            AND progress.%s IS NOT NULL""" \
-            % (attribute, planner[0], attribute))
+            AND progress.%s IS NOT NULL"""
+            % (attribute, planner[0], attribute)
+        )
         if cur.fetchone()[0] > 0:
             plannerNames.append(planner[1])
-            cur.execute("""SELECT DISTINCT progress.runid FROM progress INNER JOIN runs
-            WHERE progress.runid=runs.id AND runs.plannerid=?""", (planner[0],))
+            cur.execute(
+                """SELECT DISTINCT progress.runid FROM progress INNER JOIN runs
+            WHERE progress.runid=runs.id AND runs.plannerid=?""",
+                (planner[0],),
+            )
             runids = [t[0] for t in cur.fetchall()]
             timeTable = []
             dataTable = []
             for r in runids:
                 # Select data for given run
-                cur.execute('SELECT time, %s FROM progress WHERE runid = %s ORDER BY time' % (attribute,r))
+                cur.execute(
+                    "SELECT time, %s FROM progress WHERE runid = %s ORDER BY time"
+                    % (attribute, r)
+                )
                 (time, data) = zip(*(cur.fetchall()))
                 timeTable.append(time)
                 dataTable.append(data)
@@ -428,39 +550,50 @@ each planner."""
             fewestSamples = min(len(time[:]) for time in timeTable)
             times = np.array(timeTable[0][:fewestSamples])
             dataArrays = np.array([data[:fewestSamples] for data in dataTable])
-            filteredData = ma.masked_array(dataArrays, np.equal(dataArrays, None), dtype=float)
+            filteredData = ma.masked_array(
+                dataArrays, np.equal(dataArrays, None), dtype=float
+            )
 
             means = np.mean(filteredData, axis=0)
             stddevs = np.std(filteredData, axis=0, ddof=1)
 
             # plot average with error bars
-            plt.errorbar(times, means, yerr=2*stddevs, errorevery=max(1, len(times) // 20))
+            plt.errorbar(
+                times, means, yerr=2 * stddevs, errorevery=max(1, len(times) // 20)
+            )
             ax.legend(plannerNames)
-    if len(plannerNames)>0:
+    if len(plannerNames) > 0:
         plt.show()
     else:
         plt.clf()
+
 
 def plotStatistics(dbname, fname):
     """Create a PDF file with box plots for all attributes."""
     print("Generating plots...")
     conn = sqlite3.connect(dbname)
     c = conn.cursor()
-    c.execute('PRAGMA FOREIGN_KEYS = ON')
-    c.execute('SELECT id, name FROM plannerConfigs')
-    planners = [(t[0],t[1].replace('geometric_','').replace('control_',''))
-        for t in c.fetchall()]
-    c.execute('PRAGMA table_info(runs)')
+    c.execute("PRAGMA FOREIGN_KEYS = ON")
+    c.execute("SELECT id, name FROM plannerConfigs")
+    planners = [
+        (t[0], t[1].replace("geometric_", "").replace("control_", ""))
+        for t in c.fetchall()
+    ]
+    c.execute("PRAGMA table_info(runs)")
     colInfo = c.fetchall()[3:]
 
     pp = PdfPages(fname)
     for col in colInfo:
-        if col[2] == 'BOOLEAN' or col[2] == 'ENUM' or \
-           col[2] == 'INTEGER' or col[2] == 'REAL':
-           plotAttribute(c, planners, col[1], col[2])
-           pp.savefig(plt.gcf())
+        if (
+            col[2] == "BOOLEAN"
+            or col[2] == "ENUM"
+            or col[2] == "INTEGER"
+            or col[2] == "REAL"
+        ):
+            plotAttribute(c, planners, col[1], col[2])
+            pp.savefig(plt.gcf())
 
-    c.execute('PRAGMA table_info(progress)')
+    c.execute("PRAGMA table_info(progress)")
     colInfo = c.fetchall()[2:]
     for col in colInfo:
         plotProgressAttribute(c, planners, col[1])
@@ -472,34 +605,41 @@ def plotStatistics(dbname, fname):
     c.execute("""SELECT id, name, timelimit, memorylimit FROM experiments""")
     experiments = c.fetchall()
     for experiment in experiments:
-        c.execute("""SELECT count(*) FROM runs WHERE runs.experimentid = %d
-            GROUP BY runs.plannerid""" % experiment[0])
+        c.execute(
+            """SELECT count(*) FROM runs WHERE runs.experimentid = %d
+            GROUP BY runs.plannerid"""
+            % experiment[0]
+        )
         numRuns = [run[0] for run in c.fetchall()]
-        numRuns = numRuns[0] if len(set(numRuns)) == 1 else ','.join(numRuns)
+        numRuns = numRuns[0] if len(set(numRuns)) == 1 else ",".join(numRuns)
 
         plt.figtext(pagex, pagey, 'Experiment "%s"' % experiment[1])
-        plt.figtext(pagex, pagey-0.05, 'Number of averaged runs: %d' % numRuns)
-        plt.figtext(pagex, pagey-0.10, "Time limit per run: %g seconds" % experiment[2])
-        plt.figtext(pagex, pagey-0.15, "Memory limit per run: %g MB" % experiment[3])
+        plt.figtext(pagex, pagey - 0.05, "Number of averaged runs: %d" % numRuns)
+        plt.figtext(
+            pagex, pagey - 0.10, "Time limit per run: %g seconds" % experiment[2]
+        )
+        plt.figtext(pagex, pagey - 0.15, "Memory limit per run: %g MB" % experiment[3])
         pagey -= 0.22
     plt.show()
     pp.savefig(plt.gcf())
     pp.close()
 
+
 def saveAsMysql(dbname, mysqldump):
     # See http://stackoverflow.com/questions/1067060/perl-to-python
     import re
+
     print("Saving as MySQL dump file...")
 
     conn = sqlite3.connect(dbname)
-    mysqldump = open(mysqldump,'w')
+    mysqldump = open(mysqldump, "w")
 
     # make sure all tables are dropped in an order that keepd foreign keys valid
     c = conn.cursor()
     c.execute("SELECT name FROM sqlite_master WHERE type='table'")
-    table_names = [ str(t[0]) for t in c.fetchall() ]
+    table_names = [str(t[0]) for t in c.fetchall()]
     c.close()
-    last = ['experiments', 'planner_configs']
+    last = ["experiments", "planner_configs"]
     for table in table_names:
         if table.startswith("sqlite"):
             continue
@@ -511,44 +651,52 @@ def saveAsMysql(dbname, mysqldump):
 
     for line in conn.iterdump():
         process = False
-        for nope in ('BEGIN TRANSACTION','COMMIT',
-            'sqlite_sequence','CREATE UNIQUE INDEX', 'CREATE VIEW'):
-            if nope in line: break
+        for nope in (
+            "BEGIN TRANSACTION",
+            "COMMIT",
+            "sqlite_sequence",
+            "CREATE UNIQUE INDEX",
+            "CREATE VIEW",
+        ):
+            if nope in line:
+                break
         else:
             process = True
-        if not process: continue
+        if not process:
+            continue
         line = re.sub(r"[\n\r\t ]+", " ", line)
-        m = re.search('CREATE TABLE ([a-zA-Z0-9_]*)(.*)', line)
+        m = re.search("CREATE TABLE ([a-zA-Z0-9_]*)(.*)", line)
         if m:
             name, sub = m.groups()
-            sub = sub.replace('"','`')
-            line = '''CREATE TABLE IF NOT EXISTS %(name)s%(sub)s'''
+            sub = sub.replace('"', "`")
+            line = """CREATE TABLE IF NOT EXISTS %(name)s%(sub)s"""
             line = line % dict(name=name, sub=sub)
             # make sure we use an engine that supports foreign keys
             line = line.rstrip("\n\t ;") + " ENGINE = InnoDB;\n"
         else:
             m = re.search('INSERT INTO "([a-zA-Z0-9_]*)"(.*)', line)
             if m:
-                line = 'INSERT INTO %s%s\n' % m.groups()
-                line = line.replace('"', r'\"')
+                line = "INSERT INTO %s%s\n" % m.groups()
+                line = line.replace('"', r"\"")
                 line = line.replace('"', "'")
 
         line = re.sub(r"([^'])'t'(.)", "\\1THIS_IS_TRUE\\2", line)
-        line = line.replace('THIS_IS_TRUE', '1')
+        line = line.replace("THIS_IS_TRUE", "1")
         line = re.sub(r"([^'])'f'(.)", "\\1THIS_IS_FALSE\\2", line)
-        line = line.replace('THIS_IS_FALSE', '0')
-        line = line.replace('AUTOINCREMENT', 'AUTO_INCREMENT')
+        line = line.replace("THIS_IS_FALSE", "0")
+        line = line.replace("AUTOINCREMENT", "AUTO_INCREMENT")
         mysqldump.write(line)
     mysqldump.close()
+
 
 def computeViews(dbname):
     conn = sqlite3.connect(dbname)
     c = conn.cursor()
-    c.execute('PRAGMA FOREIGN_KEYS = ON')
-    c.execute('PRAGMA table_info(runs)')
+    c.execute("PRAGMA FOREIGN_KEYS = ON")
+    c.execute("PRAGMA table_info(runs)")
     # kinodynamic paths cannot be simplified (or least not easily),
     # so simplification_time may not exist as a database column
-    if 'simplification_time' in [col[1] for col in c.fetchall()]:
+    if "simplification_time" in [col[1] for col in c.fetchall()]:
         s0 = """SELECT plannerid, plannerConfigs.name AS plannerName, experimentid, solved, time + simplification_time AS total_time
             FROM plannerConfigs INNER JOIN experiments INNER JOIN runs
             ON plannerConfigs.id=runs.plannerid AND experiments.id=runs.experimentid"""
@@ -556,34 +704,68 @@ def computeViews(dbname):
         s0 = """SELECT plannerid, plannerConfigs.name AS plannerName, experimentid, solved, time AS total_time
             FROM plannerConfigs INNER JOIN experiments INNER JOIN runs
             ON plannerConfigs.id=runs.plannerid AND experiments.id=runs.experimentid"""
-    s1 = """SELECT plannerid, plannerName, experimentid, AVG(solved) AS avg_solved, AVG(total_time) AS avg_total_time
-        FROM (%s) GROUP BY plannerid, experimentid""" % s0
-    s2 = """SELECT plannerid, experimentid, MIN(avg_solved) AS avg_solved, avg_total_time
-        FROM (%s) GROUP BY plannerName, experimentid ORDER BY avg_solved DESC, avg_total_time ASC""" % s1
-    c.execute('DROP VIEW IF EXISTS bestPlannerConfigsPerExperiment')
-    c.execute('CREATE VIEW IF NOT EXISTS bestPlannerConfigsPerExperiment AS %s' % s2)
+    s1 = (
+        """SELECT plannerid, plannerName, experimentid, AVG(solved) AS avg_solved, AVG(total_time) AS avg_total_time
+        FROM (%s) GROUP BY plannerid, experimentid"""
+        % s0
+    )
+    s2 = (
+        """SELECT plannerid, experimentid, MIN(avg_solved) AS avg_solved, avg_total_time
+        FROM (%s) GROUP BY plannerName, experimentid ORDER BY avg_solved DESC, avg_total_time ASC"""
+        % s1
+    )
+    c.execute("DROP VIEW IF EXISTS bestPlannerConfigsPerExperiment")
+    c.execute("CREATE VIEW IF NOT EXISTS bestPlannerConfigsPerExperiment AS %s" % s2)
 
-    s1 = """SELECT plannerid, plannerName, AVG(solved) AS avg_solved, AVG(total_time) AS avg_total_time
-        FROM (%s) GROUP BY plannerid""" % s0
-    s2 = """SELECT plannerid, MIN(avg_solved) AS avg_solved, avg_total_time
-        FROM (%s) GROUP BY plannerName ORDER BY avg_solved DESC, avg_total_time ASC""" % s1
-    c.execute('DROP VIEW IF EXISTS bestPlannerConfigs')
-    c.execute('CREATE VIEW IF NOT EXISTS bestPlannerConfigs AS %s' % s2)
+    s1 = (
+        """SELECT plannerid, plannerName, AVG(solved) AS avg_solved, AVG(total_time) AS avg_total_time
+        FROM (%s) GROUP BY plannerid"""
+        % s0
+    )
+    s2 = (
+        """SELECT plannerid, MIN(avg_solved) AS avg_solved, avg_total_time
+        FROM (%s) GROUP BY plannerName ORDER BY avg_solved DESC, avg_total_time ASC"""
+        % s1
+    )
+    c.execute("DROP VIEW IF EXISTS bestPlannerConfigs")
+    c.execute("CREATE VIEW IF NOT EXISTS bestPlannerConfigs AS %s" % s2)
 
     conn.commit()
     c.close()
 
+
 if __name__ == "__main__":
     usage = """%prog [options] [<benchmark.log> ...]"""
     parser = OptionParser("A script to parse benchmarking results.\n" + usage)
-    parser.add_option("-d", "--database", dest="dbname", default="benchmark.db",
-        help="Filename of benchmark database [default: %default]")
-    parser.add_option("-v", "--view", action="store_true", dest="view", default=False,
-        help="Compute the views for best planner configurations")
-    parser.add_option("-p", "--plot", dest="plot", default=None,
-        help="Create a PDF of plots with the filename provided")
-    parser.add_option("-m", "--mysql", dest="mysqldb", default=None,
-        help="Save SQLite3 database as a MySQL dump file")
+    parser.add_option(
+        "-d",
+        "--database",
+        dest="dbname",
+        default="benchmark.db",
+        help="Filename of benchmark database [default: %default]",
+    )
+    parser.add_option(
+        "-v",
+        "--view",
+        action="store_true",
+        dest="view",
+        default=False,
+        help="Compute the views for best planner configurations",
+    )
+    parser.add_option(
+        "-p",
+        "--plot",
+        dest="plot",
+        default=None,
+        help="Create a PDF of plots with the filename provided",
+    )
+    parser.add_option(
+        "-m",
+        "--mysql",
+        dest="mysqldb",
+        default=None,
+        help="Save SQLite3 database as a MySQL dump file",
+    )
     (options, args) = parser.parse_args()
 
     if len(args) == 0:

--- a/moveit_ros/move_group/scripts/load_map
+++ b/moveit_ros/move_group/scripts/load_map
@@ -5,10 +5,10 @@ from moveit_msgs.srv import LoadMap
 
 filename = sys.argv[1]
 
-rospy.init_node('load_map', anonymous=True)
+rospy.init_node("load_map", anonymous=True)
 
-load_map_service = rospy.ServiceProxy('move_group/load_map', LoadMap)
+load_map_service = rospy.ServiceProxy("move_group/load_map", LoadMap)
 if load_map_service(filename):
-    rospy.loginfo('Succeeded')
+    rospy.loginfo("Succeeded")
 else:
-    rospy.loginfo('Failed')
+    rospy.loginfo("Failed")

--- a/moveit_ros/move_group/scripts/save_map
+++ b/moveit_ros/move_group/scripts/save_map
@@ -5,10 +5,10 @@ from moveit_msgs.srv import SaveMap
 
 filename = sys.argv[1]
 
-rospy.init_node('save_map', anonymous=True)
+rospy.init_node("save_map", anonymous=True)
 
-save_map_service = rospy.ServiceProxy('move_group/save_map', SaveMap)
+save_map_service = rospy.ServiceProxy("move_group/save_map", SaveMap)
 if save_map_service(filename):
-    rospy.loginfo('Succeeded')
+    rospy.loginfo("Succeeded")
 else:
-    rospy.loginfo('Failed')
+    rospy.loginfo("Failed")

--- a/moveit_ros/move_group/test/test_cancel_before_plan_execution.py
+++ b/moveit_ros/move_group/test/test_cancel_before_plan_execution.py
@@ -5,14 +5,19 @@ import rospy
 import unittest
 from actionlib import SimpleActionClient
 import moveit_commander
-from moveit_msgs.msg import MoveItErrorCodes, MoveGroupGoal, Constraints, JointConstraint, MoveGroupAction
+from moveit_msgs.msg import (
+    MoveItErrorCodes,
+    MoveGroupGoal,
+    Constraints,
+    JointConstraint,
+    MoveGroupAction,
+)
 
 
 class TestMoveActionCancelDrop(unittest.TestCase):
-
     def setUp(self):
         # create a action client of move group
-        self._move_client = SimpleActionClient('move_group', MoveGroupAction)
+        self._move_client = SimpleActionClient("move_group", MoveGroupAction)
         self._move_client.wait_for_server()
 
         moveit_commander.roscpp_initialize(sys.argv)
@@ -57,7 +62,10 @@ class TestMoveActionCancelDrop(unittest.TestCase):
 
         # check the error code in result
         # error code is 0 if the server ends with RECALLED status
-        self.assertTrue(result.error_code.val == MoveItErrorCodes.PREEMPTED or result.error_code.val == 0)
+        self.assertTrue(
+            result.error_code.val == MoveItErrorCodes.PREEMPTED
+            or result.error_code.val == 0
+        )
 
     def test_cancel_drop_plan_only(self):
         # set the plan only flag
@@ -80,7 +88,10 @@ class TestMoveActionCancelDrop(unittest.TestCase):
 
         # check the error code in result
         # error code is 0 if the server ends with RECALLED status
-        self.assertTrue(result.error_code.val == MoveItErrorCodes.PREEMPTED or result.error_code.val == 0)
+        self.assertTrue(
+            result.error_code.val == MoveItErrorCodes.PREEMPTED
+            or result.error_code.val == 0
+        )
 
     def test_cancel_resend(self):
         # send the goal
@@ -105,7 +116,12 @@ class TestMoveActionCancelDrop(unittest.TestCase):
         self.assertEqual(result.error_code.val, MoveItErrorCodes.SUCCESS)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import rostest
-    rospy.init_node('cancel_before_plan_execution')
-    rostest.rosrun('moveit_ros_move_group', 'test_cancel_before_plan_execution', TestMoveActionCancelDrop)
+
+    rospy.init_node("cancel_before_plan_execution")
+    rostest.rosrun(
+        "moveit_ros_move_group",
+        "test_cancel_before_plan_execution",
+        TestMoveActionCancelDrop,
+    )

--- a/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.py
+++ b/moveit_ros/move_group/test/test_check_state_validity_in_empty_scene.py
@@ -10,35 +10,56 @@ from moveit_msgs.srv import GetStateValidity
 
 
 class TestCheckStateValidityInEmptyScene(unittest.TestCase):
-
     def setUp(self):
         moveit_commander.roscpp_initialize(sys.argv)
         self.robot_commander = moveit_commander.RobotCommander()
         self.group_name = self.robot_commander.get_group_names()[0]
         self.group_commander = moveit_commander.MoveGroupCommander(self.group_name)
 
-        self._check_state_validity = rospy.ServiceProxy('/check_state_validity', GetStateValidity)
+        self._check_state_validity = rospy.ServiceProxy(
+            "/check_state_validity", GetStateValidity
+        )
 
     def test_check_collision_free_state_validity_in_empty_scene(self):
         current_robot_state = self.robot_commander.get_current_state()
 
-        validity_report = self._check_state_validity(current_robot_state, self.group_name, Constraints())
-        self.assertListEqual(validity_report.contacts, [], "In the default_robot_state, the robot should not collide with itself")
-
+        validity_report = self._check_state_validity(
+            current_robot_state, self.group_name, Constraints()
+        )
+        self.assertListEqual(
+            validity_report.contacts,
+            [],
+            "In the default_robot_state, the robot should not collide with itself",
+        )
 
     def test_check_colliding_state_validity_in_empty_scene(self):
         current_robot_state = self.robot_commander.get_current_state()
 
         # force a colliding state with the Fanuc M-10iA
-        current_robot_state.joint_state.position = list(current_robot_state.joint_state.position)
-        current_robot_state.joint_state.position[current_robot_state.joint_state.name.index("joint_3")] = -2
+        current_robot_state.joint_state.position = list(
+            current_robot_state.joint_state.position
+        )
+        current_robot_state.joint_state.position[
+            current_robot_state.joint_state.name.index("joint_3")
+        ] = -2
 
-        validity_report = self._check_state_validity(current_robot_state, self.group_name, Constraints())
+        validity_report = self._check_state_validity(
+            current_robot_state, self.group_name, Constraints()
+        )
 
-        self.assertNotEqual(len(validity_report.contacts), 0, "When the robot collides with itself, it should have some contacts (with itself)")
+        self.assertNotEqual(
+            len(validity_report.contacts),
+            0,
+            "When the robot collides with itself, it should have some contacts (with itself)",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import rostest
-    rospy.init_node('check_state_validity_in_empty_scene')
-    rostest.rosrun('moveit_ros_move_group', 'test_check_state_validity_in_empty_scene', TestCheckStateValidityInEmptyScene)
+
+    rospy.init_node("check_state_validity_in_empty_scene")
+    rostest.rosrun(
+        "moveit_ros_move_group",
+        "test_check_state_validity_in_empty_scene",
+        TestCheckStateValidityInEmptyScene,
+    )

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -4,84 +4,129 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # Get parameters for the Pose Tracking node
-    pose_tracking_yaml = load_yaml('moveit_servo', 'config/pose_tracking_settings.yaml')
-    pose_tracking_params = { 'moveit_servo' : pose_tracking_yaml }
+    pose_tracking_yaml = load_yaml("moveit_servo", "config/pose_tracking_settings.yaml")
+    pose_tracking_params = {"moveit_servo": pose_tracking_yaml}
 
     # Get parameters for the Servo node
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config_pose_tracking.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml(
+        "moveit_servo", "config/panda_simulated_config_pose_tracking.yaml"
+    )
+    servo_params = {"moveit_servo": servo_yaml}
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
 
-    #RViz
-    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_pose_tracking.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     #prefix=['xterm -e gdb -ex run --args'],
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description, robot_description_semantic, kinematics_yaml])
+    # RViz
+    rviz_config_file = (
+        get_package_share_directory("moveit_servo")
+        + "/config/demo_rviz_pose_tracking.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        # prefix=['xterm -e gdb -ex run --args'],
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic, kinematics_yaml],
+    )
 
     # Publishes tf's for the robot
     robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        output='screen',
-        parameters=[robot_description]
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[robot_description],
     )
 
     # A node to publish world -> panda_link0 transform
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     pose_tracking_node = Node(
-        package='moveit_servo',
-        executable='servo_pose_tracking_demo',
-        #prefix=['xterm -e gdb -ex run --args'],
-        output='screen',
-        parameters=[robot_description, robot_description_semantic, kinematics_yaml, pose_tracking_params, servo_params]
+        package="moveit_servo",
+        executable="servo_pose_tracking_demo",
+        # prefix=['xterm -e gdb -ex run --args'],
+        output="screen",
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            pose_tracking_params,
+            servo_params,
+        ],
     )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
-                                              robot_description])
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
-    return LaunchDescription([rviz_node, static_tf, pose_tracking_node, fake_joint_driver_node, robot_state_publisher])
+    return LaunchDescription(
+        [
+            rviz_node,
+            static_tf,
+            pose_tracking_node,
+            fake_joint_driver_node,
+            robot_state_publisher,
+        ]
+    )

--- a/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
@@ -4,77 +4,112 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def generate_launch_description():
     # Get parameters for the Servo node
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
 
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # A node to publish world -> panda_link0 transform
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # The servo cpp interface demo
     # Creates the Servo node and publishes commands to it
     servo_node = Node(
-        package='moveit_servo',
-        executable='servo_cpp_demo',
-        output='screen',
-        parameters=[servo_params, robot_description, robot_description_semantic ]
+        package="moveit_servo",
+        executable="servo_cpp_demo",
+        output="screen",
+        parameters=[servo_params, robot_description, robot_description_semantic],
     )
 
     # Publishes tf's for the robot
     robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        output='screen',
-        parameters=[robot_description]
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[robot_description],
     )
 
     # RViz
-    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_config.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description, robot_description_semantic])
+    rviz_config_file = (
+        get_package_share_directory("moveit_servo") + "/config/demo_rviz_config.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic],
+    )
 
     # Is a perfect controller without dynamics
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
-                                              robot_description])
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
-    return LaunchDescription([ rviz_node, static_tf, servo_node, fake_joint_driver_node, robot_state_publisher ])
+    return LaunchDescription(
+        [
+            rviz_node,
+            static_tf,
+            servo_node,
+            fake_joint_driver_node,
+            robot_state_publisher,
+        ]
+    )

--- a/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
@@ -6,80 +6,112 @@ from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def generate_launch_description():
     # Get parameters for the Servo node
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
 
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # RViz
-    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_config.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description, robot_description_semantic])
+    rviz_config_file = (
+        get_package_share_directory("moveit_servo") + "/config/demo_rviz_config.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic],
+    )
 
     # Is a perfect controller without dynamics
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
-                                              robot_description])
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
     # Launch as much as possible in components
     container = ComposableNodeContainer(
-            name='moveit_servo_demo_container',
-            namespace='/',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='robot_state_publisher',
-                    plugin='robot_state_publisher::RobotStatePublisher',
-                    name='robot_state_publisher',
-                    parameters=[robot_description]),
-                ComposableNode(
-                    package='tf2_ros',
-                    plugin='tf2_ros::StaticTransformBroadcasterNode',
-                    name='static_tf2_broadcaster',
-                    parameters=[ {'/child_frame_id' : 'panda_link0', '/frame_id' : 'world'} ]),
-                ComposableNode(
-                    package='moveit_servo',
-                    plugin='moveit_servo::ServoServer',
-                    name='servo_server',
-                    parameters=[servo_params, robot_description, robot_description_semantic],
-                    extra_arguments=[{'use_intra_process_comms' : True}])
-            ],
-            output='screen',
+        name="moveit_servo_demo_container",
+        namespace="/",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="robot_state_publisher",
+                plugin="robot_state_publisher::RobotStatePublisher",
+                name="robot_state_publisher",
+                parameters=[robot_description],
+            ),
+            ComposableNode(
+                package="tf2_ros",
+                plugin="tf2_ros::StaticTransformBroadcasterNode",
+                name="static_tf2_broadcaster",
+                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+            ),
+            ComposableNode(
+                package="moveit_servo",
+                plugin="moveit_servo::ServoServer",
+                name="servo_server",
+                parameters=[
+                    servo_params,
+                    robot_description,
+                    robot_description_semantic,
+                ],
+                extra_arguments=[{"use_intra_process_comms": True}],
+            ),
+        ],
+        output="screen",
     )
 
-    return LaunchDescription([ rviz_node, fake_joint_driver_node, container ])
+    return LaunchDescription([rviz_node, fake_joint_driver_node, container])

--- a/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
@@ -6,90 +6,124 @@ from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def generate_launch_description():
     # Get parameters for the Servo node
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
 
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # RViz
-    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_config.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description, robot_description_semantic])
+    rviz_config_file = (
+        get_package_share_directory("moveit_servo") + "/config/demo_rviz_config.rviz"
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file],
+        parameters=[robot_description, robot_description_semantic],
+    )
 
     # Is a perfect controller without dynamics
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
-                                              robot_description])
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
     # Launch as much as possible in components
     container = ComposableNodeContainer(
-            name='moveit_servo_demo_container',
-            namespace='/',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='robot_state_publisher',
-                    plugin='robot_state_publisher::RobotStatePublisher',
-                    name='robot_state_publisher',
-                    parameters=[robot_description]),
-                ComposableNode(
-                    package='tf2_ros',
-                    plugin='tf2_ros::StaticTransformBroadcasterNode',
-                    name='static_tf2_broadcaster',
-                    parameters=[ {'/child_frame_id' : 'panda_link0', '/frame_id' : 'world'} ]),
-                ComposableNode(
-                    package='moveit_servo',
-                    plugin='moveit_servo::ServoServer',
-                    name='servo_server',
-                    parameters=[servo_params, robot_description, robot_description_semantic],
-                    extra_arguments=[{'use_intra_process_comms' : True}]),
-                ComposableNode(
-                    package='moveit_servo',
-                    plugin='moveit_servo::JoyToServoPub',
-                    name='controller_to_servo_node',
-                    extra_arguments=[{'use_intra_process_comms' : True}]),
-                ComposableNode(
-                    package='joy',
-                    plugin='joy::Joy',
-                    name='joy_node',
-                    extra_arguments=[{'use_intra_process_comms' : True}])
-            ],
-            output='screen',
+        name="moveit_servo_demo_container",
+        namespace="/",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="robot_state_publisher",
+                plugin="robot_state_publisher::RobotStatePublisher",
+                name="robot_state_publisher",
+                parameters=[robot_description],
+            ),
+            ComposableNode(
+                package="tf2_ros",
+                plugin="tf2_ros::StaticTransformBroadcasterNode",
+                name="static_tf2_broadcaster",
+                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+            ),
+            ComposableNode(
+                package="moveit_servo",
+                plugin="moveit_servo::ServoServer",
+                name="servo_server",
+                parameters=[
+                    servo_params,
+                    robot_description,
+                    robot_description_semantic,
+                ],
+                extra_arguments=[{"use_intra_process_comms": True}],
+            ),
+            ComposableNode(
+                package="moveit_servo",
+                plugin="moveit_servo::JoyToServoPub",
+                name="controller_to_servo_node",
+                extra_arguments=[{"use_intra_process_comms": True}],
+            ),
+            ComposableNode(
+                package="joy",
+                plugin="joy::Joy",
+                name="joy_node",
+                extra_arguments=[{"use_intra_process_comms": True}],
+            ),
+        ],
+        output="screen",
     )
 
-    return LaunchDescription([ rviz_node, fake_joint_driver_node, container ])
+    return LaunchDescription([rviz_node, fake_joint_driver_node, container])

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -10,90 +10,126 @@ from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
-def generate_servo_test_description(*args,
-                                    gtest_name: SomeSubstitutionsType,
-                                    start_position_path: SomeSubstitutionsType = '../config/start_positions.yaml'):
+
+def generate_servo_test_description(
+    *args,
+    gtest_name: SomeSubstitutionsType,
+    start_position_path: SomeSubstitutionsType = "../config/start_positions.yaml"
+):
 
     # Get parameters using the demo config file
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
 
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # Is a perfect controller without dynamics
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(os.path.dirname(__file__), start_position_path),
-                                              robot_description])
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(os.path.dirname(__file__), start_position_path),
+            robot_description,
+        ],
+    )
 
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(
-            name='test_servo_integration_container',
-            namespace='/',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='robot_state_publisher',
-                    plugin='robot_state_publisher::RobotStatePublisher',
-                    name='robot_state_publisher',
-                    parameters=[robot_description]),
-                ComposableNode(
-                    package='tf2_ros',
-                    plugin='tf2_ros::StaticTransformBroadcasterNode',
-                    name='static_tf2_broadcaster',
-                    parameters=[ {'/child_frame_id' : 'panda_link0', '/frame_id' : 'world'} ]),
-                ComposableNode(
-                    package='moveit_servo',
-                    plugin='moveit_servo::ServoServer',
-                    name='servo_server',
-                    parameters=[servo_params, robot_description, robot_description_semantic],
-                    extra_arguments=[{'use_intra_process_comm': True}])
-            ],
-            output='screen',
+        name="test_servo_integration_container",
+        namespace="/",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="robot_state_publisher",
+                plugin="robot_state_publisher::RobotStatePublisher",
+                name="robot_state_publisher",
+                parameters=[robot_description],
+            ),
+            ComposableNode(
+                package="tf2_ros",
+                plugin="tf2_ros::StaticTransformBroadcasterNode",
+                name="static_tf2_broadcaster",
+                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+            ),
+            ComposableNode(
+                package="moveit_servo",
+                plugin="moveit_servo::ServoServer",
+                name="servo_server",
+                parameters=[
+                    servo_params,
+                    robot_description,
+                    robot_description_semantic,
+                ],
+                extra_arguments=[{"use_intra_process_comm": True}],
+            ),
+        ],
+        output="screen",
     )
 
     # Unknown how to set timeout
     # https://github.com/ros2/launch/issues/466
     servo_gtest = launch_ros.actions.Node(
-        executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
+        executable=PathJoinSubstitution(
+            [LaunchConfiguration("test_binary_dir"), gtest_name]
+        ),
         parameters=[servo_params],
-        output='screen',
+        output="screen",
     )
 
-    return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument(name='test_binary_dir',
-                                             description='Binary directory of package '
-                                                         'containing test executables'),
-        fake_joint_driver_node,
-        test_container,
-        servo_gtest,
-        launch_testing.actions.ReadyToTest()
-    ]), {'test_container': test_container, 'servo_gtest': servo_gtest, 'fake_joint_driver_node': fake_joint_driver_node}
+    return launch.LaunchDescription(
+        [
+            launch.actions.DeclareLaunchArgument(
+                name="test_binary_dir",
+                description="Binary directory of package "
+                "containing test executables",
+            ),
+            fake_joint_driver_node,
+            test_container,
+            servo_gtest,
+            launch_testing.actions.ReadyToTest(),
+        ]
+    ), {
+        "test_container": test_container,
+        "servo_gtest": servo_gtest,
+        "fake_joint_driver_node": fake_joint_driver_node,
+    }

--- a/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
@@ -9,18 +9,22 @@ from servo_launch_test_common import generate_servo_test_description
 
 
 def generate_test_description():
-    return generate_servo_test_description(gtest_name='test_servo_collision',
-                                           start_position_path='../config/collision_start_positions.yaml')
+    return generate_servo_test_description(
+        gtest_name="test_servo_collision",
+        start_position_path="../config/collision_start_positions.yaml",
+    )
 
 
 class TestGTestProcessActive(unittest.TestCase):
-
-    def test_gtest_run_complete(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_run_complete(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
-    def test_gtest_pass(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_pass(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)

--- a/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
@@ -3,21 +3,28 @@ import sys
 import unittest
 
 import launch_testing.asserts
+
 sys.path.append(os.path.dirname(__file__))
 from servo_launch_test_common import generate_servo_test_description
 
+
 def generate_test_description():
-    return generate_servo_test_description(gtest_name='test_servo_integration',
-                                            start_position_path='../config/start_positions.yaml')
+    return generate_servo_test_description(
+        gtest_name="test_servo_integration",
+        start_position_path="../config/start_positions.yaml",
+    )
 
 
 class TestGTestProcessActive(unittest.TestCase):
-
-    def test_gtest_run_complete(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_run_complete(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
+
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
-    def test_gtest_pass(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_pass(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -17,107 +17,155 @@ from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node, ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
-def generate_servo_test_description(*args,
-                                    gtest_name: SomeSubstitutionsType,
-                                    start_position_path: SomeSubstitutionsType = '../config/start_positions.yaml'):
+def generate_servo_test_description(
+    *args,
+    gtest_name: SomeSubstitutionsType,
+    start_position_path: SomeSubstitutionsType = "../config/start_positions.yaml"
+):
 
     # Get URDF and SRDF
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
     # Get parameters for the Pose Tracking node
-    pose_tracking_yaml = load_yaml('moveit_servo', 'config/pose_tracking_settings.yaml')
-    pose_tracking_params = { 'moveit_servo' : pose_tracking_yaml }
+    pose_tracking_yaml = load_yaml("moveit_servo", "config/pose_tracking_settings.yaml")
+    pose_tracking_params = {"moveit_servo": pose_tracking_yaml}
 
     # Get parameters for the Servo node
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config_pose_tracking.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml(
+        "moveit_servo", "config/panda_simulated_config_pose_tracking.yaml"
+    )
+    servo_params = {"moveit_servo": servo_yaml}
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
-                                              robot_description]
-                                )
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "fake_joint_trajectory_controller"},
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "panda_controllers.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("moveit_servo"),
+                "config",
+                "start_positions.yaml",
+            ),
+            robot_description,
+        ],
+    )
 
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(
-            name='test_pose_tracking_container',
-            namespace='/',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='robot_state_publisher',
-                    plugin='robot_state_publisher::RobotStatePublisher',
-                    name='robot_state_publisher',
-                    parameters=[robot_description]),
-                ComposableNode(
-                    package='tf2_ros',
-                    plugin='tf2_ros::StaticTransformBroadcasterNode',
-                    name='static_tf2_broadcaster',
-                    parameters=[ {'/child_frame_id' : 'panda_link0', '/frame_id' : 'world'} ]),
-            ],
-            output='screen',
+        name="test_pose_tracking_container",
+        namespace="/",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="robot_state_publisher",
+                plugin="robot_state_publisher::RobotStatePublisher",
+                name="robot_state_publisher",
+                parameters=[robot_description],
+            ),
+            ComposableNode(
+                package="tf2_ros",
+                plugin="tf2_ros::StaticTransformBroadcasterNode",
+                name="static_tf2_broadcaster",
+                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+            ),
+        ],
+        output="screen",
     )
 
     pose_tracking_gtest = launch_ros.actions.Node(
-                executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
-                parameters=[robot_description, robot_description_semantic, pose_tracking_params, servo_params, kinematics_yaml],
-                output='screen',
-        )
+        executable=PathJoinSubstitution(
+            [LaunchConfiguration("test_binary_dir"), gtest_name]
+        ),
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            pose_tracking_params,
+            servo_params,
+            kinematics_yaml,
+        ],
+        output="screen",
+    )
 
-    return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument(name='test_binary_dir',
-                                             description='Binary directory of package '
-                                                         'containing test executables'),
-        fake_joint_driver_node,
-        test_container,
-        pose_tracking_gtest,
-        launch_testing.actions.ReadyToTest()
-    ]), {'test_container': test_container ,'servo_gtest': pose_tracking_gtest, 'fake_joint_driver_node': fake_joint_driver_node }
+    return launch.LaunchDescription(
+        [
+            launch.actions.DeclareLaunchArgument(
+                name="test_binary_dir",
+                description="Binary directory of package "
+                "containing test executables",
+            ),
+            fake_joint_driver_node,
+            test_container,
+            pose_tracking_gtest,
+            launch_testing.actions.ReadyToTest(),
+        ]
+    ), {
+        "test_container": test_container,
+        "servo_gtest": pose_tracking_gtest,
+        "fake_joint_driver_node": fake_joint_driver_node,
+    }
+
 
 def generate_test_description():
-    return generate_servo_test_description(gtest_name='test_servo_pose_tracking',
-                                           start_position_path='../config/collision_start_positions.yaml')
+    return generate_servo_test_description(
+        gtest_name="test_servo_pose_tracking",
+        start_position_path="../config/collision_start_positions.yaml",
+    )
 
 
 class TestGTestProcessActive(unittest.TestCase):
-
-    def test_gtest_run_complete(self, proc_info, test_container, servo_gtest, fake_joint_driver_node):
+    def test_gtest_run_complete(
+        self, proc_info, test_container, servo_gtest, fake_joint_driver_node
+    ):
         proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
-    def test_gtest_pass(self, proc_info, test_container, servo_gtest, fake_joint_driver_node):
+    def test_gtest_pass(
+        self, proc_info, test_container, servo_gtest, fake_joint_driver_node
+    ):
         launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)

--- a/moveit_ros/moveit_servo/test/launch/test_servo_singularity.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_singularity.test.py
@@ -3,21 +3,28 @@ import sys
 import unittest
 
 import launch_testing.asserts
+
 sys.path.append(os.path.dirname(__file__))
 from servo_launch_test_common import generate_servo_test_description
 
+
 def generate_test_description():
-    return generate_servo_test_description(gtest_name='test_servo_singularity',
-                                            start_position_path='../config/singularity_start_positions.yaml')
+    return generate_servo_test_description(
+        gtest_name="test_servo_singularity",
+        start_position_path="../config/singularity_start_positions.yaml",
+    )
 
 
 class TestGTestProcessActive(unittest.TestCase):
-
-    def test_gtest_run_complete(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_run_complete(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
+
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
-    def test_gtest_pass(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
+    def test_gtest_pass(
+        self, proc_info, servo_gtest, test_container, fake_joint_driver_node
+    ):
         launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)

--- a/moveit_ros/moveit_servo/test/launch/unit_test_servo_calcs.test.py
+++ b/moveit_ros/moveit_servo/test/launch/unit_test_servo_calcs.test.py
@@ -8,32 +8,38 @@ import unittest
 sys.path.append(os.path.dirname(__file__))
 from servo_launch_test_common import load_yaml
 
+
 def generate_test_description():
     # Get parameters using the demo config file
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
 
-    test_binary_dir_arg = launch.actions.DeclareLaunchArgument(name='test_binary_dir',
-                                             description='Binary directory of package '
-                                                         'containing test executables')
+    test_binary_dir_arg = launch.actions.DeclareLaunchArgument(
+        name="test_binary_dir",
+        description="Binary directory of package " "containing test executables",
+    )
 
     servo_gtest = launch_ros.actions.Node(
         executable=launch.substitutions.PathJoinSubstitution(
-            [launch.substitutions.LaunchConfiguration('test_binary_dir'), 'unit_test_servo_calcs']
+            [
+                launch.substitutions.LaunchConfiguration("test_binary_dir"),
+                "unit_test_servo_calcs",
+            ]
         ),
         parameters=[servo_params],
-        output='screen',
+        output="screen",
         # prefix="kitty gdb -e run --args"
     )
 
-    return launch.LaunchDescription([
-        test_binary_dir_arg,
-        servo_gtest,
-        launch_testing.actions.ReadyToTest()
-    ]), {'servo_gtest': servo_gtest}
+    return (
+        launch.LaunchDescription(
+            [test_binary_dir_arg, servo_gtest, launch_testing.actions.ReadyToTest()]
+        ),
+        {"servo_gtest": servo_gtest},
+    )
+
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
     def test_gtest_pass(self, proc_info, servo_gtest):
         launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)

--- a/moveit_ros/planning_interface/setup.py
+++ b/moveit_ros/planning_interface/setup.py
@@ -2,8 +2,8 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
-d['packages'] = ['moveit_ros_planning_interface']
-d['scripts'] = []
-d['package_dir'] = {'': 'python'}
+d["packages"] = ["moveit_ros_planning_interface"]
+d["scripts"] = []
+d["package_dir"] = {"": "python"}
 
 setup(**d)

--- a/moveit_ros/planning_interface/test/cleanup.py
+++ b/moveit_ros/planning_interface/test/cleanup.py
@@ -8,8 +8,8 @@ import subprocess
 import rospkg
 import roslib.packages
 
-PKGNAME = 'moveit_ros_planning_interface'
-NODENAME = 'moveit_cleanup_tests'
+PKGNAME = "moveit_ros_planning_interface"
+NODENAME = "moveit_cleanup_tests"
 
 # As issue #592 is related to a crash during program exit,
 # we cannot perform a standard unit test.
@@ -21,7 +21,7 @@ class CleanupTest(unittest.TestCase):
         super(CleanupTest, self).__init__(*args, **kwargs)
         self._rospack = rospkg.RosPack()
 
-    def run_cmd(self, cmd, num = 5):
+    def run_cmd(self, cmd, num=5):
         failures = 0
         for i in range(num):
             if subprocess.call(cmd) != 0:
@@ -29,10 +29,13 @@ class CleanupTest(unittest.TestCase):
         self.assertEqual(failures, 0, "%d of %d runs failed" % (failures, num))
 
     def test_py(self):
-        self.run_cmd(roslib.packages.find_node(PKGNAME, "test_cleanup.py", self._rospack))
+        self.run_cmd(
+            roslib.packages.find_node(PKGNAME, "test_cleanup.py", self._rospack)
+        )
 
     def test_cpp(self):
         self.run_cmd(roslib.packages.find_node(PKGNAME, "test_cleanup", self._rospack))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     rostest.rosrun(PKGNAME, NODENAME, CleanupTest)

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -10,136 +10,182 @@ from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
 from ament_index_python.packages import get_package_share_directory
 
+
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
+
 
 def load_test_yaml(absolute_file_path):
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsType):
 
     # planning_context
-    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
-    robot_description = {'robot_description' : robot_description_config}
+    robot_description_config = load_file(
+        "moveit_resources_panda_description", "urdf/panda.urdf"
+    )
+    robot_description = {"robot_description": robot_description_config}
 
-    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
-    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
 
-    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    robot_description_kinematics = { 'robot_description_kinematics' : kinematics_yaml }
+    kinematics_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
+    )
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
     # Planning Functionality
-    ompl_planning_pipeline_config = { 'move_group' : {
-        'planning_plugin' : 'ompl_interface/OMPLPlanner',
-        'request_adapters' : """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""" ,
-        'start_state_max_bounds_error' : 0.1 } }
+    ompl_planning_pipeline_config = {
+        "move_group": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
 
-    ompl_planning_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/ompl_planning.yaml')
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
+    )
+    ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Functionality
-    controllers_yaml = load_test_yaml(os.path.join(os.path.dirname(__file__), '../config/controllers.yaml'))
+    controllers_yaml = load_test_yaml(
+        os.path.join(os.path.dirname(__file__), "../config/controllers.yaml")
+    )
 
-    moveit_controllers = { 'moveit_simple_controller_manager' : controllers_yaml,
-                           'moveit_controller_manager': 'moveit_simple_controller_manager/MoveItSimpleControllerManager'}
+    moveit_controllers = {
+        "moveit_simple_controller_manager": controllers_yaml,
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
+    }
 
-    trajectory_execution = {'moveit_manage_controllers': True,
-                            'trajectory_execution.allowed_execution_duration_scaling': 1.2,
-                            'trajectory_execution.allowed_goal_duration_margin': 0.5,
-                            'trajectory_execution.allowed_start_tolerance': 0.01}
+    trajectory_execution = {
+        "moveit_manage_controllers": True,
+        "trajectory_execution.allowed_execution_duration_scaling": 1.2,
+        "trajectory_execution.allowed_goal_duration_margin": 0.5,
+        "trajectory_execution.allowed_start_tolerance": 0.01,
+    }
 
-    planning_scene_monitor_parameters = {"publish_planning_scene": True,
-                 "publish_geometry_updates": True,
-                 "publish_state_updates": True,
-                 "publish_transforms_updates": True}
+    planning_scene_monitor_parameters = {
+        "publish_planning_scene": True,
+        "publish_geometry_updates": True,
+        "publish_state_updates": True,
+        "publish_transforms_updates": True,
+    }
 
     # Start the actual move_group node/action server
-    run_move_group_node = Node(package='moveit_ros_move_group',
-                               executable='move_group',
-                               output='screen',
-                               parameters=[robot_description,
-                                           robot_description_semantic,
-                                           kinematics_yaml,
-                                           ompl_planning_pipeline_config,
-                                           trajectory_execution,
-                                           moveit_controllers,
-                                           planning_scene_monitor_parameters])
+    run_move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            kinematics_yaml,
+            ompl_planning_pipeline_config,
+            trajectory_execution,
+            moveit_controllers,
+            planning_scene_monitor_parameters,
+        ],
+    )
 
     # Static TF
-    static_tf = Node(package='tf2_ros',
-                     executable='static_transform_publisher',
-                     name='static_transform_publisher',
-                     output='log',
-                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+    )
 
     # Publish TF
-    robot_state_publisher = Node(package='robot_state_publisher',
-                                 executable='robot_state_publisher',
-                                 name='robot_state_publisher',
-                                 output='both',
-                                 parameters=[robot_description])
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[robot_description],
+    )
 
     # Fake joint driver
-    fake_joint_driver_node = Node(package='fake_joint_driver',
-                                  executable='fake_joint_driver_node',
-                                  parameters=[{'controller_name': 'panda_arm_controller'},
-                                              os.path.join(os.path.dirname(__file__), '../config/panda_controllers.yaml'),
-                                              os.path.join(os.path.dirname(__file__), '../config/start_positions.yaml'),
-                                              robot_description])
-
+    fake_joint_driver_node = Node(
+        package="fake_joint_driver",
+        executable="fake_joint_driver_node",
+        parameters=[
+            {"controller_name": "panda_arm_controller"},
+            os.path.join(os.path.dirname(__file__), "../config/panda_controllers.yaml"),
+            os.path.join(os.path.dirname(__file__), "../config/start_positions.yaml"),
+            robot_description,
+        ],
+    )
 
     # Warehouse mongodb server
-    mongodb_server_node = Node(package='warehouse_ros_mongo',
-                               executable='mongo_wrapper_ros.py',
-                               parameters=[{'warehouse_port': 33829},
-                                           {'warehouse_host': 'localhost'},
-                                           {'warehouse_plugin': 'warehouse_ros_mongo::MongoDatabaseConnection'}],
-                               output='screen')
-
+    mongodb_server_node = Node(
+        package="warehouse_ros_mongo",
+        executable="mongo_wrapper_ros.py",
+        parameters=[
+            {"warehouse_port": 33829},
+            {"warehouse_host": "localhost"},
+            {"warehouse_plugin": "warehouse_ros_mongo::MongoDatabaseConnection"},
+        ],
+        output="screen",
+    )
 
     # test executable
-    ompl_constraint_test = launch_ros.actions.Node(executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
-                                                   parameters=[robot_description,
-                                                              robot_description_semantic,
-                                                              kinematics_yaml],
-                                                   output='screen',)
+    ompl_constraint_test = launch_ros.actions.Node(
+        executable=PathJoinSubstitution(
+            [LaunchConfiguration("test_binary_dir"), gtest_name]
+        ),
+        parameters=[robot_description, robot_description_semantic, kinematics_yaml],
+        output="screen",
+    )
 
-    return launch.LaunchDescription([
-        launch.actions.DeclareLaunchArgument(name='test_binary_dir',
-                                             description='Binary directory of package '
-                                                         'containing test executables'),
-        run_move_group_node,
-        static_tf,
-        robot_state_publisher,
-        fake_joint_driver_node,
-        mongodb_server_node,
-        ompl_constraint_test,
-        launch_testing.actions.ReadyToTest()
-    ]), {'run_move_group_node': run_move_group_node,
-         'static_tf': static_tf,
-         'robot_state_publisher': robot_state_publisher,
-         'fake_joint_driver_node': fake_joint_driver_node,
-         'mongodb_server_node': mongodb_server_node,
-         'ompl_constraint_test': ompl_constraint_test}
+    return launch.LaunchDescription(
+        [
+            launch.actions.DeclareLaunchArgument(
+                name="test_binary_dir",
+                description="Binary directory of package "
+                "containing test executables",
+            ),
+            run_move_group_node,
+            static_tf,
+            robot_state_publisher,
+            fake_joint_driver_node,
+            mongodb_server_node,
+            ompl_constraint_test,
+            launch_testing.actions.ReadyToTest(),
+        ]
+    ), {
+        "run_move_group_node": run_move_group_node,
+        "static_tf": static_tf,
+        "robot_state_publisher": robot_state_publisher,
+        "fake_joint_driver_node": fake_joint_driver_node,
+        "mongodb_server_node": mongodb_server_node,
+        "ompl_constraint_test": ompl_constraint_test,
+    }

--- a/moveit_ros/planning_interface/test/launch/move_group_ompl_constraints.test.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_ompl_constraints.test.py
@@ -3,19 +3,41 @@ import sys
 import unittest
 
 import launch_testing.asserts
+
 sys.path.append(os.path.dirname(__file__))
 from move_group_launch_test_common import generate_move_group_test_description
 
+
 def generate_test_description():
-    return generate_move_group_test_description(gtest_name='move_group_ompl_constraints_test')
+    return generate_move_group_test_description(
+        gtest_name="move_group_ompl_constraints_test"
+    )
+
 
 class TestGTestProcessActive(unittest.TestCase):
-
-    def test_gtest_run_complete(self, proc_info, ompl_constraint_test, run_move_group_node, static_tf, robot_state_publisher, fake_joint_driver_node, mongodb_server_node):
+    def test_gtest_run_complete(
+        self,
+        proc_info,
+        ompl_constraint_test,
+        run_move_group_node,
+        static_tf,
+        robot_state_publisher,
+        fake_joint_driver_node,
+        mongodb_server_node,
+    ):
         proc_info.assertWaitForShutdown(ompl_constraint_test, timeout=4000.0)
+
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
-
-    def test_gtest_pass(self, proc_info, ompl_constraint_test, run_move_group_node, static_tf, robot_state_publisher, fake_joint_driver_node, mongodb_server_node):
+    def test_gtest_pass(
+        self,
+        proc_info,
+        ompl_constraint_test,
+        run_move_group_node,
+        static_tf,
+        robot_state_publisher,
+        fake_joint_driver_node,
+        mongodb_server_node,
+    ):
         launch_testing.asserts.assertExitCodes(proc_info, process=ompl_constraint_test)

--- a/moveit_ros/planning_interface/test/python_move_group.py
+++ b/moveit_ros/planning_interface/test/python_move_group.py
@@ -6,7 +6,9 @@ import rospy
 import rostest
 import os
 
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
+from moveit_ros_planning_interface._moveit_move_group_interface import (
+    MoveGroupInterface,
+)
 from moveit_msgs.msg import MoveItErrorCodes
 
 
@@ -15,7 +17,9 @@ class PythonMoveGroupTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.group = MoveGroupInterface(self.PLANNING_GROUP, "robot_description", rospy.get_namespace())
+        self.group = MoveGroupInterface(
+            self.PLANNING_GROUP, "robot_description", rospy.get_namespace()
+        )
 
     @classmethod
     def tearDown(self):
@@ -26,16 +30,20 @@ class PythonMoveGroupTest(unittest.TestCase):
             args = [expect]
         self.group.set_joint_value_target(*args)
         res = self.group.get_joint_value_target()
-        self.assertTrue(np.all(np.asarray(res) == np.asarray(expect)),
-                        "Setting failed for %s, values: %s" % (type(args[0]), res))
+        self.assertTrue(
+            np.all(np.asarray(res) == np.asarray(expect)),
+            "Setting failed for %s, values: %s" % (type(args[0]), res),
+        )
 
     def test_target_setting(self):
         n = self.group.get_variable_count()
         self.check_target_setting([0.1] * n)
         self.check_target_setting((0.2,) * n)
         self.check_target_setting(np.zeros(n))
-        self.check_target_setting([0.3] * n, {name: 0.3 for name in self.group.get_active_joints()})
-        self.check_target_setting([0.5] + [0.3]*(n-1), "joint_1", 0.5)
+        self.check_target_setting(
+            [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
+        )
+        self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
 
     def plan(self, target):
         self.group.set_joint_value_target(target)
@@ -72,24 +80,33 @@ class PythonMoveGroupTest(unittest.TestCase):
         current = self.group.get_current_joint_values()
         result = self.group.get_jacobian_matrix(current)
         # Value check by known value at the initial pose
-        expected = np.array([[ 0.  ,  0.8 , -0.2 ,  0.  ,  0.  ,  0.  ],
-                             [ 0.89,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ],
-                             [ 0.  , -0.74,  0.74,  0.  ,  0.1 ,  0.  ],
-                             [ 0.  ,  0.  ,  0.  , -1.  ,  0.  , -1.  ],
-                             [ 0.  ,  1.  , -1.  ,  0.  , -1.  ,  0.  ],
-                             [ 1.  ,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ]])
+        expected = np.array(
+            [
+                [0.0, 0.8, -0.2, 0.0, 0.0, 0.0],
+                [0.89, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, -0.74, 0.74, 0.0, 0.1, 0.0],
+                [0.0, 0.0, 0.0, -1.0, 0.0, -1.0],
+                [0.0, 1.0, -1.0, 0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
         self.assertTrue(np.allclose(result, expected))
 
         result = self.group.get_jacobian_matrix(current, [1.0, 1.0, 1.0])
-        expected = np.array([[ 1.  ,  1.8 , -1.2 ,  0.  , -1.  ,  0.  ],
-                             [ 1.89,  0.  ,  0.  ,  1.  ,  0.  ,  1.  ],
-                             [ 0.  , -1.74,  1.74,  1.  ,  1.1 ,  1.  ],
-                             [ 0.  ,  0.  ,  0.  , -1.  ,  0.  , -1.  ],
-                             [ 0.  ,  1.  , -1.  ,  0.  , -1.  ,  0.  ],
-                             [ 1.  ,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ]])
+        expected = np.array(
+            [
+                [1.0, 1.8, -1.2, 0.0, -1.0, 0.0],
+                [1.89, 0.0, 0.0, 1.0, 0.0, 1.0],
+                [0.0, -1.74, 1.74, 1.0, 1.1, 1.0],
+                [0.0, 0.0, 0.0, -1.0, 0.0, -1.0],
+                [0.0, 1.0, -1.0, 0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_move_group'
+
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_move_group"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveGroupTest)

--- a/moveit_ros/planning_interface/test/python_move_group_ns.py
+++ b/moveit_ros/planning_interface/test/python_move_group_ns.py
@@ -43,7 +43,9 @@ import rospy
 import rostest
 import os
 
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
+from moveit_ros_planning_interface._moveit_move_group_interface import (
+    MoveGroupInterface,
+)
 from moveit_msgs.msg import MoveItErrorCodes
 
 
@@ -53,7 +55,11 @@ class PythonMoveGroupNsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.group = MoveGroupInterface(self.PLANNING_GROUP, "%srobot_description" % self.PLANNING_NS, self.PLANNING_NS)
+        self.group = MoveGroupInterface(
+            self.PLANNING_GROUP,
+            "%srobot_description" % self.PLANNING_NS,
+            self.PLANNING_NS,
+        )
 
     @classmethod
     def tearDown(self):
@@ -64,16 +70,20 @@ class PythonMoveGroupNsTest(unittest.TestCase):
             args = [expect]
         self.group.set_joint_value_target(*args)
         res = self.group.get_joint_value_target()
-        self.assertTrue(np.all(np.asarray(res) == np.asarray(expect)),
-                        "Setting failed for %s, values: %s" % (type(args[0]), res))
+        self.assertTrue(
+            np.all(np.asarray(res) == np.asarray(expect)),
+            "Setting failed for %s, values: %s" % (type(args[0]), res),
+        )
 
     def test_target_setting(self):
         n = self.group.get_variable_count()
         self.check_target_setting([0.1] * n)
         self.check_target_setting((0.2,) * n)
         self.check_target_setting(np.zeros(n))
-        self.check_target_setting([0.3] * n, {name: 0.3 for name in self.group.get_active_joints()})
-        self.check_target_setting([0.5] + [0.3]*(n-1), "joint_1", 0.5)
+        self.check_target_setting(
+            [0.3] * n, {name: 0.3 for name in self.group.get_active_joints()}
+        )
+        self.check_target_setting([0.5] + [0.3] * (n - 1), "joint_1", 0.5)
 
     def plan(self, target):
         self.group.set_joint_value_target(target)
@@ -107,8 +117,8 @@ class PythonMoveGroupNsTest(unittest.TestCase):
         self.assertEqual(error_code.val, MoveItErrorCodes.SUCCESS)
 
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_python_move_group'
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_move_group"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, PythonMoveGroupNsTest)

--- a/moveit_ros/planning_interface/test/robot_state_update.py
+++ b/moveit_ros/planning_interface/test/robot_state_update.py
@@ -6,7 +6,9 @@ import rospy
 import rostest
 import os
 
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
+from moveit_ros_planning_interface._moveit_move_group_interface import (
+    MoveGroupInterface,
+)
 from moveit_msgs.msg import MoveItErrorCodes
 
 
@@ -15,7 +17,9 @@ class RobotStateUpdateTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.group = MoveGroupInterface(self.PLANNING_GROUP, "robot_description", rospy.get_namespace())
+        self.group = MoveGroupInterface(
+            self.PLANNING_GROUP, "robot_description", rospy.get_namespace()
+        )
 
     @classmethod
     def tearDown(self):
@@ -33,7 +37,9 @@ class RobotStateUpdateTest(unittest.TestCase):
             error_code1, plan, time = self.plan(target)
             error_code = MoveItErrorCodes()
             error_code.deserialize(error_code1)
-            if (error_code.val == MoveItErrorCodes.SUCCESS) and self.group.execute(plan):
+            if (error_code.val == MoveItErrorCodes.SUCCESS) and self.group.execute(
+                plan
+            ):
                 actual = np.asarray(self.group.get_current_joint_values())
                 self.assertTrue(np.allclose(target, actual, atol=1e-4, rtol=0.0))
             # otherwise current state should be still the same
@@ -42,9 +48,9 @@ class RobotStateUpdateTest(unittest.TestCase):
                 self.assertTrue(np.allclose(current, actual, atol=1e-4, rtol=0.0))
 
 
-if __name__ == '__main__':
-    PKGNAME = 'moveit_ros_planning_interface'
-    NODENAME = 'moveit_test_robot_state_update'
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_robot_state_update"
     rospy.init_node(NODENAME)
     rostest.rosrun(PKGNAME, NODENAME, RobotStateUpdateTest)
 

--- a/moveit_ros/planning_interface/test/serialize_msg.py
+++ b/moveit_ros/planning_interface/test/serialize_msg.py
@@ -35,17 +35,21 @@
 # Author: Bjarne von Horn
 #
 
-from moveit_ros_planning_interface._moveit_planning_interface_test_serialize_msg_cpp_helper import ByteStringTestHelper
+from moveit_ros_planning_interface._moveit_planning_interface_test_serialize_msg_cpp_helper import (
+    ByteStringTestHelper,
+)
 from geometry_msgs.msg import Vector3
 import unittest
 
 try:
     # Try Python 2.7 behaviour first
     from StringIO import StringIO
+
     py_version_maj = 2
 except ImportError:
     # Use Python 3.x behaviour as fallback and choose the non-unicode version
     from io import BytesIO as StringIO
+
     py_version_maj = 3
 
 
@@ -98,13 +102,15 @@ class PythonMsgSerializeTest(unittest.TestCase):
 
     def test_rejectUnicode(self):
         with self.assertRaisesRegexp(Exception, "Python argument types in"):
-            self.helper.compareEmbeddedZeros(u'kdasd')
+            self.helper.compareEmbeddedZeros(u"kdasd")
 
     @unittest.skipIf(py_version_maj == 2, "does not trigger with python 2.7")
     def test_rejectUnicodeTuple(self):
-        with self.assertRaisesRegexp(RuntimeError, "Underlying python object is not a Bytes/String instance"):
-            self.helper.compareVectorTuple((u'kdasd',))
+        with self.assertRaisesRegexp(
+            RuntimeError, "Underlying python object is not a Bytes/String instance"
+        ):
+            self.helper.compareVectorTuple((u"kdasd",))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/moveit_ros/planning_interface/test/test_cleanup.py
+++ b/moveit_ros/planning_interface/test/test_cleanup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
 import rospy
-from moveit_ros_planning_interface._moveit_move_group_interface import MoveGroupInterface
+from moveit_ros_planning_interface._moveit_move_group_interface import (
+    MoveGroupInterface,
+)
+
 group = MoveGroupInterface("manipulator", "robot_description", rospy.get_namespace())

--- a/moveit_ros/visualization/setup.py
+++ b/moveit_ros/visualization/setup.py
@@ -2,6 +2,6 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
-d['packages'] = ['moveit_ros_visualization']
-d['package_dir'] = {'': 'src'}
+d["packages"] = ["moveit_ros_visualization"]
+d["package_dir"] = {"": "src"}
 setup(**d)

--- a/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
+++ b/moveit_ros/visualization/src/moveit_ros_visualization/moveitjoy_module.py
@@ -54,17 +54,19 @@ from sensor_msgs.msg import Joy
 from geometry_msgs.msg import PoseStamped
 from visualization_msgs.msg import InteractiveMarkerInit
 
+
 def signedSquare(val):
-  if val > 0:
-    sign = 1
-  else:
-    sign = -1
-  return val * val * sign
+    if val > 0:
+        sign = 1
+    else:
+        sign = -1
+    return val * val * sign
 
 
 # classes to use joystick of xbox, ps3(wired) and ps3(wireless).
 
-class JoyStatus():
+
+class JoyStatus:
     def __init__(self):
         self.center = False
         self.select = False
@@ -87,6 +89,7 @@ class JoyStatus():
         self.left_analog_y = 0.0
         self.right_analog_x = 0.0
         self.right_analog_y = 0.0
+
 
 class XBoxStatus(JoyStatus):
     def __init__(self, msg):
@@ -164,6 +167,7 @@ class XBoxStatus(JoyStatus):
         self.right_analog_x = msg.axes[3]
         self.right_analog_y = msg.axes[4]
         self.orig_msg = msg
+
 
 class PS3Status(JoyStatus):
     def __init__(self, msg):
@@ -243,6 +247,7 @@ class PS3Status(JoyStatus):
         self.right_analog_y = msg.axes[3]
         self.orig_msg = msg
 
+
 class PS3WiredStatus(JoyStatus):
     def __init__(self, msg):
         JoyStatus.__init__(self)
@@ -321,10 +326,11 @@ class PS3WiredStatus(JoyStatus):
         self.right_analog_y = msg.axes[3]
         self.orig_msg = msg
 
+
 class PS4Status(JoyStatus):
     def __init__(self, msg):
         JoyStatus.__init__(self)
-        #creating from sensor_msg/Joy
+        # creating from sensor_msg/Joy
         if msg.buttons[12] == 1:
             self.center = True
         else:
@@ -399,10 +405,11 @@ class PS4Status(JoyStatus):
         self.right_analog_y = msg.axes[2]
         self.orig_msg = msg
 
+
 class PS4WiredStatus(JoyStatus):
     def __init__(self, msg):
         JoyStatus.__init__(self)
-        #creating from sensor_msg/Joy
+        # creating from sensor_msg/Joy
         if msg.buttons[10] == 1:
             self.center = True
         else:
@@ -478,31 +485,37 @@ class PS4WiredStatus(JoyStatus):
         self.orig_msg = msg
 
 
-class StatusHistory():
-  def __init__(self, max_length=10):
-    self.max_length = max_length
-    self.buffer = []
-  def add(self, status):
-    self.buffer.append(status)
-    if len(self.buffer) > self.max_length:
-      self.buffer = self.buffer[1:self.max_length+1]
-  def all(self, proc):
-    for status in self.buffer:
-      if not proc(status):
-        return False
-    return True
-  def latest(self):
-    if len(self.buffer) > 0:
-      return self.buffer[-1]
-    else:
-      return None
-  def length(self):
-    return len(self.buffer)
-  def new(self, status, attr):
-    if len(self.buffer) == 0:
-      return getattr(status, attr)
-    else:
-      return getattr(status, attr) and not getattr(self.latest(), attr)
+class StatusHistory:
+    def __init__(self, max_length=10):
+        self.max_length = max_length
+        self.buffer = []
+
+    def add(self, status):
+        self.buffer.append(status)
+        if len(self.buffer) > self.max_length:
+            self.buffer = self.buffer[1 : self.max_length + 1]
+
+    def all(self, proc):
+        for status in self.buffer:
+            if not proc(status):
+                return False
+        return True
+
+    def latest(self):
+        if len(self.buffer) > 0:
+            return self.buffer[-1]
+        else:
+            return None
+
+    def length(self):
+        return len(self.buffer)
+
+    def new(self, status, attr):
+        if len(self.buffer) == 0:
+            return getattr(status, attr)
+        else:
+            return getattr(status, attr) and not getattr(self.latest(), attr)
+
 
 class MoveitJoy:
     def parseSRDF(self):
@@ -510,16 +523,21 @@ class MoveitJoy:
         planning_groups = {}
         for g in ri.get_group_names():
             self.planning_groups_tips[g] = ri.get_group_joint_tips(g)
-            planning_groups[g] = ["/rviz/moveit/move_marker/goal_" + l
-                                  for l in self.planning_groups_tips[g]]
+            planning_groups[g] = [
+                "/rviz/moveit/move_marker/goal_" + l
+                for l in self.planning_groups_tips[g]
+            ]
         for name in planning_groups.keys():
             if len(planning_groups[name]) == 0:
                 del planning_groups[name]
             else:
                 print(name, planning_groups[name])
         self.planning_groups = planning_groups
-        self.planning_groups_keys = planning_groups.keys()   #we'd like to store the 'order'
+        self.planning_groups_keys = (
+            planning_groups.keys()
+        )  # we'd like to store the 'order'
         self.frame_id = ri.get_planning_frame()
+
     def __init__(self):
         self.initial_poses = {}
         self.planning_groups_tips = {}
@@ -535,18 +553,28 @@ class MoveitJoy:
         self.initialize_poses = False
         self.initialized = False
         self.parseSRDF()
-        self.plan_group_pub = rospy.Publisher('/rviz/moveit/select_planning_group', String, queue_size=5)
+        self.plan_group_pub = rospy.Publisher(
+            "/rviz/moveit/select_planning_group", String, queue_size=5
+        )
         self.updatePlanningGroup(0)
         self.updatePoseTopic(0, False)
         self.joy_pose_pub = rospy.Publisher("/joy_pose", PoseStamped, queue_size=1)
         self.plan_pub = rospy.Publisher("/rviz/moveit/plan", Empty, queue_size=5)
         self.execute_pub = rospy.Publisher("/rviz/moveit/execute", Empty, queue_size=5)
-        self.update_start_state_pub = rospy.Publisher("/rviz/moveit/update_start_state", Empty, queue_size=5)
-        self.update_goal_state_pub = rospy.Publisher("/rviz/moveit/update_goal_state", Empty, queue_size=5)
-        self.interactive_marker_sub = rospy.Subscriber("/rviz_moveit_motion_planning_display/robot_interaction_interactive_marker_topic/update_full",
-                                                       InteractiveMarkerInit,
-                                                       self.markerCB, queue_size=1)
+        self.update_start_state_pub = rospy.Publisher(
+            "/rviz/moveit/update_start_state", Empty, queue_size=5
+        )
+        self.update_goal_state_pub = rospy.Publisher(
+            "/rviz/moveit/update_goal_state", Empty, queue_size=5
+        )
+        self.interactive_marker_sub = rospy.Subscriber(
+            "/rviz_moveit_motion_planning_display/robot_interaction_interactive_marker_topic/update_full",
+            InteractiveMarkerInit,
+            self.markerCB,
+            queue_size=1,
+        )
         self.sub = rospy.Subscriber("/joy", Joy, self.joyCB, queue_size=1)
+
     def updatePlanningGroup(self, next_index):
         if next_index >= len(self.planning_groups_keys):
             self.current_planning_group_index = 0
@@ -556,13 +584,16 @@ class MoveitJoy:
             self.current_planning_group_index = next_index
         next_planning_group = None
         try:
-            next_planning_group = self.planning_groups_keys[self.current_planning_group_index]
+            next_planning_group = self.planning_groups_keys[
+                self.current_planning_group_index
+            ]
         except IndexError:
-            msg = 'Check if you started movegroups. Exiting.'
+            msg = "Check if you started movegroups. Exiting."
             rospy.logfatal(msg)
             raise rospy.ROSInitException(msg)
         rospy.loginfo("Changed planning group to " + next_planning_group)
         self.plan_group_pub.publish(next_planning_group)
+
     def updatePoseTopic(self, next_index, wait=True):
         planning_group = self.planning_groups_keys[self.current_planning_group_index]
         topics = self.planning_groups[planning_group]
@@ -574,11 +605,15 @@ class MoveitJoy:
             self.current_eef_index = next_index
         next_topic = topics[self.current_eef_index]
 
-        rospy.loginfo("Changed controlled end effector to " + self.planning_groups_tips[planning_group][self.current_eef_index])
+        rospy.loginfo(
+            "Changed controlled end effector to "
+            + self.planning_groups_tips[planning_group][self.current_eef_index]
+        )
         self.pose_pub = rospy.Publisher(next_topic, PoseStamped, queue_size=5)
         if wait:
             self.waitForInitialPose(next_topic)
         self.current_pose_topic = next_topic
+
     def markerCB(self, msg):
         try:
             self.marker_lock.acquire()
@@ -591,14 +626,24 @@ class MoveitJoy:
                     if marker.header.frame_id != self.frame_id:
                         ps = PoseStamped(header=marker.header, pose=marker.pose)
                         try:
-                            transformed_pose = self.tf_listener.transformPose(self.frame_id, ps)
+                            transformed_pose = self.tf_listener.transformPose(
+                                self.frame_id, ps
+                            )
                             self.initial_poses[marker.name[3:]] = transformed_pose.pose
-                        except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException, e):
+                        except (
+                            tf.LookupException,
+                            tf.ConnectivityException,
+                            tf.ExtrapolationException,
+                            e,
+                        ):
                             rospy.logerr("tf error when resolving tf: %s" % e)
                     else:
-                        self.initial_poses[marker.name[3:]] = marker.pose   #tf should be resolved
+                        self.initial_poses[
+                            marker.name[3:]
+                        ] = marker.pose  # tf should be resolved
         finally:
             self.marker_lock.release()
+
     def waitForInitialPose(self, next_topic, timeout=None):
         counter = 0
         while not rospy.is_shutdown():
@@ -615,11 +660,13 @@ class MoveitJoy:
                     return True
                 else:
                     rospy.logdebug(self.initial_poses.keys())
-                    rospy.loginfo("Waiting for pose topic of '%s' to be initialized",
-                                  topic_suffix)
+                    rospy.loginfo(
+                        "Waiting for pose topic of '%s' to be initialized", topic_suffix
+                    )
                     rospy.sleep(1)
             finally:
                 self.marker_lock.release()
+
     def joyCB(self, msg):
         if len(msg.axes) == 27 and len(msg.buttons) == 19:
             status = PS3WiredStatus(msg)
@@ -635,12 +682,16 @@ class MoveitJoy:
             raise Exception("Unknown joystick")
         self.run(status)
         self.history.add(status)
+
     def computePoseFromJoy(self, pre_pose, status):
         new_pose = PoseStamped()
         new_pose.header.frame_id = self.frame_id
         new_pose.header.stamp = rospy.Time(0.0)
         # move in local
-        dist = status.left_analog_y * status.left_analog_y + status.left_analog_x * status.left_analog_x
+        dist = (
+            status.left_analog_y * status.left_analog_y
+            + status.left_analog_x * status.left_analog_x
+        )
         scale = 200.0
         x_diff = signedSquare(status.left_analog_y) / scale
         y_diff = signedSquare(status.left_analog_x) / scale
@@ -655,15 +706,16 @@ class MoveitJoy:
             z_scale = 4.0
         else:
             z_scale = 2.0
-        local_move = numpy.array((x_diff, y_diff,
-                                  z_diff * z_scale,
-                                  1.0))
-        q = numpy.array((pre_pose.pose.orientation.x,
-                         pre_pose.pose.orientation.y,
-                         pre_pose.pose.orientation.z,
-                         pre_pose.pose.orientation.w))
-        xyz_move = numpy.dot(tf.transformations.quaternion_matrix(q),
-                         local_move)
+        local_move = numpy.array((x_diff, y_diff, z_diff * z_scale, 1.0))
+        q = numpy.array(
+            (
+                pre_pose.pose.orientation.x,
+                pre_pose.pose.orientation.y,
+                pre_pose.pose.orientation.z,
+                pre_pose.pose.orientation.w,
+            )
+        )
+        xyz_move = numpy.dot(tf.transformations.quaternion_matrix(q), local_move)
         new_pose.pose.position.x = pre_pose.pose.position.x + xyz_move[0]
         new_pose.pose.position.y = pre_pose.pose.position.y + xyz_move[1]
         new_pose.pose.position.z = pre_pose.pose.position.z + xyz_move[2]
@@ -708,17 +760,26 @@ class MoveitJoy:
         new_pose.pose.orientation.z = new_q[2]
         new_pose.pose.orientation.w = new_q[3]
         return new_pose
+
     def run(self, status):
         if not self.initialized:
             # when not initialized, we will force to change planning_group
             while True:
                 self.updatePlanningGroup(self.current_planning_group_index)
-                planning_group = self.planning_groups_keys[self.current_planning_group_index]
+                planning_group = self.planning_groups_keys[
+                    self.current_planning_group_index
+                ]
                 topics = self.planning_groups[planning_group]
                 next_topic = topics[self.current_eef_index]
                 if not self.waitForInitialPose(next_topic, timeout=3):
-                    rospy.logwarn("Unable to initialize planning group " + planning_group + ". Trying different group.")
-                    rospy.logwarn("Is 'Allow External Comm.' enabled in Rviz? Is the 'Query Goal State' robot enabled?")
+                    rospy.logwarn(
+                        "Unable to initialize planning group "
+                        + planning_group
+                        + ". Trying different group."
+                    )
+                    rospy.logwarn(
+                        "Is 'Allow External Comm.' enabled in Rviz? Is the 'Query Goal State' robot enabled?"
+                    )
                 else:
                     rospy.loginfo("Initialized planning group")
                     self.initialized = True
@@ -727,15 +788,15 @@ class MoveitJoy:
                 # Try to initialize with different planning group
                 self.current_planning_group_index += 1
                 if self.current_planning_group_index >= len(self.planning_groups_keys):
-                    self.current_planning_group_index = 0 # reset loop
-        if self.history.new(status, "select"):   #increment planning group
+                    self.current_planning_group_index = 0  # reset loop
+        if self.history.new(status, "select"):  # increment planning group
             self.updatePlanningGroup(self.current_planning_group_index + 1)
-            self.current_eef_index = 0    # force to reset
+            self.current_eef_index = 0  # force to reset
             self.updatePoseTopic(self.current_eef_index)
             return
-        elif self.history.new(status, "start"):   #decrement planning group
+        elif self.history.new(status, "start"):  # decrement planning group
             self.updatePlanningGroup(self.current_planning_group_index - 1)
-            self.current_eef_index = 0    # force to reset
+            self.current_eef_index = 0  # force to reset
             self.updatePoseTopic(self.current_eef_index)
             return
         elif self.history.new(status, "triangle"):
@@ -744,11 +805,11 @@ class MoveitJoy:
         elif self.history.new(status, "cross"):
             self.updatePoseTopic(self.current_eef_index - 1)
             return
-        elif self.history.new(status, "square"):   #plan
+        elif self.history.new(status, "square"):  # plan
             rospy.loginfo("Plan")
             self.plan_pub.publish(Empty())
             return
-        elif self.history.new(status, "circle"):   #execute
+        elif self.history.new(status, "circle"):  # execute
             rospy.loginfo("Execute")
             self.execute_pub.publish(Empty())
             return

--- a/moveit_ros/visualization/test/test_moveit_joy.py
+++ b/moveit_ros/visualization/test/test_moveit_joy.py
@@ -42,8 +42,9 @@ import rospy
 import rostest
 import os
 
-_PKGNAME = 'moveit_ros_visualization'
-_NODENAME = 'test_moveit_joy'
+_PKGNAME = "moveit_ros_visualization"
+_NODENAME = "test_moveit_joy"
+
 
 class TestMoveitJoy(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -54,7 +55,8 @@ class TestMoveitJoy(unittest.TestCase):
         # However, at least we tested, that MoveitJoy constructor can be called...
         self.assertRaises(RuntimeError, MoveitJoy)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     rospy.init_node(_NODENAME)
     rostest.rosrun(_PKGNAME, _NODENAME, TestMoveitJoy)
     # Don't get trapped by https://github.com/ros/ros_comm/issues/870

--- a/moveit_ros/warehouse/warehouse/src/db_path_config.py
+++ b/moveit_ros/warehouse/warehouse/src/db_path_config.py
@@ -4,12 +4,14 @@
 # This is used in conjunction with ROS_HOME & roslaunch
 # to set the default path for database storage
 
-import roslib; roslib.load_manifest('moveit_warehouse')
+import roslib
+
+roslib.load_manifest("moveit_warehouse")
 import rospy
 import os
 
-if __name__ == '__main__':
-    rospy.init_node('moveit_warehouse')
+if __name__ == "__main__":
+    rospy.init_node("moveit_warehouse")
     path_base = os.getcwd() + "/moveit_warehouse/"
-    rospy.set_param('~database_path_base', path_base)
-    rospy.set_param('~default_database', path_base + "default")
+    rospy.set_param("~database_path_base", path_base)
+    rospy.set_param("~default_database", path_base + "default")


### PR DESCRIPTION
### Description

This adds the `black` python formatter to CI.  This formatter is like `clang-format` in that it will automatically reformat all code to match a pre-defined style.  This makes reading the code much nicer.  It will also enforce that all the python code is python3.

I know this is a large reformatting PR.  I will make the same PR against the ros1 moveit repo to add the same functionality there for this and the other pre-commit tests.  That way this will not impact being able to sync between the two repos.