### PR TITLE
Fix typo

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -136,7 +136,7 @@ public:
   /** \brief Get a joint by its name. Throw an exception if the joint is not part of this group. */
   const JointModel* getJointModel(const std::string& joint) const;
 
-  /** \brief Get a joint by its name. Throw an exception if the joint is not part of this group. */
+  /** \brief Get a link by its name. Throw an exception if the link is not part of this group. */
   const LinkModel* getLinkModel(const std::string& link) const;
 
   /** \brief Get all the joints in this group (including fixed and mimic joints). */


### PR DESCRIPTION
### Description

I fixed a typo in the documentation

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
