### PR TITLE
Remove move_group namespace

### DIFF
--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.rviz
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.rviz
@@ -310,7 +310,7 @@ Visualization Manager:
         Show Trail: false
         State Display Time: 0.05 s
         Trail Step Size: 1
-        Trajectory Topic: /move_group/display_planned_path
+        Trajectory Topic: /display_planned_path
       Planning Metrics:
         Payload: 1
         Show Joint Torques: false

--- a/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.rviz
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.rviz
@@ -252,7 +252,7 @@ Visualization Manager:
         Show Trail: false
         State Display Time: 0.05 s
         Trail Step Size: 1
-        Trajectory Topic: /move_group/display_planned_path
+        Trajectory Topic: /display_planned_path
       Planning Metrics:
         Payload: 1
         Show Joint Torques: false

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -76,7 +76,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
 
   if (listen_to_planning_scene)
     planning_scene_topic_property_ = new rviz_common::properties::RosTopicProperty(
-        "Planning Scene Topic", "move_group/monitored_planning_scene",
+        "Planning Scene Topic", "/monitored_planning_scene",
         rosidl_generator_traits::data_type<moveit_msgs::msg::PlanningScene>(),
         "The topic on which the moveit_msgs::msg::PlanningScene messages are received", this,
         SLOT(changedPlanningSceneTopic()), this);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -74,7 +74,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz_common::properties::Proper
   , trajectory_slider_dock_panel_(nullptr)
 {
   trajectory_topic_property_ = new rviz_common::properties::RosTopicProperty(
-      "Trajectory Topic", "/move_group/display_planned_path",
+      "Trajectory Topic", "/display_planned_path",
       rosidl_generator_traits::data_type<moveit_msgs::msg::DisplayTrajectory>(),
       "The topic on which the moveit_msgs::msg::DisplayTrajectory messages are received", widget,
       SLOT(changedTrajectoryTopic()), this);

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit.rviz
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/moveit.rviz
@@ -331,7 +331,7 @@ Visualization Manager:
         Show Robot Visual: true
         Show Trail: false
         State Display Time: 0.05 s
-        Trajectory Topic: move_group/display_planned_path
+        Trajectory Topic: display_planned_path
       Planning Metrics:
         Payload: 1
         Show Joint Torques: false
@@ -350,7 +350,7 @@ Visualization Manager:
         Show Workspace: false
         Start State Alpha: 1
         Start State Color: 0; 255; 0
-      Planning Scene Topic: move_group/monitored_planning_scene
+      Planning Scene Topic: monitored_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 1


### PR DESCRIPTION
Related to #417, @JafarAbdi and I discussed and looked for solutions. We tried to add ~/ to the nodes though these result in a namespace of move_group_private which we thought would have to change and break quite a bit of stuff. So we thought to leave it the way it is right now and removed move_group namespaces from the relevant files. @henningkayser can you check if it makes sense, or we still want the private node stuff?

If you approve I will send a PR to moveit2_tutorials and moveit_resources related to this. I've tested this with run_move_group, run_moveit_cpp and quickstart rviz (didn't send a PR for this one yet) all seem to work fine.
