### PR TITLE
Optional thread deadline scheduling for Servo

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -15,6 +15,7 @@ scale:
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]
 low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
+schedule_thread_deadline: true  # For better realtime performance
 
 # What type of topic does your robot driver expect?
 # Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -100,6 +100,7 @@ struct ServoParameters
   double hard_stop_singularity_threshold;
   double joint_limit_margin;
   bool low_latency_mode;
+  bool schedule_thread_deadline;
   // Collision checking
   bool check_collisions;
   double collision_check_rate;

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -234,9 +234,9 @@ void ServoCalcs::start()
         int32_t sched_nice;
         uint32_t sched_priority;
         // Allocate 100% of the period to this thread. (Exact values don't matter, just the 100%)
-        uint64_t sched_runtime = 1 * 1e9;  // nanoseconds
-        uint64_t sched_deadline = 1 * 1e9;
-        uint64_t sched_period = 1 * 1e9;
+        uint64_t sched_runtime = 1e9;  // nanoseconds
+        uint64_t sched_deadline = 1e9;
+        uint64_t sched_period = 1e9;
       };
 
       SchedAttr attr;

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -132,6 +132,7 @@ ServoParameters::SharedConstPtr ServoParameters::makeServoParameters(const rclcp
   declareOrGetParam<bool>(parameters->publish_joint_velocities, ns + ".publish_joint_velocities", node, logger);
   declareOrGetParam<bool>(parameters->publish_joint_accelerations, ns + ".publish_joint_accelerations", node, logger);
   declareOrGetParam<bool>(parameters->low_latency_mode, ns + ".low_latency_mode", node, logger);
+  declareOrGetParam<bool>(parameters->schedule_thread_deadline, ns + ".schedule_thread_deadline", node, logger);
 
   // Incoming Joint State properties
   declareOrGetParam<std::string>(parameters->joint_topic, ns + ".joint_topic", node, logger);


### PR DESCRIPTION
This allows users to allocate plenty of CPU time to a thread. Description of thread scheduling is here:

https://nicolovaligi.com/articles/concurrency-and-parallelism-in-ros1-and-ros2-linux-kernel-tools/

(Under The Deadline Scheduler section)

@zultron does this make sense to you?
