### PR TITLE
Include optional in pose_tracking

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <atomic>
+#include <boost/optional/optional.hpp>
 #include <control_toolbox/pid.hpp>
 #include <moveit_servo/make_shared_from_pool.h>
 #include <moveit_servo/servo.h>
@@ -46,7 +47,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
 #include <rclcpp/rclcpp.hpp>
-#include <boost/optional/optional.hpp>
 
 // Conventions:
 // Calculations are done in the planning_frame_ unless otherwise noted.

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -46,6 +46,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
 #include <rclcpp/rclcpp.hpp>
+#include <boost/optional/optional.hpp>
 
 // Conventions:
 // Calculations are done in the planning_frame_ unless otherwise noted.


### PR DESCRIPTION
### Description

CI is failing for not being able to find `boost::optional` [see](https://github.com/ros-planning/moveit2/pull/310/checks?check_run_id=2230312292#step:7:450)

```
/home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h:193:10: error: ‘optional’ in namespace ‘boost’ does not name a template type; did you mean ‘conditional’?
```
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
