### PR TITLE
Pluginlib Deprecation Fix

### DIFF
--- a/moveit_core/collision_detection_bullet/src/collision_detector_bullet_plugin_loader.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_detector_bullet_plugin_loader.cpp
@@ -35,7 +35,7 @@
 /* Author: Jens Petit */
 
 #include <moveit/collision_detection_bullet/collision_detector_bullet_plugin_loader.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace collision_detection
 {

--- a/moveit_kinematics/cached_ik_kinematics_plugin/README.md
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/README.md
@@ -58,7 +58,7 @@ The Cached IK Kinematics Plugin is implemented as a wrapper around classed deriv
 
     #include "cached_ik_kinematics_plugin.h"
     #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
-    #include <pluginlib/class_list_macros.h>
+    #include <pluginlib/class_list_macros.hpp>
     PLUGINLIB_EXPORT_CLASS(cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>, kinematics::KinematicsBase);
 
 In the catkin `package.xml` file for your plugin, you add these lines just before `</package>`:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -42,7 +42,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_interface/planning_interface.h>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 // Boost includes
 #include <boost/scoped_ptr.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -300,5 +300,5 @@ void MoveGroupSequenceAction::setMoveState(move_group::MoveGroupState state)
 
 }  // namespace pilz_industrial_motion_planner
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(pilz_industrial_motion_planner::MoveGroupSequenceAction, move_group::MoveGroupCapability)

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -101,5 +101,5 @@ bool MoveGroupSequenceService::plan(moveit_msgs::GetMotionSequence::Request& req
 
 }  // namespace pilz_industrial_motion_planner
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(pilz_industrial_motion_planner::MoveGroupSequenceService, move_group::MoveGroupCapability)

--- a/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
@@ -44,9 +44,9 @@
 // Boost includes
 #include <boost/scoped_ptr.hpp>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_circ.cpp
@@ -37,7 +37,7 @@
 #include "pilz_industrial_motion_planner/planning_context_base.h"
 #include "pilz_industrial_motion_planner/planning_context_circ.h"
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 pilz_industrial_motion_planner::PlanningContextLoaderCIRC::PlanningContextLoaderCIRC()
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_lin.cpp
@@ -37,7 +37,7 @@
 #include "pilz_industrial_motion_planner/planning_context_base.h"
 #include "pilz_industrial_motion_planner/planning_context_lin.h"
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 pilz_industrial_motion_planner::PlanningContextLoaderLIN::PlanningContextLoaderLIN()
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_ptp.cpp
@@ -36,7 +36,7 @@
 #include "moveit/planning_scene/planning_scene.h"
 #include "pilz_industrial_motion_planner/planning_context_ptp.h"
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 pilz_industrial_motion_planner::PlanningContextLoaderPTP::PlanningContextLoaderPTP()
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_planning_context_loaders.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_planning_context_loaders.cpp
@@ -37,7 +37,7 @@
 // Boost includes
 #include <boost/scoped_ptr.hpp>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_ptp.cpp
@@ -43,7 +43,7 @@
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 // parameters for parameterized tests
 const std::string PARAM_MODEL_NO_GRIPPER_NAME{ "robot_description" };


### PR DESCRIPTION
### Description

Link to the proper pluginlib headers. See [this deprecation warning](https://github.com/ros/pluginlib/blob/galactic/pluginlib/include/pluginlib/class_loader.h#L36)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
