### PR TITLE
Add backport bot

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Backport
     steps:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,3 +1,7 @@
+# Backporting Github Actions that ports a given PR to specified branch (via backport branch_name label) if the following conditions are met:
+# 1) The PR is merged
+# 2) The PR has a label of "backport branch_name" and branch_name is an existing branch.
+# The label can be specified before or after the original PR is merged. Once these two conditions are met the bot will open a backport PR.
 name: Backport
 on:
   pull_request:


### PR DESCRIPTION
Closes #669 and adds a simple backport bot that backports desired PRs. So the backport conditions are:

- PRs should be labeled as in `backport branch` format (ie: `backport foxy` or `backport main`)
- The backport PR will be opened by github-actions bot, after the original PR is merged.

Thus, I appreciate if you can create these labels @henningkayser.

I've tested this in my fork and seemed to work nicely, see https://github.com/vatanaksoytezer/moveit2/pull/20 and https://github.com/vatanaksoytezer/moveit2/pull/19.