### PR TITLE
Small matrix calc speedup in collision_distance_field_types

### DIFF
--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -160,7 +160,7 @@ public:
   double getDistanceGradient(double x, double y, double z, double& gradient_x, double& gradient_y, double& gradient_z,
                              bool& in_bounds) const
   {
-    Eigen::Vector3d rel_pos = pose_.inverse() * Eigen::Vector3d(x, y, z);
+    Eigen::Vector3d rel_pos = pose_.linear().transpose() * Eigen::Vector3d(x, y, z);
     double gx, gy, gz;
     double res = distance_field::PropagationDistanceField::getDistanceGradient(rel_pos.x(), rel_pos.y(), rel_pos.z(),
                                                                                gx, gy, gz, in_bounds);

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -160,6 +160,7 @@ public:
   double getDistanceGradient(double x, double y, double z, double& gradient_x, double& gradient_y, double& gradient_z,
                              bool& in_bounds) const
   {
+    // Transpose of a rotation matrix equals its inverse, but computationally cheaper
     Eigen::Vector3d rel_pos = pose_.linear().transpose() * Eigen::Vector3d(x, y, z);
     double gx, gy, gz;
     double res = distance_field::PropagationDistanceField::getDistanceGradient(rel_pos.x(), rel_pos.y(), rel_pos.z(),


### PR DESCRIPTION
I thought it would be a good idea to scour the codebase for places where the fact that [(rotation matrix transpose) == (rot. matrix inverse)](https://www.google.com/search?channel=fs&client=ubuntu&q=transpose+of+rotation+matrix+is+inverse) could be used to speed up calculations. Since a transpose is cheaper than an inverse.

This is the only place I found where that applies.

Eigen has some internal optimizations for Isometry3d types, but I doubt it's smart enough to look ahead and realize it only needs to invert the 3x3 rotation matrix.

Reviewers will need a slightly advanced background in linear algebra, which is why I tagged @mamoll and @v4hn.