### PR TITLE
Fix clearDiffs() within the planning scene

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1029,6 +1029,7 @@ void PlanningScene::decoupleParent()
   if (!acm_)
     acm_.reset(new collision_detection::AllowedCollisionMatrix(parent_->getAllowedCollisionMatrix()));
 
+  parent_.reset();
   world_diff_.reset();
 
   if (!object_colors_)


### PR DESCRIPTION
Some small fixups for recent changes to the planning scene.

I've tested that it fixes #429 (robot collides when an object is attached). Hopefully it also fixes #407,444.

You can verify this fixes #429 by installing the moveit2 tutorials from source then running...

> ros2 launch moveit2_tutorials move_group.launch.py
> ros2 launch moveit2_tutorials move_group_interface_tutorial.launch.py

Hopefully this PR replaces #456.

- The first commit resets the `parent_` pointer when decouple() is called. I think that's a pretty obvious fix b/c the whole point of that function is to decouple from the parent.
- The second commit restores the original logic from [here](https://github.com/ros-planning/moveit2/blob/b479cf6167fe81a67241afe9d0d5b8cc017afd66/moveit_core/planning_scene/src/planning_scene.cpp#L391).