### PR TITLE
Fix source versions of ros2_control, ros2_controllers

### DIFF
--- a/moveit2_galactic.repos
+++ b/moveit2_galactic.repos
@@ -3,8 +3,8 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control
-    version: master
+    version: 0.8.0
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: 0.5.0


### PR DESCRIPTION
Fixes CI by only installing released versions for Galactic. This should also prevent sync issues in the future.