### PR TITLE
Clean OpenSSL dependencies

### DIFF
--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -16,12 +16,11 @@ find_package(warehouse_ros REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(OpenSSL)
 
 # Finds Boost Components
 include(ConfigExtras.cmake)
 
-include_directories(warehouse/include ${OPENSSL_INCLUDE_DIR})
+include_directories(warehouse/include)
 
 add_subdirectory(warehouse)
 

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -16,7 +16,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>
-  <build_depend>libssl-dev</build_depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_ros/warehouse/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/warehouse/CMakeLists.txt
@@ -11,7 +11,6 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME} rclcpp Boost moveit_core warehouse_ros moveit_ros_planning)
-target_link_libraries(${MOVEIT_LIB_NAME})
 
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)
 ament_target_dependencies(moveit_warehouse_broadcast rclcpp Boost warehouse_ros moveit_ros_planning)

--- a/moveit_ros/warehouse/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/warehouse/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME} rclcpp Boost moveit_core warehouse_ros moveit_ros_planning)
-target_link_libraries(${MOVEIT_LIB_NAME} ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(${MOVEIT_LIB_NAME})
 
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)
 ament_target_dependencies(moveit_warehouse_broadcast rclcpp Boost warehouse_ros moveit_ros_planning)


### PR DESCRIPTION
prerelease on Rolling was failing in my fork with current master with SSL errors: https://github.com/vatanaksoytezer/moveit2/runs/2909420963?check_suite_focus=true

I just applied the same solution with https://github.com/ros-planning/warehouse_ros_mongo/pull/63. Now I can confirm that pre-release is passing on Rolling https://github.com/vatanaksoytezer/moveit2/runs/2909699212?check_suite_focus=true.

Galactic prerelease still fails because of geometric shapes failing on Galactic in buildfarm due to a bloom issue I suppose (see https://build.ros2.org/job/Gsrc_uF__geometric_shapes__ubuntu_focal__source/12/console)