### PR TITLE
Forward port 2844, never use cache in source builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -200,7 +200,6 @@ jobs:
           push: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
-          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,8 +24,18 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
+      - name: Check for apt updates
+        uses: addnab/docker-run-action@v3
+        id: apt
+        with:
+          image: ${{ env.GH_IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Containter Registry
         uses: docker/login-action@v1
         with:
@@ -39,11 +49,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |
@@ -64,8 +75,18 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
+      - name: Check for apt updates
+        uses: addnab/docker-run-action@v3
+        id: apt
+        with:
+          image: ${{ env.GH_IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Containter Registry
         uses: docker/login-action@v1
         with:
@@ -79,11 +100,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |
@@ -105,8 +127,18 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
+      - name: Check for apt updates
+        uses: addnab/docker-run-action@v3
+        id: apt
+        with:
+          image: ${{ env.GH_IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Containter Registry
         uses: docker/login-action@v1
         with:
@@ -120,11 +152,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |
@@ -167,6 +200,7 @@ jobs:
           push: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -200,6 +200,7 @@ jobs:
           push: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}


### PR DESCRIPTION
Forward ports https://github.com/ros-planning/moveit/commit/0ad09153cadfa92d74354598953d0ff853e52d47 in https://github.com/ros-planning/moveit/pull/2844.

Also I realized we are caching the same docker image in source builds. So although the source code changes the docker image does not get built again. This PR updates source dockers to never use cache. We can still use caching by changing the Dockerfiles to be more cache-able. But I prefer leaving it to another PR.