### PR TITLE
MoveIt sync

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/occupancy_map.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/occupancy_map.h
@@ -45,7 +45,7 @@
 #include <memory>
 #include <string>
 
-namespace occupancy_map_monitor
+namespace collision_detection
 {
 typedef octomap::OcTreeNode OccMapNode;
 
@@ -118,4 +118,4 @@ private:
 
 using OccMapTreePtr = std::shared_ptr<OccMapTree>;
 using OccMapTreeConstPtr = std::shared_ptr<const OccMapTree>;
-}  // namespace occupancy_map_monitor
+}  // namespace collision_detection

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -36,6 +36,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/collision_detection/occupancy_map.h>
 #include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
 #include <geometric_shapes/shape_operations.h>
 #include <moveit/collision_detection/collision_tools.h>
@@ -379,14 +380,7 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
                                    collision_detection::CollisionResult& res,
                                    const moveit::core::RobotState& robot_state) const
 {
-  // check collision with the world using the padded version
-  getCollisionEnv()->checkRobotCollision(req, res, robot_state, getAllowedCollisionMatrix());
-
-  if (!res.collision || (req.contacts && res.contacts.size() < req.max_contacts))
-  {
-    // do self-collision checking with the unpadded version of the robot
-    getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, getAllowedCollisionMatrix());
-  }
+  checkCollision(req, res, robot_state, getAllowedCollisionMatrix());
 }
 
 void PlanningScene::checkSelfCollision(const collision_detection::CollisionRequest& req,
@@ -1159,6 +1153,26 @@ bool PlanningScene::usePlanningSceneMsg(const moveit_msgs::msg::PlanningScene& s
     return setPlanningSceneMsg(scene_msg);
 }
 
+collision_detection::OccMapTreePtr createOctomap(const octomap_msgs::msg::Octomap& map)
+{
+  std::shared_ptr<collision_detection::OccMapTree> om =
+      std::make_shared<collision_detection::OccMapTree>(map.resolution);
+  if (map.binary)
+  {
+    octomap_msgs::readTree(om.get(), map);
+  }
+  else
+  {
+    std::stringstream datastream;
+    if (map.data.size() > 0)
+    {
+      datastream.write((const char*)&map.data[0], map.data.size());
+      om->readData(datastream);
+    }
+  }
+  return om;
+}
+
 void PlanningScene::processOctomapMsg(const octomap_msgs::msg::Octomap& map)
 {
   // each octomap replaces any previous one
@@ -1173,7 +1187,7 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::msg::Octomap& map)
     return;
   }
 
-  std::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map)));
+  std::shared_ptr<collision_detection::OccMapTree> om = createOctomap(map);
   if (!map.header.frame_id.empty())
   {
     const Eigen::Isometry3d& t = getFrameTransform(map.header.frame_id);
@@ -1211,7 +1225,8 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::msg::OctomapWithPose& 
     return;
   }
 
-  std::shared_ptr<octomap::OcTree> om(static_cast<octomap::OcTree*>(octomap_msgs::msgToMap(map.octomap)));
+  std::shared_ptr<collision_detection::OccMapTree> om = createOctomap(map.octomap);
+
   const Eigen::Isometry3d& t = getFrameTransform(map.header.frame_id);
   Eigen::Isometry3d p;
   tf2::fromMsg(map.origin, p);

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/collision_detection/occupancy_map.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 #include <moveit_msgs/srv/load_map.hpp>
 #include <moveit_msgs/srv/save_map.hpp>
@@ -165,20 +165,16 @@ public:
    */
   void stopMonitor();
 
-  /**
-   * @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
-   *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance.
-   */
-  const OccMapTreePtr& getOcTreePtr()
+  /** @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
+   *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance. */
+  const collision_detection::OccMapTreePtr& getOcTreePtr()
   {
     return tree_;
   }
 
-  /**
-   * @brief Get a const pointer to the underlying octree for this monitor. Lock the
-   *  tree before reading this pointer
-   */
-  const OccMapTreeConstPtr& getOcTreePtr() const
+  /** @brief Get a const pointer to the underlying octree for this monitor. Lock the
+   *  tree before reading this pointer */
+  const collision_detection::OccMapTreeConstPtr& getOcTreePtr() const
   {
     return tree_const_;
   }
@@ -322,8 +318,8 @@ private:
   Parameters parameters_;
   std::mutex parameters_lock_; /*!< Mutex for synchronizing access to parameters */
 
-  OccMapTreePtr tree_;            /*!< Oct map tree */
-  OccMapTreeConstPtr tree_const_; /*!< Shared pointer to a const oct map tree */
+  collision_detection::OccMapTreePtr tree_;            /*!< Oct map tree */
+  collision_detection::OccMapTreeConstPtr tree_const_; /*!< Shared pointer to a const oct map tree */
 
   std::vector<OccupancyMapUpdaterPtr> map_updaters_;             /*!< The Occupancy map updaters */
   std::vector<std::map<ShapeHandle, ShapeHandle>> mesh_handles_; /*!< The mesh handles */

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include <moveit/macros/class_forward.h>
-#include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/collision_detection/occupancy_map.h>
 
 #include <geometric_shapes/shapes.h>
 #include <rclcpp/rclcpp.hpp>
@@ -105,7 +105,7 @@ public:
 protected:
   OccupancyMapMonitor* monitor_;
   std::string type_;
-  OccMapTreePtr tree_;
+  collision_detection::OccMapTreePtr tree_;
   TransformCacheProvider transform_provider_callback_;
   ShapeTransformCache transform_cache_;
   bool debug_info_;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -34,7 +34,8 @@
 
 /* Author: Ioan Sucan, Jon Binney */
 
-#include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/collision_detection/occupancy_map.h>
+
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor_middleware_handle.hpp>
 #include <moveit_msgs/srv/load_map.hpp>
@@ -97,7 +98,7 @@ OccupancyMapMonitor::OccupancyMapMonitor(std::unique_ptr<MiddlewareHandle> middl
                         "No transforms will be applied to received data.");
   }
 
-  tree_ = std::make_shared<OccMapTree>(parameters_.map_resolution);
+  tree_ = std::make_shared<collision_detection::OccMapTree>(parameters_.map_resolution);
   tree_const_ = tree_;
 
   for (const auto& [sensor_name, sensor_type] : parameters_.sensor_plugins)

--- a/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
+++ b/moveit_ros/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/collision_detection/occupancy_map.h>
 #include <boost/thread.hpp>
 #include <deque>
 #include <unordered_map>
@@ -46,7 +46,7 @@ namespace occupancy_map_monitor
 class LazyFreeSpaceUpdater
 {
 public:
-  LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned int max_batch_size = 10);
+  LazyFreeSpaceUpdater(const collision_detection::OccMapTreePtr& tree, unsigned int max_batch_size = 10);
   ~LazyFreeSpaceUpdater();
 
   void pushLazyUpdate(octomap::KeySet* occupied_cells, octomap::KeySet* model_cells,
@@ -67,7 +67,7 @@ private:
   void lazyUpdateThread();
   void processThread();
 
-  OccMapTreePtr tree_;
+  collision_detection::OccMapTreePtr tree_;
   bool running_;
   std::size_t max_batch_size_;
   double max_sensor_delta_;

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -42,7 +42,7 @@ namespace occupancy_map_monitor
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.perception.lazy_free_space_updater");
 
-LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr& tree, unsigned int max_batch_size)
+LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const collision_detection::OccMapTreePtr& tree, unsigned int max_batch_size)
   : tree_(tree)
   , running_(true)
   , max_batch_size_(max_batch_size)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -396,7 +396,7 @@ void PlanningSceneMonitor::scenePublishingThread()
   {
     moveit_msgs::msg::PlanningScene msg;
     {
-      occupancy_map_monitor::OccMapTree::ReadLock lock;
+      collision_detection::OccMapTree::ReadLock lock;
       if (octomap_monitor_)
         lock = octomap_monitor_->getOcTreePtr()->reading();
       scene_->getPlanningSceneMsg(msg);
@@ -423,7 +423,7 @@ void PlanningSceneMonitor::scenePublishingThread()
             is_full = true;
           else
           {
-            occupancy_map_monitor::OccMapTree::ReadLock lock;
+            collision_detection::OccMapTree::ReadLock lock;
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
@@ -454,7 +454,7 @@ void PlanningSceneMonitor::scenePublishingThread()
           }
           if (is_full)
           {
-            occupancy_map_monitor::OccMapTree::ReadLock lock;
+            collision_detection::OccMapTree::ReadLock lock;
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneMsg(msg);

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/default_warehouse_db.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/default_warehouse_db.launch
@@ -5,7 +5,7 @@
   <arg name="moveit_warehouse_database_path" default="$(find [GENERATED_PACKAGE_NAME])/default_warehouse_mongo_db" />
 
   <!-- Launch the warehouse with the configured database location -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo.launch
@@ -43,7 +43,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="execution_type" value="$(arg execution_type)"/>
@@ -54,13 +54,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch" if="$(arg use_rviz)">
+  <include file="$(dirname)/moveit_rviz.launch" if="$(arg use_rviz)">
     <arg name="rviz_config" value="$(find [GENERATED_PACKAGE_NAME])/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/demo_gazebo.launch
@@ -28,7 +28,7 @@
   <arg name="urdf_path" default="[URDF_LOCATION]"/>
 
   <!-- launch the gazebo simulator and spawn the robot -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/gazebo.launch" >
+  <include file="$(dirname)/gazebo.launch" >
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
     <arg name="urdf_path" value="$(arg urdf_path)"/>
@@ -51,7 +51,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
@@ -60,13 +60,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/moveit_rviz.launch">
+  <include file="$(dirname)/moveit_rviz.launch">
     <arg name="rviz_config" value="$(find [GENERATED_PACKAGE_NAME])/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/edit_configuration_package.launch
@@ -10,6 +10,7 @@
   <node pkg="moveit_setup_assistant" type="moveit_setup_assistant" name="moveit_setup_assistant"
         args="--config_pkg=[GENERATED_PACKAGE_NAME]"
         launch-prefix="$(arg launch_prefix)"
+        required="true"
         output="screen" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/gazebo.launch
@@ -18,6 +18,6 @@
   <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -x 0 -y 0 -z 0"
     respawn="false" output="screen" />
 
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/ros_controllers.launch"/>
+  <include file="$(dirname)/ros_controllers.launch"/>
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -4,7 +4,7 @@
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix"
-           value="gdb -x $(find [GENERATED_PACKAGE_NAME])/launch/gdb_settings.gdb --ex run --args" />
+           value="gdb -x $(dirname)/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />
@@ -39,7 +39,7 @@
 
   <arg name="load_robot_description" default="true" />
   <!-- load URDF, SRDF and joint_limits configuration -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
   </include>
 
@@ -47,29 +47,29 @@
   <group ns="move_group/planning_pipelines">
 
     <!-- OMPL -->
-    <include ns="ompl" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
     <!-- CHOMP -->
-    <include ns="chomp" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
     <!-- Pilz Industrial Motion-->
-    <include ns="pilz_industrial_motion_planner" file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Support custom planning pipeline -->
     <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])"
-	     file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_pipeline.launch.xml">
+	     file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
   </group>
 
   <!-- Trajectory Execution Functionality -->
-  <include ns="move_group" file="$(find [GENERATED_PACKAGE_NAME])/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="[ROBOT_NAME]" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
@@ -77,7 +77,7 @@
   </include>
 
   <!-- Sensors Functionality -->
-  <include ns="move_group" file="$(find [GENERATED_PACKAGE_NAME])/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_sensor_manager" value="[ROBOT_NAME]" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
@@ -5,6 +5,6 @@
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_ompl.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/run_benchmark_ompl.launch
@@ -4,12 +4,12 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_ompl_benchmark_warehouse"/>
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/sensor_manager.launch.xml
@@ -12,6 +12,6 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="[ROBOT_NAME]" />
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  <include file="$(dirname)/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
 
 </launch>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajectory_execution.launch.xml
@@ -17,7 +17,7 @@
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="[ROBOT_NAME]" />
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
+  <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="execution_type" value="$(arg execution_type)" />
   </include>
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/warehouse.launch
@@ -4,7 +4,7 @@
   <arg name="moveit_warehouse_database_path" />
 
   <!-- Load warehouse parameters -->
-  <include file="$(find [GENERATED_PACKAGE_NAME])/launch/warehouse_settings.launch.xml" />
+  <include file="$(dirname)/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">


### PR DESCRIPTION
- Move OccMapTree to moveit_core/collision_detection
- Implement checkCollision with default ACM as wrapper
- use lockable octomap for MotionPlanningDisplay as well
- Remove gtest include from non-testing source (#2747)
- MSA: kill setup_assistant.launch after MSA finished (#2749)
- use $(dirname) in MoveIt Setup Assistant (#2748)

### Description

MoveIt1 -> MoveIt2 sync of smaller size that hopefully is simple enough to review.  I'm sorry about the mess that was the last one.
