### PR TITLE
Add new option to MoveGroupInterface to specify move group node's namespace

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -110,8 +110,10 @@ public:
   /** \brief Specification of options to use when constructing the MoveGroupInterface class */
   struct Options
   {
-    Options(std::string group_name, std::string desc = ROBOT_DESCRIPTION)
-      : group_name_(std::move(group_name)), robot_description_(std::move(desc))
+    Options(std::string group_name, std::string move_group_namespace = "", std::string desc = ROBOT_DESCRIPTION)
+      : group_name_(std::move(group_name))
+      , robot_description_(std::move(desc))
+      , move_group_namespace_(std::move(move_group_namespace))
     {
     }
 
@@ -123,6 +125,9 @@ public:
 
     /// Optionally, an instance of the RobotModel to use can be also specified
     moveit::core::RobotModelConstPtr robot_model_;
+
+    /// The namespace for the move group node
+    std::string move_group_namespace_;
   };
 
   MOVEIT_STRUCT_FORWARD(Plan);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -57,6 +57,7 @@
 #include <moveit_msgs/srv/grasp_planning.hpp>
 #include <moveit_msgs/srv/get_planner_params.hpp>
 #include <moveit_msgs/srv/set_planner_params.hpp>
+#include <moveit/utils/rclcpp_utils.h>
 // TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
 // #include <moveit_msgs/msg/place_location.hpp>
 // #include <moveit_msgs/action/pickup.hpp>
@@ -137,13 +138,18 @@ public:
     pose_reference_frame_ = getRobotModel()->getModelFrame();
 
     trajectory_event_publisher_ = pnode_->create_publisher<std_msgs::msg::String>(
-        trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC, 1);
+        rclcpp::names::append(opt_.move_group_namespace_,
+                              trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC),
+        1);
     attached_object_publisher_ = pnode_->create_publisher<moveit_msgs::msg::AttachedCollisionObject>(
-        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC, 1);
+        rclcpp::names::append(opt_.move_group_namespace_,
+                              planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC),
+        1);
 
     current_state_monitor_ = getSharedStateMonitor(node_, robot_model_, tf_buffer_);
 
-    move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(pnode_, move_group::MOVE_ACTION);
+    move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(
+        pnode_, rclcpp::names::append(opt_.move_group_namespace_, move_group::MOVE_ACTION));
     move_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
     // TODO(JafarAbdi): Enable once moveit_ros_manipulation is ported
     // pick_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Pickup>(
@@ -153,19 +159,19 @@ public:
     //    place_action_client_ = rclcpp_action::create_client<moveit_msgs::action::Place>(
     //        node_, move_group::PLACE_ACTION);
     //    place_action_client_->wait_for_action_server(std::chrono::nanoseconds(timeout_for_servers.nanoseconds()));
-    execute_action_client_ =
-        rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(pnode_, move_group::EXECUTE_ACTION_NAME);
+    execute_action_client_ = rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(
+        pnode_, rclcpp::names::append(opt_.move_group_namespace_, move_group::EXECUTE_ACTION_NAME));
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
 
-    query_service_ =
-        pnode_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(move_group::QUERY_PLANNERS_SERVICE_NAME);
-    get_params_service_ =
-        pnode_->create_client<moveit_msgs::srv::GetPlannerParams>(move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
-    set_params_service_ =
-        pnode_->create_client<moveit_msgs::srv::SetPlannerParams>(move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
+    query_service_ = pnode_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
+        rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME));
+    get_params_service_ = pnode_->create_client<moveit_msgs::srv::GetPlannerParams>(
+        rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME));
+    set_params_service_ = pnode_->create_client<moveit_msgs::srv::SetPlannerParams>(
+        rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME));
 
-    cartesian_path_service_ =
-        pnode_->create_client<moveit_msgs::srv::GetCartesianPath>(move_group::CARTESIAN_PATH_SERVICE_NAME);
+    cartesian_path_service_ = pnode_->create_client<moveit_msgs::srv::GetCartesianPath>(
+        rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME));
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1141,8 +1141,8 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   PlanningSceneDisplay::onRobotModelLoaded();
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
-  robot_interaction_.reset(
-      new robot_interaction::RobotInteraction(getRobotModel(), node_, "rviz_moveit_motion_planning_display"));
+  robot_interaction_.reset(new robot_interaction::RobotInteraction(
+      getRobotModel(), node_, rclcpp::names::append(getMoveGroupNS(), "rviz_moveit_motion_planning_display")));
   robot_interaction::KinematicOptions o;
   o.state_validity_callback_ = boost::bind(&MotionPlanningDisplay::isIKSolutionCollisionFree, this,
                                            boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -381,7 +381,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
       return;
     RCLCPP_INFO(LOGGER, "Constructing new MoveGroup connection for group '%s' in namespace '%s'", group.c_str(),
                 planning_display_->getMoveGroupNS().c_str());
-    moveit::planning_interface::MoveGroupInterface::Options opt(group);
+    moveit::planning_interface::MoveGroupInterface::Options opt(group, planning_display_->getMoveGroupNS());
     opt.robot_model_ = robot_model;
     opt.robot_description_.clear();
     try


### PR DESCRIPTION
### Description

Currently, it's not possible to specify the move group node's namespace in the move group interface, which makes it not possible to have different motion planning displays that connect to different move groups, could be tested with https://github.com/JafarAbdi/moveit2_tutorials/tree/pr-multi_arm

Fix: https://answers.ros.org/question/381276/ros2-rviz-node-two-robots-with-different-namespaces/

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
