### PR TITLE
Update launch files to use ros2 control spawner

### DIFF
--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
@@ -157,30 +157,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Warehouse mongodb server
     mongodb_server_node = Node(

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -142,30 +142,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     return LaunchDescription(
         [

--- a/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
@@ -158,30 +158,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Warehouse mongodb server
     mongodb_server_node = Node(

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -123,30 +123,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     return LaunchDescription(
         [

--- a/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_cpp_interface_demo.launch.py
@@ -108,30 +108,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     return LaunchDescription(
         [rviz_node, static_tf, servo_node, ros2_control_node, robot_state_publisher]

--- a/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_server_demo.launch.py
@@ -84,30 +84,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Launch as much as possible in components
     container = ComposableNodeContainer(

--- a/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_teleop.launch.py
@@ -82,30 +82,16 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Launch as much as possible in components
     container = ComposableNodeContainer(

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -92,30 +92,16 @@ def generate_servo_test_description(
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -9,7 +9,7 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, TimerAction
 import xacro
 
 
@@ -156,7 +156,7 @@ def generate_servo_test_description(
             ),
             ros2_control_node,
             test_container,
-            servo_gtest,
+            TimerAction(period=2.0, actions=[servo_gtest]),
             launch_testing.actions.ReadyToTest(),
         ]
         + load_controllers

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -91,30 +91,16 @@ def generate_servo_test_description(*args, gtest_name: SomeSubstitutionsType):
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -12,7 +12,7 @@ import launch_testing.asserts
 from launch import LaunchDescription
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, TimerAction
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -148,7 +148,7 @@ def generate_servo_test_description(*args, gtest_name: SomeSubstitutionsType):
             ),
             ros2_control_node,
             test_container,
-            pose_tracking_gtest,
+            TimerAction(period=2.0, actions=[pose_tracking_gtest]),
             launch_testing.actions.ReadyToTest(),
         ]
         + load_controllers

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -156,30 +156,16 @@ def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsTyp
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=["ros2 control load_configure_controller panda_arm_controller"],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_arm_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_controller"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # test executable
     ompl_constraint_test = launch_ros.actions.Node(

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -5,7 +5,7 @@ import launch_ros
 import launch_testing
 import xacro
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, TimerAction
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer, Node
@@ -187,7 +187,7 @@ def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsTyp
             static_tf,
             robot_state_publisher,
             ros2_control_node,
-            ompl_constraint_test,
+            TimerAction(period=2.0, actions=[ompl_constraint_test]),
             launch_testing.actions.ReadyToTest(),
         ]
         + load_controllers


### PR DESCRIPTION
### Description

Fix: https://github.com/ros-planning/moveit2/issues/399
Use the newly merged spawner https://github.com/ros-controls/ros2_control/pull/310 to load the controllers

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
