### PR TITLE
Servo: do not cause a joint jump when SuddenHalt() is called

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -203,8 +203,7 @@ void ServoCalcs::start()
     // I do not know of a robot that takes acceleration commands.
     // However, some controllers check that this data is non-empty.
     // Send all zeros, for now.
-    std::vector<double> acceleration(num_joints_);
-    point.accelerations = acceleration;
+    point.accelerations.resize(num_joints_);
   }
   initial_joint_trajectory->points.push_back(point);
   last_sent_command_ = std::move(initial_joint_trajectory);
@@ -865,8 +864,10 @@ void ServoCalcs::suddenHalt(trajectory_msgs::msg::JointTrajectory& joint_traject
   // being 0 seconds in the past, the smallest supported timestep is added as time from start to the trajectory point.
   point.time_from_start = rclcpp::Duration(0, 1);
 
-  point.positions.resize(num_joints_);
-  point.velocities.resize(num_joints_);
+  if (parameters_->publish_joint_positions)
+    point.positions.resize(num_joints_);
+  if (parameters_->publish_joint_velocities)
+    point.velocities.resize(num_joints_);
 
   // Assert the following loop is safe to execute
   assert(original_joint_state_.position.size() >= num_joints_);


### PR DESCRIPTION
We found out the hard way, when the suddenHalt() function was called for a robot in velocity control mode, it would send a command vector of all-zero positions. That could cause a really big joint jump depending what type of ros2_controller is active. This fixes that.

Also (really minor fix) it sets trajectory accelerations to 0 to match the comment.
