### PR TITLE
Switch back to using master branch of ros2_control repos

### DIFF
--- a/moveit2_galactic.repos
+++ b/moveit2_galactic.repos
@@ -3,8 +3,8 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control
-    version: 0.8.0
+    version: master
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: 0.5.0
+    version: master


### PR DESCRIPTION
### Description

This is a test to see if we can switch back to using the ros2_control repo master branches for Galactic.  I was told today in the WG meeting that it should now work again.