### PR TITLE
WIP: Remove const SharedPtrs, get main building

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -85,7 +85,7 @@ private:
   planning_scene_monitor::LockedPlanningSceneRO getLockedPlanningSceneRO() const;
 
   /** \brief Callback for collision stopping time, from the thread that is aware of velocity and acceleration */
-  void worstCaseStopTimeCB(const std_msgs::msg::Float64::SharedPtr msg);
+  void worstCaseStopTimeCB(std_msgs::msg::Float64::SharedPtr msg);
 
   // Pointer to the ROS node
   const std::shared_ptr<rclcpp::Node> node_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -141,7 +141,7 @@ private:
   bool satisfiesPoseTolerance(const Eigen::Vector3d& positional_tolerance, const double angular_tolerance);
 
   /** \brief Subscribe to the target pose on this topic */
-  void targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
+  void targetPoseCallback(geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
 
   /** \brief Update PID controller target positions & orientations */
   void updateControllerSetpoints();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -230,12 +230,12 @@ protected:
   void enforceControlDimensions(geometry_msgs::msg::TwistStamped& command);
 
   /* \brief Callback for joint subsription */
-  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr msg);
+  void jointStateCB(sensor_msgs::msg::JointState::SharedPtr msg);
 
   /* \brief Command callbacks */
-  void twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
-  void jointCmdCB(const control_msgs::msg::JointJog::SharedPtr msg);
-  void collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr msg);
+  void twistStampedCB(geometry_msgs::msg::TwistStamped::SharedPtr msg);
+  void jointCmdCB(control_msgs::msg::JointJog::SharedPtr msg);
+  void collisionVelocityScaleCB(std_msgs::msg::Float64::SharedPtr msg);
 
   /**
    * Allow drift in certain dimensions. For example, may allow the wrist to rotate freely.

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -159,7 +159,7 @@ void CollisionCheck::run()
   }
 }
 
-void CollisionCheck::worstCaseStopTimeCB(const std_msgs::msg::Float64::SharedPtr msg)
+void CollisionCheck::worstCaseStopTimeCB(std_msgs::msg::Float64::SharedPtr msg)
 {
   worst_case_stop_time_ = msg.get()->data;
 }

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -60,7 +60,7 @@ public:
   }
 
 private:
-  void statusCB(const std_msgs::msg::Int8::ConstSharedPtr msg)
+  void statusCB(std_msgs::msg::Int8::ConstSharedPtr msg)
   {
     moveit_servo::StatusCode latest_status = static_cast<moveit_servo::StatusCode>(msg->data);
     if (latest_status != status_)

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -229,7 +229,7 @@ bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tole
           (std::abs(z_error) < positional_tolerance(2)) && (std::abs(*angular_error_) < angular_tolerance));
 }
 
-void PoseTracking::targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
+void PoseTracking::targetPoseCallback(geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(target_pose_mtx_);
   target_pose_ = *msg;

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1085,7 +1085,7 @@ bool ServoCalcs::getEEFrameTransform(geometry_msgs::msg::TransformStamped& trans
   return true;
 }
 
-void ServoCalcs::twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr msg)
+void ServoCalcs::twistStampedCB(geometry_msgs::msg::TwistStamped::SharedPtr msg)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   latest_twist_stamped_ = msg;
@@ -1099,7 +1099,7 @@ void ServoCalcs::twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPt
   input_cv_.notify_all();
 }
 
-void ServoCalcs::jointCmdCB(const control_msgs::msg::JointJog::SharedPtr msg)
+void ServoCalcs::jointCmdCB(control_msgs::msg::JointJog::SharedPtr msg)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   latest_joint_cmd_ = msg;
@@ -1113,7 +1113,7 @@ void ServoCalcs::jointCmdCB(const control_msgs::msg::JointJog::SharedPtr msg)
   input_cv_.notify_all();
 }
 
-void ServoCalcs::collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr msg)
+void ServoCalcs::collisionVelocityScaleCB(std_msgs::msg::Float64::SharedPtr msg)
 {
   collision_velocity_scale_ = msg.get()->data;
 }

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -218,7 +218,7 @@ public:
       collision_pub_thread_.join();
   }
 
-  void joyCB(const sensor_msgs::msg::Joy::SharedPtr msg)
+  void joyCB(sensor_msgs::msg::Joy::SharedPtr msg)
   {
     // Create the messages we might publish
     auto twist_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();

--- a/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
+++ b/moveit_ros/moveit_servo/test/basic_servo_tests.cpp
@@ -67,8 +67,8 @@ TEST_F(ServoFixture, SendTwistStampedTest)
 
   // count trajectory messages sent by servo
   size_t received_count = 0;
-  std::function<void(const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
-      [&received_count](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) { ++received_count; };
+  std::function<void(trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
+      [&received_count](trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) { ++received_count; };
   auto traj_sub = node_->create_subscription<trajectory_msgs::msg::JointTrajectory>(
       resolveServoTopicName(parameters->command_out_topic), 1, traj_callback);
 
@@ -120,8 +120,8 @@ TEST_F(ServoFixture, SendJointServoTest)
 
   // count trajectory messages sent by servo
   size_t received_count = 0;
-  std::function<void(const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
-      [&received_count](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) { ++received_count; };
+  std::function<void(trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
+      [&received_count](trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) { ++received_count; };
   auto traj_sub = node_->create_subscription<trajectory_msgs::msg::JointTrajectory>(cmd_out_topic, 1, traj_callback);
 
   // Create publisher to send servo commands

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -158,8 +158,8 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
   // halt Servoing when first msg to ros_control is received
   // and test some conditions
   trajectory_msgs::msg::JointTrajectory last_received_msg;
-  std::function<void(const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
-      [&/* this */](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) {
+  std::function<void(trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
+      [&/* this */](trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) {
         EXPECT_EQ(msg->header.frame_id, "panda_link0");
         // Check for an expected joint position command
         // As of now, the robot doesn't actually move because there are no controllers enabled.

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -271,7 +271,7 @@ public:
     return true;
   }
 
-  void statusCB(const std_msgs::msg::Int8::SharedPtr msg)
+  void statusCB(std_msgs::msg::Int8::SharedPtr msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_status_;
@@ -280,28 +280,28 @@ public:
       status_seen_ = true;
   }
 
-  void collisionScaleCB(const std_msgs::msg::Float64::SharedPtr msg)
+  void collisionScaleCB(std_msgs::msg::Float64::SharedPtr msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_collision_scale_;
     latest_collision_scale_ = msg.get()->data;
   }
 
-  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr msg)
+  void jointStateCB(sensor_msgs::msg::JointState::SharedPtr msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_joint_state_;
     latest_joint_state_ = msg;
   }
 
-  void trajectoryCommandCB(const trajectory_msgs::msg::JointTrajectory::SharedPtr msg)
+  void trajectoryCommandCB(trajectory_msgs::msg::JointTrajectory::SharedPtr msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_commands_;
     latest_traj_cmd_ = msg;
   }
 
-  void arrayCommandCB(const std_msgs::msg::Float64MultiArray::SharedPtr msg)
+  void arrayCommandCB(std_msgs::msg::Float64MultiArray::SharedPtr msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_commands_;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -43,7 +43,7 @@
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.occupancy_map_server");
 
-static void publishOctomap(const rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr& octree_binary_pub,
+static void publishOctomap(rclcpp::Publisher<octomap_msgs::msg::Octomap>::SharedPtr& octree_binary_pub,
                            occupancy_map_monitor::OccupancyMapMonitor* server)
 {
   octomap_msgs::msg::Octomap map;

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -61,8 +61,8 @@ public:
   void forgetShape(ShapeHandle handle) override;
 
 private:
-  void depthImageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& depth_msg,
-                          const sensor_msgs::msg::CameraInfo::ConstSharedPtr& info_msg);
+  void depthImageCallback(sensor_msgs::msg::Image::ConstSharedPtr& depth_msg,
+                          sensor_msgs::msg::CameraInfo::ConstSharedPtr& info_msg);
   bool getShapeTransform(mesh_filter::MeshHandle h, Eigen::Isometry3d& transform) const;
   void stopHelper();
 

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -215,8 +215,8 @@ bool host_is_big_endian()
 
 static const bool HOST_IS_BIG_ENDIAN = host_is_big_endian();
 
-void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& depth_msg,
-                                                  const sensor_msgs::msg::CameraInfo::ConstSharedPtr& info_msg)
+void DepthImageOctomapUpdater::depthImageCallback(sensor_msgs::msg::Image::ConstSharedPtr& depth_msg,
+                                                  sensor_msgs::msg::CameraInfo::ConstSharedPtr& info_msg)
 {
   RCLCPP_DEBUG(LOGGER, "Received a new depth image message (frame = '%s', encoding='%s')",
                depth_msg->header.frame_id.c_str(), depth_msg->encoding.c_str());

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -68,7 +68,7 @@ protected:
 
 private:
   bool getShapeTransform(ShapeHandle h, Eigen::Isometry3d& transform) const;
-  void cloudMsgCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud_msg);
+  void cloudMsgCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud_msg);
   void stopHelper();
 
   // TODO: Enable private node for publishing filtered point cloud

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -167,7 +167,7 @@ void PointCloudOctomapUpdater::updateMask(const sensor_msgs::msg::PointCloud2& /
 {
 }
 
-void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud_msg)
+void PointCloudOctomapUpdater::cloudMsgCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr& cloud_msg)
 {
   RCLCPP_DEBUG(LOGGER, "Received a new point cloud message");
   rclcpp::Time start = rclcpp::Clock(RCL_ROS_TIME).now();

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -136,7 +136,7 @@ private:
 
   shapes::Mesh* orientPlanarPolygon(const shapes::Mesh& polygon) const;
 
-  void tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr msg);
+  void tableCallback(object_recognition_msgs::msg::TableArray::SharedPtr msg);
 
   void transformTableArray(object_recognition_msgs::msg::TableArray& table_array) const;
 

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -472,7 +472,7 @@ std::string SemanticWorld::findObjectTable(const geometry_msgs::msg::Pose& pose,
   return std::string();
 }
 
-void SemanticWorld::tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr msg)
+void SemanticWorld::tableCallback(object_recognition_msgs::msg::TableArray::SharedPtr msg)
 {
   table_array_ = *msg;
   RCLCPP_INFO(LOGGER, "Table callback with %d tables", (int)table_array_.tables.size());

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -67,7 +67,7 @@ public:
   class MiddlewareHandle
   {
   public:
-    using TfCallback = std::function<void(const tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
+    using TfCallback = std::function<void(tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
 
     /**
      * @brief      Destroys the object.
@@ -315,7 +315,7 @@ private:
 
   void jointStateCallback(sensor_msgs::msg::JointState::ConstSharedPtr joint_state);
   void updateMultiDofJoints();
-  void transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static);
+  void transformCallback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static);
 
   std::unique_ptr<MiddlewareHandle> middleware_handle_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor_middleware_handle.hpp
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor_middleware_handle.hpp
@@ -79,7 +79,7 @@ public:
    *
    * @param[in]  callback  The callback
    */
-  void createStaticTfSubscription(std::function<void(const tf2_msgs::msg::TFMessage::ConstSharedPtr)> callback) override;
+  void createStaticTfSubscription(std::function<void(tf2_msgs::msg::TFMessage::ConstSharedPtr)> callback) override;
 
   /**
    * @brief      Creates a dynamic transform message subscription
@@ -87,7 +87,7 @@ public:
    * @param[in]  callback  The callback
    */
   void
-  createDynamicTfSubscription(std::function<void(const tf2_msgs::msg::TFMessage::ConstSharedPtr)> callback) override;
+  createDynamicTfSubscription(std::function<void(tf2_msgs::msg::TFMessage::ConstSharedPtr)> callback) override;
 
   /**
    * @brief      Reset the joint state subscription

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -536,13 +536,13 @@ private:
   void scenePublishingThread();
 
   // called by current_state_monitor_ when robot state (as monitored on joint state topic) changes
-  void onStateUpdate(const sensor_msgs::msg::JointState::ConstSharedPtr& joint_state);
+  void onStateUpdate(sensor_msgs::msg::JointState::ConstSharedPtr& joint_state);
 
   // called by state_update_timer_ when a state update it pending
   void stateUpdateTimerCallback();
 
   // Callback for a new planning scene msg
-  void newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr scene);
+  void newPlanningSceneCallback(moveit_msgs::msg::PlanningScene::SharedPtr scene);
 
   // Callback for requesting the full planning scene via service
   void getPlanningSceneServiceCallback(moveit_msgs::srv::GetPlanningScene::Request::SharedPtr req,

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -460,7 +460,7 @@ void CurrentStateMonitor::updateMultiDofJoints()
 }
 
 // Copied from https://github.com/ros2/geometry2/blob/ros2/tf2_ros/src/transform_listener.cpp
-void CurrentStateMonitor::transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static)
+void CurrentStateMonitor::transformCallback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static)
 {
   for (const auto& transform : msg->transforms)
   {

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1265,7 +1265,7 @@ void PlanningSceneMonitor::stopStateMonitor()
   }
 }
 
-void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::msg::JointState::ConstSharedPtr& /*joint_state */)
+void PlanningSceneMonitor::onStateUpdate(sensor_msgs::msg::JointState::ConstSharedPtr& /*joint_state */)
 {
   const std::chrono::system_clock::time_point& n = std::chrono::system_clock::now();
   std::chrono::duration<double> dt = n - last_robot_state_update_wall_time_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -309,7 +309,7 @@ private:
 
   void stopExecutionInternal();
 
-  void receiveEvent(const std_msgs::msg::String::SharedPtr event);
+  void receiveEvent(std_msgs::msg::String::SharedPtr event);
 
   void loadControllerParams();
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -265,7 +265,7 @@ void TrajectoryExecutionManager::processEvent(const std::string& event)
     RCLCPP_WARN_STREAM(LOGGER, "Unknown event type: '" << event << "'");
 }
 
-void TrajectoryExecutionManager::receiveEvent(const std_msgs::msg::String::SharedPtr event)
+void TrajectoryExecutionManager::receiveEvent(std_msgs::msg::String::SharedPtr event)
 {
   RCLCPP_INFO_STREAM(LOGGER, "Received event '" << event->data << "'");
   processEvent(event->data);

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -99,7 +99,7 @@ typedef boost::function<bool(const moveit::core::RobotState& state, visualizatio
 ///           is somehow invalid or erronious (e.g. in collision).  true if
 ///           everything worked well.
 typedef boost::function<bool(moveit::core::RobotState& state,
-                             const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)>
+                             visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)>
     ProcessFeedbackFn;
 
 /// Type of function for updating marker pose for new state.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -191,17 +191,17 @@ public:
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleEndEffector(const EndEffectorInteraction& eef,
-                                 const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
+                                 visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleJoint(const JointInteraction& vj,
-                           const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
+                           visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
   virtual void handleGeneric(const GenericInteraction& g,
-                             const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
+                             visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
 
   /** \brief Check if the marker corresponding to this end-effector leads to an
    * invalid state */
@@ -219,7 +219,7 @@ public:
   void clearError();
 
 protected:
-  bool transformFeedbackPose(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback,
+  bool transformFeedbackPose(visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback,
                              const geometry_msgs::msg::Pose& offset, geometry_msgs::msg::PoseStamped& tpose);
 
   const std::string name_;
@@ -232,7 +232,7 @@ private:
   // Update RobotState using a generic interaction feedback message.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
   void updateStateGeneric(moveit::core::RobotState* state, const GenericInteraction* g,
-                          const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr* feedback,
+                          visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr* feedback,
                           StateChangeCallbackFn* callback);
 
   // Update RobotState for a new pose of an eef.

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -172,7 +172,7 @@ private:
   // called by decideActiveComponents(); add markers for planar and floating joints
   void decideActiveJoints(const std::string& group);
 
-  void moveInteractiveMarker(const std::string& name, const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
+  void moveInteractiveMarker(const std::string& name, geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
   // register the name of the topic and marker name to move interactive marker from other ROS nodes
   void registerMoveInteractiveMarkerTopic(const std::string& marker_name, const std::string& name);
   // return the diameter of the sphere that certainly can enclose the AABB of the link
@@ -191,7 +191,7 @@ private:
                              bool position = true, bool orientation = true);
 
   void
-  processInteractiveMarkerFeedback(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
+  processInteractiveMarkerFeedback(visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
   void subscribeMoveInteractiveMarker(const std::string marker_name, const std::string& name);
   void processingThread();
   void clearInteractiveMarkersUnsafe();

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -212,7 +212,7 @@ void InteractionHandler::clearMenuHandler()
 }
 
 void InteractionHandler::handleGeneric(
-    const GenericInteraction& g, const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
+    const GenericInteraction& g, visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
 {
   if (g.process_feedback)
   {
@@ -229,7 +229,7 @@ void InteractionHandler::handleGeneric(
 
 void InteractionHandler::handleEndEffector(
     const EndEffectorInteraction& eef,
-    const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
+    visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
 {
   if (feedback->event_type != visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE)
     return;
@@ -260,7 +260,7 @@ void InteractionHandler::handleEndEffector(
 }
 
 void InteractionHandler::handleJoint(const JointInteraction& vj,
-                                     const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
+                                     visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
 {
   if (feedback->event_type != visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE)
     return;
@@ -293,7 +293,7 @@ void InteractionHandler::handleJoint(const JointInteraction& vj,
 // MUST hold state_lock_ when calling this!
 void InteractionHandler::updateStateGeneric(
     moveit::core::RobotState* state, const GenericInteraction* g,
-    const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr* feedback, StateChangeCallbackFn* callback)
+    visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr* feedback, StateChangeCallbackFn* callback)
 {
   bool ok = g->process_feedback(*state, *feedback);
   bool error_state_changed = setErrorState(g->marker_name_suffix, !ok);
@@ -378,7 +378,7 @@ bool InteractionHandler::getErrorState(const std::string& name) const
 }
 
 bool InteractionHandler::transformFeedbackPose(
-    const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback,
+    visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback,
     const geometry_msgs::msg::Pose& offset, geometry_msgs::msg::PoseStamped& tpose)
 {
   tpose.header = feedback->header;

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -580,8 +580,8 @@ void RobotInteraction::toggleMoveInteractiveMarkerTopic(bool enable)
       {
         std::string topic_name = int_marker_move_topics_[i];
         std::string marker_name = int_marker_names_[i];
-        std::function<void(const geometry_msgs::msg::PoseStamped::SharedPtr)> subscription_callback =
-            [this, marker_name](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        std::function<void(geometry_msgs::msg::PoseStamped::SharedPtr)> subscription_callback =
+            [this, marker_name](geometry_msgs::msg::PoseStamped::SharedPtr msg) {
               moveInteractiveMarker(marker_name, msg);
             };
         auto subscription =
@@ -689,7 +689,7 @@ bool RobotInteraction::showingMarkers(const InteractionHandlerPtr& handler)
 }
 
 void RobotInteraction::moveInteractiveMarker(const std::string& name,
-                                             const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
+                                             geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
 {
   std::map<std::string, std::size_t>::const_iterator it = shown_markers_.find(name);
   if (it != shown_markers_.end())
@@ -709,7 +709,7 @@ void RobotInteraction::moveInteractiveMarker(const std::string& name,
 }
 
 void RobotInteraction::processInteractiveMarkerFeedback(
-    const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
+    visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback)
 {
   // perform some validity checks
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -245,7 +245,7 @@ protected:
   void setQueryStateHelper(bool use_start_state, const std::string& v);
   void populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
-  void selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg);
+  void selectPlanningGroupCallback(std_msgs::msg::String::ConstSharedPtr msg);
 
   // overrides from Display
   void onInitialize() override;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -295,7 +295,7 @@ private:
   std::string selected_support_surface_name_;
 
   rclcpp_action::Client<object_recognition_msgs::action::ObjectRecognition>::SharedPtr object_recognition_client_;
-  void listenDetectedObjects(const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr msg);
+  void listenDetectedObjects(object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr msg);
   rclcpp::Subscription<object_recognition_msgs::msg::RecognizedObjectArray>::SharedPtr object_recognition_subscriber_;
 
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr plan_subscriber_;
@@ -311,13 +311,13 @@ private:
   shapes::ShapePtr loadMeshResource(const std::string& url);
   void loadStoredStates(const std::string& pattern);
 
-  void remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg);
-  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg);
+  void remotePlanCallback(std_msgs::msg::Empty::ConstSharedPtr msg);
+  void remoteExecuteCallback(std_msgs::msg::Empty::ConstSharedPtr msg);
+  void remoteStopCallback(std_msgs::msg::Empty::ConstSharedPtr msg);
+  void remoteUpdateStartStateCallback(std_msgs::msg::Empty::ConstSharedPtr msg);
+  void remoteUpdateGoalStateCallback(std_msgs::msg::Empty::ConstSharedPtr msg);
+  void remoteUpdateCustomStartStateCallback(moveit_msgs::msg::RobotState::ConstSharedPtr msg);
+  void remoteUpdateCustomGoalStateCallback(moveit_msgs::msg::RobotState::ConstSharedPtr msg);
 
   /* Selects or unselects a item in a list by the item name */
   void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -299,7 +299,7 @@ void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)
   }
 }
 
-void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg)
+void MotionPlanningDisplay::selectPlanningGroupCallback(std_msgs::msg::String::ConstSharedPtr msg)
 {
   // synchronize ROS callback with main loop
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::changePlanningGroup, this, msg->data));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -168,7 +168,7 @@ void MotionPlanningFrame::triggerObjectDetection()
 }
 
 void MotionPlanningFrame::listenDetectedObjects(
-    const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr /*msg*/)
+    object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr /*msg*/)
 {
   rclcpp::sleep_for(std::chrono::seconds(1));
   planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::processDetectedObjects, this));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -555,22 +555,22 @@ void MotionPlanningFrame::configureForPlanning()
     planning_display_->dropVisualizedTrajectory();
 }
 
-void MotionPlanningFrame::remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remotePlanCallback(std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   planButtonClicked();
 }
 
-void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteExecuteCallback(std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   executeButtonClicked();
 }
 
-void MotionPlanningFrame::remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteStopCallback(std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   stopButtonClicked();
 }
 
-void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteUpdateStartStateCallback(std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -584,7 +584,7 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Em
   }
 }
 
-void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteUpdateGoalStateCallback(std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -598,7 +598,7 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Emp
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
+void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(moveit_msgs::msg::RobotState::ConstSharedPtr msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();
@@ -616,7 +616,7 @@ void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
+void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(moveit_msgs::msg::RobotState::ConstSharedPtr msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -111,7 +111,7 @@ protected:
   void setLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name, const QColor& color);
   void unsetLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name);
 
-  void newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state);
+  void newRobotStateCallback(moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state);
 
   void setRobotHighlights(const moveit_msgs::msg::DisplayRobotState::_highlight_links_type& highlight_links);
   void setHighlight(const std::string& link_name, const std_msgs::msg::ColorRGBA& color);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -305,7 +305,7 @@ void RobotStateDisplay::changedRobotStateTopic()
       robot_state_topic_property_->getStdString(), 10, std::bind(&RobotStateDisplay::newRobotStateCallback, this, _1));
 }
 
-void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state_msg)
+void RobotStateDisplay::newRobotStateCallback(moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state_msg)
 {
   if (!robot_model_)
     return;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -124,7 +124,7 @@ protected:
   /**
    * \brief ROS callback for an incoming path message
    */
-  void incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg);
+  void incomingDisplayTrajectory(moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg);
   float getStateDisplayTime();
   void clearTrajectoryTrail();
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -492,7 +492,7 @@ void TrajectoryVisualization::update(float wall_dt, float /*ros_dt*/)
                                    (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible())));
 }
 
-void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg)
+void TrajectoryVisualization::incomingDisplayTrajectory(moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg)
 {
   // Error check
   if (!robot_state_ || !robot_model_)

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -70,7 +70,7 @@ void onSceneUpdate(planning_scene_monitor::PlanningSceneMonitor* psm, moveit_war
     RCLCPP_INFO(LOGGER, "Scene name is empty. Not saving.");
 }
 
-void onMotionPlanRequest(const moveit_msgs::msg::MotionPlanRequest::ConstSharedPtr req,
+void onMotionPlanRequest(moveit_msgs::msg::MotionPlanRequest::ConstSharedPtr req,
                          planning_scene_monitor::PlanningSceneMonitor* psm, moveit_warehouse::PlanningSceneStorage* pss)
 {
   if (psm->getPlanningScene()->getName().empty())
@@ -81,7 +81,7 @@ void onMotionPlanRequest(const moveit_msgs::msg::MotionPlanRequest::ConstSharedP
   pss->addPlanningQuery(*req, psm->getPlanningScene()->getName());
 }
 
-void onConstraints(const moveit_msgs::msg::Constraints::ConstSharedPtr msg, moveit_warehouse::ConstraintsStorage* cs)
+void onConstraints(moveit_msgs::msg::Constraints::ConstSharedPtr msg, moveit_warehouse::ConstraintsStorage* cs)
 {
   if (msg->name.empty())
   {
@@ -102,7 +102,7 @@ void onConstraints(const moveit_msgs::msg::Constraints::ConstSharedPtr msg, move
   }
 }
 
-void onRobotState(const moveit_msgs::msg::RobotState::ConstSharedPtr msg, moveit_warehouse::RobotStateStorage* rs)
+void onRobotState(moveit_msgs::msg::RobotState::ConstSharedPtr msg, moveit_warehouse::RobotStateStorage* rs)
 {
   std::vector<std::string> names;
   rs->getKnownRobotStates(names);


### PR DESCRIPTION
### Description

Something weird is going on with CI. When I build MoveIt using the latest ros:rolling-ros-base-focal base image I get a lot of complaints about messages and `note:   no known conversion for argument 1 from 'const`. I don't know if docker is caching a previous image, which will prevent it from pulling in an updated debian. It could be the case because on the base image, the newest timestamps on my rolling debians are ~Jul 16, whereas after I upgrade they are ~Aug 11.

This should replace all the const SharedPtr usages
`find . -type f -exec sed -i -E 's/([[:space:]\(])(const )([^,]*[:_]msg::.*SharedPtr)/\1\3/g' {} +`

Currently I'm attempting to get a successful build with source checkouts of moveit2 and the following message packages:
- control_msgs
- moveit_msgs
- octomap_msgs

It looks like there is an issue with Boost and sensor_msgs::msg::JointState still so something isn't quite right.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
