### PR TITLE
Fixed message when parameter was found

### DIFF
--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -107,7 +107,7 @@ protected:
     }
     else
     {
-      RCLCPP_INFO(logger, "Param '%s' was set to %s", full_name.c_str(), std::to_string(default_value).c_str());
+      RCLCPP_INFO(logger, "Param '%s' was set to %s", full_name.c_str(), std::to_string(value).c_str());
       return value;
     }
   }


### PR DESCRIPTION
The informational message referred to the default value even though the parameter was changed internally.