### PR TITLE
Fix PlanningScene CollisionDetector diff handling

### DIFF
--- a/moveit_core/collision_detection_bullet/src/collision_detector_bullet_plugin_loader.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_detector_bullet_plugin_loader.cpp
@@ -41,7 +41,7 @@ namespace collision_detection
 {
 bool CollisionDetectorBtPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene, bool exclusive) const
 {
-  scene->setActiveCollisionDetector(CollisionDetectorAllocatorBullet::create(), exclusive);
+  scene->allocateCollisionDetector(CollisionDetectorAllocatorBullet::create(), exclusive);
   return true;
 }
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_detector_fcl_plugin_loader.cpp
@@ -41,7 +41,7 @@ namespace collision_detection
 {
 bool CollisionDetectorFCLPluginLoader::initialize(const planning_scene::PlanningScenePtr& scene) const
 {
-  scene->setCollisionDetectorType(CollisionDetectorAllocatorFCL::create());
+  scene->allocateCollisionDetector(CollisionDetectorAllocatorFCL::create());
   return true;
 }
 }  // namespace collision_detection

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -912,7 +912,7 @@ public:
   /** \brief Clone a planning scene. Even if the scene \e scene depends on a parent, the cloned scene will not. */
   static PlanningScenePtr clone(const PlanningSceneConstPtr& scene);
 
-  /** \brief Replace previous collision detector with a new collision detector type (or create new, if none previously).
+  /** \brief Allocate a new collision detector and replace the previous one if there was any.
    *
    * The collision detector type is specified with (a shared pointer to) an
    * allocator which is a subclass of CollisionDetectorAllocator.  This
@@ -922,10 +922,13 @@ public:
    * A new PlanningScene uses an FCL collision detector by default.
    *
    * example: to add FCL collision detection (normally not necessary) call
-   *   planning_scene->setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
+   *   planning_scene->allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
    *
    * */
-  void setCollisionDetectorType(const collision_detection::CollisionDetectorAllocatorPtr& allocator);
+  void allocateCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator)
+  {
+    allocateCollisionDetector(allocator, nullptr /* no parent_detector */);
+  }
 
 private:
   /* Private constructor used by the diff() methods. */
@@ -948,6 +951,10 @@ private:
   static void poseMsgToEigen(const geometry_msgs::msg::Pose& msg, Eigen::Isometry3d& out);
 
   MOVEIT_STRUCT_FORWARD(CollisionDetector)
+
+  /* Construct a new CollisionDector from allocator, copy-construct environments from parent_detector if specified */
+  void allocateCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                 const CollisionDetectorPtr& parent_detector);
 
   /* \brief A set of compatible collision detectors */
   struct CollisionDetector

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -952,7 +952,7 @@ private:
 
   MOVEIT_STRUCT_FORWARD(CollisionDetector)
 
-  /* Construct a new CollisionDector from allocator, copy-construct environments from parent_detector if specified */
+  /* Construct a new CollisionDector from allocator, copy-construct environments from parent_detector if not null */
   void allocateCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
                                  const CollisionDetectorPtr& parent_detector);
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -161,7 +161,7 @@ void PlanningScene::initialize()
   for (const srdf::Model::DisabledCollision& it : dc)
     acm_->setEntry(it.link1_, it.link2_, true);
 
-  setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
+  allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
 }
 
 /* return NULL on failure */
@@ -193,7 +193,7 @@ PlanningScene::PlanningScene(const PlanningSceneConstPtr& parent) : parent_(pare
   // record changes to the world
   world_diff_.reset(new collision_detection::WorldDiff(world_));
 
-  setCollisionDetectorType(parent_->collision_detector_->alloc_);
+  allocateCollisionDetector(parent_->collision_detector_->alloc_, parent_->collision_detector_);
   collision_detector_->copyPadding(*parent_->collision_detector_);
 }
 
@@ -223,36 +223,37 @@ void PlanningScene::CollisionDetector::copyPadding(const PlanningScene::Collisio
   cenv_->setLinkScale(src.getCollisionEnv()->getLinkScale());
 }
 
-void PlanningScene::setCollisionDetectorType(const collision_detection::CollisionDetectorAllocatorPtr& allocator)
+void PlanningScene::allocateCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
+                                              const CollisionDetectorPtr& parent_detector)
 {
-  // Temporary copy of the previous (if any), to copy padding
-  CollisionDetector prev_coll_detector;
-  bool have_previous_coll_detector = false;
-  if (collision_detector_)
-  {
-    have_previous_coll_detector = true;
-    prev_coll_detector = *collision_detector_;
-  }
+  // Temporary store the previous (if any) collision detector to copy padding from
+  CollisionDetectorPtr prev_coll_detector = collision_detector_;
 
-  // TODO(andyz): uncomment this for a small speed boost when another collision detector type is available in MoveIt2
-  // For now, it is useful in the switchCollisionDetectorType() unit test
-  //  const std::string& name = allocator->getName();
-  //  if (name == getCollisionDetectorName())  // already using this collision detector
-  //    return;
-
+  // Construct a fresh CollisionDetector and store allocator
   collision_detector_.reset(new CollisionDetector());
-
   collision_detector_->alloc_ = allocator;
-  collision_detector_->cenv_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
-  collision_detector_->cenv_const_ = collision_detector_->cenv_;
-  collision_detector_->cenv_unpadded_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
-  collision_detector_->cenv_unpadded_const_ = collision_detector_->cenv_unpadded_;
 
-  // Copy padding from the previous collision detector
-  if (have_previous_coll_detector)
+  // If parent_detector is specified, copy-construct collision environments (copies link shapes and attached objects)
+  // Otherwise, construct new collision environment from world and robot model
+  if (parent_detector)
   {
-    collision_detector_->copyPadding(prev_coll_detector);
+    collision_detector_->cenv_ = collision_detector_->alloc_->allocateEnv(parent_detector->cenv_, world_);
+    collision_detector_->cenv_unpadded_ =
+        collision_detector_->alloc_->allocateEnv(parent_detector->cenv_unpadded_, world_);
   }
+  else
+  {
+    collision_detector_->cenv_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
+    collision_detector_->cenv_unpadded_ = collision_detector_->alloc_->allocateEnv(world_, getRobotModel());
+
+    // Copy padding to collision_detector_->cenv_
+    if (prev_coll_detector)
+      collision_detector_->copyPadding(*prev_coll_detector);
+  }
+
+  // Assign const pointers
+  collision_detector_->cenv_const_ = collision_detector_->cenv_;
+  collision_detector_->cenv_unpadded_const_ = collision_detector_->cenv_unpadded_;
 }
 
 const collision_detection::CollisionEnvConstPtr&
@@ -295,11 +296,8 @@ void PlanningScene::clearDiffs()
   if (current_world_object_update_callback_)
     current_world_object_update_observer_handle_ = world_->addObserver(current_world_object_update_callback_);
 
-  if (parent_)
-  {
-    collision_detector_->copyPadding(*parent_->collision_detector_);
-  }
-  collision_detector_->cenv_const_ = collision_detector_->cenv_;
+  // Reset collision detector to the the parent's version
+  allocateCollisionDetector(parent_->collision_detector_->alloc_, parent_->collision_detector_);
 
   scene_transforms_.reset();
   robot_state_.reset();

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -226,7 +226,7 @@ void PlanningScene::CollisionDetector::copyPadding(const PlanningScene::Collisio
 void PlanningScene::allocateCollisionDetector(const collision_detection::CollisionDetectorAllocatorPtr& allocator,
                                               const CollisionDetectorPtr& parent_detector)
 {
-  // Temporary store the previous (if any) collision detector to copy padding from
+  // Temporarily keep pointer to the previous (if any) collision detector to copy padding from
   CollisionDetectorPtr prev_coll_detector = collision_detector_;
 
   // Construct a fresh CollisionDetector and store allocator

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -224,7 +224,7 @@ TEST(PlanningScene, switchCollisionDetectorType)
     EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));
   }
 
-  ps->setCollisionDetectorType(collision_detection::CollisionDetectorAllocatorFCL::create());
+  ps->allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
   if (ps->isStateColliding(current_state, "left_arm"))
   {
     EXPECT_FALSE(ps->isStateValid(current_state, "left_arm"));


### PR DESCRIPTION
This fixes how PlanningScene diffs are created and managed (replaces #463 and #456).
https://github.com/ros-planning/moveit2/pull/364 introduced a bug where a child scene would not copy-construct the collision environments so that it wouldn't include any of the parent's link geometries or attached objects. The link geometries aren't that bad because they would be constructed from the robot model anyway, but there was no way to sync back the attached objects. This PR fixes that by providing a private allocate function that allows passing the parent detector which implements the old behavior. I tested this and it fixes #429 and #407 for me. I didn't test #444 yet.

However, there is still a bug (or irritation) where the start state of the MotionPlanningPanel doesn't include the attached object right away after publishing the collision objects. The reason is that the internal start state of the panel is not updated automatically which is also exactly the case for MoveIt 1. The requested plan then solves a trajectory which is then being rejected right away because it's in collision. To make the plan succeed, the start state needs to be updated either by selecting "\<current\>" again or by changing it to a different state. I actually don't think that this needs fixing and it's definitely out of scope of this PR.
