### PR TITLE
[moveit_core] Add pluginlib dependency

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -41,6 +41,7 @@
   <depend>moveit_msgs</depend>
   <depend>octomap</depend>
   <depend>octomap_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>random_numbers</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>


### PR DESCRIPTION
Jenkins is failing otherwise:

https://build.ros2.org/job/Fbin_uF64__moveit_core__ubuntu_focal_amd64__binary/

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)