### PR TITLE
Check for nullptr on getGlobalLinkTransform

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1291,7 +1291,7 @@ public:
    *   A related, more comprehensive function is |getFrameTransform|, which additionally to link frames
    *   also searches for attached object frames and their subframes.
    *
-   *   This will throw a std::runtime_error if the passed link is not found
+   *   This will throw an exception if the passed link is not found
    *
    *  The returned transformation is always a valid isometry.
    */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1291,6 +1291,8 @@ public:
    *   A related, more comprehensive function is |getFrameTransform|, which additionally to link frames
    *   also searches for attached object frames and their subframes.
    *
+   *   This will throw a std::runtime_error if the passed link is not found
+   *
    *  The returned transformation is always a valid isometry.
    */
   const Eigen::Isometry3d& getGlobalLinkTransform(const std::string& link_name)
@@ -1300,6 +1302,10 @@ public:
 
   const Eigen::Isometry3d& getGlobalLinkTransform(const LinkModel* link)
   {
+    if (!link)
+    {
+      throw std::runtime_error("Invalid link");
+    }
     updateLinkTransforms();
     return global_link_transforms_[link->getLinkIndex()];
   }
@@ -1311,6 +1317,10 @@ public:
 
   const Eigen::Isometry3d& getGlobalLinkTransform(const LinkModel* link) const
   {
+    if (!link)
+    {
+      throw std::runtime_error("Invalid link");
+    }
     BOOST_VERIFY(checkLinkTransforms());
     return global_link_transforms_[link->getLinkIndex()];
   }

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1304,7 +1304,7 @@ public:
   {
     if (!link)
     {
-      throw std::runtime_error("Invalid link");
+      throw Exception("Invalid link");
     }
     updateLinkTransforms();
     return global_link_transforms_[link->getLinkIndex()];
@@ -1319,7 +1319,7 @@ public:
   {
     if (!link)
     {
-      throw std::runtime_error("Invalid link");
+      throw Exception("Invalid link");
     }
     BOOST_VERIFY(checkLinkTransforms());
     return global_link_transforms_[link->getLinkIndex()];


### PR DESCRIPTION
### Description
Checks for `nullptr` when looking up a link transformation. The `LinkModel*` is set as `nullptr` [here](https://github.com/ros-planning/moveit2/blob/bf6357e895e364fa055da218ad7fcbd9ec3591f2/moveit_core/robot_model/src/robot_model.cpp#L1256-L1280) if the link name isn't known. This PR makes it throw in this case, instead of Seg Faulting. This should probably be backported to Moveit1 as well

I found this by modifying [this line](https://github.com/ros-planning/moveit2_tutorials/blob/9b1e55f2d665d12742388588f9b0ab2d1b9e0cb0/doc/realtime_servo/src/servo_keyboard_input.cpp#L74) to be an unknown frame, then running the [servo teleop demo](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) with keyboard (arrow keys) input

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
