### PR TITLE
[main] Migrate to joint_state_broadcaster

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/geometric_shapes
     version: ros2
+  moveit_resources:
+    type: git
+    url: https://github.com/ros-planning/moveit_resources
+    version: ros2
   warehouse_ros:
     type: git
     url: https://github.com/ros-planning/warehouse_ros

--- a/moveit2_galactic.repos
+++ b/moveit2_galactic.repos
@@ -1,5 +1,9 @@
 # TODO(henningkayser): Remove once ros2_control is released (https://github.com/ros-controls/ros2_control/issues/421)
 repositories:
+  moveit_resources:
+    type: git
+    url: https://github.com/ros-planning/moveit_resources
+    version: ros2
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control

--- a/moveit2_galactic.repos
+++ b/moveit2_galactic.repos
@@ -1,9 +1,5 @@
 # TODO(henningkayser): Remove once ros2_control is released (https://github.com/ros-controls/ros2_control/issues/421)
 repositories:
-  moveit_resources:
-    type: git
-    url: https://github.com/ros-planning/moveit_resources
-    version: ros2
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control

--- a/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_move_group/launch/run_move_group.launch.py
@@ -171,7 +171,7 @@ def generate_launch_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_controller",
+        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(

--- a/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
+++ b/moveit_demo_nodes/run_moveit_cpp/launch/run_moveit_cpp.launch.py
@@ -155,7 +155,7 @@ def generate_launch_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_controller",
+        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(

--- a/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/launch/run_move_group.launch.py
@@ -168,7 +168,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -136,7 +136,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -34,7 +34,7 @@
   <depend>trajectory_msgs</depend>
 
   <exec_depend>gripper_controllers</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>tf2_ros</exec_depend>

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -99,7 +99,7 @@ def generate_servo_test_description(
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -94,7 +94,7 @@ def generate_servo_test_description(*args, gtest_name: SomeSubstitutionsType):
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -167,7 +167,7 @@ def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsTyp
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -993,10 +993,10 @@ bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
     // Joint State Controller
     emitter << YAML::Comment("Publish all joint states");
     emitter << YAML::Newline << YAML::Comment("Creates the /joint_states topic necessary in ROS");
-    emitter << YAML::Key << "joint_state_controller" << YAML::Value << YAML::BeginMap;
+    emitter << YAML::Key << "joint_state_broadcaster" << YAML::Value << YAML::BeginMap;
     {
       emitter << YAML::Key << "type";
-      emitter << YAML::Value << "joint_state_controller/JointStateController";
+      emitter << YAML::Value << "joint_state_broadcaster/JointStateBroadcaster";
       emitter << YAML::Key << "publish_rate";
       emitter << YAML::Value << "50";
       emitter << YAML::EndMap;


### PR DESCRIPTION
With ros-controls/ros2_controllers#230 ros2_control now removed joint_state_controller in favor of joint_state_broadcaster. This PR migrates our main branch to joint_state_broadcaster. Depends on ros-planning/moveit_resources#96.