### PR TITLE
Revert "Eliminate ability to keep multiple collision detectors updated"

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_plugin.h
@@ -87,7 +87,7 @@ public:
   /**
    * @brief This should be used to load your collision plugin.
    */
-  virtual bool initialize(const planning_scene::PlanningScenePtr& scene) const = 0;
+  virtual bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const = 0;
 };
 
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_fcl_plugin_loader.h
@@ -44,6 +44,6 @@ namespace collision_detection
 class CollisionDetectorFCLPluginLoader : public CollisionPlugin
 {
 public:
-  bool initialize(const planning_scene::PlanningScenePtr& scene) const override;
+  bool initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const override;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
@@ -39,9 +39,9 @@
 
 namespace collision_detection
 {
-bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene) const
+bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
 {
-  scene->setCollisionDetectorType(CollisionDetectorAllocatorFCL::create());
+  scene->setActiveCollisionDetector(CollisionDetectorAllocatorFCL::create(), exclusive);
   return true;
 }
 }  // namespace collision_detection

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -233,11 +233,53 @@ public:
    */
   /**@{*/
 
-  const std::string getCollisionDetectorName() const
+  /** \brief Add a new collision detector type.
+   *
+   * A collision detector type is specified with (a shared pointer to) an
+   * allocator which is a subclass of CollisionDetectorAllocator.  This
+   * identifies a combination of CollisionWorld/CollisionRobot which can ve
+   * used together.
+   *
+   * This does nothing if this type of collision detector has already been added.
+   *
+   * A new PlanningScene contains an FCL collision detector.  This FCL
+   * collision detector will always be available unless it is removed by
+   * calling setActiveCollisionDetector() with exclusive=true.
+   *
+   * example: to add FCL collision detection (normally not necessary) call
+   *   planning_scene->addCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
+   *
+   * */
+  void addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
+
+  /** \brief Set the type of collision detector to use.
+   * Calls addCollisionDetector() to add it if it has not already been added.
+   *
+   * If exclusive is true then all other collision detectors will be removed
+   * and only this one will be available.
+   *
+   * example: to use FCL collision call
+   *   planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
+   */
+  void setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                  bool exclusive = false);
+
+  /** \brief Set the type of collision detector to use.
+   * This type must have already been added with addCollisionDetector().
+   *
+   * Returns true on success, false if \e collision_detector_name is not the
+   * name of a collision detector that has been previously added with
+   * addCollisionDetector(). */
+  bool setActiveCollisionDetector(const std::string& collision_detector_name);
+
+  const std::string& getActiveCollisionDetectorName() const
   {
-    // If no collision detector is allocated, return an empty string
-    return collision_detector_ ? (collision_detector_->alloc_->getName()) : "";
+    return active_collision_->alloc_->getName();
   }
+
+  /** \brief get the types of collision detector that have already been added.
+   * These are the types which can be passed to setActiveCollisionDetector(). */
+  void getCollisionDetectorNames(std::vector<std::string>& names) const;
 
   /** \brief Get the representation of the world */
   const collision_detection::WorldConstPtr& getWorld() const
@@ -256,13 +298,13 @@ public:
   /** \brief Get the active collision environment */
   const collision_detection::CollisionEnvConstPtr& getCollisionEnv() const
   {
-    return collision_detector_->getCollisionEnv();
+    return active_collision_->getCollisionEnv();
   }
 
   /** \brief Get the active collision detector for the robot */
   const collision_detection::CollisionEnvConstPtr& getCollisionEnvUnpadded() const
   {
-    return collision_detector_->getCollisionEnvUnpadded();
+    return active_collision_->getCollisionEnvUnpadded();
   }
 
   /** \brief Get a specific collision detector for the world.  If not found return active CollisionWorld. */
@@ -274,8 +316,15 @@ public:
   getCollisionEnvUnpadded(const std::string& collision_detector_name) const;
 
   /** \brief Get the representation of the collision robot
-   * This can be used to set padding and link scale on the active collision_robot. */
+   * This can be used to set padding and link scale on the active collision_robot.
+   * NOTE: After modifying padding and scale on the active robot call
+   * propogateRobotPadding() to copy it to all the other collision detectors. */
   const collision_detection::CollisionEnvPtr& getCollisionEnvNonConst();
+
+  /** \brief Copy scale and padding from active CollisionRobot to other CollisionRobots.
+   * This should be called after any changes are made to the scale or padding of the active
+   * CollisionRobot.  This has no effect on the unpadded CollisionRobots. */
+  void propogateRobotPadding();
 
   /** \brief Get the allowed collision matrix */
   const collision_detection::AllowedCollisionMatrix& getAllowedCollisionMatrix() const
@@ -912,21 +961,6 @@ public:
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
   static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);
 
-  /** \brief Replace previous collision detector with a new collision detector type (or create new, if none previously).
-   *
-   * The collision detector type is specified with (a shared pointer to) an
-   * allocator which is a subclass of CollisionDetectorAllocator.  This
-   * identifies a combination of CollisionWorld/CollisionRobot which can be
-   * used together.
-   *
-   * A new PlanningScene uses an FCL collision detector by default.
-   *
-   * example: to add FCL collision detection (normally not necessary) call
-   *   planning_scene->setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
-   *
-   * */
-  void setCollisionDetectorType(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
-
 private:
   /* Private constructor used by the diff() methods. */
   PlanningScene(const PlanningSceneConstPtr& parent);
@@ -959,17 +993,26 @@ private:
     collision_detection::CollisionEnvPtr cenv_unpadded_;
     collision_detection::CollisionEnvConstPtr cenv_unpadded_const_;
 
+    CollisionDetectorConstPtr parent_;  // may be NULL
+
     const collision_detection::CollisionEnvConstPtr& getCollisionEnv() const
     {
-      return cenv_const_;
+      return cenv_const_ ? cenv_const_ : parent_->getCollisionEnv();
     }
     const collision_detection::CollisionEnvConstPtr& getCollisionEnvUnpadded() const
     {
-      return cenv_unpadded_const_;
+      return cenv_unpadded_const_ ? cenv_unpadded_const_ : parent_->getCollisionEnvUnpadded();
     }
+    void findParent(const PlanningScene& scene);
     void copyPadding(const CollisionDetector& src);
   };
   friend struct CollisionDetector;
+
+  using CollisionDetectorIterator = std::map<std::string, CollisionDetectorPtr>::iterator;
+  using CollisionDetectorConstIterator = std::map<std::string, CollisionDetectorPtr>::const_iterator;
+
+  void allocateCollisionDetectors();
+  void allocateCollisionDetectors(CollisionDetector& detector);
 
   std::string name_;  // may be empty
 
@@ -992,7 +1035,8 @@ private:
   collision_detection::World::ObserverCallbackFn current_world_object_update_callback_;
   collision_detection::World::ObserverHandle current_world_object_update_observer_handle_;
 
-  CollisionDetectorPtr collision_detector_;  // Never NULL.
+  std::map<std::string, CollisionDetectorPtr> collision_;  // never empty
+  CollisionDetectorPtr active_collision_;                  // copy of one of the entries in collision_.  Never NULL.
 
   collision_detection::AllowedCollisionMatrixPtr acm_;  // if NULL use parent's
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -161,7 +161,7 @@ void PlanningScene::initialize()
   for (const srdf::Model::DisabledCollision& it : dc)
     acm_->setEntry(it.link1_, it.link2_, true);
 
-  setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
+  setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
 }
 
 /* return NULL on failure */
@@ -193,8 +193,22 @@ PlanningScene::PlanningScene(const PlanningSceneConstPtr& parent) : parent_(pare
   // record changes to the world
   world_diff_.reset(new collision_detection::WorldDiff(world_));
 
-  setCollisionDetectorType(parent_->collision_detector_->alloc_);
-  collision_detector_->copyPadding(*parent_->collision_detector_);
+  // Set up the same collision detectors as the parent
+  for (const std::pair<const std::string, CollisionDetectorPtr>& it : parent_->collision_)
+  {
+    const CollisionDetectorPtr& parent_detector = it.second;
+    CollisionDetectorPtr& detector = collision_[it.first];
+    detector.reset(new CollisionDetector());
+    detector->alloc_ = parent_detector->alloc_;
+    detector->parent_ = parent_detector;
+
+    detector->cenv_ = detector->alloc_->allocateEnv(parent_detector->cenv_, world_);
+    detector->cenv_const_ = detector->cenv_;
+
+    detector->cenv_unpadded_ = detector->alloc_->allocateEnv(parent_detector->cenv_unpadded_, world_);
+    detector->cenv_unpadded_const_ = detector->cenv_unpadded_;
+  }
+  setActiveCollisionDetector(parent_->getActiveCollisionDetectorName());
 }
 
 PlanningScenePtr PlanningScene::clone(const PlanningSceneConstPtr& scene)
@@ -223,64 +237,137 @@ void PlanningScene::CollisionDetector::copyPadding(const PlanningScene::Collisio
   cenv_->setLinkScale(src.getCollisionEnv()->getLinkScale());
 }
 
-void PlanningScene::setCollisionDetectorType(const collision_detection::CollisionDetectorAllocatorPtr& allocator)
+void PlanningScene::propogateRobotPadding()
 {
-  // Temporary copy of the previous (if any), to copy padding
-  CollisionDetector prev_coll_detector;
-  bool have_previous_coll_detector = false;
-  if (collision_detector_)
+  for (std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
   {
-    have_previous_coll_detector = true;
-    prev_coll_detector = *collision_detector_;
+    if (it.second != active_collision_)
+      it.second->copyPadding(*active_collision_);
+  }
+}
+
+void PlanningScene::CollisionDetector::findParent(const PlanningScene& scene)
+{
+  if (parent_ || !scene.parent_)
+    return;
+
+  CollisionDetectorConstIterator it = scene.parent_->collision_.find(alloc_->getName());
+  if (it != scene.parent_->collision_.end())
+    parent_ = it->second->parent_;
+}
+
+void PlanningScene::addCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator)
+{
+  const std::string& name = allocator->getName();
+  CollisionDetectorPtr& detector = collision_[name];
+
+  if (detector)  // already added this one
+    return;
+
+  detector.reset(new CollisionDetector());
+
+  detector->alloc_ = allocator;
+
+  if (!active_collision_)
+    active_collision_ = detector;
+
+  detector->findParent(*this);
+
+  detector->cenv_ = detector->alloc_->allocateEnv(world_, getRobotModel());
+  detector->cenv_const_ = detector->cenv_;
+
+  // if the current active detector is not the added one, copy its padding to the new one and allocate unpadded
+  if (detector != active_collision_)
+  {
+    detector->cenv_unpadded_ = detector->alloc_->allocateEnv(world_, getRobotModel());
+    detector->cenv_unpadded_const_ = detector->cenv_unpadded_;
+
+    detector->copyPadding(*active_collision_);
   }
 
-  // TODO(andyz): uncomment this for a small speed boost when another collision detector type is available in MoveIt2
-  // For now, it is useful in the switchCollisionDetectorType() unit test
-  //  const std::string& name = allocator->getName();
-  //  if (name == getCollisionDetectorName())  // already using this collision detector
-  //    return;
+  detector->cenv_unpadded_ = detector->alloc_->allocateEnv(world_, getRobotModel());
+  detector->cenv_unpadded_const_ = detector->cenv_unpadded_;
+}
 
-  collision_detector_.reset(new CollisionDetector());
-
-  collision_detector_->alloc_ = allocator;
-  collision_detector_->cenv_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
-  collision_detector_->cenv_const_ = collision_detector_->cenv_;
-  collision_detector_->cenv_unpadded_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
-  collision_detector_->cenv_unpadded_const_ = collision_detector_->cenv_unpadded_;
-
-  // Copy padding from the previous collision detector
-  if (have_previous_coll_detector)
+void PlanningScene::setActiveCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                               bool exclusive)
+{
+  if (exclusive)
   {
-    collision_detector_->copyPadding(prev_coll_detector);
+    CollisionDetectorPtr p;
+    CollisionDetectorIterator it = collision_.find(allocator->getName());
+    if (it != collision_.end())
+      p = it->second;
+
+    collision_.clear();
+    active_collision_.reset();
+
+    if (p)
+    {
+      collision_[allocator->getName()] = p;
+      active_collision_ = p;
+      return;
+    }
   }
+
+  addCollisionDetector(allocator);
+  setActiveCollisionDetector(allocator->getName());
+}
+
+bool PlanningScene::setActiveCollisionDetector(const std::string& collision_detector_name)
+{
+  CollisionDetectorIterator it = collision_.find(collision_detector_name);
+  if (it != collision_.end())
+  {
+    active_collision_ = it->second;
+    return true;
+  }
+  else
+  {
+    RCLCPP_ERROR(LOGGER,
+                 "Cannot setActiveCollisionDetector to '%s' -- it has been added to PlanningScene. "
+                 "Keeping existing active collision detector '%s'",
+                 collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    return false;
+  }
+}
+
+void PlanningScene::getCollisionDetectorNames(std::vector<std::string>& names) const
+{
+  names.clear();
+  names.reserve(collision_.size());
+  for (const std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
+    names.push_back(it.first);
 }
 
 const collision_detection::CollisionEnvConstPtr&
 PlanningScene::getCollisionEnv(const std::string& collision_detector_name) const
 {
-  if (collision_detector_name != getCollisionDetectorName())
+  CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
+  if (it == collision_.end())
   {
     RCLCPP_ERROR(LOGGER, "Could not get CollisionRobot named '%s'.  Returning active CollisionRobot '%s' instead",
-                 collision_detector_name.c_str(), collision_detector_->alloc_->getName().c_str());
-    return collision_detector_->getCollisionEnv();
+                 collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    return active_collision_->getCollisionEnv();
   }
 
-  return collision_detector_->getCollisionEnv();
+  return it->second->getCollisionEnv();
 }
 
 const collision_detection::CollisionEnvConstPtr&
 PlanningScene::getCollisionEnvUnpadded(const std::string& collision_detector_name) const
 {
-  if (collision_detector_name != getCollisionDetectorName())
+  CollisionDetectorConstIterator it = collision_.find(collision_detector_name);
+  if (it == collision_.end())
   {
     RCLCPP_ERROR(LOGGER,
                  "Could not get CollisionRobotUnpadded named '%s'. "
                  "Returning active CollisionRobotUnpadded '%s' instead",
-                 collision_detector_name.c_str(), collision_detector_->alloc_->getName().c_str());
-    return collision_detector_->getCollisionEnvUnpadded();
+                 collision_detector_name.c_str(), active_collision_->alloc_->getName().c_str());
+    return active_collision_->getCollisionEnvUnpadded();
   }
 
-  return collision_detector_->getCollisionEnvUnpadded();
+  return it->second->getCollisionEnvUnpadded();
 }
 
 void PlanningScene::clearDiffs()
@@ -295,11 +382,28 @@ void PlanningScene::clearDiffs()
   if (current_world_object_update_callback_)
     current_world_object_update_observer_handle_ = world_->addObserver(current_world_object_update_callback_);
 
-  if (parent_)
+  // use parent crobot_ if it exists.  Otherwise copy padding from parent.
+  for (std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
   {
-    collision_detector_->copyPadding(*parent_->collision_detector_);
+    if (!it.second->parent_)
+      it.second->findParent(*this);
+
+    if (it.second->parent_)
+    {
+      it.second->cenv_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_, world_);
+      it.second->cenv_const_ = it.second->cenv_;
+
+      it.second->cenv_unpadded_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_unpadded_, world_);
+      it.second->cenv_unpadded_const_ = it.second->cenv_unpadded_;
+    }
+    else
+    {
+      it.second->copyPadding(*parent_->active_collision_);
+
+      it.second->cenv_ = it.second->alloc_->allocateEnv(it.second->parent_->cenv_, world_);
+      it.second->cenv_const_ = it.second->cenv_;
+    }
   }
-  collision_detector_->cenv_const_ = collision_detector_->cenv_;
 
   scene_transforms_.reset();
   robot_state_.reset();
@@ -335,8 +439,9 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
     scene->getAllowedCollisionMatrixNonConst() = *acm_;
 
   collision_detection::CollisionEnvPtr active_cenv = scene->getCollisionEnvNonConst();
-  active_cenv->setLinkPadding(collision_detector_->cenv_->getLinkPadding());
-  active_cenv->setLinkScale(collision_detector_->cenv_->getLinkScale());
+  active_cenv->setLinkPadding(active_collision_->cenv_->getLinkPadding());
+  active_cenv->setLinkScale(active_collision_->cenv_->getLinkScale());
+  scene->propogateRobotPadding();
 
   if (world_diff_)
   {
@@ -481,7 +586,7 @@ void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const mov
 
 const collision_detection::CollisionEnvPtr& PlanningScene::getCollisionEnvNonConst()
 {
-  return collision_detector_->cenv_;
+  return active_collision_->cenv_;
 }
 
 moveit::core::RobotState& PlanningScene::getCurrentStateNonConst()
@@ -570,8 +675,8 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::msg::PlanningScene& sce
   else
     scene_msg.allowed_collision_matrix = moveit_msgs::msg::AllowedCollisionMatrix();
 
-  collision_detector_->cenv_->getPadding(scene_msg.link_padding);
-  collision_detector_->cenv_->getScale(scene_msg.link_scale);
+  active_collision_->cenv_->getPadding(scene_msg.link_padding);
+  active_collision_->cenv_->getScale(scene_msg.link_scale);
 
   scene_msg.object_colors.clear();
   if (object_colors_)
@@ -1029,6 +1134,10 @@ void PlanningScene::decoupleParent()
   if (!acm_)
     acm_.reset(new collision_detection::AllowedCollisionMatrix(parent_->getAllowedCollisionMatrix()));
 
+  for (std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
+  {
+    it.second->parent_.reset();
+  }
   world_diff_.reset();
 
   if (!object_colors_)
@@ -1096,8 +1205,11 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::msg::PlanningScen
 
   if (!scene_msg.link_padding.empty() || !scene_msg.link_scale.empty())
   {
-    collision_detector_->cenv_->setPadding(scene_msg.link_padding);
-    collision_detector_->cenv_->setScale(scene_msg.link_scale);
+    for (std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
+    {
+      it.second->cenv_->setPadding(scene_msg.link_padding);
+      it.second->cenv_->setScale(scene_msg.link_scale);
+    }
   }
 
   // if any colors have been specified, replace the ones we have with the specified ones
@@ -1131,8 +1243,11 @@ bool PlanningScene::setPlanningSceneMsg(const moveit_msgs::msg::PlanningScene& s
   scene_transforms_->setTransforms(scene_msg.fixed_frame_transforms);
   setCurrentState(scene_msg.robot_state);
   acm_.reset(new collision_detection::AllowedCollisionMatrix(scene_msg.allowed_collision_matrix));
-  collision_detector_->cenv_->setPadding(scene_msg.link_padding);
-  collision_detector_->cenv_->setScale(scene_msg.link_scale);
+  for (std::pair<const std::string, CollisionDetectorPtr>& it : collision_)
+  {
+    it.second->cenv_->setPadding(scene_msg.link_padding);
+    it.second->cenv_->setScale(scene_msg.link_scale);
+  }
   object_colors_.reset(new ObjectColorMap());
   for (const moveit_msgs::msg::ObjectColor& object_color : scene_msg.object_colors)
     setObjectColor(object_color.id, object_color.color);

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -35,7 +35,6 @@
 /* Author: Ioan Sucan */
 
 #include <gtest/gtest.h>
-#include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/utils/message_checks.h>
 #include <moveit/utils/robot_model_test_utils.h>
@@ -210,25 +209,6 @@ TEST(PlanningScene, loadBadSceneGeometry)
                                "0 0 1 0.3\n"
                                ".\n");
   EXPECT_FALSE(ps->loadGeometryFromStream(malformed_scene_geometry));
-}
-
-// Test the setting of a new collision detector type. For now, only FCL is available in MoveIt2.
-// TODO(andyz): switch to a different type when one becomes available.
-TEST(PlanningScene, switchCollisionDetectorType)
-{
-  moveit::core::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("pr2");
-  auto ps = std::make_shared<planning_scene::PlanningScene>(robot_model->getURDF(), robot_model->getSRDF());
-  moveit::core::RobotState current_state = ps->getCurrentState();
-  if (ps->isStateColliding(current_state, "left_arm"))
-  {
-    EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));
-  }
-
-  ps->setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
-  if (ps->isStateColliding(current_state, "left_arm"))
-  {
-    EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));
-  }
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
+++ b/moveit_ros/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
@@ -59,7 +59,7 @@ public:
    * @param exclusive If true, sets the new detection robot/world to be the only one.
    * @return True if collision robot/world were added to scene.
    */
-  bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene);
+  bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene, bool exclusive);
 
 private:
   MOVEIT_CLASS_FORWARD(CollisionPluginLoaderImpl)  // Defines CollisionPluginLoaderImplPtr, ConstPtr, WeakPtr... etc

--- a/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/moveit_ros/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -70,7 +70,7 @@ public:
     return plugin;
   }
 
-  bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene)
+  bool activate(const std::string& name, const planning_scene::PlanningScenePtr& scene, bool exclusive)
   {
     std::map<std::string, CollisionPluginPtr>::iterator it = plugins_.find(name);
     if (it == plugins_.end())
@@ -78,13 +78,13 @@ public:
       CollisionPluginPtr plugin = load(name);
       if (plugin)
       {
-        return plugin->initialize(scene);
+        return plugin->initialize(scene, exclusive);
       }
       return false;
     }
     if (it->second)
     {
-      return it->second->initialize(scene);
+      return it->second->initialize(scene, exclusive);
     }
     return false;
   }
@@ -101,9 +101,10 @@ CollisionPluginLoader::CollisionPluginLoader()
 
 CollisionPluginLoader::~CollisionPluginLoader() = default;
 
-bool CollisionPluginLoader::activate(const std::string& name, const planning_scene::PlanningScenePtr& scene)
+bool CollisionPluginLoader::activate(const std::string& name, const planning_scene::PlanningScenePtr& scene,
+                                     bool exclusive)
 {
-  return loader_->activate(name, scene);
+  return loader_->activate(name, scene, exclusive);
 }
 
 void CollisionPluginLoader::setupScene(const rclcpp::Node::SharedPtr& node,
@@ -136,8 +137,8 @@ void CollisionPluginLoader::setupScene(const rclcpp::Node::SharedPtr& node,
     return;
   }
 
-  activate(collision_detector_name, scene);
-  RCLCPP_INFO(LOGGER, "Using collision detector: %s", scene->getCollisionDetectorName().c_str());
+  activate(collision_detector_name, scene, true);
+  RCLCPP_INFO(LOGGER, "Using collision detector: %s", scene->getActiveCollisionDetectorName().c_str());
 }
 
 }  // namespace collision_detection

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -172,6 +172,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
         {
           scene_->getCollisionEnvNonConst()->setLinkScale(it.first, it.second);
         }
+        scene_->propogateRobotPadding();
       }
       catch (moveit::ConstructException& e)
       {


### PR DESCRIPTION
Fix: https://github.com/ros-planning/moveit2/issues/407
Fix: https://github.com/ros-planning/moveit2/issues/444
Fix: https://github.com/ros-planning/moveit2/issues/429

Reverts ros-planning/moveit2#364

I wasn't able to trace where the bug is actually happening (it only happen when the planning scene have a parent scene), so just reverting it for now
