### PR TITLE
Fix some format strings

### DIFF
--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -312,7 +312,7 @@ void BodyDecomposition::init(const std::vector<shapes::ShapeConstPtr>& shapes, c
   }
   bodies::mergeBoundingSpheres(bounding_spheres, relative_bounding_sphere_);
 
-  RCLCPP_DEBUG(LOGGER, "BodyDecomposition generated %i collision spheres out of %i shapes", collision_spheres_.size(),
+  RCLCPP_DEBUG(LOGGER, "BodyDecomposition generated %li collision spheres out of %zu shapes", collision_spheres_.size(),
                shapes.size());
 }
 

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -312,7 +312,7 @@ void BodyDecomposition::init(const std::vector<shapes::ShapeConstPtr>& shapes, c
   }
   bodies::mergeBoundingSpheres(bounding_spheres, relative_bounding_sphere_);
 
-  RCLCPP_DEBUG(LOGGER, "BodyDecomposition generated %li collision spheres out of %zu shapes", collision_spheres_.size(),
+  RCLCPP_DEBUG(LOGGER, "BodyDecomposition generated %zu collision spheres out of %zu shapes", collision_spheres_.size(),
                shapes.size());
 }
 

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -941,7 +941,7 @@ DistanceFieldCacheEntryPtr CollisionEnvDistanceField::generateDistanceFieldCache
       }
 
       dfce->distance_field_->addPointsToField(all_points);
-      RCLCPP_DEBUG(LOGGER, "CollisionRobot distance field has been initialized with %d points.", all_points.size());
+      RCLCPP_DEBUG(LOGGER, "CollisionRobot distance field has been initialized with %zu points.", all_points.size());
     }
   }
   return dfce;
@@ -1171,14 +1171,14 @@ void CollisionEnvDistanceField::getGroupStateRepresentation(const DistanceFieldC
         link_size = Eigen::Vector3d(diameter, diameter, diameter);
         link_origin = link_bd->getBoundingSphereCenter() - 0.5 * link_size;
 
-        RCLCPP_DEBUG(LOGGER, "Creating PosedDistanceField for link %s with size [%i, %i , %i] and origin %i %i %i ",
+        RCLCPP_DEBUG(LOGGER, "Creating PosedDistanceField for link %s with size [%f, %f , %f] and origin %f %f %f ",
                      dfce->link_names_[i].c_str(), link_size.x(), link_size.y(), link_size.z(), link_origin.x(),
                      link_origin.y(), link_origin.z());
 
         gsr->link_distance_fields_.push_back(PosedDistanceFieldPtr(new PosedDistanceField(
             link_size, link_origin, resolution_, max_propogation_distance_, use_signed_distance_field_)));
         gsr->link_distance_fields_.back()->addPointsToField(link_bd->getCollisionPoints());
-        RCLCPP_DEBUG(LOGGER, "Created PosedDistanceField for link %s with %d points", dfce->link_names_[i].c_str(),
+        RCLCPP_DEBUG(LOGGER, "Created PosedDistanceField for link %s with %zu points", dfce->link_names_[i].c_str(),
                      link_bd->getCollisionPoints().size());
 
         gsr->link_body_decompositions_.back()->updatePose(state.getFrameTransform(ls->getName()));
@@ -1260,7 +1260,7 @@ bool CollisionEnvDistanceField::compareCacheEntryToState(const DistanceFieldCach
         fabs(dfce->state_values_[dfce->state_check_indices_[i]] - new_state_values[dfce->state_check_indices_[i]]);
     if (diff > EPSILON)
     {
-      RCLCPP_WARN(LOGGER, "State for Variable %s has changed by %s radians",
+      RCLCPP_WARN(LOGGER, "State for Variable %s has changed by %f radians",
                   state.getVariableNames()[dfce->state_check_indices_[i]].c_str(), diff);
       return false;
     }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -570,7 +570,7 @@ void streamToRobotState(RobotState& state, const std::string& line, const std::s
   {
     // Get a variable
     if (!std::getline(line_stream, cell, separator[0]))
-      RCLCPP_ERROR(LOGGER, "Missing variable ", state.getVariableNames()[i].c_str());
+      RCLCPP_ERROR(LOGGER, "Missing variable %s", state.getVariableNames()[i].c_str());
     state.getVariablePositions()[i] = boost::lexical_cast<double>(cell.c_str());
   }
 }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1515,7 +1515,7 @@ bool RobotState::setToIKSolverFrame(Eigen::Isometry3d& pose, const std::string& 
         getLinkModel((!ik_frame.empty() && ik_frame[0] == '/') ? ik_frame.substr(1) : ik_frame);
     if (!link_model)
     {
-      RCLCPP_ERROR(LOGGER, "The following IK frame does not exist:", ik_frame.c_str());
+      RCLCPP_ERROR(LOGGER, "The following IK frame does not exist: %s", ik_frame.c_str());
       return false;
     }
     pose = getGlobalLinkTransform(link_model).inverse() * pose;
@@ -1673,7 +1673,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
           const moveit::core::LinkModel* link_model = getLinkModel(pose_frame);
           if (!link_model)
           {
-            RCLCPP_ERROR(LOGGER, "The following Pose Frame does not exist ", pose_frame.c_str());
+            RCLCPP_ERROR(LOGGER, "The following Pose Frame does not exist: %s", pose_frame.c_str());
             return false;
           }
           const moveit::core::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -242,7 +242,7 @@ void RobotModelBuilder::addCollisionBox(const std::string& link_name, const std:
 {
   if (dims.size() != 3)
   {
-    RCLCPP_ERROR(LOGGER, "There can only be 3 dimensions of a box (given %zu!)");
+    RCLCPP_ERROR(LOGGER, "There can only be 3 dimensions of a box (given %zu!)", dims.size());
     is_valid_ = false;
     return;
   }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1022,7 +1022,7 @@ bool PlanningSceneMonitor::waitForCurrentRobotState(const rclcpp::Time& t, doubl
   while (last_robot_motion_time_ < t &&  // Wait until the state update actually reaches the scene.
          timeout > std::chrono::seconds())
   {
-    RCLCPP_DEBUG(LOGGER, "last robot motion: %i ago", (t - last_robot_motion_time_).seconds());
+    RCLCPP_DEBUG(LOGGER, "last robot motion: %f ago", (t - last_robot_motion_time_).seconds());
     new_scene_update_condition_.wait_for(lock, boost::chrono::nanoseconds((int)timeout.count()));
     timeout -= std::chrono::system_clock::now() - start;  // compute remaining wait_time
   }
@@ -1031,7 +1031,7 @@ bool PlanningSceneMonitor::waitForCurrentRobotState(const rclcpp::Time& t, doubl
   if (!success && prev_robot_motion_time != last_robot_motion_time_)
     RCLCPP_WARN(LOGGER, "Maybe failed to update robot state, time diff: %.3fs", (t - last_robot_motion_time_).seconds());
 
-  RCLCPP_DEBUG(LOGGER, "sync done: robot motion: %i scene update: %i", (t - last_robot_motion_time_).seconds(),
+  RCLCPP_DEBUG(LOGGER, "sync done: robot motion: %f scene update: %f", (t - last_robot_motion_time_).seconds(),
                (t - last_update_time_).seconds());
   return success;
 }

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -222,7 +222,7 @@ void RobotModelLoader::configure(const Options& opt)
   if (model_ && opt.load_kinematics_solvers_)
     loadKinematicsSolvers();
 
-  RCLCPP_DEBUG(node_->get_logger(), "Loaded kinematic model in %d seconds", (clock.now() - start).seconds());
+  RCLCPP_DEBUG(node_->get_logger(), "Loaded kinematic model in %f seconds", (clock.now() - start).seconds());
 }
 
 void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr& kloader)


### PR DESCRIPTION
### Description

Fixed some format string errors in logging macros.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
