### PR TITLE
Servo: Check frames are known before getting their TFs

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -85,7 +85,11 @@ public:
 
   ~ServoCalcs();
 
-  /** \brief Start the timer where we do work and publish outputs */
+  /**
+   * Start the timer where we do work and publish outputs
+   *
+   * @exception can throw a std::runtime_error if the setup was not completed
+   */
   void start();
 
   /**

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -246,6 +246,19 @@ void ServoCalcs::start()
   last_sent_command_ = std::move(initial_joint_trajectory);
 
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
+
+  // Check that all links are known to the robot
+  auto check_link_is_known = [this](const std::string& frame_name) {
+    if (!current_state_->knowsFrameTransform(frame_name))
+    {
+      std::string error_string = "Unknown frame: " + frame_name;
+      throw std::runtime_error(error_string);
+    }
+  };
+  check_link_is_known(parameters_->planning_frame);
+  check_link_is_known(parameters_->ee_frame_name);
+  check_link_is_known(robot_link_command_frame_);
+
   tf_moveit_to_ee_frame_ = current_state_->getGlobalLinkTransform(parameters_->planning_frame).inverse() *
                            current_state_->getGlobalLinkTransform(parameters_->ee_frame_name);
   tf_moveit_to_robot_cmd_frame_ = current_state_->getGlobalLinkTransform(parameters_->planning_frame).inverse() *
@@ -532,6 +545,16 @@ rcl_interfaces::msg::SetParametersResult ServoCalcs::robotLinkCommandFrameCallba
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   rcl_interfaces::msg::SetParametersResult result;
+
+  // Check that the new frame is known
+  if (!current_state_->knowsFrameTransform(parameter.as_string()))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Failed to change robot_link_command_frame. Passed frame '" << parameter.as_string()
+                                                                                            << "' is unknown");
+    result.successful = false;
+    return result;
+  }
+
   result.successful = true;
   robot_link_command_frame_ = parameter.as_string();
   RCLCPP_INFO_STREAM(LOGGER, "robot_link_command_frame changed to: " + robot_link_command_frame_);
@@ -1004,6 +1027,15 @@ bool ServoCalcs::checkValidCommand(const geometry_msgs::msg::TwistStamped& cmd)
                                   "Component of incoming command is >1. Skipping this datapoint.");
       return false;
     }
+  }
+
+  // Check that the command frame is known
+  if (!current_state_->knowsFrameTransform(cmd.header.frame_id))
+  {
+    rclcpp::Clock& clock = *node_->get_clock();
+    RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                "Commanded frame '" << cmd.header.frame_id << "' is unknown, skipping this command");
+    return false;
   }
 
   return true;

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -251,8 +251,7 @@ void ServoCalcs::start()
   auto check_link_is_known = [this](const std::string& frame_name) {
     if (!current_state_->knowsFrameTransform(frame_name))
     {
-      std::string error_string = "Unknown frame: " + frame_name;
-      throw std::runtime_error(error_string);
+      throw std::runtime_error{ "Unknown frame: " + frame_name };
     }
   };
   check_link_is_known(parameters_->planning_frame);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1030,7 +1030,7 @@ bool ServoCalcs::checkValidCommand(const geometry_msgs::msg::TwistStamped& cmd)
   }
 
   // Check that the command frame is known
-  if (!current_state_->knowsFrameTransform(cmd.header.frame_id))
+  if (!cmd.header.frame_id.empty() && !current_state_->knowsFrameTransform(cmd.header.frame_id))
   {
     rclcpp::Clock& clock = *node_->get_clock();
     RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,


### PR DESCRIPTION
### Description
Noticed this when I was looking at #611 originally. Servo should check the frames it needs to do TF math with exist in the robot state before trying to look them up. 

Can test this before/after by: modifying [this line](https://github.com/ros-planning/moveit2_tutorials/blob/9b1e55f2d665d12742388588f9b0ab2d1b9e0cb0/doc/realtime_servo/src/servo_keyboard_input.cpp#L74) to be an unknown frame, then running the[ servo teleop demo](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) with keyboard (arrow keys) input. After this change, Servo will not crash if the command frame is invalid, but will instead print a warning and skip the command.

Note that this might break the test on `checkValidCommand()` when it is re-enabled with #603. If that is merged first, I will rebase and make sure the test passes (and add a test case for this invalid frame)

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
