### PR TITLE
Fix node install directory in run_move_group

### DIFF
--- a/moveit_demo_nodes/run_move_group/CMakeLists.txt
+++ b/moveit_demo_nodes/run_move_group/CMakeLists.txt
@@ -29,7 +29,7 @@ install(TARGETS run_move_group
   EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
   INCLUDES DESTINATION include
 )
 ament_export_targets(export_${PROJECT_NAME})

--- a/moveit_demo_nodes/run_move_group/CMakeLists.txt
+++ b/moveit_demo_nodes/run_move_group/CMakeLists.txt
@@ -26,13 +26,11 @@ ament_target_dependencies(run_move_group
 )
 
 install(TARGETS run_move_group
-  EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
   INCLUDES DESTINATION include
 )
-ament_export_targets(export_${PROJECT_NAME})
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
Fixes #384 and #415. 

run_moveit_cpp was already fixed by a previous commit.

run_move_group_interface now correctly launches but does nothing? I am not sure what it supposed to do. @JafarAbdi can you check it