### PR TITLE
Add fix trailing whitespace check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: trailing-whitespace
 
   - repo: local
     hooks:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,11 +2,11 @@
 
 Like the technical community as a whole, the MoveIt team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 
-Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few basic rules that we ask people to adhere to. This code applies equally to maintainers, contributors, and those seeking help and guidance. 
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few basic rules that we ask people to adhere to. This code applies equally to maintainers, contributors, and those seeking help and guidance.
 It applies to all kinds of communication, including discussions on GitHub (issue tracker, pull requests), MoveIt maintainer meetings and any other forums created by the project team, which the community uses for communication.
 
 - **Be friendly and patient.**
-- **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. 
+- **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities.
 - **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
 - **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the MoveIt community should be respectful when dealing with other members as well as with people outside the MoveIt community.
 - **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. Treat others like you want to be treated.

--- a/doc/MIGRATION_GUIDE.md
+++ b/doc/MIGRATION_GUIDE.md
@@ -10,23 +10,23 @@ This leads to the following basic migration steps:
 1. Replace `LOGNAME` with `rclcpp::Logger` instance:
 
     <b>Old:</b>
-    
+
         constexpr char LOGNAME[] = "logger_name";
-  
+
     <b>New:</b>
-    
+
         static const rclcpp::Logger LOGGER = rclcpp::get_logger("logger_name");
-  
+
 2. Replace logging macros:
 
     <b>Old:</b>
-    
+
         ROS_INFO_NAMED(LOGNAME, "Very important info message");
-   
+
    <b>New:</b>
 
        RCLCPP_INFO(LOGGER, "Very important info message");
-       
+
 ### Logger naming convention
 
 Migrating the loggers is a good opportunity to make logger names more consistent.

--- a/moveit_demo_nodes/run_move_group/README.md
+++ b/moveit_demo_nodes/run_move_group/README.md
@@ -3,14 +3,14 @@
 # MoveIt 2 Beta - MoveGroup Demo
 
 This demo includes a launch configuration for running MoveGroup and a separate MoveGroupInterface demo node.
- 
+
 The MoveGroup setup can be started using the launch file `run_move_group.launch.py`:
- 
+
      ros2 launch run_move_group run_move_group.launch.py
-     
+
 This allows you to start planning and executing motions using the RViz MotionPlanning display.
 The MoveGroupInterface demo can be started by additionally running:
 
      ros2 launch run_move_group run_move_group_interface.launch.py
-     
+
 This will open an interactive xterm that will prompt for user input for running consecutive planning/execution steps.

--- a/moveit_demo_nodes/run_moveit_cpp/README.md
+++ b/moveit_demo_nodes/run_moveit_cpp/README.md
@@ -15,12 +15,12 @@ There are two options and launch files for simulating the robot controllers (the
 
 1. ros2_control using a fake_joint driver: `run_moveit_cpp.launch.py`
 1. MoveIt's fake controller: `run_moveit_cpp_fake_controller.launch.py`
-    
+
 ## Running the Demo
- 
+
 The demo can be run using the launch files `run_moveit_cpp.launch.py` or `run_moveit_cpp_fake_controller.launch.py`:
- 
+
      ros2 launch run_moveit_cpp run_moveit_cpp.launch.py
-     
+
 The demo launches the RViz GUI and demonstrates planning and execution of a simple collision-free motion plan with the panda robot.
 This involves a big range of functioning components: IK solver and collision checking plugins, `PlanningScene`, `RobotModel`, `PlanningPipeline` including adapters, OMPL planner and RViz visualization (`Trajectory` and `PlanningScene` displays).

--- a/moveit_demo_nodes/run_moveit_cpp/config/moveit_cpp.yaml
+++ b/moveit_demo_nodes/run_moveit_cpp/config/moveit_cpp.yaml
@@ -8,11 +8,11 @@ run_moveit_cpp:
       publish_planning_scene_topic: "/moveit_cpp/publish_planning_scene"
       monitored_planning_scene_topic: "/moveit_cpp/monitored_planning_scene"
       wait_for_initial_state_timeout: 10.0
-    
+
     planning_pipelines:
       #namespace: "moveit_cpp"  # optional, default is ~
       pipeline_names: ["ompl"]
-    
+
     plan_request_params:
       planning_attempts: 10
       planning_pipeline: ompl

--- a/moveit_demo_nodes/run_ompl_constrained_planning/README.md
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/README.md
@@ -2,8 +2,8 @@
 
 # MoveIt 2 Beta - OMPL Constrained Planning Demo
 ## Setup
-Before running the demo add the following lines to `ompl_planning.yaml` in the `panda_config` package 
-bellow `panda_arm:` 
+Before running the demo add the following lines to `ompl_planning.yaml` in the `panda_config` package
+bellow `panda_arm:`
 
 ```
 enforce_constrained_state_space: true
@@ -13,11 +13,11 @@ projection_evaluator: joints(panda_joint1,panda_joint2)
 ## Running
 This demo includes a launch configuration for running MoveGroup and a separate demo node.
 
-- Note: This demo shows how to construct a variety of 
+- Note: This demo shows how to construct a variety of
 constraints. See [util.cpp](https://github.com/ros-planning/moveit2/blob/main/moveit_core/kinematic_constraints/src/utils.cpp) for helper functions to automate constructing the constraint messages.
- 
+
 The MoveGroup setup can be started:
-``` 
+```
 ros2 launch run_ompl_constrained_planning run_move_group.launch.py
 ```
 
@@ -26,7 +26,7 @@ This allows you to start planning and executing motions:
 ros2 launch run_move_group run_move_group_interface.launch.py
 ```
 
-## Details 
+## Details
 ### State space selection process
 There are three options for state space selection.
 

--- a/moveit_experimental/collision_distance_field_ros/mainpage.dox
+++ b/moveit_experimental/collision_distance_field_ros/mainpage.dox
@@ -2,9 +2,9 @@
 \mainpage
 \htmlinclude manifest.html
 
-\b collision_distance_field_ros 
+\b collision_distance_field_ros
 
-<!-- 
+<!--
 Provide an overview of your package.
 -->
 

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/mainpage.dox
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/mainpage.dox
@@ -2,9 +2,9 @@
 \mainpage
 \htmlinclude manifest.html
 
-\b kinematics_cache 
+\b kinematics_cache
 
-<!-- 
+<!--
 Provide an overview of your package.
 -->
 

--- a/moveit_planners/pilz_industrial_motion_planner/doc/.gitignore
+++ b/moveit_planners/pilz_industrial_motion_planner/doc/.gitignore
@@ -4,9 +4,9 @@
 *.dvi
 *.log
 *.ps
-*.tps 
-*.fdb_latexmk 
-*.fls 
+*.tps
+*.fdb_latexmk
+*.fls
 *.out
 *.synctex.gz
 *.pdf

--- a/moveit_planners/pilz_industrial_motion_planner/doc/MotionBlendAlgorithmDescription.tex
+++ b/moveit_planners/pilz_industrial_motion_planner/doc/MotionBlendAlgorithmDescription.tex
@@ -88,21 +88,21 @@ For the sake of clarity, it is important to note that our functions for $u_{ij}(
 		\caption{Motion blend case 1: $T_s = 6s$, blending starts at 3.5s, ends at 8s. The resulted blending trajectory comes to a stop in the middle.}%
 		\label{blend_case_1}%
 	\end{subfigure}
-	
+
 	\begin{subfigure}[ht]{0.8\textwidth}%
 		\centering
 		\includegraphics[width=0.8\columnwidth]{figure/blend_case_2.eps}%
 		\caption{Motion blend case 2: $T_s = 3.5s$, blending starts at 3.5s, ends at 5.5s. The resulted blending trajectory smoothly transits from first trajectory to the second trajectory. The velocity profile has no jumps.}%
 		\label{blend_case_2}%
 	\end{subfigure}
-	
+
 	\begin{subfigure}[ht]{0.8\textwidth}%
 		\centering
 		\includegraphics[width=0.8\columnwidth]{figure/blend_case_3.eps}%
 		\caption{Motion blend case 3: $T_s = 4.5s$, blending starts at 3.5s, ends at 6.5s. The resulted blending trajectory smoothly transits from first trajectory to the second trajectory. The velocity profile has no jumps.}%
 		\label{blend_case_3}%
 	\end{subfigure}
-	
+
 \end{figure}
 
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/prbt/launch/test_context.launch
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/prbt/launch/test_context.launch
@@ -39,5 +39,5 @@
   <group ns="$(arg robot_description)_kinematics">
     <rosparam command="load" file="$(find moveit_resources_prbt_moveit_config)/config/kinematics.yaml"/>
   </group>
-  
+
 </launch>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_class_circ_auxiliary.uxf
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_class_circ_auxiliary.uxf
@@ -32,7 +32,7 @@
       <w>470</w>
       <h>80</h>
     </coordinates>
-    <panel_attributes>template=ConfigType&gt; 
+    <panel_attributes>template=ConfigType&gt;
 CircAuxiliary
 {abstract}
 --
@@ -47,7 +47,7 @@ CircAuxiliary
       <w>230</w>
       <h>50</h>
     </coordinates>
-    <panel_attributes>template=ConfigType, Builder&gt; 
+    <panel_attributes>template=ConfigType, Builder&gt;
 Center</panel_attributes>
     <additional_attributes/>
   </element>
@@ -59,7 +59,7 @@ Center</panel_attributes>
       <w>220</w>
       <h>50</h>
     </coordinates>
-    <panel_attributes>template=ConfigType, Builder&gt; 
+    <panel_attributes>template=ConfigType, Builder&gt;
 Interim</panel_attributes>
     <additional_attributes/>
   </element>
@@ -94,7 +94,7 @@ Interim</panel_attributes>
       <h>130</h>
     </coordinates>
     <panel_attributes>lt=&lt;&lt;.
-&lt;&lt;bind&gt;&gt; 
+&lt;&lt;bind&gt;&gt;
 &lt;ConfigType-&gt;CartesianConfiguration&gt;
 &lt;Builder-&gt;CartesianPathConstraintsBuilder&gt;</panel_attributes>
     <additional_attributes>10.0;10.0;10.0;110.0</additional_attributes>
@@ -125,7 +125,7 @@ Interim</panel_attributes>
 
 
 
-&lt;&lt;bind&gt;&gt; 
+&lt;&lt;bind&gt;&gt;
 &lt;ConfigType-&gt;CartesianConfiguration&gt;
 &lt;Builder-&gt;CartesianPathConstraintsBuilder&gt;</panel_attributes>
     <additional_attributes>10.0;10.0;10.0;190.0</additional_attributes>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_class_commands.uxf
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_class_commands.uxf
@@ -8,7 +8,7 @@
       <w>560</w>
       <h>150</h>
     </coordinates>
-    <panel_attributes>template=StartType, GoalType 
+    <panel_attributes>template=StartType, GoalType
 BaseCommand
 {abstract}
 --
@@ -28,7 +28,7 @@ BaseCommand
       <w>230</w>
       <h>70</h>
     </coordinates>
-    <panel_attributes>template=StartType, GoalType 
+    <panel_attributes>template=StartType, GoalType
 Ptp</panel_attributes>
     <additional_attributes/>
   </element>
@@ -62,7 +62,7 @@ Ptp</panel_attributes>
       <w>230</w>
       <h>70</h>
     </coordinates>
-    <panel_attributes>template=StartType, GoalType 
+    <panel_attributes>template=StartType, GoalType
 Lin</panel_attributes>
     <additional_attributes/>
   </element>
@@ -74,7 +74,7 @@ Lin</panel_attributes>
       <w>300</w>
       <h>70</h>
     </coordinates>
-    <panel_attributes>template=StartType, AuxiliaryType, GoalType 
+    <panel_attributes>template=StartType, AuxiliaryType, GoalType
 Circ</panel_attributes>
     <additional_attributes/>
   </element>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_seq_testdataloader_usage.uxf
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/doc/diagrams/diag_seq_testdataloader_usage.uxf
@@ -150,7 +150,7 @@ transparency=0</panel_attributes>
       <h>48</h>
     </coordinates>
     <panel_attributes>lt=&lt;-
-toRequest() : 
+toRequest() :
 moveit_msgs::MotionPlanRequest</panel_attributes>
     <additional_attributes>220.0;20.0;10.0;20.0</additional_attributes>
   </element>

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.launch.py
@@ -27,7 +27,7 @@ def load_yaml(package_name, file_path):
 def generate_launch_description():
 
     moveit_ros_benchmarks_yaml = load_yaml('moveit_ros_benchmarks', 'demo_panda_predefined_poses.yaml')
-    moveit_ros_benchmarks_config = { 'benchmark_config' : moveit_ros_benchmarks_yaml }    
+    moveit_ros_benchmarks_config = { 'benchmark_config' : moveit_ros_benchmarks_yaml }
 
     # Component yaml files are grouped in separate namespaces
     robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')

--- a/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.yaml
+++ b/moveit_ros/benchmarks/examples/demo_panda_predefined_poses.yaml
@@ -18,7 +18,7 @@ parameters:
     predefined_poses: # List of named targets
         - ready
         - extended
-planning_pipelines: 
+planning_pipelines:
   pipelines: [pipeline1]
   pipeline1:
     name: ompl

--- a/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
+++ b/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
@@ -355,7 +355,7 @@ def plotAttribute(cur, planners, attribute, typename):
         measurementsPercentage = [sum(m) * 100. / len(m) for m in measurements]
         ind = range(len(measurements))
         plt.bar(ind, measurementsPercentage, width)
-        ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers. 
+        ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers.
         ### Fits situations where you need more control in the plot, such as in an academic publication for example
         #labels = [l.replace('kConfigDefault', '') for l in labels]
 
@@ -371,11 +371,11 @@ def plotAttribute(cur, planners, attribute, typename):
 
         #xtickNames = plt.xticks(labels, rotation=30, fontsize=10)
         #plt.subplots_adjust(bottom=0.3) # Squish the plot into the upper 2/3 of the page.  Leave room for labels
-	
-        ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers. 
+
+        ### uncommenting this line will remove the term 'kConfigDefault' from the labels for OMPL Solvers.
         ### Fits situations where you need more control in the plot, such as in an academic publication for example
         #labels = [l.replace('kConfigDefault', '') for l in labels]
-        
+
         xtickNames = plt.setp(ax,xticklabels=labels)
         plt.setp(xtickNames, rotation=30, fontsize=8, ha='right')
         for tick in ax.xaxis.get_major_ticks(): # shrink the font size of the x tick labels

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -65,7 +65,7 @@
       Provide a ROS service that allows for clearing the octomap
     </description>
   </class>
-  
+
   <class name="move_group/TfPublisher" type="move_group::TfPublisher" base_class_type="move_group::MoveGroupCapability">
     <description>
       Provide a capability that publishes PlanningScene frames to the tf system

--- a/moveit_ros/moveit_servo/doc/running_the_demos.md
+++ b/moveit_ros/moveit_servo/doc/running_the_demos.md
@@ -31,7 +31,7 @@ colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE
 ```
 
 ## Cpp Interface Demo
-The simplest demo is the C++ interface demo. In it, a simulated Panda arm is spawned and shown in Rviz, along with a collision object. 
+The simplest demo is the C++ interface demo. In it, a simulated Panda arm is spawned and shown in Rviz, along with a collision object.
 
 First, a simple joint command is sent to the arm for a few seconds.
 
@@ -47,7 +47,7 @@ ros2 launch moveit_servo servo_cpp_interface_demo.launch.py
 ![Alt Text](Images/C%2B%2B_Interface_Demo.gif)
 
 ## Component Demo
-`moveit_servo` is also offered as a composable node that may be run in a container with other components. 
+`moveit_servo` is also offered as a composable node that may be run in a container with other components.
 
 This demo starts a `moveit_servo` instance in a container with the `tf` publisher. Commands may be sent to the arm by publishing to the `moveit_servo` input topics, and the `moveit_servo` behavior may be controlled by its offered services.
 
@@ -67,11 +67,11 @@ ros2 run moveit_servo fake_command_publisher
 ![Alt Text](Images/Servo_Component_Demo.gif)
 
 ## Teleoperation Demo
-`moveit_servo` is a versatile tool for teleoperating a manipulator. Inputs can include generic `TwistStamped` or `JointJog` commands, collisions can be detected and avoided, and singular positions can be avoided. 
+`moveit_servo` is a versatile tool for teleoperating a manipulator. Inputs can include generic `TwistStamped` or `JointJog` commands, collisions can be detected and avoided, and singular positions can be avoided.
 
-The teleoperation demo spawns a Panda arm and shows it in Rviz with a few simulated tables. Then it uses `moveit_servo` to control the arm following user inputs with a game controller. 
+The teleoperation demo spawns a Panda arm and shows it in Rviz with a few simulated tables. Then it uses `moveit_servo` to control the arm following user inputs with a game controller.
 
-This demo was written for an Xbox 1 controller, but can easily be modified for any generic gamepad that works with the [Joy package](https://index.ros.org/p/joy/#foxy). 
+This demo was written for an Xbox 1 controller, but can easily be modified for any generic gamepad that works with the [Joy package](https://index.ros.org/p/joy/#foxy).
 
 #### To run
 Make sure your controller is plugged in and can be detected by `ros2 run joy joy_node`. Usually this happens automatically after plugging the controller in.

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
     servo_params = { 'moveit_servo' : servo_yaml }
 
     kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
-    
+
     #RViz
     rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_pose_tracking.rviz"
     rviz_node = Node(package='rviz2',

--- a/moveit_ros/moveit_servo/test/config/collision_start_positions.yaml
+++ b/moveit_ros/moveit_servo/test/config/collision_start_positions.yaml
@@ -17,4 +17,3 @@ fake_joint_driver_node:
         - 0.0
         - 1.1
         - 0.785
-        

--- a/moveit_ros/moveit_servo/test/config/singularity_start_positions.yaml
+++ b/moveit_ros/moveit_servo/test/config/singularity_start_positions.yaml
@@ -17,4 +17,3 @@ fake_joint_driver_node:
         - 0.117
         - 1.439
         - -1.286
-        

--- a/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_integration.test.py
@@ -4,7 +4,7 @@ import unittest
 
 import launch_testing.asserts
 sys.path.append(os.path.dirname(__file__))
-from servo_launch_test_common import generate_servo_test_description 
+from servo_launch_test_common import generate_servo_test_description
 
 def generate_test_description():
     return generate_servo_test_description(gtest_name='test_servo_integration',

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -43,7 +43,7 @@
 
   <class name="default_planner_request_adapters/AddTimeOptimalParameterization" type="default_planner_request_adapters::AddTimeOptimalParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
-      This is an improved time parameterization using Time-Optimal Trajectory Generation for Path Following With Bounded Acceleration and Velocity (Kunz and Stilman, RSS 2008) 
+      This is an improved time parameterization using Time-Optimal Trajectory Generation for Path Following With Bounded Acceleration and Velocity (Kunz and Stilman, RSS 2008)
     </description>
   </class>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -57,7 +57,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="load_robot_description" value="$(arg load_robot_description)"/>
-  </include>  
+  </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
   <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch">

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit_controller_manager.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <!-- loads moveit_controller_manager on the parameter server which is taken as argument 
+  <!-- loads moveit_controller_manager on the parameter server which is taken as argument
     if no argument is passed, moveit_simple_controller_manager will be set -->
   <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>


### PR DESCRIPTION
### Description

This adds a step to the pre-commit test to fix trailing whitespace.  This is one more awesome feature that can cut down on having to fix these through code review comments.