### PR TITLE
Removed the BULLET_ENABLE flag

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -18,6 +18,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 # TODO: Move collision detection into separate packages
 find_package(Bullet 2.87 REQUIRED)
 
+if(BULLET_ENABLE)
+  set(BULLET_INC "collision_detection_bullet/include")
+  set(BULLET_LIB "moveit_collision_detection_bullet")
+endif()
+
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(LIBFCL REQUIRED "fcl>=0.5.0")
@@ -128,7 +133,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   Eigen3
   eigen3_cmake_module
   OCTOMAP
-  ${BULLET_ENABLE}
 )
 pluginlib_export_plugin_description_file(moveit_core collision_detector_fcl_description.xml)
 
@@ -176,11 +180,13 @@ add_subdirectory(distance_field)
 add_subdirectory(collision_distance_field)
 add_subdirectory(kinematics_metrics)
 add_subdirectory(dynamics_solver)
+
 # TODO(henningkayser): enable bullet once the library is migrated to ROS2
 if(BULLET_ENABLE)
-add_subdirectory(collision_detection_bullet)
+  add_subdirectory(collision_detection_bullet)
+  pluginlib_export_plugin_description_file(moveit_core collision_detector_bullet_description.xml)
 else()
-install(FILES collision_detection_bullet/empty_description.xml DESTINATION share/${PROJECT_NAME} RENAME collision_detector_bullet_description.xml)
+  install(FILES collision_detection_bullet/empty_description.xml DESTINATION share/${PROJECT_NAME} RENAME collision_detector_bullet_description.xml)
 endif()
 
 install(

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -15,13 +15,7 @@ include(ConfigExtras.cmake)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
-# TODO: Move collision detection into separate packages
 find_package(Bullet 2.87 REQUIRED)
-
-if(BULLET_ENABLE)
-  set(BULLET_INC "collision_detection_bullet/include")
-  set(BULLET_LIB "moveit_collision_detection_bullet")
-endif()
 
 find_package(PkgConfig REQUIRED)
 
@@ -64,7 +58,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     backtrace/include
     collision_detection/include
     collision_detection_fcl/include
-    ${BULLET_INC}
+    collision_detection_bullet/include
     constraint_samplers/include
     controller_manager/include
     distance_field/include
@@ -98,7 +92,7 @@ set(THIS_PACKAGE_LIBRARIES
     moveit_planning_interface
     moveit_collision_detection
     moveit_collision_detection_fcl
-    ${BULLET_LIB}
+    moveit_collision_detection_bullet
     moveit_kinematic_constraints
     moveit_planning_scene
     moveit_constraint_samplers
@@ -134,7 +128,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   eigen3_cmake_module
   OCTOMAP
 )
+
 pluginlib_export_plugin_description_file(moveit_core collision_detector_fcl_description.xml)
+pluginlib_export_plugin_description_file(moveit_core collision_detector_bullet_description.xml)
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
   ${LIBFCL_INCLUDE_DIRS}
@@ -180,14 +176,9 @@ add_subdirectory(distance_field)
 add_subdirectory(collision_distance_field)
 add_subdirectory(kinematics_metrics)
 add_subdirectory(dynamics_solver)
+add_subdirectory(collision_detection_bullet)
 
-# TODO(henningkayser): enable bullet once the library is migrated to ROS2
-if(BULLET_ENABLE)
-  add_subdirectory(collision_detection_bullet)
-  pluginlib_export_plugin_description_file(moveit_core collision_detector_bullet_description.xml)
-else()
-  install(FILES collision_detection_bullet/empty_description.xml DESTINATION share/${PROJECT_NAME} RENAME collision_detector_bullet_description.xml)
-endif()
+pluginlib_export_plugin_description_file(moveit_core collision_detector_bullet_description.xml)
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -127,6 +127,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   Eigen3
   eigen3_cmake_module
   OCTOMAP
+  Bullet
 )
 
 pluginlib_export_plugin_description_file(moveit_core collision_detector_fcl_description.xml)
@@ -134,7 +135,6 @@ pluginlib_export_plugin_description_file(moveit_core collision_detector_bullet_d
 
 include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
   ${LIBFCL_INCLUDE_DIRS}
-  ${BULLET_INCLUDE_DIRS}
 )
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS}

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -10,7 +10,9 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/bullet_integration/ros_bullet_utils.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-
+ament_target_dependencies(${MOVEIT_LIB_NAME} SYSTEM
+  BULLET
+)
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   rmw_implementation
@@ -22,21 +24,23 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
 )
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_collision_detection
-  ${BULLET_LIBRARIES}
 )
 
 add_library(collision_detector_bullet_plugin SHARED src/collision_detector_bullet_plugin_loader.cpp)
 set_target_properties(collision_detector_bullet_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(collision_detector_bullet_plugin PUBLIC
-  ${MOVEIT_LIB_NAME}
-  moveit_planning_scene
+ament_target_dependencies(collision_detector_bullet_plugin SYSTEM
+  BULLET
 )
-ament_target_dependencies(collision_detector_bullet_plugin PUBLIC
+ament_target_dependencies(collision_detector_bullet_plugin
   rclcpp
   urdf
   visualization_msgs
   pluginlib
   rmw_implementation
+)
+target_link_libraries(collision_detector_bullet_plugin
+  ${MOVEIT_LIB_NAME}
+  moveit_planning_scene
 )
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_collision_detection_bullet)
 
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/bullet_integration/bullet_utils.cpp
   src/bullet_integration/bullet_discrete_bvh_manager.cpp
   src/bullet_integration/bullet_cast_bvh_manager.cpp
@@ -25,29 +25,27 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   ${BULLET_LIBRARIES}
 )
 
-add_library(collision_detector_bullet_plugin src/collision_detector_bullet_plugin_loader.cpp)
+add_library(collision_detector_bullet_plugin SHARED src/collision_detector_bullet_plugin_loader.cpp)
 set_target_properties(collision_detector_bullet_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(collision_detector_bullet_plugin
+target_link_libraries(collision_detector_bullet_plugin PUBLIC
+  ${MOVEIT_LIB_NAME}
+  moveit_planning_scene
+)
+ament_target_dependencies(collision_detector_bullet_plugin PUBLIC
   rclcpp
   urdf
   visualization_msgs
   pluginlib
   rmw_implementation
 )
-target_link_libraries(collision_detector_bullet_plugin
-  ${MOVEIT_LIB_NAME}
-  moveit_planning_scene
-)
 
+install(DIRECTORY include/ DESTINATION include)
 install(TARGETS ${MOVEIT_LIB_NAME} EXPORT ${MOVEIT_LIB_NAME}
   TARGETS collision_detector_bullet_plugin EXPORT collision_detector_bullet_plugin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
 )
-install(DIRECTORY include/ DESTINATION include)
-
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(BUILD_TESTING)
   if(WIN32)

--- a/moveit_core/collision_detector_bullet_description.xml
+++ b/moveit_core/collision_detector_bullet_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libcollision_detector_bt_plugin">
+<library path="collision_detector_bullet_plugin">
   <class name="Bullet" type="collision_detection::CollisionDetectorBtPluginLoader"
   base_class_type="collision_detection::CollisionPlugin">
     <description>


### PR DESCRIPTION
### Description

Addresses issue #473
Removed the BULLET_ENABLE flag
Properly installs the bullet collision plugin

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
