### PR TITLE
move_group: Fix default_planning_pipeline for deprecated behavior

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -264,6 +264,7 @@ int main(int argc, char** argv)
     else
     {
       RCLCPP_WARN(LOGGER, "Falling back to using the the move_group node namespace (deprecated behavior).");
+      default_planning_pipeline = "move_group";
       moveit_cpp_options.planning_pipeline_options.pipeline_names = { default_planning_pipeline };
       moveit_cpp_options.planning_pipeline_options.parent_namespace = nh->get_effective_namespace();
     }


### PR DESCRIPTION
### Description

Fix: https://github.com/ros-planning/moveit2/issues/522

We only enter this else statement when `default_planning_pipeline` is empty which will cause to not load any planning pipeline

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
