### PR TITLE
Declare joint limit parameters

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -139,7 +139,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_position_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name);
           }
           node_->get_parameter(param_name, has_position_limits);
 
@@ -147,7 +147,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_vel_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name);
           }
           node_->get_parameter(param_name, has_vel_limits);
 
@@ -155,7 +155,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_acc_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name);
           }
           node_->get_parameter(param_name, has_acc_limits);
 
@@ -165,19 +165,24 @@ void RobotModelLoader::configure(const Options& opt)
 
           if (has_position_limits && canSpecifyPosition(joint_model, joint_id))
           {
-            param_name = prefix + "max_position";
-            if (!node_->has_parameter(param_name))
+            const auto max_pos_name = prefix + "max_position";
+            if (!node_->has_parameter(max_pos_name))
             {
-              node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(max_pos_name);
             }
-            node_->get_parameter(param_name, joint_limit[joint_id].max_position);
 
-            param_name = prefix + "min_position";
-            if (!node_->has_parameter(param_name))
+            const auto min_pos_name = prefix + "min_position";
+            if (!node_->has_parameter(min_pos_name))
             {
-              node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(min_pos_name);
             }
-            node_->get_parameter(param_name, joint_limit[joint_id].min_position);
+
+            if (!node_->get_parameter(max_pos_name, joint_limit[joint_id].max_position) ||
+                !node_->get_parameter(min_pos_name, joint_limit[joint_id].min_position))
+            {
+              RCLCPP_ERROR(LOGGER, "Specified a position limit for joint: %s but did not set a max or min position",
+                           joint_limit[joint_id].joint_name.c_str());
+            }
 
             joint_limit[joint_id].has_position_limits = has_position_limits;
           }
@@ -187,22 +192,29 @@ void RobotModelLoader::configure(const Options& opt)
             param_name = prefix + "max_velocity";
             if (!node_->has_parameter(param_name))
             {
-              node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name);
             }
 
-            node_->get_parameter(param_name, joint_limit[joint_id].max_velocity);
+            if (!node_->get_parameter(param_name, joint_limit[joint_id].max_velocity))
+            {
+              RCLCPP_ERROR(LOGGER, "Specified a velocity limit for joint: %s but did not set a max velocity",
+                           joint_limit[joint_id].joint_name.c_str());
+            }
           }
 
           if (has_acc_limits)
           {
             param_name = prefix + "max_acceleration";
-
             if (!node_->has_parameter(param_name))
             {
-              node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name);
             }
 
-            node_->get_parameter(param_name, joint_limit[joint_id].max_acceleration);
+            if (!node_->get_parameter(param_name, joint_limit[joint_id].max_acceleration))
+            {
+              RCLCPP_ERROR(LOGGER, "Specified an acceleration limit for joint: %s but did not set a max acceleration",
+                           joint_limit[joint_id].joint_name.c_str());
+            }
           }
         }
         catch (const rclcpp::ParameterTypeException& e)

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -139,7 +139,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_position_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            has_position_limits = node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name, false);
           }
           node_->get_parameter(param_name, has_position_limits);
 
@@ -147,7 +147,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_vel_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            has_vel_limits = node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name, false);
           }
           node_->get_parameter(param_name, has_vel_limits);
 
@@ -155,7 +155,7 @@ void RobotModelLoader::configure(const Options& opt)
           bool has_acc_limits = false;
           if (!node_->has_parameter(param_name))
           {
-            has_acc_limits = node_->declare_parameter(param_name, false);
+            node_->declare_parameter(param_name, false);
           }
           node_->get_parameter(param_name, has_acc_limits);
 

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -165,54 +165,44 @@ void RobotModelLoader::configure(const Options& opt)
 
           if (has_position_limits && canSpecifyPosition(joint_model, joint_id))
           {
-            double max_position = 0.0;
-            double min_position = 0.0;
-
             param_name = prefix + "max_position";
             if (!node_->has_parameter(param_name))
             {
-              max_position = node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name, 0.0);
             }
-            node_->get_parameter(param_name, max_position);
+            node_->get_parameter(param_name, joint_limit[joint_id].max_position);
 
             param_name = prefix + "min_position";
             if (!node_->has_parameter(param_name))
             {
-              min_position = node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name, 0.0);
             }
-            node_->get_parameter(param_name, min_position);
+            node_->get_parameter(param_name, joint_limit[joint_id].min_position);
 
             joint_limit[joint_id].has_position_limits = has_position_limits;
-            joint_limit[joint_id].max_position = max_position;
-            joint_limit[joint_id].min_position = min_position;
           }
 
           if (has_vel_limits)
           {
             param_name = prefix + "max_velocity";
-            double max_velocity = 0.0;
-
             if (!node_->has_parameter(param_name))
             {
-              max_velocity = node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name, 0.0);
             }
 
-            node_->get_parameter(param_name, max_velocity);
-            joint_limit[joint_id].max_velocity = max_velocity;
+            node_->get_parameter(param_name, joint_limit[joint_id].max_velocity);
           }
 
           if (has_acc_limits)
           {
             param_name = prefix + "max_acceleration";
-            double max_acc = 0.0;
 
             if (!node_->has_parameter(param_name))
             {
-              max_acc = node_->declare_parameter(param_name, 0.0);
+              node_->declare_parameter(param_name, 0.0);
             }
 
-            node_->get_parameter(param_name, max_acc);
-            joint_limit[joint_id].max_acceleration = max_acc;
+            node_->get_parameter(param_name, joint_limit[joint_id].max_acceleration);
           }
         }
         catch (const rclcpp::ParameterTypeException& e)

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -131,15 +131,12 @@ void RobotModelLoader::configure(const Options& opt)
         std::string param_name;
         try
         {
-          bool has_position_limits = false;
-          bool has_vel_limits = false;
-          bool has_acc_limits = false;
-
           // Need to check before setting to true
           joint_limit[joint_id].has_position_limits = false;
 
           // Check if parameter has been declared to avoid exception
           param_name = prefix + "has_position_limits";
+          bool has_position_limits = false;
           if (!node_->has_parameter(param_name))
           {
             has_position_limits = node_->declare_parameter(param_name, false);
@@ -147,6 +144,7 @@ void RobotModelLoader::configure(const Options& opt)
           node_->get_parameter(param_name, has_position_limits);
 
           param_name = prefix + "has_velocity_limits";
+          bool has_vel_limits = false;
           if (!node_->has_parameter(param_name))
           {
             has_vel_limits = node_->declare_parameter(param_name, false);
@@ -154,6 +152,7 @@ void RobotModelLoader::configure(const Options& opt)
           node_->get_parameter(param_name, has_vel_limits);
 
           param_name = prefix + "has_acceleration_limits";
+          bool has_acc_limits = false;
           if (!node_->has_parameter(param_name))
           {
             has_acc_limits = node_->declare_parameter(param_name, false);

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -160,7 +160,7 @@ void RobotModelLoader::configure(const Options& opt)
           }
           node_->get_parameter(param_name, has_acc_limits);
 
-          // All types of joints can handle velocity and accletation limits
+          // All types of joints can handle velocity and acceleration limits
           joint_limit[joint_id].has_velocity_limits = has_vel_limits;
           joint_limit[joint_id].has_acceleration_limits = has_acc_limits;
 


### PR DESCRIPTION
Joint position, velocity, and accleration parameter limits
where not declared in the `robot_model_loader`. This prevented
the use of joint limits. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
