### PR TITLE
Move clang tidy under galactic-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,8 @@ jobs:
             CCOV: true
           - IMAGE: rolling-ci-testing
             IKFAST_TEST: true
-            CLANG_TIDY: pedantic
           - IMAGE: galactic-ci
+            CLANG_TIDY: pedantic
           - IMAGE: galactic-ci-testing
     env:
       CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"


### PR DESCRIPTION
As per discussion in #651 I think it is a good idea to enforce clang-tidy and move it under galactic-ci job (which is enforced).

Update: @henningkayser or any admin needs to change the required jobs before merging this.