### PR TITLE
Fix Servo logging frequency

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -50,7 +50,7 @@
 using namespace std::chrono_literals;  // for s, ms, etc.
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo_calcs");
-constexpr auto ROS_LOG_THROTTLE_PERIOD = std::chrono::nanoseconds(30ms).count();
+constexpr auto ROS_LOG_THROTTLE_PERIOD = std::chrono::milliseconds(3000).count();
 
 namespace moveit_servo
 {


### PR DESCRIPTION
A small fix to correct logger frequencies.

Prior to this, the messages only printed once.

main branch, message only prints once:  (This is a gif, but nothing changes)

![main_no_updates](https://user-images.githubusercontent.com/11284393/117481390-8d5a7380-af28-11eb-82e3-a7ae85f35534.gif)

With this PR, prints every 3s:

![every_3s](https://user-images.githubusercontent.com/11284393/117481353-803d8480-af28-11eb-8039-120a6344ba7b.gif)