### PR TITLE
Fix Foxy CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -23,7 +23,7 @@ jobs:
             CLANG_TIDY: true
     env:
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
-      UPSTREAM_WORKSPACE: moveit2.repos
+      UPSTREAM_WORKSPACE: moveit2_foxy.repos
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       BEFORE_TARGET_TEST_EMBED: ${{ matrix.env.IKFAST_TEST && 'set +u && source moveit_kinematics/test/test_ikfast_plugins.sh && set -u' || '' }}
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
@@ -57,9 +57,9 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ${{ env.BASEDIR }}/upstream_ws
-          key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('moveit2.repos') }}-${{ github.run_id }}
+          key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('moveit2_foxy.repos') }}-${{ github.run_id }}
           restore-keys: |
-            upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('moveit2.repos') }}
+            upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('moveit2_foxy.repos') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws

--- a/moveit2_foxy.repos
+++ b/moveit2_foxy.repos
@@ -1,0 +1,33 @@
+repositories:
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs
+    version: ros2
+  moveit_resources:
+    type: git
+    url: https://github.com/ros-planning/moveit_resources
+    version: ros2
+  geometric_shapes:
+    type: git
+    url: https://github.com/ros-planning/geometric_shapes
+    version: foxy
+  srdfdom:
+    type: git
+    url: https://github.com/ros-planning/srdfdom
+    version: ros2
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control
+    version: master
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: master
+  warehouse_ros:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros
+    version: ros2
+  warehouse_ros_mongo:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros_mongo
+    version: ros2


### PR DESCRIPTION
Foxy CI is broken because we've branched off for geometric_shapes. We need to use the correct branch of geometric_shapes for foxy to prevent CI failures.