### PR TITLE
Add jerk to the robot model

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -63,6 +63,9 @@ struct VariableBounds
     , min_acceleration_(0.0)
     , max_acceleration_(0.0)
     , acceleration_bounded_(false)
+    , min_jerk_(0.0)
+    , max_jerk_(0.0)
+    , jerk_bounded_(false)
   {
   }
 
@@ -77,6 +80,10 @@ struct VariableBounds
   double min_acceleration_;
   double max_acceleration_;
   bool acceleration_bounded_;
+
+  double min_jerk_;
+  double max_jerk_;
+  bool jerk_bounded_;
 };
 
 class LinkModel;

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -183,6 +183,8 @@ void JointModel::computeVariableBoundsMsg()
     lim.has_acceleration_limits = variable_bounds_[i].acceleration_bounded_;
     lim.max_acceleration =
         std::min(fabs(variable_bounds_[i].min_acceleration_), fabs(variable_bounds_[i].max_acceleration_));
+    lim.has_jerk_limits = variable_bounds_[i].jerk_bounded_;
+    lim.max_jerk = std::min(fabs(variable_bounds_[i].min_jerk_), fabs(variable_bounds_[i].max_jerk_));
     variable_bounds_msg_.push_back(lim);
   }
 }
@@ -240,6 +242,11 @@ std::ostream& operator<<(std::ostream& out, const VariableBounds& b)
   printBoundHelper(out, b.min_acceleration_);
   out << ", ";
   printBoundHelper(out, b.max_acceleration_);
+  out << "]; "
+      << "J." << (b.jerk_bounded_ ? "bounded" : "unbounded") << " [";
+  printBoundHelper(out, b.min_jerk_);
+  out << ", ";
+  printBoundHelper(out, b.max_jerk_);
   out << "];";
   return out;
 }

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -157,6 +157,12 @@ void JointModel::setVariableBounds(const std::vector<moveit_msgs::msg::JointLimi
           variable_bounds_[j].min_acceleration_ = -joint_limit.max_acceleration;
           variable_bounds_[j].max_acceleration_ = joint_limit.max_acceleration;
         }
+        variable_bounds_[j].jerk_bounded_ = joint_limit.has_jerk_limits;
+        if (joint_limit.has_jerk_limits)
+        {
+          variable_bounds_[j].min_jerk_ = -joint_limit.max_jerk;
+          variable_bounds_[j].max_jerk_ = joint_limit.max_jerk;
+        }
         break;
       }
   computeVariableBoundsMsg();

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -80,6 +80,18 @@ TEST_F(LoadPlanningModelsPr2, Model)
     ASSERT_EQ(links[i]->getLinkIndex(), static_cast<int>(i));
   }
   moveit::tools::Profiler::Status();
+
+  // This joint has effort and velocity limits defined in the URDF. Nothing else.
+  const std::string joint_name = "fl_caster_rotation_joint";
+  const auto& joint = robot_model_->getJointModel(joint_name);
+  const auto& bounds = joint->getVariableBounds(joint->getName());
+
+  EXPECT_TRUE(bounds.velocity_bounded_);
+  EXPECT_EQ(bounds.max_velocity_, 10.0);
+
+  EXPECT_FALSE(bounds.position_bounded_);
+  EXPECT_FALSE(bounds.acceleration_bounded_);
+  EXPECT_FALSE(bounds.jerk_bounded_);
 }
 
 TEST(SiblingAssociateLinks, SimpleYRobot)

--- a/moveit_ros/planning/robot_model_loader/CMakeLists.txt
+++ b/moveit_ros/planning/robot_model_loader/CMakeLists.txt
@@ -11,6 +11,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf
   Boost
   moveit_core
+  moveit_msgs
 )
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_rdf_loader

--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -180,6 +180,15 @@ void RobotModelLoader::configure(const Options& opt)
           if (node_->get_parameter(param_name, has_acc_limits))
             joint_limit[joint_id].has_acceleration_limits = has_acc_limits;
 
+          param_name = prefix + "has_jerk_limits";
+          if (!node_->has_parameter(param_name))
+          {
+            node_->declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_BOOL);
+          }
+          bool has_jerk_limits = false;
+          if (node_->get_parameter(param_name, has_jerk_limits))
+            joint_limit[joint_id].has_jerk_limits = has_jerk_limits;
+
           if (has_vel_limits)
           {
             param_name = prefix + "max_velocity";
@@ -206,6 +215,21 @@ void RobotModelLoader::configure(const Options& opt)
             if (!node_->get_parameter(param_name, joint_limit[joint_id].max_acceleration))
             {
               RCLCPP_ERROR(LOGGER, "Specified an acceleration limit for joint: %s but did not set a max acceleration",
+                           joint_limit[joint_id].joint_name.c_str());
+            }
+          }
+
+          if (has_jerk_limits)
+          {
+            param_name = prefix + "max_jerk";
+            if (!node_->has_parameter(param_name))
+            {
+              node_->declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_DOUBLE);
+            }
+
+            if (!node_->get_parameter(param_name, joint_limit[joint_id].max_jerk))
+            {
+              RCLCPP_ERROR(LOGGER, "Specified a jerk limit for joint: %s but did not set a max jerk",
                            joint_limit[joint_id].joint_name.c_str());
             }
           }


### PR DESCRIPTION
Now that we have some MoveIt capabilities that can process jerk limits, I think we should add jerk limits to the robot model. This simply adds the jerk parameters to joint_limits.yaml and adds the parsing code to robot_model_loader.cpp.

Fixes #574 