### PR TITLE
Improvement on Servo enforcePositionLimits()

### DIFF
--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -163,7 +163,9 @@ bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bou
   if (continuous_)
     return true;
   else
+  {
     return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  }
 }
 
 bool RevoluteJointModel::harmonizePosition(double* values, const JointModel::Bounds& other_bounds) const

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -156,7 +156,7 @@ protected:
   void enforceVelLimits(Eigen::ArrayXd& delta_theta);
 
   /** \brief Avoid overshooting joint limits */
-  bool enforcePositionLimits();
+  bool enforcePositionLimits(trajectory_msgs::msg::JointTrajectory& joint_trajectory) const;
 
   /** \brief Possibly calculate a velocity scaling factor, due to proximity of
    * singularity and direction of motion


### PR DESCRIPTION
Previously, the incoming robot state velocity was used to check if the robot would move beyond the joint limit. That was a problem if the robot state did not contain velocity data, i.e. if "copy dynamics" hadn't been turned on.

This PR uses the prospective robot velocity from Servo itself to check if the joint would move beyond the position limit and halt, if so. This velocity should always be available regardless of whether "copy dynamics" is ON.