### PR TITLE
Fix urdf joint limits being overridden when no joint_limits parameter is loaded

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -144,24 +144,22 @@ void RobotModelLoader::configure(const Options& opt)
           node_->get_parameter(param_name, has_position_limits);
 
           param_name = prefix + "has_velocity_limits";
-          bool has_vel_limits = false;
           if (!node_->has_parameter(param_name))
           {
             node_->declare_parameter(param_name);
           }
-          node_->get_parameter(param_name, has_vel_limits);
+          bool has_vel_limits = false;
+          if (node_->get_parameter(param_name, has_vel_limits))
+            joint_limit[joint_id].has_velocity_limits = has_vel_limits;
 
           param_name = prefix + "has_acceleration_limits";
-          bool has_acc_limits = false;
           if (!node_->has_parameter(param_name))
           {
             node_->declare_parameter(param_name);
           }
-          node_->get_parameter(param_name, has_acc_limits);
-
-          // All types of joints can handle velocity and acceleration limits
-          joint_limit[joint_id].has_velocity_limits = has_vel_limits;
-          joint_limit[joint_id].has_acceleration_limits = has_acc_limits;
+          bool has_acc_limits = false;
+          if (node_->get_parameter(param_name, has_acc_limits))
+            joint_limit[joint_id].has_acceleration_limits = has_acc_limits;
 
           if (has_position_limits && canSpecifyPosition(joint_model, joint_id))
           {


### PR DESCRIPTION
### Description

Fix the second point of https://github.com/ros-planning/moveit2/issues/541

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
