### PR TITLE
[foxy] Point CI to  foxy branches of ros2_control and ros2_controllers

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -18,11 +18,11 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control
-    version: master
+    version: foxy
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: foxy
   warehouse_ros:
     type: git
     url: https://github.com/ros-planning/warehouse_ros


### PR DESCRIPTION
ros2_control and ros2_controllers main branches can't compile on Foxy anymore with the recent changes, this PR makes the CI point to correct branches of ros2_control and ros2_controllers.