### PR TITLE
mesh_shape: Fix resource group for meshes

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -74,7 +74,7 @@ void MeshShape::beginTriangles()
   if (!started_)
   {
     started_ = true;
-    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST, "rviz_rendering");
   }
 }
 
@@ -126,7 +126,7 @@ void MeshShape::endTriangles()
     entity_ = scene_manager_->createEntity(name);
     if (entity_)
     {
-      entity_->setMaterialName(material_name_);
+      entity_->setMaterialName(material_name_, "rviz_rendering");
       offset_node_->attachObject(entity_);
     }
     else


### PR DESCRIPTION
### Description

Fixes a bug causing RViz to print a ton of error messages about material not existing in the `General` resource group when adding a mesh to the planning scene

```
[rviz2-1] rviz2: Can't assign material Shape94Material to the ManualObject MeshShape_ManualObject0 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape96Material to the ManualObject MeshShape_ManualObject1 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape98Material to the ManualObject MeshShape_ManualObject2 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape100Material to the ManualObject MeshShape_ManualObject3 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape102Material to the ManualObject MeshShape_ManualObject4 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape104Material to the ManualObject MeshShape_ManualObject5 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
[rviz2-1] rviz2: Can't assign material Shape106Material to the ManualObject MeshShape_ManualObject6 because this Material does not exist in group General. Have you forgotten to define it in a .material script?
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
