### PR TITLE
Use StatusOr for getJointModel

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/warehouse_ros_mongo
     version: ros2
+  abseil-cpp:
+    type: git
+    url: https://github.com/PickNikRobotics/abseil-cpp.git
+    version: master

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -23,6 +23,8 @@ foreach(LIBFCL_LIBRARY ${LIBFCL_LIBRARIES})
 endforeach()
 set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 
+find_package(absl REQUIRED statusor)
+
 find_package(Bullet 2.87 REQUIRED)
 find_package(angles REQUIRED)
 find_package(OCTOMAP REQUIRED)
@@ -114,6 +116,7 @@ set(THIS_PACKAGE_LIBRARIES
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  absl
   angles
   eigen_stl_containers
   geometric_shapes

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -145,18 +145,18 @@ bool JointConstraint::configure(const moveit_msgs::msg::JointConstraint& jc)
   joint_variable_name_ = jc.joint_name;
   local_variable_name_.clear();
   if (robot_model_->hasJointModel(joint_variable_name_))
-    joint_model_ = robot_model_->getJointModel(joint_variable_name_);
+    joint_model_ = robot_model_->getJointModel(joint_variable_name_).value();
   else
   {
     std::size_t pos = jc.joint_name.find_last_of('/');
     if (pos != std::string::npos)
     {
-      joint_model_ = robot_model_->getJointModel(jc.joint_name.substr(0, pos));
+      std::string name = jc.joint_name.substr(0, pos);
+      if (robot_model_->hasJointModel(name))
+        joint_model_ = robot_model_->getJointModel(name).value();
       if (pos + 1 < jc.joint_name.length())
         local_variable_name_ = jc.joint_name.substr(pos + 1);
     }
-    else
-      joint_model_ = robot_model_->getJointModel(jc.joint_name);
   }
 
   if (joint_model_)

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${MOVEIT_LIB_NAME} SHARED src/kinematics_base.cpp)
 include(GenerateExportHeader)
 generate_export_header(${MOVEIT_LIB_NAME})
 target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+target_link_libraries(${MOVEIT_LIB_NAME} absl::statusor)
 
 # This line is needed to ensure that messages are done being built before this is built
 ament_target_dependencies(

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -23,6 +23,7 @@
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
   <build_depend>moveit_common</build_depend>
 
+  <depend>absl</depend>
   <depend>angles</depend>
   <depend>rclcpp</depend>
   <depend>common_interfaces</depend>

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/robot_model.cpp
 )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
 ament_target_dependencies(${MOVEIT_LIB_NAME}
+  absl
   angles
   moveit_msgs
   Eigen3
@@ -28,6 +30,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_profiler
   moveit_exceptions
   moveit_kinematics_base
+  absl::statusor
 )
 
 if(BUILD_TESTING)
@@ -37,7 +40,10 @@ if(BUILD_TESTING)
     rclcpp
     Boost
   )
-  target_link_libraries(test_robot_model moveit_test_utils ${MOVEIT_LIB_NAME})
+  target_link_libraries(test_robot_model
+    ${MOVEIT_LIB_NAME}
+    moveit_test_utils
+  )
 endif()
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -41,7 +41,10 @@
 #include <moveit/robot_model/link_model.h>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <srdfdom/model.h>
+
+#include <absl/status/statusor.h>
 #include <boost/function.hpp>
+
 #include <set>
 
 namespace moveit
@@ -134,7 +137,7 @@ public:
   bool hasLinkModel(const std::string& link) const;
 
   /** \brief Get a joint by its name. Throw an exception if the joint is not part of this group. */
-  const JointModel* getJointModel(const std::string& joint) const;
+  const absl::StatusOr<const JointModel*> getJointModel(const std::string& joint) const;
 
   /** \brief Get a link by its name. Throw an exception if the link is not part of this group. */
   const LinkModel* getLinkModel(const std::string& link) const;

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -48,6 +48,9 @@
 #include <moveit/robot_model/planar_joint_model.h>
 #include <moveit/robot_model/revolute_joint_model.h>
 #include <moveit/robot_model/prismatic_joint_model.h>
+
+#include <absl/status/statusor.h>
+
 #include <Eigen/Geometry>
 #include <iostream>
 
@@ -136,13 +139,13 @@ public:
   bool hasJointModel(const std::string& name) const;
 
   /** \brief Get a joint by its name. Output error and return NULL when the joint is missing. */
-  const JointModel* getJointModel(const std::string& joint) const;
+  const absl::StatusOr<JointModel*> getJointModel(const std::string& joint) const;
 
   /** \brief Get a joint by its index. Output error and return NULL when the link is missing. */
-  const JointModel* getJointModel(int index) const;
+  const absl::StatusOr<JointModel*> getJointModel(int index) const;
 
   /** \brief Get a joint by its name. Output error and return NULL when the joint is missing. */
-  JointModel* getJointModel(const std::string& joint);
+  absl::StatusOr<JointModel*> getJointModel(const std::string& joint);
 
   /** \brief Get the array of joints, in the order they appear
       in the robot state. */

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -314,7 +314,6 @@ const absl::StatusOr<const JointModel*> JointModelGroup::getJointModel(const std
   {
     std::stringstream ss;
     ss << "Joint '" << name.c_str() << "' not found in group '" << name_.c_str() << "'";
-    RCLCPP_ERROR_STREAM(LOGGER, ss.str());
     return absl::NotFoundError(ss.str());
   }
   return it->second;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -288,7 +288,7 @@ void JointModelGroup::getSubgroups(std::vector<const JointModelGroup*>& sub_grou
 
 bool JointModelGroup::hasJointModel(const std::string& joint) const
 {
-  return joint_model_map_.find(joint) != joint_model_map_.end();
+  return getJointModel(joint).ok();
 }
 
 bool JointModelGroup::hasLinkModel(const std::string& link) const

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1234,7 +1234,6 @@ const absl::StatusOr<JointModel*> RobotModel::getJointModel(const std::string& n
   {
     std::stringstream ss;
     ss << "Joint '" << name.c_str() << "' not found in model '" << model_name_.c_str() << "'";
-    RCLCPP_ERROR_STREAM(LOGGER, ss.str());
     return absl::NotFoundError(ss.str());
   }
 }
@@ -1245,7 +1244,6 @@ const absl::StatusOr<JointModel*> RobotModel::getJointModel(int index) const
   {
     std::stringstream ss;
     ss << "Joint index '" << index << "' out of bounds of joints in model '" << model_name_.c_str() << "'";
-    RCLCPP_ERROR_STREAM(LOGGER, ss.str());
     return absl::OutOfRangeError(ss.str());
   }
   assert(joint_model_vector_[index]->getJointIndex() == index);
@@ -1261,7 +1259,6 @@ absl::StatusOr<JointModel*> RobotModel::getJointModel(const std::string& name)
   {
     std::stringstream ss;
     ss << "Joint '" << name.c_str() << "' not found in model '" << model_name_.c_str() << "'";
-    RCLCPP_ERROR_STREAM(LOGGER, ss.str());
     return absl::NotFoundError(ss.str());
   }
 }

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1217,7 +1217,7 @@ shapes::ShapePtr RobotModel::constructShape(const urdf::Geometry* geom)
 
 bool RobotModel::hasJointModel(const std::string& name) const
 {
-  return joint_model_map_.find(name) != joint_model_map_.end();
+  return getJointModel(name).ok();
 }
 
 bool RobotModel::hasLinkModel(const std::string& name) const

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -72,7 +72,8 @@ TEST_F(LoadPlanningModelsPr2, Model)
   for (std::size_t i = 0; i < joints.size(); ++i)
   {
     ASSERT_EQ(joints[i]->getJointIndex(), static_cast<int>(i));
-    ASSERT_EQ(robot_model_->getJointModel(joints[i]->getName()), joints[i]);
+    ASSERT_TRUE(robot_model_->getJointModel(joints[i]->getName()).ok());
+    ASSERT_EQ(robot_model_->getJointModel(joints[i]->getName()).value(), joints[i]);
   }
   const std::vector<const moveit::core::LinkModel*>& links = robot_model_->getLinkModels();
   for (std::size_t i = 0; i < links.size(); ++i)

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -40,13 +40,16 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/attached_body.h>
 #include <moveit/transforms/transforms.h>
+
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
 #include <geometry_msgs/msg/twist.hpp>
-#include <cassert>
 
+#include <absl/status/statusor.h>
 #include <boost/assert.hpp>
+
+#include <cassert>
 
 /* Terminology
    * Model Frame: RobotModel's root frame == PlanningScene's planning frame
@@ -125,7 +128,7 @@ public:
   }
 
   /** \brief Get the model of a particular joint */
-  const JointModel* getJointModel(const std::string& joint) const
+  const absl::StatusOr<JointModel*> getJointModel(const std::string& joint) const
   {
     return robot_model_->getJointModel(joint);
   }
@@ -514,12 +517,12 @@ public:
    */
   void setJointPositions(const std::string& joint_name, const double* position)
   {
-    setJointPositions(robot_model_->getJointModel(joint_name), position);
+    setJointPositions(robot_model_->getJointModel(joint_name).value(), position);
   }
 
   void setJointPositions(const std::string& joint_name, const std::vector<double>& position)
   {
-    setJointPositions(robot_model_->getJointModel(joint_name), &position[0]);
+    setJointPositions(robot_model_->getJointModel(joint_name).value(), &position[0]);
   }
 
   void setJointPositions(const JointModel* joint, const std::vector<double>& position)
@@ -536,7 +539,7 @@ public:
 
   void setJointPositions(const std::string& joint_name, const Eigen::Isometry3d& transform)
   {
-    setJointPositions(robot_model_->getJointModel(joint_name), transform);
+    setJointPositions(robot_model_->getJointModel(joint_name).value(), transform);
   }
 
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
@@ -556,7 +559,7 @@ public:
 
   const double* getJointPositions(const std::string& joint_name) const
   {
-    return getJointPositions(robot_model_->getJointModel(joint_name));
+    return getJointPositions(robot_model_->getJointModel(joint_name).value());
   }
 
   const double* getJointPositions(const JointModel* joint) const
@@ -566,7 +569,7 @@ public:
 
   const double* getJointVelocities(const std::string& joint_name) const
   {
-    return getJointVelocities(robot_model_->getJointModel(joint_name));
+    return getJointVelocities(robot_model_->getJointModel(joint_name).value());
   }
 
   const double* getJointVelocities(const JointModel* joint) const
@@ -576,7 +579,7 @@ public:
 
   const double* getJointAccelerations(const std::string& joint_name) const
   {
-    return getJointAccelerations(robot_model_->getJointModel(joint_name));
+    return getJointAccelerations(robot_model_->getJointModel(joint_name).value());
   }
 
   const double* getJointAccelerations(const JointModel* joint) const
@@ -586,7 +589,7 @@ public:
 
   const double* getJointEffort(const std::string& joint_name) const
   {
-    return getJointEffort(robot_model_->getJointModel(joint_name));
+    return getJointEffort(robot_model_->getJointModel(joint_name).value());
   }
 
   const double* getJointEffort(const JointModel* joint) const
@@ -1359,7 +1362,7 @@ public:
 
   const Eigen::Isometry3d& getJointTransform(const std::string& joint_name)
   {
-    return getJointTransform(robot_model_->getJointModel(joint_name));
+    return getJointTransform(robot_model_->getJointModel(joint_name).value());
   }
 
   const Eigen::Isometry3d& getJointTransform(const JointModel* joint)
@@ -1376,7 +1379,7 @@ public:
 
   const Eigen::Isometry3d& getJointTransform(const std::string& joint_name) const
   {
-    return getJointTransform(robot_model_->getJointModel(joint_name));
+    return getJointTransform(robot_model_->getJointModel(joint_name).value());
   }
 
   const Eigen::Isometry3d& getJointTransform(const JointModel* joint) const

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -489,18 +489,18 @@ TEST_F(OneRobot, FK)
   std::map<std::string, double> upd_a;
   upd_a["joint_a"] = 0.2;
   state.setVariablePositions(upd_a);
-  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a")));
+  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a").ok()));
   EXPECT_NEAR(state.getVariablePosition("joint_a"), 0.2, 1e-3);
   state.enforceBounds();
   EXPECT_NEAR(state.getVariablePosition("joint_a"), 0.2, 1e-3);
 
   upd_a["joint_a"] = 3.2;
   state.setVariablePositions(upd_a);
-  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a")));
+  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a").ok()));
   EXPECT_NEAR(state.getVariablePosition("joint_a"), 3.2, 1e-3);
   state.enforceBounds();
   EXPECT_NEAR(state.getVariablePosition("joint_a"), -3.083185, 1e-3);
-  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a")));
+  EXPECT_TRUE(state.satisfiesBounds(model->getJointModel("joint_a").ok()));
 
   // mimic joints
   state.setToDefaultValues();

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -218,7 +218,8 @@ bool KDLKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
   unsigned int joint_counter = 0;
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
-    const moveit::core::JointModel* jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
+    const moveit::core::JointModel* jm =
+        robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName()).value();
 
     // first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == nullptr && jm->getVariableCount() > 0)
@@ -249,7 +250,7 @@ bool KDLKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
     if (!mimic_joint.active)
     {
       const moveit::core::JointModel* joint_model =
-          joint_model_group_->getJointModel(mimic_joint.joint_name)->getMimic();
+          joint_model_group_->getJointModel(mimic_joint.joint_name).value()->getMimic();
       for (JointMimic& mimic_joint_recal : mimic_joints_)
       {
         if (mimic_joint_recal.joint_name == joint_model->getName())

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -763,7 +763,7 @@ void ChompOptimizer::computeJointProperties(int trajectory_point)
 {
   for (int j = 0; j < num_joints_; j++)
   {
-    const moveit::core::JointModel* joint_model = state_.getJointModel(joint_names_[j]);
+    const moveit::core::JointModel* joint_model = state_.getJointModel(joint_names_[j]).value();
     const moveit::core::RevoluteJointModel* revolute_joint =
         dynamic_cast<const moveit::core::RevoluteJointModel*>(joint_model);
     const moveit::core::PrismaticJointModel* prismatic_joint =
@@ -1060,12 +1060,12 @@ void ChompOptimizer::perturbTrajectory()
 
 //     RobotState *::JointState* jointState = jointStates[i];
 //     const RevoluteJointModel* revolute_joint
-//       = dynamic_cast<const RevoluteJointModel*>(jointState->getJointModel());
+//       = dynamic_cast<const RevoluteJointModel*>(jointState->getJointModel().value());
 //     if(revolute_joint && revolute_joint->continuous_) {
 //       continuous = true;
 //     }
 
-//     map<string, pair<double, double> > bounds = jointState->getJointModel()->getAllVariableBounds();
+//     map<string, pair<double, double> > bounds = jointState->getJointModel().value()->getAllVariableBounds();
 //     int j = 0;
 //     for(map<string, pair<double, double> >::iterator it = bounds.begin(); it != bounds.end(); it++)
 //     {

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -183,7 +183,7 @@ ompl_interface::ModelBasedPlanningContext::getProjectionEvaluator(const std::str
       ss >> joint >> std::ws;
       if (getJointModelGroup()->hasJointModel(joint))
       {
-        unsigned int variable_count = getJointModelGroup()->getJointModel(joint)->getVariableCount();
+        unsigned int variable_count = getJointModelGroup()->getJointModel(joint).value()->getVariableCount();
         if (variable_count > 0)
         {
           int idx = getJointModelGroup()->getVariableGroupIndex(joint);

--- a/moveit_planners/ompl/ompl_interface/test/test_constrained_planning_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_constrained_planning_state_space.cpp
@@ -212,7 +212,9 @@ protected:
 
     for (std::size_t joint_index = 0; joint_index < num_dofs_; joint_index++)
     {
-      const moveit::core::JointModel* joint_model = joint_model_group_->getJointModel(joint_model_names[joint_index]);
+      const auto get_joint_model_result = joint_model_group_->getJointModel(joint_model_names[joint_index]);
+      EXPECT_TRUE(get_joint_model_result.ok());
+      const moveit::core::JointModel* joint_model = get_joint_model_result.value();
       EXPECT_FALSE(joint_model == nullptr);
 
       RCLCPP_DEBUG_STREAM(LOGGER, "Joint model: " << joint_model->getName() << " index: " << joint_index);

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -166,8 +166,11 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
     std::vector<std::string> joint_model_names = joint_model_group->getActiveJointModelNames();
     for (std::size_t joint_index = 0; joint_index < joint_model_group->getVariableCount(); ++joint_index)
     {
-      const moveit::core::JointModel* joint_model = joint_model_group->getJointModel(joint_model_names[joint_index]);
-      EXPECT_NE(joint_model, nullptr);
+      const auto get_joint_model_result = joint_model_group->getJointModel(joint_model_names[joint_index]);
+      EXPECT_TRUE(get_joint_model_result.ok());
+      const moveit::core::JointModel* joint_model = get_joint_model_result.value();
+      EXPECT_FALSE(joint_model == nullptr);
+
       joint_model_state_space.copyJointToOMPLState(state, robot_state, joint_model, joint_index);
     }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_joint_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_joint_limits_aggregator.cpp
@@ -104,9 +104,9 @@ TEST_F(JointLimitsAggregator, CorrectOverwriteByParamterPosition)
     // Check that nothing else changed
     else
     {
-      EXPECT_EQ(robot_model_->getJointModel(lim.first)->getVariableBounds()[0].min_position_,
+      EXPECT_EQ(robot_model_->getJointModel(lim.first).value()->getVariableBounds()[0].min_position_,
                 container.getLimit(lim.first).min_position);
-      EXPECT_EQ(robot_model_->getJointModel(lim.first)->getVariableBounds()[0].max_position_,
+      EXPECT_EQ(robot_model_->getJointModel(lim.first).value()->getVariableBounds()[0].max_position_,
                 container.getLimit(lim.first).max_position);
     }
   }
@@ -133,7 +133,7 @@ TEST_F(JointLimitsAggregator, CorrectOverwriteByParamterVelocity)
     }
     else
     {
-      EXPECT_EQ(robot_model_->getJointModel(lim.first)->getVariableBounds()[0].max_velocity_,
+      EXPECT_EQ(robot_model_->getJointModel(lim.first).value()->getVariableBounds()[0].max_velocity_,
                 container.getLimit(lim.first).max_velocity);
     }
   }

--- a/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
@@ -646,7 +646,7 @@ void EnvironmentChain3D::setMotionPrimitives(const std::string& group_name)
   const planning_models::RobotModel::JointModelGroup* jmg = joint_state_group_->getJointModelGroup();
   for (unsigned int i = 0; i < jmg->getActiveDOFNames().size(); i++)
   {
-    const planning_models::RobotModel::JointModel* joint = jmg->getJointModel(jmg->getActiveDOFNames()[i]);
+    const planning_models::RobotModel::JointModel* joint = jmg->getJointModel(jmg->getActiveDOFNames()[i]).value();
     boost::shared_ptr<JointMotionWrapper> jmw(new JointMotionWrapper(joint));
     joint_motion_wrappers_.push_back(jmw);
     // TODO - figure out which DOFs have something to do with end effector position

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -323,9 +323,11 @@ void CurrentStateMonitor::jointStateCallback(sensor_msgs::msg::JointState::Const
     current_state_time_ = joint_state->header.stamp;
     for (std::size_t i = 0; i < n; ++i)
     {
-      const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
-      if (!jm)
+      auto get_joint_model_result = robot_model_->getJointModel(joint_state->name[i]);
+      if (!get_joint_model_result.ok())
         continue;
+
+      const moveit::core::JointModel* jm = get_joint_model_result.value();
       // ignore fixed joints, multi-dof joints (they should not even be in the message)
       if (jm->getVariableCount() != 1)
         continue;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -846,9 +846,10 @@ bool TrajectoryExecutionManager::distributeTrajectory(const moveit_msgs::msg::Ro
   std::set<std::string> actuated_joints_single;
   for (const std::string& joint_name : trajectory.joint_trajectory.joint_names)
   {
-    const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_name);
-    if (jm)
+    const auto get_joint_model_result = robot_model_->getJointModel(joint_name);
+    if (get_joint_model_result.ok())
     {
+      const moveit::core::JointModel* jm = get_joint_model_result.value();
       if (jm->isPassive() || jm->getMimic() != nullptr || jm->getType() == moveit::core::JointModel::FIXED)
         continue;
       actuated_joints_single.insert(jm->getName());
@@ -999,12 +1000,13 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
 
       for (std::size_t i = 0, end = joint_names.size(); i < end; ++i)
       {
-        const moveit::core::JointModel* jm = current_state->getJointModel(joint_names[i]);
-        if (!jm)
+        const auto get_joint_model_result = robot_model_->getJointModel(joint_names[i]);
+        if (!get_joint_model_result.ok())
         {
           RCLCPP_ERROR_STREAM(LOGGER, "Unknown joint in trajectory: " << joint_names[i]);
           return false;
         }
+        const moveit::core::JointModel* jm = get_joint_model_result.value();
 
         double cur_position = current_state->getJointPositions(jm)[0];
         double traj_position = positions[i];
@@ -1036,12 +1038,13 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
 
       for (std::size_t i = 0, end = joint_names.size(); i < end; ++i)
       {
-        const moveit::core::JointModel* jm = current_state->getJointModel(joint_names[i]);
-        if (!jm)
+        const auto get_joint_model_result = robot_model_->getJointModel(joint_names[i]);
+        if (!get_joint_model_result.ok())
         {
           RCLCPP_ERROR_STREAM(LOGGER, "Unknown joint in trajectory: " << joint_names[i]);
           return false;
         }
+        const moveit::core::JointModel* jm = get_joint_model_result.value();
 
         // compute difference (offset vector and rotation angle) between current transform
         // and start transform in trajectory
@@ -1079,8 +1082,9 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
   std::set<std::string> actuated_joints;
 
   auto is_actuated = [this](const std::string& joint_name) -> bool {
-    const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_name);
-    return (jm && !jm->isPassive() && !jm->getMimic() && jm->getType() != moveit::core::JointModel::FIXED);
+    const auto jm = robot_model_->getJointModel(joint_name);
+    return (jm.ok() && !jm.value()->isPassive() && !jm.value()->getMimic() &&
+            jm.value()->getType() != moveit::core::JointModel::FIXED);
   };
   for (const std::string& joint_name : trajectory.multi_dof_joint_trajectory.joint_names)
     if (is_actuated(joint_name))
@@ -1611,11 +1615,12 @@ bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionCon
 
       for (std::size_t i = 0; i < n && !moved; ++i)
       {
-        const moveit::core::JointModel* jm = cur_state->getJointModel(joint_names[i]);
-        if (!jm)
+        const auto jm = cur_state->getJointModel(joint_names[i]);
+        if (!jm.ok())
           continue;  // joint vanished from robot state (shouldn't happen), but we don't care
 
-        if (fabs(cur_state->getJointPositions(jm)[0] - prev_state->getJointPositions(jm)[0]) > allowed_start_tolerance_)
+        if (fabs(cur_state->getJointPositions(jm.value())[0] - prev_state->getJointPositions(jm.value())[0]) >
+            allowed_start_tolerance_)
         {
           moved = true;
           no_motion_count = 0;
@@ -1676,10 +1681,11 @@ bool TrajectoryExecutionManager::ensureActiveControllersForJoints(const std::vec
   std::set<std::string> jset;
   for (const std::string& joint : joints)
   {
-    const moveit::core::JointModel* jm = robot_model_->getJointModel(joint);
-    if (jm)
+    const auto jm = robot_model_->getJointModel(joint);
+    if (jm.ok())
     {
-      if (jm->isPassive() || jm->getMimic() != nullptr || jm->getType() == moveit::core::JointModel::FIXED)
+      if (jm.value()->isPassive() || jm.value()->getMimic() != nullptr ||
+          jm.value()->getType() == moveit::core::JointModel::FIXED)
         continue;
       jset.insert(joint);
     }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1794,11 +1794,11 @@ bool MoveGroupInterface::setJointValueTarget(const std::string& joint_name, doub
 bool MoveGroupInterface::setJointValueTarget(const std::string& joint_name, const std::vector<double>& values)
 {
   impl_->setTargetType(JOINT);
-  const moveit::core::JointModel* jm = impl_->getJointModelGroup()->getJointModel(joint_name);
-  if (jm && jm->getVariableCount() == values.size())
+  const auto jm = impl_->getJointModelGroup()->getJointModel(joint_name);
+  if (jm.ok() && jm.value()->getVariableCount() == values.size())
   {
-    impl_->getTargetRobotState().setJointPositions(jm, values);
-    return impl_->getTargetRobotState().satisfiesBounds(jm, impl_->getGoalJointTolerance());
+    impl_->getTargetRobotState().setJointPositions(jm.value(), values);
+    return impl_->getTargetRobotState().satisfiesBounds(jm.value(), impl_->getGoalJointTolerance());
   }
 
   RCLCPP_ERROR_STREAM(LOGGER,

--- a/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/moveit_ros/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -135,10 +135,10 @@ public:
   bp::list getJointLimits(const std::string& name) const
   {
     bp::list result;
-    const moveit::core::JointModel* jm = robot_model_->getJointModel(name);
-    if (jm)
+    const auto jm = robot_model_->getJointModel(name);
+    if (jm.ok())
     {
-      const std::vector<moveit_msgs::msg::JointLimits>& lim = jm->getVariableBoundsMsg();
+      const std::vector<moveit_msgs::msg::JointLimits>& lim = jm.value()->getVariableBoundsMsg();
       for (const moveit_msgs::msg::JointLimits& joint_limit : lim)
       {
         bp::list l;
@@ -200,11 +200,11 @@ public:
     if (!ensureCurrentState())
       return l;
     moveit::core::RobotStatePtr state = current_state_monitor_->getCurrentState();
-    const moveit::core::JointModel* jm = state->getJointModel(name);
-    if (jm)
+    const auto jm = state->getJointModel(name);
+    if (jm.ok())
     {
-      const double* pos = state->getJointPositions(jm);
-      const unsigned int sz = jm->getVariableCount();
+      const double* pos = state->getJointPositions(jm.value());
+      const unsigned int sz = jm.value()->getVariableCount();
       for (unsigned int i = 0; i < sz; ++i)
         l.append(pos[i]);
     }

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1282,8 +1282,8 @@ std::string MoveItConfigData::decideProjectionJoints(const std::string& planning
   if (joints.size() >= 2)
   {
     // Check that the first two joints have only 1 variable
-    if (group->getJointModel(joints[0])->getVariableCount() == 1 &&
-        group->getJointModel(joints[1])->getVariableCount() == 1)
+    if (group->getJointModel(joints[0]).value()->getVariableCount() == 1 &&
+        group->getJointModel(joints[1]).value()->getVariableCount() == 1)
     {
       // Just choose the first two joints.
       joint_pair = "joints(" + joints[0] + "," + joints[1] + ")";

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.cpp
@@ -101,7 +101,7 @@ void PassiveJointsWidget::focusGiven()
   }
   std::vector<std::string> active_joints;
   for (const std::string& joint : joints)
-    if (model->getJointModel(joint)->getVariableCount() > 0)
+    if (model->getJointModel(joint).value()->getVariableCount() > 0)
       active_joints.push_back(joint);
 
   // Set the available joints (left box)

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -325,10 +325,10 @@ void PlanningGroupsWidget::loadGroupsTreeRecursive(srdf::Model::Group& group_it,
     std::string joint_name;
 
     // Get the type of joint this is
-    const moveit::core::JointModel* jm = model->getJointModel(*joint_it);
-    if (jm)  // check if joint model was found
+    const auto jm = model->getJointModel(*joint_it);
+    if (jm.ok())  // check if joint model was found
     {
-      joint_name = *joint_it + " - " + jm->getTypeName();
+      joint_name = *joint_it + " - " + jm.value()->getTypeName();
     }
     else
     {

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -477,16 +477,16 @@ void ROSControllersWidget::previewSelectedJoints(const std::vector<std::string>&
 
   for (const std::string& joint : joints)
   {
-    const moveit::core::JointModel* joint_model = config_data_->getRobotModel()->getJointModel(joint);
+    const auto joint_model = config_data_->getRobotModel()->getJointModel(joint);
 
     // Check that a joint model was found
-    if (!joint_model)
+    if (!joint_model.ok())
     {
       continue;
     }
 
     // Get the name of the link
-    const std::string link = joint_model->getChildLinkModel()->getName();
+    const std::string link = joint_model.value()->getChildLinkModel()->getName();
 
     if (link.empty())
     {


### PR DESCRIPTION
### Description

This is an alternative to the PR I created that throws exceptions.  This one throws exceptions too if they are enabled, if not it calls exit.  More interestingly though I got absl building as a ros package (forked under picknik where I just added a package.xml and set some CMake args)

I've had the pleasure of using StatusOr before and have wanted it to in moveit for a long time.  There are probably many approaches we could take to making that happen (including copying and refactoring it to be much simpler).  This is only one of those approaches.  One really nice sideafect of this approach is other ros projects can easily use abseil and we can use other features from it if we want to easily.

Instead of trying to explain it myself here is just the comment copied from the header of statusor.h:

```
// absl::StatusOr<T>
//
// The `absl::StatusOr<T>` class template is a union of an `absl::Status` object
// and an object of type `T`. The `absl::StatusOr<T>` models an object that is
// either a usable object, or an error (of type `absl::Status`) explaining why
// such an object is not present. An `absl::StatusOr<T>` is typically the return
// value of a function which may fail.
//
// An `absl::StatusOr<T>` can never hold an "OK" status (an
// `absl::StatusCode::kOk` value); instead, the presence of an object of type
// `T` indicates success. Instead of checking for a `kOk` value, use the
// `absl::StatusOr<T>::ok()` member function. (It is for this reason, and code
// readability, that using the `ok()` function is preferred for `absl::Status`
// as well.)
//
// Example:
//
//   StatusOr<Foo> result = DoBigCalculationThatCouldFail();
//   if (result.ok()) {
//     result->DoSomethingCool();
//   } else {
//     LOG(ERROR) << result.status();
//   }
//
// Accessing the object held by an `absl::StatusOr<T>` should be performed via
// `operator*` or `operator->`, after a call to `ok()` confirms that the
// `absl::StatusOr<T>` holds an object of type `T`:
//
// Example:
//
//   absl::StatusOr<int> i = GetCount();
//   if (i.ok()) {
//     updated_total += *i
//   }
//
// NOTE: using `absl::StatusOr<T>::value()` when no valid value is present will
// throw an exception if exceptions are enabled or terminate the process when
// exceptions are not enabled.
//
// Example:
//
//   StatusOr<Foo> result = DoBigCalculationThatCouldFail();
//   const Foo& foo = result.value();    // Crash/exception if no value present
//   foo.DoSomethingCool();
//
// A `absl::StatusOr<T*>` can be constructed from a null pointer like any other
// pointer value, and the result will be that `ok()` returns `true` and
// `value()` returns `nullptr`. Checking the value of pointer in an
// `absl::StatusOr<T>` generally requires a bit more care, to ensure both that a
// value is present and that value is not null:
//
//  StatusOr<std::unique_ptr<Foo>> result = FooFactory::MakeNewFoo(arg);
//  if (!result.ok()) {
//    LOG(ERROR) << result.status();
//  } else if (*result == nullptr) {
//    LOG(ERROR) << "Unexpected null pointer";
//  } else {
//    (*result)->DoSomethingCool();
//  }
//
// Example factory implementation returning StatusOr<T>:
//
//  StatusOr<Foo> FooFactory::MakeFoo(int arg) {
//    if (arg <= 0) {
//      return absl::Status(absl::StatusCode::kInvalidArgument,
//                          "Arg must be positive");
//    }
//    return Foo(arg);
//  }
```

One thing that is really awesome about absl is the header files contain awesome documentation.  I hope you all like this approach as much as I do.  It was kind of a pain to figure out how to configure cmake to work but I think I've gotten it down in this PR.
