### PR TITLE
Fix crash if MoveIt Servo collision check is disabled

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -71,7 +71,10 @@ public:
 
   ~CollisionCheck()
   {
-    timer_->cancel();
+    if (timer_)
+    {
+      timer_->cancel();
+    }
   }
 
   /** \brief start the Timer that regulates collision check rate */


### PR DESCRIPTION
### Description

If the Servo collision check parameter is set to `false`, `CollisionCheck`'s `rclcpp::TimerBase::SharedPtr` `timer_` member is never initialized. Since `~CollisionCheck()` calls `timer_->cancel()`, requesting that Servo start if collision checking was not enabled causes a crash.

This fixes the crash by checking if `timer_` was actually set before trying to cancel it.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
