### PR TITLE
Fix build directory for foxy-source image

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Build the workspace
-RUN . /opt/ros/${ROS_DISTRO}/setup.sh &&\
+RUN cd .. && . /opt/ros/${ROS_DISTRO}/setup.sh &&\
     colcon build \
             --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
               --ament-cmake-args -DCMAKE_BUILD_TYPE=Release \

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Build the workspace
-RUN cd .. && . /opt/ros/${ROS_DISTRO}/setup.sh &&\
+RUN cd $ROS_UNDERLAY/.. && . /opt/ros/${ROS_DISTRO}/setup.sh &&\
     colcon build \
             --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
               --ament-cmake-args -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
### Description

This's a bug introduced by my previous PR, I forgot to change the directory before building causing the `install`, `build`, and `log` folders to be inside `src`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
