### PR TITLE
rolling-ci-testing to rolling-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: rolling-ci-testing
+          - IMAGE: rolling-ci
             CCOV: true
           - IMAGE: rolling-ci-testing
             IKFAST_TEST: true


### PR DESCRIPTION
I realized after #629, we don't build on rolling-ci images but instead building on rolling-ci-testing twice, this PR fixes that.