### PR TITLE
Fix CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The MoveIt Motion Planning Framework for **ROS 2**. For ROS 1, see [MoveIt 1](ht
 ## Continuous Integration Status
 
 [![Formatting (pre-commit)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml?query=branch%3Amain)
-[![CI (Rolling and Galactic)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_rolling.yaml?query=branch%3Amain)
+[![CI (Rolling and Galactic)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml?query=branch%3Amain)
 [![Code Coverage](https://codecov.io/gh/ros-planning/moveit2/branch/main/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit2)
 
 ## General MoveIt Documentation

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ The MoveIt Motion Planning Framework for **ROS 2**. For ROS 1, see [MoveIt 1](ht
 ## Continuous Integration Status
 
 [![Formatting (pre-commit)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml?query=branch%3Amain)
-[![Build and Test (Rolling)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_rolling.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_rolling.yaml?query=branch%3Amain)
-[![Build and Test (Galactic)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_galactic.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_galactic.yaml?query=branch%3Amain)
+[![CI (Rolling and Galactic)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/build_and_test_rolling.yaml?query=branch%3Amain)
 [![Code Coverage](https://codecov.io/gh/ros-planning/moveit2/branch/main/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit2)
 
 ## General MoveIt Documentation


### PR DESCRIPTION
Filename for CI is changed with the recent changes, breaking the badge in the main readme. This fixes the badge.