### PR TITLE
RobotTrajectory as standard container

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -279,13 +279,10 @@ public:
    */
   bool getStateAtDurationFromStart(const double request_duration, moveit::core::RobotStatePtr& output_state) const;
 
-  class Iterator : public std::iterator<std::input_iterator_tag, std::pair<moveit::core::RobotStatePtr, double>, long,
-                                        const std::pair<moveit::core::RobotStatePtr, double>*,
-                                        std::pair<moveit::core::RobotStatePtr, double> >
+  class Iterator
   {
     std::deque<moveit::core::RobotStatePtr>::iterator waypoint_iterator;
     std::deque<double>::iterator duration_iterator;
-    bool duration_is_empty = false;
 
   public:
     explicit Iterator(std::deque<moveit::core::RobotStatePtr>::iterator _waypoint_iterator,
@@ -313,10 +310,17 @@ public:
     {
       return !(*this == other);
     }
-    reference operator*() const
+    std::pair<moveit::core::RobotStatePtr, double> operator*() const
     {
       return std::pair{ *waypoint_iterator, *duration_iterator };
     }
+
+    // iterator traits
+    using difference_type = long;
+    using value_type = std::pair<moveit::core::RobotStatePtr, double>;
+    using pointer = const std::pair<moveit::core::RobotStatePtr, double>*;
+    using reference = std::pair<moveit::core::RobotStatePtr, double>;
+    using iterator_category = std::input_iterator_tag;
   };
 
   RobotTrajectory::Iterator begin()

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -279,7 +279,7 @@ public:
    */
   bool getStateAtDurationFromStart(const double request_duration, moveit::core::RobotStatePtr& output_state) const;
 
-  class iterator : public std::iterator<std::input_iterator_tag, std::pair<moveit::core::RobotStatePtr, double>, long,
+  class Iterator : public std::iterator<std::input_iterator_tag, std::pair<moveit::core::RobotStatePtr, double>, long,
                                         const std::pair<moveit::core::RobotStatePtr, double>*,
                                         std::pair<moveit::core::RobotStatePtr, double> >
   {
@@ -288,28 +288,28 @@ public:
     bool duration_is_empty = false;
 
   public:
-    explicit iterator(std::deque<moveit::core::RobotStatePtr>::iterator _waypoint_iterator,
+    explicit Iterator(std::deque<moveit::core::RobotStatePtr>::iterator _waypoint_iterator,
                       std::deque<double>::iterator _duration_iterator)
       : waypoint_iterator(_waypoint_iterator), duration_iterator(_duration_iterator)
     {
     }
-    iterator& operator++()
+    Iterator& operator++()
     {
       waypoint_iterator++;
       duration_iterator++;
       return *this;
     }
-    iterator operator++(int)
+    Iterator operator++(int)
     {
-      iterator retval = *this;
+      Iterator retval = *this;
       ++(*this);
       return retval;
     }
-    bool operator==(iterator other) const
+    bool operator==(Iterator other) const
     {
       return ((waypoint_iterator == other.waypoint_iterator) && (duration_iterator == other.duration_iterator));
     }
-    bool operator!=(iterator other) const
+    bool operator!=(Iterator other) const
     {
       return !(*this == other);
     }
@@ -319,15 +319,15 @@ public:
     }
   };
 
-  RobotTrajectory::iterator begin()
+  RobotTrajectory::Iterator begin()
   {
     assert(waypoints_.size() == duration_from_previous_.size());
-    return iterator(waypoints_.begin(), duration_from_previous_.begin());
+    return Iterator(waypoints_.begin(), duration_from_previous_.begin());
   }
-  RobotTrajectory::iterator end()
+  RobotTrajectory::Iterator end()
   {
     assert(waypoints_.size() == duration_from_previous_.size());
-    return iterator(waypoints_.end(), duration_from_previous_.end());
+    return Iterator(waypoints_.end(), duration_from_previous_.end());
   }
   /** @brief Print information about the trajectory
    * @param out              Stream to print to

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -315,7 +315,7 @@ public:
     }
     reference operator*() const
     {
-      return std::pair<moveit::core::RobotStatePtr, double>(*waypoint_iterator, *duration_iterator);
+      return std::pair{*waypoint_iterator, *duration_iterator};
     }
   };
 

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -315,7 +315,7 @@ public:
     }
     reference operator*() const
     {
-      return std::pair{*waypoint_iterator, *duration_iterator};
+      return std::pair{ *waypoint_iterator, *duration_iterator };
     }
   };
 

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -75,7 +75,7 @@ protected:
     double duration_from_previous = 0.1;
     std::size_t waypoint_count = 5;
     for (std::size_t ix = 0; ix < waypoint_count; ++ix)
-      trajectory->addSuffixWayPoint(robot_state_, duration_from_previous);
+      trajectory->addSuffixWayPoint(*robot_state_, duration_from_previous);
     // Quick check that getDuration is working correctly
     EXPECT_EQ(trajectory->getDuration(), duration_from_previous * waypoint_count)
         << "Generated trajectory duration incorrect";

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -226,9 +226,9 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryIterator)
   }
 
   unsigned int count = 0;
-  for (auto waypoint_and_duration : *trajectory)
+  for (const auto& waypoint_and_duration : *trajectory)
   {
-    auto waypoint = waypoint_and_duration.first;
+    const auto& waypoint = waypoint_and_duration.first;
     waypoint->copyJointGroupPositions(arm_jmg_name_, positions);
     EXPECT_EQ(start_pos + count * 0.01, positions[0]);
     count++;

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -81,6 +81,7 @@ protected:
         << "Generated trajectory duration incorrect";
     EXPECT_EQ(waypoint_count, trajectory->getWayPointDurations().size())
         << "Generated trajectory has the wrong number of waypoints";
+    EXPECT_EQ(waypoint_count, trajectory->size());
   }
 
   void copyTrajectory(const robot_trajectory::RobotTrajectoryPtr& trajectory,
@@ -202,6 +203,50 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDeepCopy)
 
   // Check that we updated the value correctly in the trajectory
   EXPECT_NE(trajectory_first_state_after_update[0], trajectory_copy_first_state_after_update[0]);
+}
+
+TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryIterator)
+{
+  robot_trajectory::RobotTrajectoryPtr trajectory;
+  initTestTrajectory(trajectory);
+
+  ASSERT_EQ(5u, trajectory->size());
+  std::vector<double> positions;
+
+  double start_pos = 0.0;
+
+  for (size_t i = 0; i < trajectory->size(); i++)
+  {
+    auto waypoint = trajectory->getWayPointPtr(i);
+    // modify joint values
+    waypoint->copyJointGroupPositions(arm_jmg_name_, positions);
+    start_pos = positions[0];
+    positions[0] += 0.01 * i;
+    waypoint->setJointGroupPositions(arm_jmg_name_, positions);
+  }
+
+  unsigned int count = 0;
+  for (auto waypoint_and_duration : *trajectory)
+  {
+    auto waypoint = waypoint_and_duration.first;
+    waypoint->copyJointGroupPositions(arm_jmg_name_, positions);
+    EXPECT_EQ(start_pos + count * 0.01, positions[0]);
+    count++;
+  }
+
+  EXPECT_EQ(count, trajectory->size());
+
+  // Consistency checks
+  EXPECT_EQ(trajectory->begin(), trajectory->begin());
+  EXPECT_EQ(trajectory->end(), trajectory->end());
+
+  // trajectory has length 5; incrementing begin 5 times should reach the end
+  EXPECT_NE(trajectory->begin(), trajectory->end());
+  EXPECT_NE(++trajectory->begin(), trajectory->end());
+  EXPECT_NE(++(++trajectory->begin()), trajectory->end());
+  EXPECT_NE(++(++(++trajectory->begin())), trajectory->end());
+  EXPECT_NE(++(++(++(++trajectory->begin()))), trajectory->end());
+  EXPECT_EQ(++(++(++(++(++trajectory->begin())))), trajectory->end());
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

Ported version of https://github.com/ros-planning/moveit/pull/1162 for MoveIt2. This currently does not have any tests. 

- [x] Add iterator to RobotTrajectory class.
- [x] Add .size() method to RobotTrajectory class.
- [x] Add basic tests for RobotTrajectory class.
- [x] ~~Add equality operator for RobotState class in order to complete RobotTrajectory tests.~~ Note: This seems outside the scope. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
