### PR TITLE
Skip publishing to Servo topics if input commands are stale

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -383,14 +383,6 @@ void ServoCalcs::calculateSingleIteration()
     }
   }
 
-  // Print a warning to the user if both are stale
-  if (twist_command_is_stale_ && joint_command_is_stale_)
-  {
-    rclcpp::Clock& clock = *node_->get_clock();
-    RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
-                                "Stale command. Try a larger 'incoming_command_timeout' parameter?");
-  }
-
   // If we should halt
   if (!have_nonzero_command_)
   {
@@ -414,7 +406,7 @@ void ServoCalcs::calculateSingleIteration()
     ok_to_publish_ = false;
     rclcpp::Clock& clock = *node_->get_clock();
     RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
-                                 "Skipping publishing because commands are stale.");
+                                 "Skipping publishing because incoming commands are stale.");
   }
   else
   {

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -408,6 +408,14 @@ void ServoCalcs::calculateSingleIteration()
     rclcpp::Clock& clock = *node_->get_clock();
     RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD, "All-zero command. Doing nothing.");
   }
+  // Skip servoing publication if both types of commands are stale.
+  else if (twist_command_is_stale_ && joint_command_is_stale_)
+  {
+    ok_to_publish_ = false;
+    rclcpp::Clock& clock = *node_->get_clock();
+    RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                 "Skipping publishing because commands are stale.");
+  }
   else
   {
     ok_to_publish_ = true;


### PR DESCRIPTION
### Description

While the servo update loop currently includes a check to see if the latest messages on the joint and Cartesian command topics are up-to-date, this does not actually stop Servo from continuing to publish joint control messages even if the commands are stale. If both command topics are stale, the `joint_trajectory` message used to create the control messages is [populated with the last-commanded positions and zero velocities](https://github.com/ros-planning/moveit2/blob/d184714751b347a2389cf1e8742b1be94eed63b8/moveit_ros/moveit_servo/src/servo_calcs.cpp#L376-L384). This can cause problems if Servo is paused and another method is used to move the robot, since when Servo is unpaused it will publish a control message to the last-commanded position, which could be a significant distance from the robot's current state.

This PR adds an additional check to prevent publishing control messages if both command topics are stale. Control publishing will resume once a new joint or Carteisan command message is received.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
