### PR TITLE
Fix broken test

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -489,9 +489,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
 
   double dist_threshold = cdata->req->distance_threshold;
 
-  const std::pair<const std::string&, const std::string&> pc = cd1->getID() < cd2->getID() ?
-                                                                   std::make_pair(cd1->getID(), cd2->getID()) :
-                                                                   std::make_pair(cd2->getID(), cd1->getID());
+  const std::pair<const std::string&, const std::string&> pc =
+      cd1->getID() < cd2->getID() ? std::make_pair(std::cref(cd1->getID()), std::cref(cd2->getID())) :
+                                    std::make_pair(std::cref(cd2->getID()), std::cref(cd1->getID()));
 
   DistanceMap::iterator it = cdata->res->distances.find(pc);
 


### PR DESCRIPTION
Port of https://github.com/ros-planning/moveit/pull/2820 to fix https://github.com/ros-planning/moveit2/actions/runs/1267421632
Because std::make_pair uses the decayed type (std::string), the strings were actually copied into a temporary, which was subsequently referenced by the elements of std::pair, leading to a stack-use-after-scope error.
Explicitly passing const references into std::make_pair via std::cref() resolves the issue mentioned in #2809.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
