### PR TITLE
Fix cmake warnings

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -56,12 +56,12 @@ namespace
 void checkFCLCapabilities(const DistanceRequest& req)
 {
 #if MOVEIT_FCL_VERSION < FCL_VERSION_CHECK(0, 6, 0)
-  static rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   if (req.enable_nearest_points)
   {
     // Known issues:
     //   https://github.com/flexible-collision-library/fcl/issues/171,
     //   https://github.com/flexible-collision-library/fcl/pull/288
+    rclcpp::Clock steady_clock(RCL_STEADY_TIME);
     RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 2000,
                           "You requested a distance check with enable_nearest_points=true, "
                           "but the FCL version MoveIt was compiled against (%d.%d.%d) "

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -173,7 +173,7 @@ void Profiler::console()
   std::stringstream ss;
   ss << std::endl;
   status(ss, true);
-  RCLCPP_INFO(LOGGER, ss.str().c_str());
+  RCLCPP_INFO(LOGGER, "%s", ss.str().c_str());
 }
 
 /// @cond IGNORE

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -476,8 +476,8 @@ TEST_F(KinematicsTest, unitIK)
   };
 
   std::vector<double> ground_truth, pose_values;
-  constexpr char post_type_relative[] = "relative";
-  constexpr char post_type_absolute[] = "absolute";
+  constexpr char pose_type_relative[] = "relative";
+  constexpr char pose_type_absolute[] = "absolute";
 
   /* process tests definitions on parameter server of the form
      pose_1:

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -510,15 +510,15 @@ TEST_F(KinematicsTest, unitIK)
 
     Eigen::Isometry3d pose;
     ASSERT_TRUE(parsePose(pose_values, pose)) << "Failed to parse 'pose' vector in: " << pose_name;
-    std::string pose_type = "post_type_relative";
+    std::string pose_type = "pose_type_relative";
     node_->get_parameter_or(pose_param + ".type", pose_type, pose_type);
-    if (pose_type == post_type_relative)
+    if (pose_type == pose_type_relative)
       goal = goal * pose;
-    else if (pose_type == post_type_absolute)
+    else if (pose_type == pose_type_absolute)
       goal = pose;
     else
-      FAIL() << "Found invalid 'type' in " << pose_name << ": should be one of '" << post_type_relative << "' or '"
-             << post_type_absolute << "'";
+      FAIL() << "Found invalid 'type' in " << pose_name << ": should be one of '" << pose_type_relative << "' or '"
+             << pose_type_absolute << "'";
 
     std::string desc;
     {

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -476,8 +476,8 @@ TEST_F(KinematicsTest, unitIK)
   };
 
   std::vector<double> ground_truth, pose_values;
-  constexpr char POSE_TYPE_RELATIVE[] = "relative";
-  constexpr char POSE_TYPE_ABSOLUTE[] = "absolute";
+  constexpr char post_type_relative[] = "relative";
+  constexpr char post_type_absolute[] = "absolute";
 
   /* process tests definitions on parameter server of the form
      pose_1:
@@ -510,15 +510,15 @@ TEST_F(KinematicsTest, unitIK)
 
     Eigen::Isometry3d pose;
     ASSERT_TRUE(parsePose(pose_values, pose)) << "Failed to parse 'pose' vector in: " << pose_name;
-    std::string pose_type = "POSE_TYPE_RELATIVE";
+    std::string pose_type = "post_type_relative";
     node_->get_parameter_or(pose_param + ".type", pose_type, pose_type);
-    if (pose_type == POSE_TYPE_RELATIVE)
+    if (pose_type == post_type_relative)
       goal = goal * pose;
-    else if (pose_type == POSE_TYPE_ABSOLUTE)
+    else if (pose_type == post_type_absolute)
       goal = pose;
     else
-      FAIL() << "Found invalid 'type' in " << pose_name << ": should be one of '" << POSE_TYPE_RELATIVE << "' or '"
-             << POSE_TYPE_ABSOLUTE << "'";
+      FAIL() << "Found invalid 'type' in " << pose_name << ": should be one of '" << post_type_relative << "' or '"
+             << post_type_absolute << "'";
 
     std::string desc;
     {

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -63,7 +63,6 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("test_kinematics_plugin"
 const std::string ROBOT_DESCRIPTION_PARAM = "robot_description";
 const double DEFAULT_SEARCH_DISCRETIZATION = 0.01f;
 const double EXPECTED_SUCCESS_RATE = 0.8;
-const double DEFAULT_TOLERANCE = 1e-5;
 static const std::string UNDEFINED = "<undefined>";
 
 // As loading of parameters is quite slow, we share them across all tests

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -492,8 +492,8 @@ TEST_F(KinematicsTest, unitIK)
   for (size_t i = 0; i < expected_test_poses; ++i)  // NOLINT(modernize-loop-convert)
   {
     const std::string pose_name = "pose_" + std::to_string(i);
-    const std::string pose_param = TEST_POSES_PARAM + "." + pose_name;
-    goal = initial;  // reset goal to initial
+    const std::string pose_param = TEST_POSES_PARAM + "." + pose_name;  // NOLINT
+    goal = initial;                                                     // reset goal to initial
     ground_truth.clear();
 
     node_->get_parameter_or(pose_param + ".joints", ground_truth, ground_truth);

--- a/moveit_planners/ompl/ompl_interface/test/test_threadsafe_state_storage.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_threadsafe_state_storage.cpp
@@ -42,9 +42,6 @@ The skeleton of this test was taken from test_state_validity_checker.cpp by Jero
 #include <moveit/ompl_interface/detail/threadsafe_state_storage.h>
 #include <gtest/gtest.h>
 
-/** \brief This flag sets the verbosity level for the state validity checker. **/
-constexpr bool VERBOSE = false;
-
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ompl_planning.test.test_thread_safe_storage");
 
 /** \brief Generic implementation of the tests that can be executed on different robots. **/

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -139,7 +139,7 @@ public:
   virtual void
   controllerDoneCallback(const typename rclcpp_action::ClientGoalHandle<T>::WrappedResult& wrapped_result) = 0;
 
-  bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration(-1)) override
+  bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration::from_seconds(-1.0)) override
   {
     auto result_callback_done = std::make_shared<std::promise<bool>>();
     auto result_future = controller_action_client_->async_get_result(

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -110,11 +110,6 @@ private:
   bool paused_ = false;
 
   // Variables for stop-distance-based collision checking
-  double current_collision_distance_ = 0;
-  double derivative_of_collision_distance_ = 0;
-  double prev_collision_distance_ = 0;
-  double est_time_to_collision_ = 0;
-  double safety_factor_ = 1000;
   double worst_case_stop_time_ = std::numeric_limits<double>::max();
 
   const double self_velocity_scale_coefficient_;

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -44,7 +44,6 @@
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.collision_check");
 static const double MIN_RECOMMENDED_COLLISION_RATE = 10;
-constexpr double EPSILON = 1e-6;                       // For very small numeric comparisons
 constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30 * 1000;  // Milliseconds to throttle logs inside loops
 
 namespace moveit_servo

--- a/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
+++ b/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
@@ -42,8 +42,6 @@
 
 namespace
 {
-constexpr double EPSILON = 5e-3;
-constexpr double PANDA_MAX_JOINT_VEL = 2.610;  // rad/s
 constexpr double PUBLISH_PERIOD = 0.01;
 
 void checkVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const Eigen::ArrayXd& delta_theta)


### PR DESCRIPTION
This fixes the build warnings discovered here https://github.com/ros-planning/moveit2/runs/3662305871?check_suite_focus=true#step:8:689. Should we enforce the build to be free of warnings?