### PR TITLE
Solve the problem that the click stop during the execute path process in MotionPlanning cannot respond in time

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -315,8 +315,10 @@ private:
 
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr controller_mgr_node_;
+  rclcpp::Node::SharedPtr event_node_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> private_executor_;
   std::thread private_executor_thread_;
+  std::thread event_node_thread_;
   moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr event_topic_subscriber_;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -166,8 +166,11 @@ void TrajectoryExecutionManager::initialize()
 
   // other configuration steps
   reloadControllerInformation();
-  event_topic_subscriber_ = node_->create_subscription<std_msgs::msg::String>(
+  
+  event_node_ = rclcpp::Node::make_shared("trajectory_event_node");
+  event_topic_subscriber_ = event_node_->create_subscription<std_msgs::msg::String>(
       EXECUTION_EVENT_TOPIC, 100, std::bind(&TrajectoryExecutionManager::receiveEvent, this, std::placeholders::_1));
+  event_node_thread_ = std::thread([this]() { rclcpp::spin(event_node_); });
 
   controller_mgr_node_->get_parameter("trajectory_execution.allowed_execution_duration_scaling",
                                       allowed_execution_duration_scaling_);


### PR DESCRIPTION
Problem: In the operation of rviz->MotionPlanning->planning, when you click stop during the execute process, you cannot respond in time (the corresponding stop operation will be executed after the execute ends)

PR solution: add a Node to subscribe (stop) event, and spin operation in a new thread
