### PR TITLE
moveit_servo: Fix ACM for collision checking & PSM's scene monitor topic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,14 +58,6 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
-      - name: Cache upstream workspace
-        uses: pat-s/always-upload-cache@v2.1.5
-        with:
-          path: ${{ env.BASEDIR }}/upstream_ws
-          key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
-          restore-keys: ${{ env.CACHE_PREFIX }}
-        env:
-          CACHE_PREFIX: upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: Cache target workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,14 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
+      - name: Cache upstream workspace
+        uses: pat-s/always-upload-cache@v2.1.5
+        with:
+          path: ${{ env.BASEDIR }}/upstream_ws
+          key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
+          restore-keys: ${{ env.CACHE_PREFIX }}
+        env:
+          CACHE_PREFIX: upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: Cache target workspace

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -97,7 +97,6 @@ private:
 
   // Robot state and collision matrix from planning scene
   std::shared_ptr<moveit::core::RobotState> current_state_;
-  collision_detection::AllowedCollisionMatrix acm_;
 
   // Scale robot velocity according to collision proximity and user-defined thresholds.
   // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -83,6 +83,8 @@ struct ServoParameters
   std::string move_group_name;
   std::string planning_frame;
   std::string ee_frame_name;
+  bool is_primary_planning_scene_monitor;
+  std::string monitored_planning_scene_topic;
   // Stopping behaviour
   double incoming_command_timeout;
   int num_outgoing_halt_msgs_to_publish;

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -79,7 +79,6 @@ CollisionCheck::CollisionCheck(rclcpp::Node::SharedPtr node, const ServoParamete
       std::bind(&CollisionCheck::worstCaseStopTimeCB, this, std::placeholders::_1));
 
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
-  acm_ = getLockedPlanningSceneRO()->getAllowedCollisionMatrix();
 }
 
 planning_scene_monitor::LockedPlanningSceneRO CollisionCheck::getLockedPlanningSceneRO() const
@@ -114,8 +113,8 @@ void CollisionCheck::run()
 
   collision_result_.clear();
   // Self-collisions and scene collisions are checked separately so different thresholds can be used
-  getLockedPlanningSceneRO()->getCollisionEnvUnpadded()->checkSelfCollision(collision_request_, collision_result_,
-                                                                            *current_state_, acm_);
+  getLockedPlanningSceneRO()->getCollisionEnvUnpadded()->checkSelfCollision(
+      collision_request_, collision_result_, *current_state_, getLockedPlanningSceneRO()->getAllowedCollisionMatrix());
   self_collision_distance_ = collision_result_.distance;
   collision_detected_ |= collision_result_.collision;
   collision_result_.print();

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -40,6 +40,7 @@
 */
 
 #include <moveit_servo/servo_parameters.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <rclcpp/rclcpp.hpp>
 #include <type_traits>
 
@@ -115,6 +116,11 @@ ServoParameters::SharedConstPtr ServoParameters::makeServoParameters(const rclcp
   declareOrGetParam<std::string>(parameters->move_group_name, ns + ".move_group_name", node, logger);
   declareOrGetParam<std::string>(parameters->planning_frame, ns + ".planning_frame", node, logger);
   declareOrGetParam<std::string>(parameters->ee_frame_name, ns + ".ee_frame_name", node, logger);
+  declareOrGetParam<bool>(parameters->is_primary_planning_scene_monitor, ns + ".is_primary_planning_scene_monitor",
+                          node, logger, true);
+  declareOrGetParam<std::string>(parameters->monitored_planning_scene_topic, ns + ".monitored_planning_scene_topic",
+                                 node, logger,
+                                 planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
 
   // Stopping behaviour
   declareOrGetParam<double>(parameters->incoming_command_timeout, ns + ".incoming_command_timeout", node, logger);


### PR DESCRIPTION
### Description

This fixes two bugs:
1- The collision checking for servo is only using the initial ACM and doesn't reflect the updates PSM is receiving in the scene monitor topic
2- When using servo with move_group, servo's scene monitor should point to the move_group's one, otherwise we can't sync the planning scene between them

For the second point, I'm not sure whether we should have a parameter or always use `monitored_planning_scene` @AndyZe what do you think .? I think this depends on whether the PSM in servo is the primary one or not, right .?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
