### PR TITLE
Only run cache upstream ws if no .repos file changed in PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,18 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
+      - name: Check if upstream dependencies changed
+        id: upstream_ws_changed
+        shell: bash
+        run: |
+          sudo apt-get install -qq jq
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          REPOS_CHANGED='false'
+          if [ -n "$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep "moveit2*.repos")" ]; then REPOS_CHANGED='true';fi
+          echo set-output name=REPOS_CHANGED::${REPOS_CHANGED}
+          echo ::set-output name=REPOS_CHANGED::${REPOS_CHANGED}
       - name: cache upstream_ws
+        if: steps.upstream_ws_changed.outputs.REPOS_CHANGED == 'false'
         uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ env.BASEDIR }}/upstream_ws


### PR DESCRIPTION
### Description

One issue I had in this [PR](https://github.com/ros-planning/moveit2/pull/591) is a conflict between one of the cached upstream packages and the newly added hash for it which was causing the CI to always fail with the following error during `vcs pull $BASEDIR/upstream_ws/src`

```
  === /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/moveit_resources (git) ===
  
  Already on 'pr-moveit_configs_utils'
  Your branch and 'origin/pr-moveit_configs_utils' have diverged,
  and have 1 and 3 different commits each, respectively.
    (use "git pull" to merge the remote branch into yours)
```

This will only affect PRs

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
