### PR TITLE
Fix stopping the TrajectoryExecutionManager's execution

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -166,7 +166,7 @@ void TrajectoryExecutionManager::initialize()
 
   // other configuration steps
   reloadControllerInformation();
-  // The default callback group for rclcpp::Node is MutuallyExclusive which mean we can not call
+  // The default callback group for rclcpp::Node is MutuallyExclusive which means we cannot call
   // receiveEvent while processing a different callback, to fix this we create a new callback group (the type is not
   // important since we only use it to process one callback) and associate event_topic_subscriber_ with this callback group
   auto callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -166,8 +166,15 @@ void TrajectoryExecutionManager::initialize()
 
   // other configuration steps
   reloadControllerInformation();
+  // The default callback group for rclcpp::Node is MutuallyExclusive which mean we can not call
+  // receiveEvent while processing a different callback, to fix this we create a new callback group (the type is not
+  // important since we only use it to process one callback) and associate event_topic_subscriber_ with this callback group
+  auto callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto options = rclcpp::SubscriptionOptions();
+  options.callback_group = callback_group;
   event_topic_subscriber_ = node_->create_subscription<std_msgs::msg::String>(
-      EXECUTION_EVENT_TOPIC, 100, std::bind(&TrajectoryExecutionManager::receiveEvent, this, std::placeholders::_1));
+      EXECUTION_EVENT_TOPIC, 100, std::bind(&TrajectoryExecutionManager::receiveEvent, this, std::placeholders::_1),
+      options);
 
   controller_mgr_node_->get_parameter("trajectory_execution.allowed_execution_duration_scaling",
                                       allowed_execution_duration_scaling_);

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -167,7 +167,7 @@ void TrajectoryExecutionManager::initialize()
   // other configuration steps
   reloadControllerInformation();
   // The default callback group for rclcpp::Node is MutuallyExclusive which means we cannot call
-  // receiveEvent while processing a different callback, to fix this we create a new callback group (the type is not
+  // receiveEvent while processing a different callback. To fix this we create a new callback group (the type is not
   // important since we only use it to process one callback) and associate event_topic_subscriber_ with this callback group
   auto callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   auto options = rclcpp::SubscriptionOptions();


### PR DESCRIPTION
### Description

Replace: https://github.com/ros-planning/moveit2/pull/493
Fix: https://github.com/ros-planning/moveit2/issues/503

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
