### PR TITLE
Fix robot_model & moveit_ros_visualization dependencies

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -25,7 +25,7 @@ pkg_check_modules(LIBFCL REQUIRED "fcl>=0.5.0")
 find_library(LIBFCL_LIBRARIES_FULL ${LIBFCL_LIBRARIES} ${LIBFCL_LIBRARY_DIRS})
 set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 
-
+find_package(angles REQUIRED)
 find_package(OCTOMAP REQUIRED)
 find_package(urdfdom REQUIRED)
 find_package(urdf REQUIRED)
@@ -109,6 +109,7 @@ set(THIS_PACKAGE_LIBRARIES
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  angles
   eigen_stl_containers
   geometric_shapes
   geometry_msgs

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -23,6 +23,7 @@
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
   <build_depend>moveit_common</build_depend>
 
+  <depend>angles</depend>
   <depend>rclcpp</depend>
   <depend>common_interfaces</depend>
   <depend>assimp</depend>

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME}
+  angles
   moveit_msgs
   Eigen3
   geometric_shapes

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -88,6 +88,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   tf2_eigen
   Eigen3
   rviz_ogre_vendor
+  rviz_common
+  rviz_default_plugins
 )
 
 include_directories(rviz_plugin_render_tools/include


### PR DESCRIPTION
### Description

The ros2 build is failing because it can't find `angles.h` for the robot_model [see](https://build.ros2.org/job/Fdev__moveit__ubuntu_focal_amd64/lastBuild/console), this PR fixes it & exports `rviz_common` `rviz_default_plugins` for moveit_ros_visualization