### PR TITLE
Error if Octomap 'map_frame' is not provided

### DIFF
--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
@@ -81,6 +81,10 @@ OccupancyMapMonitorMiddlewareHandle::OccupancyMapMonitorMiddlewareHandle(const r
   if (parameters_.map_frame.empty())
   {
     node_->get_parameter("octomap_frame", parameters_.map_frame);
+    if (parameters_.map_frame.empty())
+    {
+      RCLCPP_ERROR(LOGGER, "No 'map_frame' defined for octomap updates");
+    }
   }
 
   std::vector<std::string> sensor_names;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
@@ -83,7 +83,7 @@ OccupancyMapMonitorMiddlewareHandle::OccupancyMapMonitorMiddlewareHandle(const r
     node_->get_parameter("octomap_frame", parameters_.map_frame);
     if (parameters_.map_frame.empty())
     {
-      RCLCPP_ERROR(LOGGER, "No 'map_frame' defined for octomap updates");
+      RCLCPP_ERROR(LOGGER, "No 'octomap_frame' parameter defined for octomap updates");
     }
   }
 


### PR DESCRIPTION
Essentially just a copy of what is done a few lines down, if no "sensors" are provided.