### PR TITLE
WIP: Fix missing dependency resource_retriever

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -206,6 +206,13 @@ if(BUILD_TESTING)
 
   # Run all lint tests in package.xml except those listed above
   ament_lint_auto_find_test_dependencies()
+
+  # This has to be exported here because it is needed to link for the test
+  #  in collision_distance_field but exporting only works from the top level
+  #  cmake file (this one).  This means that if tests link external libraries
+  #  they need to be exported like this or libraries that depend on this one
+  #  will throw a cmake error about a missing find_package when they build.
+  ament_export_dependencies(resource_retriever)
 endif()
 
 ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -59,6 +59,7 @@
   <test_depend>orocos_kdl</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
+  <test_depend>resource_retriever</test_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
### Description

This should fix these two issues:
* https://github.com/ros-planning/moveit2/issues/440
* https://github.com/ros-planning/moveit2/issues/441

The dependency `resource_retriever` must have previously been found via one of our dependencies.  I'm not sure which one (as moveit_core has a ton of dependencies) but whichever one it was they no longer have that dependency but we still do.