### PR TITLE
moveit_servo: Fix segfault when publish_joint_velocities set to false and a joint is close to position limit

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -151,12 +151,13 @@ protected:
    * Is handled differently for position vs. velocity control.
    */
   void suddenHalt(trajectory_msgs::msg::JointTrajectory& joint_trajectory) const;
+  void suddenHalt(sensor_msgs::msg::JointState& joint_state) const;
 
   /** \brief  Scale the delta theta to match joint velocity/acceleration limits */
   void enforceVelLimits(Eigen::ArrayXd& delta_theta);
 
   /** \brief Avoid overshooting joint limits */
-  bool enforcePositionLimits(trajectory_msgs::msg::JointTrajectory& joint_trajectory) const;
+  bool enforcePositionLimits(sensor_msgs::msg::JointState& joint_state) const;
 
   /** \brief Possibly calculate a velocity scaling factor, due to proximity of
    * singularity and direction of motion

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -785,17 +785,17 @@ bool ServoCalcs::enforcePositionLimits(sensor_msgs::msg::JointState& joint_state
 
   for (auto joint : joint_model_group_->getActiveJointModels())
   {
-    for (std::size_t c = 0; c < original_joint_state_.name.size(); ++c)
+    for (std::size_t c = 0; c < joint_state.name.size(); ++c)
     {
       // Use the most recent robot joint state
-      if (original_joint_state_.name[c] == joint->getName())
+      if (joint_state.name[c] == joint->getName())
       {
-        joint_angle = original_joint_state_.position.at(c);
+        joint_angle = joint_state.position.at(c);
         break;
       }
     }
 
-    if (!current_state_->satisfiesPositionBounds(joint, -parameters_->joint_limit_margin))
+    if (!joint->satisfiesPositionBounds(&joint_angle, -parameters_->joint_limit_margin))
     {
       const std::vector<moveit_msgs::msg::JointLimits> limits = joint->getVariableBoundsMsg();
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -807,10 +807,17 @@ bool ServoCalcs::enforcePositionLimits(trajectory_msgs::msg::JointTrajectory& jo
             std::find(joint_trajectory.joint_names.begin(), joint_trajectory.joint_names.end(), joint->getName());
         auto joint_idx = std::distance(joint_trajectory.joint_names.begin(), joint_itr);
 
-        if ((joint_trajectory.points[0].velocities[joint_idx] < 0 &&
-             (joint_angle < (limits[0].min_position + parameters_->joint_limit_margin))) ||
-            (joint_trajectory.points[0].velocities[joint_idx] > 0 &&
-             (joint_angle > (limits[0].max_position - parameters_->joint_limit_margin))))
+        const bool near_min_position =
+            parameters_->publish_joint_velocities ?
+                joint_trajectory.points[0].velocities[joint_idx] < 0 &&
+                    (joint_angle < (limits[0].min_position + parameters_->joint_limit_margin)) :
+                joint_angle < (limits[0].min_position + parameters_->joint_limit_margin);
+        const bool near_max_position =
+            parameters_->publish_joint_velocities ?
+                joint_trajectory.points[0].velocities[joint_idx] > 0 &&
+                    (joint_angle > (limits[0].max_position - parameters_->joint_limit_margin)) :
+                joint_angle > (limits[0].max_position - parameters_->joint_limit_margin);
+        if (near_min_position || near_max_position)
         {
           rclcpp::Clock& clock = *node_->get_clock();
           RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,


### PR DESCRIPTION
### Description

moveit_servo is segfaulting when reaching limits if `publish_joint_velocities` set to `false`. the reason is in [ServoCalcs::enforcePositionLimits](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_calcs.cpp#L780) we do access the velocities despite being an empty vector [see](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_calcs.cpp#L810-L813)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
