### PR TITLE
[visualization] declare warehouse params in rviz plugin

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -207,6 +207,14 @@ void MotionPlanningDisplay::onInitialize()
 {
   PlanningSceneDisplay::onInitialize();
 
+  // Prepare database parameters
+  if (!node_->has_parameter("warehouse_host"))
+    node_->declare_parameter<std::string>("warehouse_host", "127.0.0.1");
+  if (!node_->has_parameter("warehouse_plugin"))
+    node_->declare_parameter<std::string>("warehouse_plugin", "warehouse_ros_mongo::MongoDatabaseConnection");
+  if (!node_->has_parameter("warehouse_port"))
+    node_->declare_parameter<int>("warehouse_port", 33829);
+
   // Planned Path Display
   trajectory_visual_->onInitialize(node_, planning_scene_node_, context_);
   QColor qcolor = attached_body_color_property_->getColor();


### PR DESCRIPTION
The Motion planning plugin currently ignores parameters for warehouse_ros,
because they are not declared yet.
This can be verified by launching `ros2 launch run_move_group run_move_group.launch.py`
(where some warehouse parameters like `warehouse_plugin` have to be defined before)
and examinig the parameters with `ros2 param dump rviz2`.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
