### PR TITLE
Unify PickNik name in copyrights

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This open source project is maintained by supporters from around the world — s
   <img src="https://picknik.ai/assets/images/logo.jpg" width="168">
 </a>
 
-[PickNik Robotics](https://picknik.ai/) is leading and organizing the development of MoveIt 2.
+[PickNik Inc.](https://picknik.ai/) is leading and organizing the development of MoveIt 2.
 If you would like to support this project, please contact hello@picknik.ai
 
 <a href="http://rosin-project.eu">

--- a/moveit/scripts/create_maintainer_table.py
+++ b/moveit/scripts/create_maintainer_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright 2021 PickNik Robotics
+# Copyright 2021 PickNik Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -13,7 +13,7 @@
 #      notice, this list of conditions and the following disclaimer in the
 #      documentation and/or other materials provided with the distribution.
 #
-#    * Neither the name of the PickNik Robotics nor the names of its
+#    * Neither the name of the PickNik Inc. nor the names of its
 #      contributors may be used to endorse or promote products derived from
 #      this software without specific prior written permission.
 #

--- a/moveit/scripts/create_readme_table.py
+++ b/moveit/scripts/create_readme_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright 2021 PickNik Robotics
+# Copyright 2021 PickNik Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -13,7 +13,7 @@
 #      notice, this list of conditions and the following disclaimer in the
 #      documentation and/or other materials provided with the distribution.
 #
-#    * Neither the name of the PickNik Robotics nor the names of its
+#    * Neither the name of the PickNik Inc. nor the names of its
 #      contributors may be used to endorse or promote products derived from
 #      this software without specific prior written permission.
 #

--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -1,4 +1,4 @@
-# Copyright 2021 PickNik Robotics
+# Copyright 2021 PickNik Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 #      notice, this list of conditions and the following disclaimer in the
 #      documentation and/or other materials provided with the distribution.
 #
-#    * Neither the name of the PickNik Robotics nor the names of its
+#    * Neither the name of the PickNik Inc. nor the names of its
 #      contributors may be used to endorse or promote products derived from
 #      this software without specific prior written permission.
 #

--- a/moveit_common/moveit_common-extras.cmake
+++ b/moveit_common/moveit_common-extras.cmake
@@ -1,4 +1,4 @@
-# Copyright 2021 PickNik Robotics
+# Copyright 2021 PickNik Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 #      notice, this list of conditions and the following disclaimer in the
 #      documentation and/or other materials provided with the distribution.
 #
-#    * Neither the name of the PickNik Robotics nor the names of its
+#    * Neither the name of the PickNik Inc. nor the names of its
 #      contributors may be used to endorse or promote products derived from
 #      this software without specific prior written permission.
 #

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -3,7 +3,7 @@
  *
  *  Copyright (c) 2013, Ioan A. Sucan
  *  Copyright (c) 2013, Willow Garage, Inc.
- *  Copyright (c) 2019, PickNik LLC.
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -3,7 +3,7 @@
  *
  *  Copyright (c) 2013, Ioan A. Sucan
  *  Copyright (c) 2013, Willow Garage, Inc.
- *  Copyright (c) 2019, PickNik LLC.
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC.
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
+++ b/moveit_demo_nodes/run_moveit_cpp/src/run_moveit_cpp.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_demo_nodes/run_ompl_constrained_planning/src/run_ompl_constrained_planning.cpp
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/src/run_ompl_constrained_planning.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2021, PickNik LLC
+ *  Copyright (c) 2021, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -9,8 +9,8 @@ This plugin and the move_group node can be used as a general
 kinematics service, from within the moveit planning environment, or in
 your own ROS node.
 
-Author: Dave Coleman, PickNik Robotics
-        Michael Lautman, PickNik Robotics
+Author: Dave Coleman, PickNik Inc.
+        Michael Lautman, PickNik Inc.
         Based heavily on the arm_kinematic_tools package by Jeremy Zoss, SwRI
         and the arm_navigation plugin generator by David Butterworth, KAIST
 

--- a/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
+++ b/moveit_planners/trajopt/include/trajopt_interface/trajopt_interface.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik, LLC.
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik, Inc.
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_planners/trajopt/test/trajectory_test.cpp
+++ b/moveit_planners/trajopt/test/trajectory_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement
  *
- *  Copyright (c) 2019, PickNik Consulting
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *********************************************************************/

--- a/moveit_ros/benchmarks/src/simple_benchmarks/CombinePredefinedPosesBenchmark.cpp
+++ b/moveit_ros/benchmarks/src/simple_benchmarks/CombinePredefinedPosesBenchmark.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the PickNik LLC nor the names of its
+ *   * Neither the name of the PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_server.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_server.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/publish_fake_jog_commands.cpp
+++ b/moveit_ros/moveit_servo/test/publish_fake_jog_commands.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_cpp_interface_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/servo_low_latency_test.cpp
+++ b/moveit_ros/moveit_servo/test/servo_low_latency_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/test_low_pass_filter.cpp
+++ b/moveit_ros/moveit_servo/test/test_low_pass_filter.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/test_servo_collision.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_collision.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/test_servo_singularity.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_singularity.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik LLC
+ *  Copyright (c) 2020, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/print_planning_scene_info.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2018, PickNik LLC
+ *  Copyright (c) 2018, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning_interface/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/moveit_cpp.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning_interface/moveit_cpp/src/planning_component.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik Robotics nor the
+ *   * Neither the name of PickNik Inc. nor the
  *     names of its contributors may be used to endorse or promote
  *     products derived from this software without specific prior
  *     written permission.

--- a/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2021, PickNik LLC
+ *  Copyright (c) 2021, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik Robotics nor the
+ *   * Neither the name of PickNik Inc. nor the
  *     names of its contributors may be used to endorse or promote
  *     products derived from this software without specific prior
  *     written permission.

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2019, PickNik LLC
+ *  Copyright (c) 2019, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of PickNik LLC nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of OMRON SINIC X or PickNik Robotics nor the
+ *   * Neither the name of OMRON SINIC X or PickNik Inc. nor the
  *     names of its contributors may be used to endorse or promote
  *     products derived from this software without specific prior
  *     written permission.


### PR DESCRIPTION
### Description

Various copyrights mention `PickNik Robotics` (these are my fault), `PickNik LLC` (from moveit1, we should fix these there too), `PickNik Consulting` (only one of these).  There is a legal requirement that these are a legal name.  This fixes that.