### PR TITLE
Add standalone executable for Servo server node

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SERVO_COMPONENT_NODE servo_server)
 set(SERVO_CONTROLLER_INPUT servo_controller_input)
 
 # Executable Nodes ##############################################
+set(SERVO_SERVER_NODE_NAME servo_server_node)
 set(POSE_TRACKING_DEMO_NAME servo_pose_tracking_demo)
 set(FAKE_SERVO_CMDS_NAME fake_command_publisher)
 
@@ -109,6 +110,11 @@ rclcpp_components_register_nodes(${SERVO_CONTROLLER_INPUT} "moveit_servo::JoyToS
 ## Executable Nodes ##
 ######################
 
+# An executable node for the servo server
+add_executable(${SERVO_SERVER_NODE_NAME} src/servo_server_node.cpp)
+target_link_libraries(${SERVO_SERVER_NODE_NAME} ${SERVO_COMPONENT_NODE})
+ament_target_dependencies(${SERVO_SERVER_NODE_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
 # An example of pose tracking
 add_executable(${POSE_TRACKING_DEMO_NAME} src/cpp_interface_demo/pose_tracking_demo.cpp)
 target_link_libraries(${POSE_TRACKING_DEMO_NAME} ${POSE_TRACKING})
@@ -144,6 +150,7 @@ install(
 # Install Binaries
 install(
   TARGETS
+    ${SERVO_SERVER_NODE_NAME}
     ${CPP_DEMO_NAME}
     ${POSE_TRACKING_DEMO_NAME}
     ${FAKE_SERVO_CMDS_NAME}

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -7,6 +7,7 @@ from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.descriptions import ComposableNode
+from launch.actions import ExecuteProcess
 from ament_index_python.packages import get_package_share_directory
 import xacro
 
@@ -39,27 +40,13 @@ def generate_launch_description():
     servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
     servo_params = {"moveit_servo": servo_yaml}
 
-    # Get URDF and SRDF
-    if start_position_path:
-        initial_positions_file = os.path.join(
-            os.path.dirname(__file__), start_position_path
+    robot_description_config = xacro.process_file(
+        os.path.join(
+            get_package_share_directory("moveit_resources_panda_moveit_config"),
+            "config",
+            "panda.urdf.xacro",
         )
-        robot_description_config = xacro.process_file(
-            os.path.join(
-                get_package_share_directory("moveit_resources_panda_moveit_config"),
-                "config",
-                "panda.urdf.xacro",
-            ),
-            mappings={"initial_positions_file": initial_positions_file},
-        )
-    else:
-        robot_description_config = xacro.process_file(
-            os.path.join(
-                get_package_share_directory("moveit_resources_panda_moveit_config"),
-                "config",
-                "panda.urdf.xacro",
-            )
-        )
+    )
 
     robot_description = {"robot_description": robot_description_config.toxml()}
 

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -101,6 +101,18 @@ def generate_launch_description():
         package="rclcpp_components",
         executable="component_container",
         composable_node_descriptions=[
+            # Example of launching Servo as a node component
+            # ComposableNode(
+            #     package="moveit_servo",
+            #     plugin="moveit_servo::ServoServer",
+            #     name="servo_server",
+            #     parameters=[
+            #         servo_params,
+            #         robot_description,
+            #         robot_description_semantic,
+            #     ],
+            #     extra_arguments=[{"use_intra_process_comms": True}],
+            # ),
             ComposableNode(
                 package="robot_state_publisher",
                 plugin="robot_state_publisher::RobotStatePublisher",

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -1,0 +1,150 @@
+import os
+import yaml
+import launch
+import launch_ros
+from launch import LaunchDescription
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import ComposableNodeContainer, Node
+from launch_ros.descriptions import ComposableNode
+from ament_index_python.packages import get_package_share_directory
+import xacro
+
+
+def load_file(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, "r") as file:
+            return file.read()
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def load_yaml(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, "r") as file:
+            return yaml.safe_load(file)
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def generate_launch_description():
+
+    # Get parameters using the demo config file
+    servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
+    servo_params = {"moveit_servo": servo_yaml}
+
+    # Get URDF and SRDF
+    if start_position_path:
+        initial_positions_file = os.path.join(
+            os.path.dirname(__file__), start_position_path
+        )
+        robot_description_config = xacro.process_file(
+            os.path.join(
+                get_package_share_directory("moveit_resources_panda_moveit_config"),
+                "config",
+                "panda.urdf.xacro",
+            ),
+            mappings={"initial_positions_file": initial_positions_file},
+        )
+    else:
+        robot_description_config = xacro.process_file(
+            os.path.join(
+                get_package_share_directory("moveit_resources_panda_moveit_config"),
+                "config",
+                "panda.urdf.xacro",
+            )
+        )
+
+    robot_description = {"robot_description": robot_description_config.toxml()}
+
+    robot_description_semantic_config = load_file(
+        "moveit_resources_panda_moveit_config", "config/panda.srdf"
+    )
+    robot_description_semantic = {
+        "robot_description_semantic": robot_description_semantic_config
+    }
+    joint_limits_yaml = {
+        "robot_description_planning": load_yaml(
+            "moveit_resources_panda_moveit_config", "config/joint_limits.yaml"
+        )
+    }
+
+    # ros2_control using FakeSystem as hardware
+    ros2_controllers_path = os.path.join(
+        get_package_share_directory("moveit_resources_panda_moveit_config"),
+        "config",
+        "panda_ros_controllers.yaml",
+    )
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[robot_description, ros2_controllers_path],
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+    )
+
+    # Load controllers
+    load_controllers = []
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
+
+    # Component nodes for tf and Servo
+    component_container = ComposableNodeContainer(
+        name="test_servo_integration_container",
+        namespace="/",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="robot_state_publisher",
+                plugin="robot_state_publisher::RobotStatePublisher",
+                name="robot_state_publisher",
+                parameters=[robot_description],
+            ),
+            ComposableNode(
+                package="tf2_ros",
+                plugin="tf2_ros::StaticTransformBroadcasterNode",
+                name="static_tf2_broadcaster",
+                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+            ),
+        ],
+        output="screen",
+    )
+
+    servo_node = Node(
+        package="moveit_servo",
+        executable="servo_server_node",
+        parameters=[
+            servo_params,
+            robot_description,
+            robot_description_semantic,
+            joint_limits_yaml,
+        ],
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+    )
+
+    return launch.LaunchDescription(
+        [
+            ros2_control_node,
+            servo_node,
+            component_container,
+        ]
+        + load_controllers
+    )

--- a/moveit_ros/moveit_servo/src/servo_server_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server_node.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * BSD 3-Clause License
  *
- * Copyright (c) 2019, Los Alamos National Security, LLC
+ * Copyright (c) 2021, PickNik Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/moveit_ros/moveit_servo/src/servo_server_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server_node.cpp
@@ -49,10 +49,7 @@ int main(int argc, char* argv[])
 
   auto node = std::make_shared<moveit_servo::ServoServer>(options);
 
-  rclcpp::executors::MultiThreadedExecutor exec;
-  exec.add_node(node);
-  exec.spin();
-  exec.remove_node(node);
+  rclcpp::spin(node);
 
   rclcpp::shutdown();
 }

--- a/moveit_ros/moveit_servo/src/servo_server_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server_node.cpp
@@ -37,7 +37,6 @@
  *      Author    : Joe Schornak
  */
 
-
 #include <moveit_servo/servo_server.h>
 
 int main(int argc, char* argv[])

--- a/moveit_ros/moveit_servo/src/servo_server_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server_node.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Los Alamos National Security, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/*      Title     : servo_server_node.cpp
+ *      Project   : moveit_servo
+ *      Created   : 08/18/2021
+ *      Author    : Joe Schornak
+ */
+
+
+#include <moveit_servo/servo_server.h>
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+
+  rclcpp::NodeOptions options;
+  options.automatically_declare_parameters_from_overrides(true);
+
+  auto node = std::make_shared<moveit_servo::ServoServer>(options);
+
+  rclcpp::executors::MultiThreadedExecutor exec;
+  exec.add_node(node);
+  exec.spin();
+  exec.remove_node(node);
+
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
### Description

Previously the servo_server node was only available as a component node. This adds a new executable to run the servo_server as a standalone node.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
