### PR TITLE
Port MoveIt1 PR 2682 (Fix collision normals and order of reported bodies)

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -304,7 +304,64 @@ TYPED_TEST_P(DistanceCheckPandaTest, DistanceSingle)
   }
 }
 
+template <class CollisionAllocatorType>
+class DistanceFullPandaTest : public CollisionDetectorPandaTest<CollisionAllocatorType>
+{
+};
+
+TYPED_TEST_CASE_P(DistanceFullPandaTest);
+
+/** \brief Tests if nearest points are computed correctly. */
+TYPED_TEST_P(DistanceFullPandaTest, DistancePoints)
+{
+  // Adding a box right in front of the robot hand
+  shapes::Box* shape = new shapes::Box(0.1, 0.1, 0.1);
+  shapes::ShapeConstPtr shape_ptr(shape);
+
+  Eigen::Isometry3d pos{ Eigen::Isometry3d::Identity() };
+  pos.translation().x() = 0.43;
+  pos.translation().y() = 0;
+  pos.translation().z() = 0.55;
+  this->cenv_->getWorld()->addToObject("box", shape_ptr, pos);
+
+  collision_detection::DistanceRequest req;
+  req.acm = &*this->acm_;
+  req.type = collision_detection::DistanceRequestTypes::SINGLE;
+  req.enable_nearest_points = true;
+  req.max_contacts_per_body = 1;
+
+  collision_detection::DistanceResult res;
+  this->cenv_->distanceRobot(req, res, *this->robot_state_);
+
+  // Checks a particular point is inside the box
+  auto checkInBox = [&](const Eigen::Vector3d& p) {
+    Eigen::Vector3d inBox = pos.inverse() * p;
+
+    constexpr double EPS = 1e-5;
+    EXPECT_LE(std::abs(inBox.x()), shape->size[0] + EPS);
+    EXPECT_LE(std::abs(inBox.y()), shape->size[1] + EPS);
+    EXPECT_LE(std::abs(inBox.z()), shape->size[2] + EPS);
+  };
+
+  // Check that all points reported on "box" are actually on the box and not
+  // on the robot
+  for (auto& distance : res.distances)
+  {
+    for (auto& pair : distance.second)
+    {
+      if (pair.link_names[0] == "box")
+        checkInBox(pair.nearest_points[0]);
+      else if (pair.link_names[1] == "box")
+        checkInBox(pair.nearest_points[1]);
+      else
+        ADD_FAILURE() << "Unrecognized link names";
+    }
+  }
+}
+
 REGISTER_TYPED_TEST_CASE_P(CollisionDetectorPandaTest, InitOK, DefaultNotInCollision, LinksInCollision,
                            RobotWorldCollision_1, RobotWorldCollision_2, PaddingTest, DistanceSelf, DistanceWorld);
 
 REGISTER_TYPED_TEST_CASE_P(DistanceCheckPandaTest, DistanceSingle);
+
+REGISTER_TYPED_TEST_CASE_P(DistanceFullPandaTest, DistancePoints);

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -154,6 +154,9 @@ private:
   /** \brief Callback function executed for each change to the world environment */
   void notifyObjectChange(const ObjectConstPtr& obj, World::Action action);
 
+  /** \brief Check if enable_nearest_distance_points is available */
+  void checkFCLNearestDistCapability(const DistanceRequest& req) const;
+
   World::ObserverHandle observer_handle_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -535,6 +535,12 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
   {
     DistanceResultsData dist_result;
     dist_result.distance = fcl_result.min_distance;
+
+    // Careful here: Get the collision geometry data again, since FCL might
+    // swap o1 and o2 in the result.
+    const CollisionGeometryData* res_cd1 = static_cast<const CollisionGeometryData*>(fcl_result.o1->getUserData());
+    const CollisionGeometryData* res_cd2 = static_cast<const CollisionGeometryData*>(fcl_result.o2->getUserData());
+
 #if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
     dist_result.nearest_points[0] = fcl_result.nearest_points[0];
     dist_result.nearest_points[1] = fcl_result.nearest_points[1];
@@ -542,10 +548,10 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     dist_result.nearest_points[0] = Eigen::Vector3d(fcl_result.nearest_points[0].data.vs);
     dist_result.nearest_points[1] = Eigen::Vector3d(fcl_result.nearest_points[1].data.vs);
 #endif
-    dist_result.link_names[0] = cd1->getID();
-    dist_result.link_names[1] = cd2->getID();
-    dist_result.body_types[0] = cd1->type;
-    dist_result.body_types[1] = cd2->type;
+    dist_result.link_names[0] = res_cd1->getID();
+    dist_result.link_names[1] = res_cd2->getID();
+    dist_result.body_types[0] = res_cd1->type;
+    dist_result.body_types[1] = res_cd2->type;
     if (cdata->req->enable_nearest_points)
     {
       dist_result.normal = (dist_result.nearest_points[1] - dist_result.nearest_points[0]).normalized();
@@ -585,8 +591,23 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 #else
         dist_result.nearest_points[0] = Eigen::Vector3d(contact.pos.data.vs);
         dist_result.nearest_points[1] = Eigen::Vector3d(contact.pos.data.vs);
-        dist_result.normal = Eigen::Vector3d(contact.normal.data.vs);
+        Eigen::Vector3d normal(contact.normal.data.vs);
 #endif
+
+        if (cdata->req->enable_nearest_points)
+        {
+#if (MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0))
+          Eigen::Vector3d normal = contact.normal;
+#else
+          Eigen::Vector3d normal(contact.normal.data.vs);
+#endif
+
+          // Check order of o1/o2 again, we might need to flip the normal
+          if (contact.o1 == o1->collisionGeometry().get())
+            dist_result.normal = normal;
+          else
+            dist_result.normal = -normal;
+        }
       }
     }
 

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -420,11 +420,12 @@ void CollisionEnvFCL::checkFCLNearestDistCapability(const DistanceRequest& req) 
     // Known issues:
     //   https://github.com/flexible-collision-library/fcl/issues/171,
     //   https://github.com/flexible-collision-library/fcl/pull/288
-    RCLCPP_ERROR(LOGGER, "You requested a distance check with enable_nearest_points=true, "
-                         "but the FCL version MoveIt was compiled against (%d.%d.%d) "
-                         "is known to return bogus nearest points. Please update your FCL "
-                         "to at least 0.6.0.",
-                         FCL_MAJOR_VERSION, FCL_MINOR_VERSION, FCL_PATCH_VERSION);
+    RCLCPP_ERROR(LOGGER,
+                 "You requested a distance check with enable_nearest_points=true, "
+                 "but the FCL version MoveIt was compiled against (%d.%d.%d) "
+                 "is known to return bogus nearest points. Please update your FCL "
+                 "to at least 0.6.0.",
+                 FCL_MAJOR_VERSION, FCL_MINOR_VERSION, FCL_PATCH_VERSION);
   }
 #endif
 }

--- a/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_collision_detection_panda.cpp
@@ -40,8 +40,17 @@
 INSTANTIATE_TYPED_TEST_CASE_P(FCLCollisionCheckPanda, CollisionDetectorPandaTest,
                               collision_detection::CollisionDetectorAllocatorFCL);
 
+// FCL < 0.6 incorrectly reports distance results in the object coordinate frame.
+// See: https://github.com/flexible-collision-library/fcl/issues/171
+//  and https://github.com/flexible-collision-library/fcl/pull/288.
+// So only execute the full distance test suite on FCL >= 0.6.
+#if MOVEIT_FCL_VERSION >= FCL_VERSION_CHECK(0, 6, 0)
+INSTANTIATE_TYPED_TEST_CASE_P(FCLDistanceCheckPanda, DistanceFullPandaTest,
+                              collision_detection::CollisionDetectorAllocatorFCL);
+#else
 INSTANTIATE_TYPED_TEST_CASE_P(FCLDistanceCheckPanda, DistanceCheckPandaTest,
                               collision_detection::CollisionDetectorAllocatorFCL);
+#endif
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
See https://github.com/ros-planning/moveit/pull/2682

This was a pretty straight-forward port
