### PR TITLE
Minor documentation and cleanup of TOTG plugin

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -49,7 +49,8 @@ namespace trajectory_processing
 static const rclcpp::Logger LOGGER =
     rclcpp::get_logger("moveit_trajectory_processing.time_optimal_trajectory_generation");
 
-constexpr double EPS = 0.000001;
+constexpr double DEFAULT_TIMESTEP = 0.001;
+constexpr double EPS = 1e-6;
 class LinearPathSegment : public PathSegment
 {
 public:
@@ -464,14 +465,11 @@ bool Trajectory::getNextAccelerationSwitchingPoint(double path_pos, TrajectorySt
 bool Trajectory::getNextVelocitySwitchingPoint(double path_pos, TrajectoryStep& next_switching_point,
                                                double& before_acceleration, double& after_acceleration)
 {
-  const double step_size = 0.001;
-  const double accuracy = 0.000001;
-
   bool start = false;
-  path_pos -= step_size;
+  path_pos -= DEFAULT_TIMESTEP;
   do
   {
-    path_pos += step_size;
+    path_pos += DEFAULT_TIMESTEP;
 
     if (getMinMaxPhaseSlope(path_pos, getVelocityMaxPathVelocity(path_pos), false) >=
         getVelocityMaxPathVelocityDeriv(path_pos))
@@ -487,9 +485,9 @@ bool Trajectory::getNextVelocitySwitchingPoint(double path_pos, TrajectoryStep& 
     return true;  // end of trajectory reached
   }
 
-  double before_path_pos = path_pos - step_size;
+  double before_path_pos = path_pos - DEFAULT_TIMESTEP;
   double after_path_pos = path_pos;
-  while (after_path_pos - before_path_pos > accuracy)
+  while (after_path_pos - before_path_pos > EPS)
   {
     path_pos = (before_path_pos + after_path_pos) / 2.0;
     if (getMinMaxPhaseSlope(path_pos, getVelocityMaxPathVelocity(path_pos), false) >
@@ -984,7 +982,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   }
 
   // Now actually call the algorithm
-  Trajectory parameterized(Path(points, path_tolerance_), max_velocity, max_acceleration, 0.001);
+  Trajectory parameterized(Path(points, path_tolerance_), max_velocity, max_acceleration, DEFAULT_TIMESTEP);
   if (!parameterized.isValid())
   {
     RCLCPP_ERROR(LOGGER, "Unable to parameterize trajectory.");

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -46,11 +46,14 @@
 
 namespace trajectory_processing
 {
+namespace
+{
 static const rclcpp::Logger LOGGER =
     rclcpp::get_logger("moveit_trajectory_processing.time_optimal_trajectory_generation");
-
-constexpr double DEFAULT_TIMESTEP = 0.001;
+constexpr double DEFAULT_TIMESTEP = 1e-3;
 constexpr double EPS = 1e-6;
+}  // namespace
+
 class LinearPathSegment : public PathSegment
 {
 public:

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -33,13 +33,11 @@
 
   <class name="default_planner_request_adapters/AddTimeParameterization" type="default_planner_request_adapters::AddTimeParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
-      A deprecated time parameterization plugin.
     </description>
   </class>
 
   <class name="default_planner_request_adapters/AddIterativeSplineParameterization" type="default_planner_request_adapters::AddIterativeSplineParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
-      A deprecated time parameterization plugin.
     </description>
   </class>
 

--- a/moveit_ros/planning/planning_request_adapters_plugin_description.xml
+++ b/moveit_ros/planning/planning_request_adapters_plugin_description.xml
@@ -33,17 +33,19 @@
 
   <class name="default_planner_request_adapters/AddTimeParameterization" type="default_planner_request_adapters::AddTimeParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
+      A deprecated time parameterization plugin.
     </description>
   </class>
 
   <class name="default_planner_request_adapters/AddIterativeSplineParameterization" type="default_planner_request_adapters::AddIterativeSplineParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
+      A deprecated time parameterization plugin.
     </description>
   </class>
 
   <class name="default_planner_request_adapters/AddTimeOptimalParameterization" type="default_planner_request_adapters::AddTimeOptimalParameterization" base_class_type="planning_request_adapter::PlanningRequestAdapter">
     <description>
-      This is an improved time parameterization using Time-Optimal Trajectory Generation for Path Following With Bounded Acceleration and Velocity (Kunz and Stilman, RSS 2008)
+      This is an improved time parameterization using Time-Optimal Trajectory Generation for Path Following With Bounded Acceleration and Velocity (Kunz and Stilman, RSS 2008). Assumes starting and ending at rest. Not jerk limited.
     </description>
   </class>
 


### PR DESCRIPTION
Pulling some changes out of #571 so they can be merged separately.

- Document some limitations of TOTG in the plugin description.
- Minor code cleanup.
- Mark iterative spline and iterative parabola plugins as deprecated since they have some known issues (https://github.com/ros-planning/moveit/issues/1711).
