### PR TITLE
getInterfaceDescription: Fix rclcpp API breakage

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -219,7 +219,7 @@ public:
     // wait until future is done
     if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
     {
-      auto response = future_response.get();
+      const auto& response = future_response.get();
       if (!response->planner_interfaces.empty())
       {
         desc = response->planner_interfaces.front();
@@ -235,7 +235,7 @@ public:
     auto future_response = query_service_->async_send_request(req);
     if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
     {
-      auto response = future_response.get();
+      const auto& response = future_response.get();
       if (!response->planner_interfaces.empty())
       {
         desc = response->planner_interfaces;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -214,14 +214,15 @@ public:
   bool getInterfaceDescription(moveit_msgs::msg::PlannerInterfaceDescription& desc)
   {
     auto req = std::make_shared<moveit_msgs::srv::QueryPlannerInterfaces::Request>();
-    auto response = query_service_->async_send_request(req);
+    auto future_response = query_service_->async_send_request(req);
 
     // wait until future is done
-    if (rclcpp::spin_until_future_complete(pnode_, response) == rclcpp::FutureReturnCode::SUCCESS)
+    if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
     {
-      if (!response.get()->planner_interfaces.empty())
+      auto response = future_response.get();
+      if (!response->planner_interfaces.empty())
       {
-        desc = response.get()->planner_interfaces.front();
+        desc = response->planner_interfaces.front();
         return true;
       }
     }
@@ -231,12 +232,13 @@ public:
   bool getInterfaceDescriptions(std::vector<moveit_msgs::msg::PlannerInterfaceDescription>& desc)
   {
     auto req = std::make_shared<moveit_msgs::srv::QueryPlannerInterfaces::Request>();
-    auto res = query_service_->async_send_request(req);
-    if (rclcpp::spin_until_future_complete(pnode_, res) == rclcpp::FutureReturnCode::SUCCESS)
+    auto future_response = query_service_->async_send_request(req);
+    if (rclcpp::spin_until_future_complete(pnode_, future_response) == rclcpp::FutureReturnCode::SUCCESS)
     {
-      if (!res.get()->planner_interfaces.empty())
+      auto response = future_response.get();
+      if (!response->planner_interfaces.empty())
       {
-        desc = res.get()->planner_interfaces;
+        desc = response->planner_interfaces;
         return true;
       }
     }


### PR DESCRIPTION
### Description

https://github.com/ros2/rclcpp/commit/679fb2ba334971d9769b44258df9095025567559 broke the API for `async_send_request`, so using `response.get()` multiple times will throw an exception `std::future_error "No associated state"`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
