### PR TITLE
Ported the collisions_updater to ROS2

### DIFF
--- a/moveit_collisions_updater/CMakeLists.txt
+++ b/moveit_collisions_updater/CMakeLists.txt
@@ -1,0 +1,91 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(moveit_collisions_updater)
+
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_ros_visualization REQUIRED)
+find_package(rviz2 REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(urdf REQUIRED)
+find_package(srdfdom REQUIRED)
+find_package(ompl REQUIRED)
+
+
+# Tools Library
+add_library(${PROJECT_NAME}_tools
+  src/tools/compute_default_collisions.cpp
+  src/tools/moveit_config_data.cpp
+)
+target_include_directories(${PROJECT_NAME}_tools PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${OMPL_INCLUDE_DIRS}
+)
+ament_target_dependencies(
+  ${PROJECT_NAME}_tools
+  "moveit_core"
+  "moveit_ros_planning"
+  "moveit_ros_visualization"
+  "rviz2"
+  "rviz_common"
+  "rclcpp"
+  "urdf"
+  "srdfdom"
+)
+
+add_executable(${PROJECT_NAME} src/collisions_updater.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_link_libraries(
+  ${PROJECT_NAME}
+  ${PROJECT_NAME}_tools
+)
+
+ament_target_dependencies(
+  ${PROJECT_NAME}
+  "moveit_core"
+  "moveit_ros_planning"
+  "moveit_ros_visualization"
+  "rviz2"
+  "rviz_common"
+  "rclcpp"
+  "urdf"
+  "srdfdom"
+)
+
+install(
+  TARGETS
+    ${PROJECT_NAME}
+  DESTINATION
+    lib/${PROJECT_NAME}
+)
+
+install(TARGETS ${PROJECT_NAME}_tools
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Unit tests
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  # These don't pass yet, disable them for now
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cppcheck_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_uncrustify_FOUND TRUE)
+
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/moveit_collisions_updater/README.md
+++ b/moveit_collisions_updater/README.md
@@ -1,0 +1,5 @@
+# MoveIt Collisions Updater
+
+To run the collision updater:
+
+ros2 run moveit_collisions_updater moveit_collisions_updater --urdf robot.urdf --srdf robot.srdf  --trials 100000

--- a/moveit_collisions_updater/include/moveit/collisions_updater/tools/compute_default_collisions.hpp
+++ b/moveit_collisions_updater/include/moveit/collisions_updater/tools/compute_default_collisions.hpp
@@ -1,0 +1,111 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman */
+
+#pragma once
+
+#include <map>
+#include <moveit/macros/class_forward.h>
+namespace planning_scene
+{
+MOVEIT_CLASS_FORWARD(PlanningScene);  // Defines PlanningScenePtr, ConstPtr, WeakPtr... etc
+}
+
+namespace moveit_collisions_updater
+{
+/**
+ * \brief Reasons for disabling link pairs. Append "in collision" for understanding.
+ * NOT_DISABLED means the link pair DOES do self collision checking
+ */
+enum DisabledReason
+{
+  NEVER,
+  DEFAULT,
+  ADJACENT,
+  ALWAYS,
+  USER,
+  NOT_DISABLED
+};
+
+/**
+ * \brief Store details on a pair of links
+ */
+struct LinkPairData
+{
+  // by default all link pairs are NOT disabled for collision checking
+  LinkPairData() : reason(NOT_DISABLED), disable_check(false){};
+  DisabledReason reason;
+  bool disable_check;
+};
+
+/**
+ * \brief LinkPairMap is an adjacency list structure containing links in string-based form. Used for disabled links
+ */
+typedef std::map<std::pair<std::string, std::string>, LinkPairData> LinkPairMap;
+
+/**
+ * \brief Generate an adjacency list of links that are always and never in collision, to speed up collision detection
+ * \param parent_scene A reference to the robot in the planning scene
+ * \param include_never_colliding Flag to disable the check for links that are never in collision
+ * \param trials Set the number random collision checks that are made. Increase the probability of correctness
+ * \param min_collision_fraction If collisions are found between a pair of links >= this fraction, the are assumed
+ * "always" in collision
+ * \return Adj List of unique set of pairs of links in string-based form
+ */
+LinkPairMap computeDefaultCollisions(const planning_scene::PlanningSceneConstPtr& parent_scene, unsigned int* progress,
+                                     const bool include_never_colliding, const unsigned int trials,
+                                     const double min_collision_faction, const bool verbose);
+
+/**
+ * \brief Generate a list of unique link pairs for all links with geometry. Order pairs alphabetically. n choose 2 pairs
+ * \param scene A reference to the robot in the planning scene
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ **/
+void computeLinkPairs(const planning_scene::PlanningScene& scene, LinkPairMap& link_pairs);
+
+/**
+ * \brief Converts a reason for disabling a link pair into a string
+ * \param reason enum reason type
+ * \return reason as string
+ */
+const std::string disabledReasonToString(DisabledReason reason);
+
+/**
+ * \brief Converts a string reason for disabling a link pair into a struct data type
+ * \param reason string that should match one of the DisableReason types. If not, is set as "USER"
+ * \return reason as struct
+ */
+DisabledReason disabledReasonFromString(const std::string& reason);
+}  // namespace moveit_collisions_updater

--- a/moveit_collisions_updater/include/moveit/collisions_updater/tools/moveit_config_data.hpp
+++ b/moveit_collisions_updater/include/moveit/collisions_updater/tools/moveit_config_data.hpp
@@ -1,0 +1,541 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman */
+
+#pragma once
+
+#include <moveit/macros/class_forward.h>
+#include <moveit/planning_scene/planning_scene.h>                          // for getting kinematic model
+#include <moveit/collisions_updater/tools/compute_default_collisions.hpp>  // for LinkPairMap
+#include <yaml-cpp/yaml.h>                                                 // outputting yaml config files
+#include <urdf/model.h>                                                    // to share throughout app
+#include <srdfdom/srdf_writer.h>                                           // for writing srdf data
+
+#include <utility>
+
+namespace moveit_collisions_updater
+{
+// ******************************************************************************************
+// Constants
+// ******************************************************************************************
+
+// Used for loading kinematic model
+static const std::string ROBOT_DESCRIPTION = "robot_description";
+static const std::string MOVEIT_ROBOT_STATE = "moveit_robot_state";
+
+// Default kin solver values
+static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION = 0.005;
+static const double DEFAULT_KIN_SOLVER_TIMEOUT = 0.005;
+
+// ******************************************************************************************
+// Structs
+// ******************************************************************************************
+
+/**
+ * Planning groups extra data not found in srdf but used in config files
+ */
+struct GroupMetaData
+{
+  std::string kinematics_solver_;               // Name of kinematics plugin to use
+  double kinematics_solver_search_resolution_;  // resolution to use with solver
+  double kinematics_solver_timeout_;            // solver timeout
+  std::string kinematics_parameters_file_;      // file for additional kinematics parameters
+  std::string default_planner_;                 // Name of the default planner to use
+};
+
+/**
+ * ROS Controllers settings which may be set in the config files
+ */
+struct ROSControlConfig
+{
+  std::string name_;                 // controller name
+  std::string type_;                 // controller type
+  std::vector<std::string> joints_;  // joints controller by this controller
+};
+
+/**
+ * Planning parameters which may be set in the config files
+ */
+struct OmplPlanningParameter
+{
+  std::string name;     // name of parameter
+  std::string value;    // value parameter will receive (but as a string)
+  std::string comment;  // comment briefly describing what this parameter does
+};
+
+/** \brief This class describes the OMPL planners by name, type, and parameter list, used to create the
+ * ompl_planning.yaml file */
+class OMPLPlannerDescription
+{
+public:
+  /** \brief Constructor
+   *  @param name: name of planner
+   *  @parameter type: type of planner
+   */
+  OMPLPlannerDescription(const std::string& name, const std::string& type)
+  {
+    name_ = name;
+    type_ = type;
+  };
+  /** \brief Destructor */
+  ~OMPLPlannerDescription()
+  {
+    parameter_list_.clear();
+  };
+  /** \brief adds a parameter to the planner description
+   * @param name: name of parameter to add
+   * @parameter: value: value of parameter as a string
+   *  @parameter: value: value of parameter as a string
+   */
+  void addParameter(const std::string& name, const std::string& value = "", const std::string& comment = "")
+  {
+    OmplPlanningParameter temp;
+    temp.name = name;
+    temp.value = value;
+    temp.comment = comment;
+    parameter_list_.push_back(temp);
+  }
+  std::vector<OmplPlanningParameter> parameter_list_;
+  std::string name_;  // name of planner
+  std::string type_;  // type of planner (geometric)
+};
+
+/**
+ * Reusable parameter class which may be used in reading and writing configuration files
+ */
+class GenericParameter
+{
+public:
+  GenericParameter()
+  {
+    comment_ = "";
+  };
+
+  void setName(std::string name)
+  {
+    name_ = std::move(name);
+  };
+  void setValue(std::string value)
+  {
+    value_ = std::move(value);
+  };
+  void setComment(std::string comment)
+  {
+    comment_ = std::move(comment);
+  };
+  std::string getName()
+  {
+    return name_;
+  };
+  std::string getValue()
+  {
+    return value_;
+  };
+  std::string getComment()
+  {
+    return comment_;
+  };
+
+private:
+  std::string name_;     // name of parameter
+  std::string value_;    // value parameter will receive (but as a string)
+  std::string comment_;  // comment briefly describing what this parameter does
+};
+
+MOVEIT_CLASS_FORWARD(MoveItConfigData);  // Defines MoveItConfigDataPtr, ConstPtr, WeakPtr... etc
+
+/** \brief This class is shared with all widgets and contains the common configuration data
+    needed for generating each robot's MoveIt configuration package.
+
+    All SRDF data is contained in a subclass of this class -
+    srdf_writer.cpp. This class also contains the functions for writing
+    out the configuration files. */
+class MoveItConfigData
+{
+public:
+  MoveItConfigData();
+  ~MoveItConfigData();
+
+  // bits of information that can be entered in Setup Assistant
+  enum InformationFields
+  {
+    COLLISIONS = 1 << 1,
+    VIRTUAL_JOINTS = 1 << 2,
+    GROUPS = 1 << 3,
+    GROUP_CONTENTS = 1 << 4,
+    GROUP_KINEMATICS = 1 << 5,
+    POSES = 1 << 6,
+    END_EFFECTORS = 1 << 7,
+    PASSIVE_JOINTS = 1 << 8,
+    AUTHOR_INFO = 1 << 9,
+    SENSORS_CONFIG = 1 << 10,
+    SRDF = COLLISIONS | VIRTUAL_JOINTS | GROUPS | GROUP_CONTENTS | POSES | END_EFFECTORS | PASSIVE_JOINTS
+  };
+  unsigned long changes;  // bitfield of changes (composed of InformationFields)
+
+  // All of the data needed for creating a MoveIt Configuration Files
+
+  // ******************************************************************************************
+  // URDF Data
+  // ******************************************************************************************
+
+  /// Full file-system path to urdf
+  std::string urdf_path_;
+
+  /// Name of package containing urdf (note: this may be empty b/c user may not have urdf in pkg)
+  std::string urdf_pkg_name_;
+
+  /// Path relative to urdf package (note: this may be same as urdf_path_)
+  std::string urdf_pkg_relative_path_;
+
+  /// Flag indicating whether the URDF was loaded from .xacro format
+  bool urdf_from_xacro_;
+  /// xacro arguments
+  std::string xacro_args_;
+
+  /// URDF robot model
+  urdf::ModelSharedPtr urdf_model_;
+
+  /// URDF robot model string
+  std::string urdf_string_;
+
+  // ******************************************************************************************
+  // SRDF Data
+  // ******************************************************************************************
+
+  /// Full file-system path to srdf
+  std::string srdf_path_;
+
+  /// Path relative to loaded configuration package
+  std::string srdf_pkg_relative_path_;
+
+  /// SRDF Data and Writer
+  srdf::SRDFWriterPtr srdf_;
+
+  // ******************************************************************************************
+  // Other Data
+  // ******************************************************************************************
+
+  /// Planning groups extra data not found in srdf but used in config files
+  std::map<std::string, GroupMetaData> group_meta_data_;
+
+  /// Setup Assistants package's path for when we use its templates
+  std::string setup_assistant_path_;
+
+  /// Loaded configuration package path - if an existing package was loaded, holds that path
+  std::string config_pkg_path_;
+
+  /// Location that moveit_collisions_updater stores its templates
+  std::string template_package_path_;
+
+  /// Is this application in debug mode?
+  bool debug_;
+
+  /// Allowed collision matrix for robot poses
+  collision_detection::AllowedCollisionMatrix allowed_collision_matrix_;
+
+  /// Timestamp when configuration package was generated, if it was previously generated
+  std::time_t config_pkg_generated_timestamp_;
+
+  /// Name of the author of this config
+  std::string author_name_;
+
+  /// Email of the author of this config
+  std::string author_email_;
+
+  // ******************************************************************************************
+  // Public Functions
+  // ******************************************************************************************
+
+  /// Load a robot model
+  void setRobotModel(const moveit::core::RobotModelPtr& robot_model);
+
+  /// Provide a shared kinematic model loader
+  moveit::core::RobotModelConstPtr getRobotModel();
+
+  /// Update the Kinematic Model with latest SRDF modifications
+  void updateRobotModel();
+
+  /// Provide a shared planning scene
+  planning_scene::PlanningScenePtr getPlanningScene();
+
+  /**
+   * Find the associated group by name
+   *
+   * @param name - name of data to find in datastructure
+   * @return pointer to data in datastructure
+   */
+  srdf::Model::Group* findGroupByName(const std::string& name);
+
+  /// Load the allowed collision matrix from the SRDF's list of link pairs
+  void loadAllowedCollisionMatrix();
+
+  // ******************************************************************************************
+  // Public Functions for outputting configuration and setting files
+  // ******************************************************************************************
+  std::vector<OMPLPlannerDescription> getOMPLPlanners();
+  bool outputSetupAssistantFile(const std::string& file_path);
+  bool outputOMPLPlanningYAML(const std::string& file_path);
+  bool outputCHOMPPlanningYAML(const std::string& file_path);
+  bool outputKinematicsYAML(const std::string& file_path);
+  bool outputJointLimitsYAML(const std::string& file_path);
+  bool outputFakeControllersYAML(const std::string& file_path);
+
+  /**
+   * Helper function for writing follow joint trajectory ROS controllers to ros_controllers.yaml
+   * @param YAML Emitter - yaml emitter used to write the config to the ROS controllers yaml file
+   * @param vector<ROSControlConfig> - a copy of ROS controllers config which will be modified in the function
+   */
+  void outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
+                                       std::vector<ROSControlConfig>& ros_controllers_config_output);
+
+  bool outputROSControllersYAML(const std::string& file_path);
+  bool output3DSensorPluginYAML(const std::string& file_path);
+
+  /**
+   * \brief Helper function to get the controller that is controlling the joint
+   * \return controller type
+   */
+  std::string getJointHardwareInterface(const std::string& joint_name);
+
+  /**
+   * \brief Parses the existing urdf and constructs a string from it with the elements required by gazebo simulator
+   * added
+   * \return gazebo compatible urdf or empty if error encountered
+   */
+  std::string getGazeboCompatibleURDF();
+
+  /**
+   * \brief Set list of collision link pairs in SRDF; sorted; with optional filter
+   * \param link_pairs list of collision link pairs
+   * \param skip_mask mask of shifted moveit_collisions_updater::DisabledReason values that will be skipped
+   */
+  void setCollisionLinkPairs(const moveit_collisions_updater::LinkPairMap& link_pairs, size_t skip_mask = 0);
+
+  /**
+   * \brief Decide the best two joints to be used for the projection evaluator
+   * \param planning_group name of group to use
+   * \return string - value to insert into yaml file
+   */
+  std::string decideProjectionJoints(const std::string& planning_group);
+
+  /**
+   * Input ompl_planning.yaml file for editing its values
+   * @param file_path path to ompl_planning.yaml in the input package
+   * @return true if the file was read correctly
+   */
+  bool inputOMPLYAML(const std::string& file_path);
+
+  /**
+   * Input kinematics.yaml file for editing its values
+   * @param file_path path to kinematics.yaml in the input package
+   * @return true if the file was read correctly
+   */
+  bool inputKinematicsYAML(const std::string& file_path);
+
+  /**
+   * Input planning_context.launch for editing its values
+   * @param file_path path to planning_context.launch in the input package
+   * @return true if the file was read correctly
+   */
+  bool inputPlanningContextLaunch(const std::string& file_path);
+
+  /**
+   * Helper function for parsing ros_controllers.yaml file
+   * @param YAML::Node - individual controller to be parsed
+   * @return true if the file was read correctly
+   */
+  bool parseROSController(const YAML::Node& controller);
+
+  /**
+   * Helper function for parsing ros_controllers.yaml file
+   * @param std::ifstream of ros_controller.yaml
+   * @return true if the file was read correctly
+   */
+  bool processROSControllers(std::ifstream& input_stream);
+
+  /**
+   * Input ros_controllers.yaml file for editing its values
+   * @param file_path path to ros_controllers.yaml in the input package
+   * @return true if the file was read correctly
+   */
+  bool inputROSControllersYAML(const std::string& file_path);
+
+  /**
+   * \brief Add a Follow Joint Trajectory action Controller for each Planning Group
+   * \return true if controllers were added to the ros_controllers_config_ data structure
+   */
+  bool addDefaultControllers();
+
+  /**
+   * Set package path; try to resolve path from package name if directory does not exist
+   * @param pkg_path path to package or package name
+   * @return true if the path was set
+   */
+  bool setPackagePath(const std::string& pkg_path);
+
+  /**
+   * determine the package name containing a given file path
+   * @param path to a file
+   * @param package_name holds the ros package name if found
+   * @param relative_filepath holds the relative path of the file to the package root
+   * @return whether the file belongs to a known package
+   */
+  bool extractPackageNameFromPath(const std::string& path, std::string& package_name,
+                                  std::string& relative_filepath) const;
+
+  /**
+   * Resolve path to .setup_assistant file
+   * @param path resolved path
+   * @return true if the path could be resolved
+   */
+  bool getSetupAssistantYAMLPath(std::string& path);
+
+  /// Make the full URDF path using the loaded .setup_assistant data
+  bool createFullURDFPath();
+
+  /// Make the full SRDF path using the loaded .setup_assistant data
+  bool createFullSRDFPath(const std::string& package_path);
+
+  /**
+   * Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
+   *
+   * @param file_path path to .setup_assistant file
+   * @return true if the file was read correctly
+   */
+  bool inputSetupAssistantYAML(const std::string& file_path);
+
+  /**
+   * Input sensors_3d file - contains 3d sensors config data
+   *
+   * @param default_file_path path to sensors_3d yaml file which contains default parameter values
+   * @param file_path path to sensors_3d yaml file in the config package
+   * @return true if the file was read correctly
+   */
+  bool input3DSensorsYAML(const std::string& default_file_path, const std::string& file_path = "");
+
+  /**
+   * Helper Function for joining a file path and a file name, or two file paths, etc,
+   * in a cross-platform way
+   *
+   * @param path1 first half of path
+   * @param path2 second half of path, or filename
+   * @return string resulting combined paths
+   */
+  std::string appendPaths(const std::string& path1, const std::string& path2);
+
+  /**
+   * \brief Adds a ROS controller to ros_controllers_config_ vector
+   * \param new_controller a new ROS Controller to add
+   * \return true if inserted correctly
+   */
+  bool addROSController(const ROSControlConfig& new_controller);
+
+  /**
+   * \brief Gets ros_controllers_config_ vector
+   * \return pointer to ros_controllers_config_
+   */
+  std::vector<ROSControlConfig>& getROSControllers();
+
+  /**
+   * Find the associated ROS controller by name
+   *
+   * @param controller_name - name of ROS controller to find in datastructure
+   * @return pointer to data in datastructure
+   */
+  ROSControlConfig* findROSControllerByName(const std::string& controller_name);
+
+  /**
+   * Delete ROS controller by name
+   *
+   * @param controller_name - name of ROS controller to delete
+   * @return true if deleted, false if not found
+   */
+  bool deleteROSController(const std::string& controller_name);
+
+  /**
+   * \brief Used for adding a sensor plugin configuration parameter to the sensor plugin configuration parameter list
+   */
+  void addGenericParameterToSensorPluginConfig(const std::string& name, const std::string& value = "",
+                                               const std::string& comment = "");
+
+  /**
+   * \brief Clear the sensor plugin configuration parameter list
+   */
+  void clearSensorPluginConfig();
+
+  /**
+   * \brief Used for adding a sensor plugin configuration parameter to the sensor plugin configuration parameter list
+   */
+  std::vector<std::map<std::string, GenericParameter> > getSensorPluginConfig();
+
+  /**
+   * \brief Helper function to get the default start pose for moveit_sim_hw_interface
+   */
+  srdf::Model::GroupState getDefaultStartPose();
+
+  /**
+   * \brief Custom std::set comparator, used for sorting the joint_limits.yaml file into alphabetical order
+   * \param jm1 - a pointer to the first joint model to compare
+   * \param jm2 - a pointer to the second joint model to compare
+   * \return bool of alphabetical sorting comparison
+   */
+  struct JointModelCompare
+  {
+    bool operator()(const moveit::core::JointModel* jm1, const moveit::core::JointModel* jm2) const
+    {
+      return jm1->getName() < jm2->getName();
+    }
+  };
+
+private:
+  // ******************************************************************************************
+  // Private Vars
+  // ******************************************************************************************
+
+  /// Sensor plugin configuration parameter list, each sensor plugin type is a map
+  std::vector<std::map<std::string, GenericParameter> > sensors_plugin_config_parameter_list_;
+
+  /// Shared kinematic model
+  moveit::core::RobotModelPtr robot_model_;
+
+  /// ROS Controllers config data
+  std::vector<ROSControlConfig> ros_controllers_config_;
+
+  /// Shared planning scene
+  planning_scene::PlanningScenePtr planning_scene_;
+};
+
+}  // namespace moveit_collisions_updater

--- a/moveit_collisions_updater/package.xml
+++ b/moveit_collisions_updater/package.xml
@@ -1,0 +1,46 @@
+<package format="2">
+  <name>moveit_collisions_updater</name>
+  <version>1.1.5</version>
+
+  <description>Generates a configuration package that makes it easy to use MoveIt</description>
+
+  <author email="dave@picknik.ai">Dave Coleman</author>
+
+  <maintainer email="dave@picknik.ai">Dave Coleman</maintainer>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
+  <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://moveit.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
+  <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_common</build_depend>
+  <build_depend>libogre-dev</build_depend>
+  <build_depend>ompl</build_depend>
+  <build_depend>rviz2</build_depend>
+  <build_depend>rviz_common</build_depend>
+
+  <depend>ament_index_cpp</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>moveit_ros_visualization</depend>
+  <depend>rclcpp</depend>
+  <depend>urdf</depend>
+  <depend>yaml-cpp</depend>
+  <depend>srdfdom</depend>
+
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/moveit_collisions_updater/src/collisions_updater.cpp
+++ b/moveit_collisions_updater/src/collisions_updater.cpp
@@ -1,0 +1,210 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+#include <moveit/collisions_updater/tools/moveit_config_data.hpp>
+#include <moveit/rdf_loader/rdf_loader.h>
+#include <rviz_common/logging.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+bool loadSetupAssistantConfig(moveit_collisions_updater::MoveItConfigData& config_data, const std::string& pkg_path)
+{
+  static const rclcpp::Logger LOGGER = rclcpp::get_logger("collision_updater");
+  if (!config_data.setPackagePath(pkg_path))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not set package path '" << pkg_path << "'");
+    return false;
+  }
+
+  std::string setup_assistant_path;
+  if (!config_data.getSetupAssistantYAMLPath(setup_assistant_path))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not resolve path to .setup_assistant");
+    return false;
+  }
+
+  if (!config_data.inputSetupAssistantYAML(setup_assistant_path))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not parse .setup_assistant file from '" << setup_assistant_path << "'");
+    return false;
+  }
+
+  config_data.createFullURDFPath();  // might fail at this point
+
+  config_data.createFullSRDFPath(config_data.config_pkg_path_);  // might fail at this point
+
+  return true;
+}
+
+bool setup(moveit_collisions_updater::MoveItConfigData& config_data, bool keep_old,
+           const std::vector<std::string>& xacro_args)
+{
+  static const rclcpp::Logger LOGGER = rclcpp::get_logger("collision_updater");
+  std::string urdf_string;
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string, config_data.urdf_path_, xacro_args))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not load URDF from '" << config_data.urdf_path_ << "'");
+    return false;
+  }
+  if (!config_data.urdf_model_->initString(urdf_string))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not parse URDF from '" << config_data.urdf_path_ << "'");
+    return false;
+  }
+
+  std::string srdf_string;
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, config_data.srdf_path_, xacro_args))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not load SRDF from '" << config_data.srdf_path_ << "'");
+    return false;
+  }
+  if (!config_data.srdf_->initString(*config_data.urdf_model_, srdf_string))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not parse SRDF from '" << config_data.srdf_path_ << "'");
+    return false;
+  }
+
+  if (!keep_old)
+    config_data.srdf_->disabled_collisions_.clear();
+
+  return true;
+}
+
+moveit_collisions_updater::LinkPairMap compute(moveit_collisions_updater::MoveItConfigData& config_data, uint32_t trials,
+                                            double min_collision_fraction, bool verbose)
+{
+  // TODO: spin thread and print progress if verbose
+  unsigned int collision_progress;
+  return moveit_collisions_updater::computeDefaultCollisions(config_data.getPlanningScene(), &collision_progress,
+                                                          trials > 0, trials, min_collision_fraction, verbose);
+}
+
+int main(int argc, char* argv[])
+{
+  std::string config_pkg_path;
+  std::string urdf_path;
+  std::string srdf_path;
+  std::string output_path;
+
+  bool include_default = false, include_always = false, keep_old = false, verbose = false;
+
+  double min_collision_fraction = 1.0;
+
+  uint32_t never_trials = 0;
+
+  po::options_description desc("Allowed options");
+  desc.add_options()
+      ("help", "show help")
+      ("config-pkg", po::value(&config_pkg_path), "path to MoveIt config package")
+      ("urdf", po::value(&urdf_path), "path to URDF ( or xacro)")
+      ("srdf", po::value(&srdf_path), "path to SRDF ( or xacro)")
+      ("output", po::value(&output_path), "output path for SRDF")
+      ("xacro-args", po::value<std::vector<std::string> >()->composing(), "additional arguments for xacro")
+      ("default", po::bool_switch(&include_default), "disable default colliding pairs")
+      ("always", po::bool_switch(&include_always), "disable always colliding pairs")
+      ("keep", po::bool_switch(&keep_old), "keep disabled link from SRDF")
+      ("verbose", po::bool_switch(&verbose), "verbose output")
+      ("trials", po::value(&never_trials), "number of trials for searching never colliding pairs")
+      ("min-collision-fraction", po::value(&min_collision_fraction), "fraction of small sample size to determine links that are always colliding");
+
+  po::positional_options_description pos_desc;
+  pos_desc.add("xacro-args", -1);
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv).options(desc).positional(pos_desc).run(), vm);
+  po::notify(vm);
+
+  if (vm.count("help"))
+  {
+    std::cout << desc << std::endl;
+    return 1;
+  }
+
+  moveit_collisions_updater::MoveItConfigData config_data;
+  static const rclcpp::Logger LOGGER = rclcpp::get_logger("collision_updater");
+
+  if (!config_pkg_path.empty())
+  {
+    if (!loadSetupAssistantConfig(config_data, config_pkg_path))
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, "Could not load config at '" << config_pkg_path << "'");
+      return 1;
+    }
+  }
+  else if (urdf_path.empty() || srdf_path.empty())
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Please provide config package or URDF and SRDF path");
+    return 1;
+  }
+  else if (rdf_loader::RDFLoader::isXacroFile(srdf_path) && output_path.empty())
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Please provide a different output file for SRDF xacro input file");
+    return 1;
+  }
+
+  // overwrite config paths if applicable
+  if (!urdf_path.empty())
+    config_data.urdf_path_ = urdf_path;
+  if (!srdf_path.empty())
+    config_data.srdf_path_ = srdf_path;
+
+  std::vector<std::string> xacro_args;
+  if (vm.count("xacro-args"))
+    xacro_args = vm["xacro-args"].as<std::vector<std::string> >();
+
+  if (!setup(config_data, keep_old, xacro_args))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not setup updater");
+    return 1;
+  }
+
+  moveit_collisions_updater::LinkPairMap link_pairs = compute(config_data, never_trials, min_collision_fraction, verbose);
+
+  size_t skip_mask = 0;
+  if (!include_default)
+    skip_mask |= (1 << moveit_collisions_updater::DEFAULT);
+  if (!include_always)
+    skip_mask |= (1 << moveit_collisions_updater::ALWAYS);
+
+  config_data.setCollisionLinkPairs(link_pairs, skip_mask);
+
+  config_data.srdf_->writeSRDF(output_path.empty() ? config_data.srdf_path_ : output_path);
+
+  return 0;
+}

--- a/moveit_collisions_updater/src/tools/compute_default_collisions.cpp
+++ b/moveit_collisions_updater/src/tools/compute_default_collisions.cpp
@@ -1,0 +1,678 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman */
+
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/collisions_updater/tools/compute_default_collisions.hpp>
+#include <boost/math/special_functions/binomial.hpp>  // for statistics at end
+#include <boost/thread.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/assign.hpp>
+#include <rviz_common/logging.hpp>
+
+namespace moveit_collisions_updater
+{
+// ******************************************************************************************
+// Custom Types, Enums and Structs
+// ******************************************************************************************
+
+// Boost mapping of reasons for disabling a link pair to strings
+const boost::unordered_map<DisabledReason, std::string> REASONS_TO_STRING = boost::assign::map_list_of(NEVER, "Never")(
+    DEFAULT, "Default")(ADJACENT, "Adjacent")(ALWAYS, "Always")(USER, "User")(NOT_DISABLED, "Not Disabled");
+
+const boost::unordered_map<std::string, DisabledReason> REASONS_FROM_STRING =
+    boost::assign::map_list_of("Never", NEVER)("Default", DEFAULT)("Adjacent", ADJACENT)("Always", ALWAYS)(
+        "User", USER)("Not Disabled", NOT_DISABLED);
+
+// Unique set of pairs of links in string-based form
+typedef std::set<std::pair<std::string, std::string> > StringPairSet;
+
+// Struct for passing parameters to threads, for cleaner code
+struct ThreadComputation
+{
+  ThreadComputation(planning_scene::PlanningScene& scene, const collision_detection::CollisionRequest& req,
+                    int thread_id, int num_trials, StringPairSet* links_seen_colliding, boost::mutex* lock,
+                    unsigned int* progress)
+    : scene_(scene)
+    , req_(req)
+    , thread_id_(thread_id)
+    , num_trials_(num_trials)
+    , links_seen_colliding_(links_seen_colliding)
+    , lock_(lock)
+    , progress_(progress)
+  {
+  }
+  planning_scene::PlanningScene& scene_;
+  const collision_detection::CollisionRequest& req_;
+  int thread_id_;
+  unsigned int num_trials_;
+  StringPairSet* links_seen_colliding_;
+  boost::mutex* lock_;
+  unsigned int* progress_;  // only to be updated by thread 0
+};
+
+// LinkGraph defines a Link's model and a set of unique links it connects
+typedef std::map<const moveit::core::LinkModel*, std::set<const moveit::core::LinkModel*> > LinkGraph;
+
+// ******************************************************************************************
+// Static Prototypes
+// ******************************************************************************************
+
+/**
+ * \brief Helper function for adding two links to the disabled links data structure
+ * \param linkA Name of first link
+ * \param linkB Name of second link
+ * \param reason Enum reason of why the link pair is disabled from C.C., if it is
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ * \return bool Was link pair already disabled from C.C.
+ */
+static bool setLinkPair(const std::string& linkA, const std::string& linkB, const DisabledReason reason,
+                        LinkPairMap& link_pairs);
+
+/**
+ * \brief Build the robot links connection graph and then check for links with no geomotry
+ * \param link The root link to begin a breadth first search on
+ * \param link_graph A representation of all bi-direcitonal joint connections between links in robot_description
+ */
+static void computeConnectionGraph(const moveit::core::LinkModel* link, LinkGraph& link_graph);
+
+/**
+ * \brief Recursively build the adj list of link connections
+ * \param link The root link to begin a breadth first search on
+ * \param link_graph A representation of all bi-direcitonal joint connections between links in robot_description
+ */
+static void computeConnectionGraphRec(const moveit::core::LinkModel* link, LinkGraph& link_graph);
+
+/**
+ * \brief Disable collision checking for adjacent links, or adjacent with no geometry links between them
+ * \param link_graph A representation of all bi-direcitonal joint connections between links in robot_description
+ * \param scene A reference to the robot in the planning scene
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ * \return number of adjacent links found and disabled
+ */
+static unsigned int disableAdjacentLinks(planning_scene::PlanningScene& scene, LinkGraph& link_graph,
+                                         LinkPairMap& link_pairs);
+
+/**
+ * \brief Disable all collision checks that occur when the robot is started in its default state
+ * \param scene A reference to the robot in the planning scene
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ * \param req A reference to a collision request that is already initialized
+ * \return number of default collision links found and disabled
+ */
+static unsigned int disableDefaultCollisions(planning_scene::PlanningScene& scene, LinkPairMap& link_pairs,
+                                             collision_detection::CollisionRequest& req);
+
+/**
+ * \brief Compute the links that are always in collision
+ * \param scene A reference to the robot in the planning scene
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ * \param req A reference to a collision request that is already initialized
+ * \param links_seen_colliding Set of links that have at some point been seen in collision
+ * \param min_collision_fraction If collisions are found between a pair of links >= this fraction, the are assumed
+ * "always" in collision
+ * \return number of always in collision links found and disabled
+ */
+static unsigned int disableAlwaysInCollision(planning_scene::PlanningScene& scene, LinkPairMap& link_pairs,
+                                             collision_detection::CollisionRequest& req,
+                                             StringPairSet& links_seen_colliding, double min_collision_faction = 0.95);
+
+/**
+ * \brief Get the pairs of links that are never in collision
+ * \param scene A reference to the robot in the planning scene
+ * \param link_pairs List of all unique link pairs and each pair's properties
+ * \param req A reference to a collision request that is already initialized
+ * \param links_seen_colliding Set of links that have at some point been seen in collision
+ * \return number of never in collision links found and disabled
+ */
+static unsigned int disableNeverInCollision(const unsigned int num_trials, planning_scene::PlanningScene& scene,
+                                            LinkPairMap& link_pairs, const collision_detection::CollisionRequest& req,
+                                            StringPairSet& links_seen_colliding, unsigned int* progress);
+
+/**
+ * \brief Thread for getting the pairs of links that are never in collision
+ * \param tc Struct that encapsulates all the data each thread needs
+ */
+static void disableNeverInCollisionThread(ThreadComputation tc);
+
+// ******************************************************************************************
+// Generates an adjacency list of links that are always and never in collision, to speed up collision detection
+// ******************************************************************************************
+LinkPairMap computeDefaultCollisions(const planning_scene::PlanningSceneConstPtr& parent_scene, unsigned int* progress,
+                                     const bool include_never_colliding, const unsigned int num_trials,
+                                     const double min_collision_fraction, const bool verbose)
+{
+  // Create new instance of planning scene using pointer
+  planning_scene::PlanningScenePtr scene = parent_scene->diff();
+
+  // Map of disabled collisions that contains a link as a key and an ordered list of links that are connected.
+  LinkPairMap link_pairs;
+
+  // Track unique edges that have been found to be in collision in some state
+  StringPairSet links_seen_colliding;
+
+  // LinkGraph is a custom type of a map with a LinkModel as key and a set of LinkModels as second
+  LinkGraph link_graph;
+
+  // RVIZ_COMMON_LOG_INFO_STREAM("Initial allowed Collision Matrix Size = " << scene.getAllowedCollisions().getSize() );
+
+  // 0. GENERATE ALL POSSIBLE LINK PAIRS -------------------------------------------------------------
+  // Generate a list of unique link pairs for all links with geometry. Order pairs alphabetically.
+  // There should be n choose 2 pairs
+  computeLinkPairs(*scene, link_pairs);
+  *progress = 1;
+
+  // 1. FIND CONNECTING LINKS ------------------------------------------------------------------------
+  // For each link, compute the set of other links it connects to via a single joint (adjacent links)
+  // or via a chain of joints with intermediate links with no geometry (like a socket joint)
+
+  // Create Connection Graph
+  computeConnectionGraph(scene->getRobotModel()->getRootLink(), link_graph);
+  *progress = 2;  // Progress bar feedback
+  boost::this_thread::interruption_point();
+
+  // 2. DISABLE ALL ADJACENT LINK COLLISIONS ---------------------------------------------------------
+  // if 2 links are adjacent, or adjacent with a zero-shape between them, disable collision checking for them
+  unsigned int num_adjacent = disableAdjacentLinks(*scene, link_graph, link_pairs);
+  *progress = 4;  // Progress bar feedback
+  boost::this_thread::interruption_point();
+
+  // 3. INITIAL CONTACTS TO CONSIDER GUESS -----------------------------------------------------------
+  // Create collision detection request object
+  collision_detection::CollisionRequest req;
+  req.contacts = true;
+  // max number of contacts to compute. initial guess is number of links on robot
+  req.max_contacts = int(link_graph.size());
+  req.max_contacts_per_pair = 1;
+  req.verbose = false;
+
+  // 4. DISABLE "DEFAULT" COLLISIONS --------------------------------------------------------
+  // Disable all collision checks that occur when the robot is started in its default state
+  unsigned int num_default = disableDefaultCollisions(*scene, link_pairs, req);
+  *progress = 6;  // Progress bar feedback
+  boost::this_thread::interruption_point();
+
+  // 5. ALWAYS IN COLLISION --------------------------------------------------------------------
+  // Compute the links that are always in collision
+  unsigned int num_always =
+      disableAlwaysInCollision(*scene, link_pairs, req, links_seen_colliding, min_collision_fraction);
+  // RVIZ_COMMON_LOG_INFO("Links seen colliding total = %d", int(links_seen_colliding.size()));
+  *progress = 8;  // Progress bar feedback
+  boost::this_thread::interruption_point();
+
+  // 6. NEVER IN COLLISION -------------------------------------------------------------------
+  // Get the pairs of links that are never in collision
+  unsigned int num_never = 0;
+  if (include_never_colliding)  // option of function
+  {
+    num_never = disableNeverInCollision(num_trials, *scene, link_pairs, req, links_seen_colliding, progress);
+  }
+
+  // RVIZ_COMMON_LOG_INFO("Link pairs seen colliding ever: %d", int(links_seen_colliding.size()));
+
+  if (verbose)
+  {
+    // Calculate number of disabled links:
+    unsigned int num_disabled = 0;
+    for (LinkPairMap::const_iterator pair_it = link_pairs.begin(); pair_it != link_pairs.end(); ++pair_it)
+    {
+      if (pair_it->second.disable_check)  // has a reason to be disabled
+        ++num_disabled;
+    }
+
+    RVIZ_COMMON_LOG_INFO("-------------------------------------------------------------------------------");
+    RVIZ_COMMON_LOG_INFO("Statistics:");
+    unsigned int num_links = int(link_graph.size());
+    double num_possible = boost::math::binomial_coefficient<double>(num_links, 2);  // n choose 2
+    unsigned int num_sometimes = num_possible - num_disabled;
+
+    RVIZ_COMMON_LOG_INFO("Total Links : " + std::to_string(num_links));
+    RVIZ_COMMON_LOG_INFO("Total possible collisions : " + std::to_string(num_possible));
+    RVIZ_COMMON_LOG_INFO("Always in collision : " + std::to_string(num_always));
+    RVIZ_COMMON_LOG_INFO("Never in collision : " + std::to_string(num_never));
+    RVIZ_COMMON_LOG_INFO("Default in collision : " + std::to_string(num_default));
+    RVIZ_COMMON_LOG_INFO("Adjacent links disabled : " + std::to_string(num_adjacent));
+    RVIZ_COMMON_LOG_INFO("Sometimes in collision : " + std::to_string(num_sometimes));
+    RVIZ_COMMON_LOG_INFO("TOTAL DISABLED : " + std::to_string(num_disabled));
+
+    /*ROS_INFO("Copy to Spreadsheet:");
+    ROS_INFO_STREAM(num_links << "\t" << num_possible << "\t" << num_always << "\t" << num_never
+                    << "\t" << num_default << "\t" << num_adjacent << "\t" << num_sometimes
+                    << "\t" << num_disabled);
+    */
+  }
+
+  *progress = 100;  // end the status bar
+
+  return link_pairs;
+}
+
+// ******************************************************************************************
+// Helper function for adding two links to the disabled links data structure
+// ******************************************************************************************
+bool setLinkPair(const std::string& linkA, const std::string& linkB, const DisabledReason reason,
+                 LinkPairMap& link_pairs)
+{
+  bool is_unique = false;  // determine if this link pair had already existsed in the link_pairs datastructure
+
+  // Determine order of the 2 links in the pair
+  std::pair<std::string, std::string> link_pair;
+
+  // compare the string names of the two links and add the lesser alphabetically, s.t. the pair is only added once
+  if (linkA < linkB)
+  {
+    link_pair = std::pair<std::string, std::string>(linkA, linkB);
+  }
+  else
+  {
+    link_pair = std::pair<std::string, std::string>(linkB, linkA);
+  }
+
+  // Update properties of this link pair using only 1 search
+  LinkPairData* link_pair_ptr = &link_pairs[link_pair];
+
+  // Check if link pair was already disabled. It also creates the entry if none existed
+  if (!link_pairs[link_pair].disable_check)  // it was not previously disabled
+  {
+    is_unique = true;
+    link_pair_ptr->reason = reason;  // only change the reason if the pair was previously enabled
+  }
+
+  // Only disable collision checking if there is a reason to disable it. This func is also used for initializing pairs
+  link_pair_ptr->disable_check = (reason != NOT_DISABLED);
+
+  return is_unique;
+}
+
+// ******************************************************************************************
+// Generate a list of unique link pairs for all links with geometry. Order pairs alphabetically. n choose 2 pairs
+// ******************************************************************************************
+void computeLinkPairs(const planning_scene::PlanningScene& scene, LinkPairMap& link_pairs)
+{
+  // Get the names of the link models that have some collision geometry associated to themselves
+  const std::vector<std::string>& names = scene.getRobotModel()->getLinkModelNamesWithCollisionGeometry();
+
+  std::pair<std::string, std::string> temp_pair;
+
+  // Loop through every combination of name pairs, 'AB' and 'BA', n^2
+  for (std::size_t i = 0; i < names.size(); ++i)
+  {
+    for (std::size_t j = i + 1; j < names.size(); ++j)
+    {
+      // Add to link pairs list
+      setLinkPair(names[i], names[j], NOT_DISABLED, link_pairs);
+    }
+  }
+}
+// ******************************************************************************************
+// Build the robot links connection graph and then check for links with no geomotry
+// ******************************************************************************************
+void computeConnectionGraph(const moveit::core::LinkModel* start_link, LinkGraph& link_graph)
+{
+  link_graph.clear();  // make sure the edges structure is clear
+
+  // Recursively build adj list of link connections
+  computeConnectionGraphRec(start_link, link_graph);
+
+  // Repeatidly check for links with no geometry and remove them, then re-check until no more removals are detected
+  bool update = true;  // track if a no geometry link was found
+  while (update)
+  {
+    update = false;  // default
+
+    // Check if each edge has a shape
+    for (LinkGraph::const_iterator edge_it = link_graph.begin(); edge_it != link_graph.end(); ++edge_it)
+    {
+      if (edge_it->first->getShapes().empty())  // link in adjList "link_graph" does not have shape, remove!
+      {
+        // Temporary list for connected links
+        std::vector<const moveit::core::LinkModel*> temp_list;
+
+        // Copy link's parent and child links to temp_list
+        for (const moveit::core::LinkModel* adj_it : edge_it->second)
+        {
+          temp_list.push_back(adj_it);
+        }
+
+        // Make all proceeding and succeeding links to the no-shape link fully connected
+        // so that they don't collision check with themselves
+        for (std::size_t i = 0; i < temp_list.size(); ++i)
+        {
+          for (std::size_t j = i + 1; j < temp_list.size(); ++j)
+          {
+            // for each LinkModel in temp_list, find its location in the link_graph structure and insert the rest
+            // of the links into its unique set.
+            // if the LinkModel is not already in the set, update is set to true so that we keep searching
+            if (link_graph[temp_list[i]].insert(temp_list[j]).second)
+              update = true;
+            if (link_graph[temp_list[j]].insert(temp_list[i]).second)
+              update = true;
+          }
+        }
+      }
+    }
+  }
+  // RVIZ_COMMON_LOG_INFO("Generated connection graph with %d links", int(link_graph.size()));
+}
+
+// ******************************************************************************************
+// Recursively build the adj list of link connections
+// ******************************************************************************************
+void computeConnectionGraphRec(const moveit::core::LinkModel* start_link, LinkGraph& link_graph)
+{
+  if (start_link)  // check that the link is a valid pointer
+  {
+    // Loop through every link attached to start_link
+    for (std::size_t i = 0; i < start_link->getChildJointModels().size(); ++i)
+    {
+      const moveit::core::LinkModel* next = start_link->getChildJointModels()[i]->getChildLinkModel();
+
+      // Bi-directional connection
+      link_graph[next].insert(start_link);
+      link_graph[start_link].insert(next);
+
+      // Iterate with subsequent link
+      computeConnectionGraphRec(next, link_graph);
+    }
+  }
+  else
+  {
+    RVIZ_COMMON_LOG_ERROR("Joint exists in URDF with no link!");
+  }
+}
+
+// ******************************************************************************************
+// Disable collision checking for adjacent links, or adjacent with no geometry links between them
+// ******************************************************************************************
+unsigned int disableAdjacentLinks(planning_scene::PlanningScene& scene, LinkGraph& link_graph, LinkPairMap& link_pairs)
+{
+  int num_disabled = 0;
+  for (LinkGraph::const_iterator link_graph_it = link_graph.begin(); link_graph_it != link_graph.end(); ++link_graph_it)
+  {
+    // disable all connected links to current link by looping through them
+    for (std::set<const moveit::core::LinkModel*>::const_iterator adj_it = link_graph_it->second.begin();
+         adj_it != link_graph_it->second.end(); ++adj_it)
+    {
+      // RVIZ_COMMON_LOG_INFO("Disabled %s to %s", link_graph_it->first->getName().c_str(), (*adj_it)->getName().c_str() );
+
+      // Check if either of the links have no geometry. If so, do not add (are we sure?)
+      if (!link_graph_it->first->getShapes().empty() && !(*adj_it)->getShapes().empty())  // both links have geometry
+      {
+        num_disabled += setLinkPair(link_graph_it->first->getName(), (*adj_it)->getName(), ADJACENT, link_pairs);
+
+        // disable link checking in the collision matrix
+        scene.getAllowedCollisionMatrixNonConst().setEntry(link_graph_it->first->getName(), (*adj_it)->getName(), true);
+      }
+    }
+  }
+  // RVIZ_COMMON_LOG_INFO("Disabled %d adjacent link pairs from collision checking", num_disabled);
+
+  return num_disabled;
+}
+
+// ******************************************************************************************
+// Disable all collision checks that occur when the robot is started in its default state
+// ******************************************************************************************
+unsigned int disableDefaultCollisions(planning_scene::PlanningScene& scene, LinkPairMap& link_pairs,
+                                      collision_detection::CollisionRequest& req)
+{
+  // Setup environment
+  collision_detection::CollisionResult res;
+  scene.getCurrentStateNonConst().setToDefaultValues();  // set to default values of 0 OR half between low and high
+                                                         // joint values
+  scene.checkSelfCollision(req, res);
+
+  // For each collision in default state, always add to disabled links set
+  int num_disabled = 0;
+  for (collision_detection::CollisionResult::ContactMap::const_iterator it = res.contacts.begin();
+       it != res.contacts.end(); ++it)
+  {
+    num_disabled += setLinkPair(it->first.first, it->first.second, DEFAULT, link_pairs);
+
+    // disable link checking in the collision matrix
+    scene.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second, true);
+  }
+
+  // RVIZ_COMMON_LOG_INFO("Disabled %d link pairs that are in collision in default state from collision checking", num_disabled);
+
+  return num_disabled;
+}
+
+// ******************************************************************************************
+// Compute the links that are always in collision
+// ******************************************************************************************
+unsigned int disableAlwaysInCollision(planning_scene::PlanningScene& scene, LinkPairMap& link_pairs,
+                                      collision_detection::CollisionRequest& req, StringPairSet& links_seen_colliding,
+                                      double min_collision_faction)
+{
+  // Trial count variables
+  static const unsigned int SMALL_TRIAL_COUNT = 200;
+  static const unsigned int SMALL_TRIAL_LIMIT = (unsigned int)((double)SMALL_TRIAL_COUNT * min_collision_faction);
+
+  bool done = false;
+  unsigned int num_disabled = 0;
+
+  while (!done)
+  {
+    // DO 'SMALL_TRIAL_COUNT' COLLISION CHECKS AND RECORD STATISTICS ---------------------------------------
+    std::map<std::pair<std::string, std::string>, unsigned int> collision_count;
+
+    // Do a large number of tests
+    for (unsigned int i = 0; i < SMALL_TRIAL_COUNT; ++i)
+    {
+      // Check for collisions
+      collision_detection::CollisionResult res;
+      scene.getCurrentStateNonConst().setToRandomPositions();
+      scene.checkSelfCollision(req, res);
+
+      // Sum the number of collisions
+      unsigned int nc = 0;
+      for (collision_detection::CollisionResult::ContactMap::const_iterator it = res.contacts.begin();
+           it != res.contacts.end(); ++it)
+      {
+        collision_count[it->first]++;
+        links_seen_colliding.insert(it->first);
+        nc += it->second.size();
+      }
+
+      // Check if the number of contacts is greater than the max count
+      if (nc >= req.max_contacts)
+      {
+        req.max_contacts *= 2;  // double the max contacts that the CollisionRequest checks for
+        // RVIZ_COMMON_LOG_INFO("Doubling max_contacts to %d", int(req.max_contacts));
+      }
+    }
+
+    // >= XX% OF TIME IN COLLISION DISABLE -----------------------------------------------------
+    // Disable collision checking for links that are >= XX% of the time in collision (XX% = 95% by default)
+    int found = 0;
+
+    // Loop through every pair of link collisions and disable if it meets the threshold
+    for (std::map<std::pair<std::string, std::string>, unsigned int>::const_iterator it = collision_count.begin();
+         it != collision_count.end(); ++it)
+    {
+      // Disable these two links permanently
+      if (it->second > SMALL_TRIAL_LIMIT)
+      {
+        num_disabled += setLinkPair(it->first.first, it->first.second, ALWAYS, link_pairs);
+
+        // disable link checking in the collision matrix
+        scene.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second, true);
+
+        found++;
+      }
+    }
+
+    // if no updates were made to the collision matrix, we stop
+    if (found == 0)
+      done = true;
+
+    // RVIZ_COMMON_LOG_INFO("Disabled %u link pairs that are always in collision from collision checking", found);
+  }
+
+  return num_disabled;
+}
+
+// ******************************************************************************************
+// Get the pairs of links that are never in collision
+// ******************************************************************************************
+unsigned int disableNeverInCollision(const unsigned int num_trials, planning_scene::PlanningScene& scene,
+                                     LinkPairMap& link_pairs, const collision_detection::CollisionRequest& req,
+                                     StringPairSet& links_seen_colliding, unsigned int* progress)
+{
+  unsigned int num_disabled = 0;
+
+  boost::thread_group bgroup;  // create a group of threads
+  boost::mutex lock;           // used for sharing the same data structures
+
+  int num_threads = boost::thread::hardware_concurrency();  // how many cores does this computer have?
+  // RVIZ_COMMON_LOG_INFO_STREAM("Performing " << num_trials << " trials for 'always in collision' checking on " <<
+  //   num_threads << " threads...");
+
+  for (int i = 0; i < num_threads; ++i)
+  {
+    ThreadComputation tc(scene, req, i, num_trials / num_threads, &links_seen_colliding, &lock, progress);
+    bgroup.create_thread(boost::bind(&disableNeverInCollisionThread, tc));
+  }
+
+  try
+  {
+    bgroup.join_all();  // wait for all threads to finish
+  }
+  catch (boost::thread_interrupted)
+  {
+    RVIZ_COMMON_LOG_WARNING("disableNeverInCollision interrupted");
+    bgroup.interrupt_all();
+    bgroup.join_all();  // wait for all threads to interrupt
+    throw;
+  }
+
+  // Loop through every possible link pair and check if it has ever been seen in collision
+  for (std::pair<const std::pair<std::string, std::string>, LinkPairData>& link_pair : link_pairs)
+  {
+    if (!link_pair.second.disable_check)  // is not disabled yet
+    {
+      // Check if current pair has been seen colliding ever. If it has never been seen colliding, add it to disabled
+      // list
+      if (links_seen_colliding.find(link_pair.first) == links_seen_colliding.end())
+      {
+        // Add to disabled list using pair ordering
+        link_pair.second.reason = NEVER;
+        link_pair.second.disable_check = true;
+
+        // Count it
+        ++num_disabled;
+      }
+    }
+  }
+  // RVIZ_COMMON_LOG_INFO("Disabled %d link pairs that are never in collision", num_disabled);
+
+  return num_disabled;
+}
+
+// ******************************************************************************************
+// Thread for getting the pairs of links that are never in collision
+// ******************************************************************************************
+void disableNeverInCollisionThread(ThreadComputation tc)
+{
+  // RVIZ_COMMON_LOG_INFO_STREAM("Thread " << tc.thread_id_ << " running " << tc.num_trials_ << " trials");
+
+  // User feedback vars
+  const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
+
+  // Create a new kinematic state for this thread to work on
+  moveit::core::RobotState robot_state(tc.scene_.getRobotModel());
+
+  // Do a large number of tests
+  for (unsigned int i = 0; i < tc.num_trials_; ++i)
+  {
+    boost::this_thread::interruption_point();
+
+    // Status update at intervals and only for 0 thread
+    if (i % progress_interval == 0 && tc.thread_id_ == 0)
+    {
+      (*tc.progress_) = i * 92 / tc.num_trials_ + 8;  // 8 is the amount of progress already completed in prev steps
+    }
+
+    collision_detection::CollisionResult res;
+    robot_state.setToRandomPositions();
+    tc.scene_.checkSelfCollision(tc.req_, res, robot_state);
+
+    // Check all contacts
+    for (collision_detection::CollisionResult::ContactMap::const_iterator it = res.contacts.begin();
+         it != res.contacts.end(); ++it)
+    {
+      // Check if this collision pair is unique before doing a thread lock
+      if (tc.links_seen_colliding_->find(it->first) == tc.links_seen_colliding_->end())
+      {
+        // Collision Matrix and links_seen_colliding is modified only if needed, based on above if statement
+
+        boost::mutex::scoped_lock slock(*tc.lock_);
+        tc.links_seen_colliding_->insert(it->first);
+
+        tc.scene_.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second,
+                                                               true);  // disable link checking in the collision matrix
+      }
+    }
+  }
+}
+
+// ******************************************************************************************
+// Converts a reason for disabling a link pair into a string
+// ******************************************************************************************
+const std::string disabledReasonToString(DisabledReason reason)
+{
+  return REASONS_TO_STRING.at(reason);
+}
+
+// ******************************************************************************************
+// Converts a string reason for disabling a link pair into a struct data type
+// ******************************************************************************************
+DisabledReason disabledReasonFromString(const std::string& reason)
+{
+  DisabledReason r;
+  try
+  {
+    r = REASONS_FROM_STRING.at(reason);
+  }
+  catch (const std::out_of_range&)
+  {
+    r = USER;
+  }
+
+  return r;
+}
+
+}  // namespace moveit_collisions_updater

--- a/moveit_collisions_updater/src/tools/moveit_config_data.cpp
+++ b/moveit_collisions_updater/src/tools/moveit_config_data.cpp
@@ -1,0 +1,2019 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman */
+
+#include <moveit/collisions_updater/tools/moveit_config_data.hpp>
+// Reading/Writing Files
+#include <iostream>  // For writing yaml and launch files
+#include <fstream>
+#include <boost/filesystem/path.hpp>        // for creating folders/files
+#include <boost/filesystem/operations.hpp>  // is_regular_file, is_directory, etc.
+#include <boost/algorithm/string/trim.hpp>
+#include <tinyxml.h>
+
+// ROS
+#include <rviz_common/logging.hpp>
+#include <ament_index_cpp/get_package_share_directory.hpp>  // for getting file path for loading images
+
+// OMPL version
+#include <ompl/config.h>
+
+namespace moveit_collisions_updater
+{
+// File system
+namespace fs = boost::filesystem;
+
+// ******************************************************************************************
+// Constructor
+// ******************************************************************************************
+MoveItConfigData::MoveItConfigData() : config_pkg_generated_timestamp_(0)
+{
+  // Create an instance of SRDF writer and URDF model for all widgets to share
+  srdf_.reset(new srdf::SRDFWriter());
+  urdf_model_.reset(new urdf::Model());
+
+  // Not in debug mode
+  debug_ = false;
+
+  // Get MoveIt Setup Assistant package path
+  setup_assistant_path_ = ament_index_cpp::get_package_share_directory("moveit_collisions_updater");
+  if (setup_assistant_path_.empty())
+  {
+    setup_assistant_path_ = ".";
+  }
+}
+
+// ******************************************************************************************
+// Destructor
+// ******************************************************************************************
+MoveItConfigData::~MoveItConfigData() = default;
+
+// ******************************************************************************************
+// Load a robot model
+// ******************************************************************************************
+void MoveItConfigData::setRobotModel(const moveit::core::RobotModelPtr& robot_model)
+{
+  robot_model_ = robot_model;
+}
+
+// ******************************************************************************************
+// Provide a kinematic model. Load a new one if necessary
+// ******************************************************************************************
+moveit::core::RobotModelConstPtr MoveItConfigData::getRobotModel()
+{
+  if (!robot_model_)
+  {
+    // Initialize with a URDF Model Interface and a SRDF Model
+    robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_->srdf_model_));
+  }
+
+  return robot_model_;
+}
+
+// ******************************************************************************************
+// Update the Kinematic Model with latest SRDF modifications
+// ******************************************************************************************
+void MoveItConfigData::updateRobotModel()
+{
+  RVIZ_COMMON_LOG_INFO("Updating kinematic model");
+
+  // Tell SRDF Writer to create new SRDF Model, use original URDF model
+  srdf_->updateSRDFModel(*urdf_model_);
+
+  // Create new kin model
+  robot_model_.reset(new moveit::core::RobotModel(urdf_model_, srdf_->srdf_model_));
+
+  // Reset the planning scene
+  planning_scene_.reset();
+}
+
+// ******************************************************************************************
+// Provide a shared planning scene
+// ******************************************************************************************
+planning_scene::PlanningScenePtr MoveItConfigData::getPlanningScene()
+{
+  if (!planning_scene_)
+  {
+    // make sure kinematic model exists
+    getRobotModel();
+
+    // Allocate an empty planning scene
+    planning_scene_.reset(new planning_scene::PlanningScene(robot_model_));
+  }
+  return planning_scene_;
+}
+
+// ******************************************************************************************
+// Load the allowed collision matrix from the SRDF's list of link pairs
+// ******************************************************************************************
+void MoveItConfigData::loadAllowedCollisionMatrix()
+{
+  // Clear the allowed collision matrix
+  allowed_collision_matrix_.clear();
+
+  // Update the allowed collision matrix, in case there has been a change
+  for (const auto& disabled_collision : srdf_->disabled_collisions_)
+  {
+    allowed_collision_matrix_.setEntry(disabled_collision.link1_, disabled_collision.link2_, true);
+  }
+}
+
+// ******************************************************************************************
+// Output MoveIt Setup Assistant hidden settings file
+// ******************************************************************************************
+bool MoveItConfigData::outputSetupAssistantFile(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  // Output every available planner ---------------------------------------------------
+  emitter << YAML::Key << "moveit_collisions_updater_config";
+
+  emitter << YAML::Value << YAML::BeginMap;
+
+  // URDF Path Location
+  emitter << YAML::Key << "URDF";
+  emitter << YAML::Value << YAML::BeginMap;
+  emitter << YAML::Key << "package" << YAML::Value << urdf_pkg_name_;
+  emitter << YAML::Key << "relative_path" << YAML::Value << urdf_pkg_relative_path_;
+  emitter << YAML::Key << "xacro_args" << YAML::Value << xacro_args_;
+  emitter << YAML::EndMap;
+
+  /// SRDF Path Location
+  emitter << YAML::Key << "SRDF";
+  emitter << YAML::Value << YAML::BeginMap;
+  emitter << YAML::Key << "relative_path" << YAML::Value << srdf_pkg_relative_path_;
+  emitter << YAML::EndMap;
+
+  /// Package generation time
+  emitter << YAML::Key << "CONFIG";
+  emitter << YAML::Value << YAML::BeginMap;
+  emitter << YAML::Key << "author_name" << YAML::Value << author_name_;
+  emitter << YAML::Key << "author_email" << YAML::Value << author_email_;
+  emitter << YAML::Key << "generated_timestamp" << YAML::Value << std::time(nullptr);  // TODO: is this cross-platform?
+  emitter << YAML::EndMap;
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Output OMPL Planning config files
+// ******************************************************************************************
+bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  // Output every available planner ---------------------------------------------------
+  emitter << YAML::Key << "planner_configs";
+
+  emitter << YAML::Value << YAML::BeginMap;
+
+  std::vector<OMPLPlannerDescription> planner_des = getOMPLPlanners();
+
+  // Add Planners with parameter values
+  std::vector<std::string> pconfigs;
+  for (OMPLPlannerDescription& planner_de : planner_des)
+  {
+    std::string defaultconfig = planner_de.name_;
+    emitter << YAML::Key << defaultconfig;
+    emitter << YAML::Value << YAML::BeginMap;
+    emitter << YAML::Key << "type" << YAML::Value << "geometric::" + planner_de.name_;
+    for (OmplPlanningParameter& ompl_planner_param : planner_de.parameter_list_)
+    {
+      emitter << YAML::Key << ompl_planner_param.name;
+      emitter << YAML::Value << ompl_planner_param.value;
+      emitter << YAML::Comment(ompl_planner_param.comment);
+    }
+    emitter << YAML::EndMap;
+
+    pconfigs.push_back(defaultconfig);
+  }
+
+  // End of every avail planner
+  emitter << YAML::EndMap;
+
+  // Output every group and the planners it can use ----------------------------------
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    emitter << YAML::Key << group.name_;
+    emitter << YAML::Value << YAML::BeginMap;
+    // Output associated planners
+    if (!group_meta_data_[group.name_].default_planner_.empty())
+      emitter << YAML::Key << "default_planner_config" << YAML::Value << group_meta_data_[group.name_].default_planner_;
+    emitter << YAML::Key << "planner_configs";
+    emitter << YAML::Value << YAML::BeginSeq;
+    for (const std::string& pconfig : pconfigs)
+      emitter << pconfig;
+    emitter << YAML::EndSeq;
+
+    // Output projection_evaluator
+    std::string projection_joints = decideProjectionJoints(group.name_);
+    if (!projection_joints.empty())
+    {
+      emitter << YAML::Key << "projection_evaluator";
+      emitter << YAML::Value << projection_joints;
+      // OMPL collision checking discretization
+      emitter << YAML::Key << "longest_valid_segment_fraction";
+      emitter << YAML::Value << "0.005";
+    }
+
+    emitter << YAML::EndMap;
+  }
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str() << std::endl;
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Output CHOMP Planning config files
+// ******************************************************************************************
+bool MoveItConfigData::outputCHOMPPlanningYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+
+  emitter << YAML::Value << YAML::BeginMap;
+  emitter << YAML::Key << "planning_time_limit" << YAML::Value << "10.0";
+  emitter << YAML::Key << "max_iterations" << YAML::Value << "200";
+  emitter << YAML::Key << "max_iterations_after_collision_free" << YAML::Value << "5";
+  emitter << YAML::Key << "smoothness_cost_weight" << YAML::Value << "0.1";
+  emitter << YAML::Key << "obstacle_cost_weight" << YAML::Value << "1.0";
+  emitter << YAML::Key << "learning_rate" << YAML::Value << "0.01";
+  emitter << YAML::Key << "smoothness_cost_velocity" << YAML::Value << "0.0";
+  emitter << YAML::Key << "smoothness_cost_acceleration" << YAML::Value << "1.0";
+  emitter << YAML::Key << "smoothness_cost_jerk" << YAML::Value << "0.0";
+  emitter << YAML::Key << "ridge_factor" << YAML::Value << "0.01";
+  emitter << YAML::Key << "use_pseudo_inverse" << YAML::Value << "false";
+  emitter << YAML::Key << "pseudo_inverse_ridge_factor" << YAML::Value << "1e-4";
+  emitter << YAML::Key << "joint_update_limit" << YAML::Value << "0.1";
+  emitter << YAML::Key << "collision_clearance" << YAML::Value << "0.2";
+  emitter << YAML::Key << "collision_threshold" << YAML::Value << "0.07";
+  emitter << YAML::Key << "use_stochastic_descent" << YAML::Value << "true";
+  emitter << YAML::Key << "enable_failure_recovery" << YAML::Value << "true";
+  emitter << YAML::Key << "max_recovery_attempts" << YAML::Value << "5";
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Output kinematic config files
+// ******************************************************************************************
+bool MoveItConfigData::outputKinematicsYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  // Output every group and the kinematic solver it can use ----------------------------------
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    // Only save kinematic data if the solver is not "None"
+    if (group_meta_data_[group.name_].kinematics_solver_.empty() ||
+        group_meta_data_[group.name_].kinematics_solver_ == "None")
+      continue;
+
+    emitter << YAML::Key << group.name_;
+    emitter << YAML::Value << YAML::BeginMap;
+
+    // Kinematic Solver
+    emitter << YAML::Key << "kinematics_solver";
+    emitter << YAML::Value << group_meta_data_[group.name_].kinematics_solver_;
+
+    // Search Resolution
+    emitter << YAML::Key << "kinematics_solver_search_resolution";
+    emitter << YAML::Value << group_meta_data_[group.name_].kinematics_solver_search_resolution_;
+
+    // Solver Timeout
+    emitter << YAML::Key << "kinematics_solver_timeout";
+    emitter << YAML::Value << group_meta_data_[group.name_].kinematics_solver_timeout_;
+
+    emitter << YAML::EndMap;
+  }
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Helper function to get the controller that is controlling the joint
+// ******************************************************************************************
+std::string MoveItConfigData::getJointHardwareInterface(const std::string& joint_name)
+{
+  for (ROSControlConfig& ros_control_config : ros_controllers_config_)
+  {
+    std::vector<std::string>::iterator joint_it =
+        std::find(ros_control_config.joints_.begin(), ros_control_config.joints_.end(), joint_name);
+    if (joint_it != ros_control_config.joints_.end())
+    {
+      if (ros_control_config.type_.substr(0, 8) == "position")
+        return "hardware_interface/PositionJointInterface";
+      else if (ros_control_config.type_.substr(0, 8) == "velocity")
+        return "hardware_interface/VelocityJointInterface";
+      // As of writing this, available joint command interfaces are position, velocity and effort.
+      else
+        return "hardware_interface/EffortJointInterface";
+    }
+  }
+  // If the joint was not found in any controller return EffortJointInterface
+  return "hardware_interface/EffortJointInterface";
+}
+
+// ******************************************************************************************
+// Writes a Gazebo compatible robot URDF to gazebo_compatible_urdf_string_
+// ******************************************************************************************
+std::string MoveItConfigData::getGazeboCompatibleURDF()
+{
+  bool new_urdf_needed = false;
+  TiXmlDocument urdf_document;
+
+  // Used to convert XmlDocument to std string
+  TiXmlPrinter printer;
+  urdf_document.Parse((const char*)urdf_string_.c_str(), nullptr, TIXML_ENCODING_UTF8);
+  try
+  {
+    for (TiXmlElement* doc_element = urdf_document.RootElement()->FirstChildElement(); doc_element != nullptr;
+         doc_element = doc_element->NextSiblingElement())
+    {
+      if (static_cast<std::string>(doc_element->Value()).find("link") != std::string::npos)
+      {
+        // Before adding inertial elements, make sure there is none and the link has collision element
+        if (doc_element->FirstChildElement("inertial") == nullptr &&
+            doc_element->FirstChildElement("collision") != nullptr)
+        {
+          new_urdf_needed = true;
+          TiXmlElement inertia_link("inertial");
+          TiXmlElement mass("mass");
+          TiXmlElement inertia_joint("inertia");
+
+          mass.SetAttribute("value", "0.1");
+
+          inertia_joint.SetAttribute("ixx", "0.03");
+          inertia_joint.SetAttribute("iyy", "0.03");
+          inertia_joint.SetAttribute("izz", "0.03");
+          inertia_joint.SetAttribute("ixy", "0.0");
+          inertia_joint.SetAttribute("ixz", "0.0");
+          inertia_joint.SetAttribute("iyz", "0.0");
+
+          inertia_link.InsertEndChild(mass);
+          inertia_link.InsertEndChild(inertia_joint);
+
+          doc_element->InsertEndChild(inertia_link);
+        }
+      }
+      else if (static_cast<std::string>(doc_element->Value()).find("joint") != std::string::npos)
+      {
+        // Before adding a transmission element, make sure there the joint is not fixed
+        if (static_cast<std::string>(doc_element->Attribute("type")) != "fixed")
+        {
+          new_urdf_needed = true;
+          std::string joint_name = static_cast<std::string>(doc_element->Attribute("name"));
+          TiXmlElement transmission("transmission");
+          TiXmlElement type("type");
+          TiXmlElement joint("joint");
+          TiXmlElement hardware_interface("hardwareInterface");
+          TiXmlElement actuator("actuator");
+          TiXmlElement mechanical_reduction("mechanicalReduction");
+
+          transmission.SetAttribute("name", std::string("trans_") + joint_name);
+          joint.SetAttribute("name", joint_name);
+          actuator.SetAttribute("name", joint_name + std::string("_motor"));
+
+          type.InsertEndChild(TiXmlText("transmission_interface/SimpleTransmission"));
+          transmission.InsertEndChild(type);
+
+          hardware_interface.InsertEndChild(TiXmlText(getJointHardwareInterface(joint_name).c_str()));
+          joint.InsertEndChild(hardware_interface);
+          transmission.InsertEndChild(joint);
+
+          mechanical_reduction.InsertEndChild(TiXmlText("1"));
+          actuator.InsertEndChild(hardware_interface);
+          actuator.InsertEndChild(mechanical_reduction);
+          transmission.InsertEndChild(actuator);
+
+          urdf_document.RootElement()->InsertEndChild(transmission);
+        }
+      }
+    }
+
+    // Add gazebo_ros_control plugin which reads the transmission tags
+    TiXmlElement gazebo("gazebo");
+    TiXmlElement plugin("plugin");
+    TiXmlElement robot_namespace("robotNamespace");
+
+    plugin.SetAttribute("name", "gazebo_ros_control");
+    plugin.SetAttribute("filename", "libgazebo_ros_control.so");
+    robot_namespace.InsertEndChild(TiXmlText(std::string("/")));
+
+    plugin.InsertEndChild(robot_namespace);
+    gazebo.InsertEndChild(plugin);
+
+    urdf_document.RootElement()->InsertEndChild(gazebo);
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM(e.what());
+    return std::string("");
+  }
+
+  if (new_urdf_needed)
+  {
+    urdf_document.Accept(&printer);
+    return std::string(printer.CStr());
+  }
+
+  return std::string("");
+}
+
+bool MoveItConfigData::outputFakeControllersYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  emitter << YAML::Key << "controller_list";
+  emitter << YAML::Value << YAML::BeginSeq;
+
+  // Loop through groups
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    // Get list of associated joints
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+    emitter << YAML::BeginMap;
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    emitter << YAML::Key << "name";
+    emitter << YAML::Value << "fake_" + group.name_ + "_controller";
+    emitter << YAML::Key << "type";
+    emitter << YAML::Value << "$(arg execution_type)";
+    emitter << YAML::Key << "joints";
+    emitter << YAML::Value << YAML::BeginSeq;
+
+    // Iterate through the joints
+    for (const moveit::core::JointModel* joint : joint_models)
+    {
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
+        continue;
+      emitter << joint->getName();
+    }
+    emitter << YAML::EndSeq;
+    emitter << YAML::EndMap;
+  }
+
+  emitter << YAML::EndSeq;
+
+  // Add an initial pose for each group
+  emitter << YAML::Key << "initial" << YAML::Comment("Define initial robot poses.");
+
+  bool poses_found = false;
+  std::string default_group_name;
+  for (const srdf::Model::Group& group : srdf_->groups_)
+  {
+    if (default_group_name.empty())
+      default_group_name = group.name_;
+    for (const srdf::Model::GroupState& group_state : srdf_->group_states_)
+    {
+      if (group.name_ == group_state.group_)
+      {
+        if (!poses_found)
+        {
+          poses_found = true;
+          emitter << YAML::Value << YAML::BeginSeq;
+        }
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "group";
+        emitter << YAML::Value << group.name_;
+        emitter << YAML::Key << "pose";
+        emitter << YAML::Value << group_state.name_;
+        emitter << YAML::EndMap;
+        break;
+      }
+    }
+  }
+  if (poses_found)
+    emitter << YAML::EndSeq;
+  else
+  {
+    // Add commented lines to show how the feature can be used
+    if (default_group_name.empty())
+      default_group_name = "group";
+    emitter << YAML::Newline;
+    emitter << YAML::Comment(" - group: " + default_group_name) << YAML::Newline;
+    emitter << YAML::Comment("   pose: home") << YAML::Newline;
+
+    // Add empty list for valid yaml
+    emitter << YAML::BeginSeq;
+    emitter << YAML::EndSeq;
+  }
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
+{
+  std::vector<OMPLPlannerDescription> planner_des;
+
+  OMPLPlannerDescription aps("AnytimePathShortening", "geometric");
+  aps.addParameter("shortcut", "true", "Attempt to shortcut all new solution paths");
+  aps.addParameter("hybridize", "true", "Compute hybrid solution trajectories");
+  aps.addParameter("max_hybrid_paths", "24", "Number of hybrid paths generated per iteration");
+  aps.addParameter("num_planners", "4", "The number of default planners to use for planning");
+// TODO: remove when ROS Melodic and older are no longer supported
+#if OMPL_VERSION_VALUE >= 1005000
+  // This parameter was added in OMPL 1.5.0
+  aps.addParameter("planners", "",
+                   "A comma-separated list of planner types (e.g., \"PRM,EST,RRTConnect\""
+                   "Optionally, planner parameters can be passed to change the default:"
+                   "\"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]\"");
+#endif
+  planner_des.push_back(aps);
+
+  OMPLPlannerDescription sbl("SBL", "geometric");
+  sbl.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()");
+  planner_des.push_back(sbl);
+
+  OMPLPlannerDescription est("EST", "geometric");
+  est.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()");
+  est.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability. default: 0.05");
+  planner_des.push_back(est);
+
+  OMPLPlannerDescription lbkpiece("LBKPIECE", "geometric");
+  lbkpiece.addParameter("range", "0.0",
+                        "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                        "setup()");
+  lbkpiece.addParameter("border_fraction", "0.9", "Fraction of time focused on boarder default: 0.9");
+  lbkpiece.addParameter("min_valid_path_fraction", "0.5", "Accept partially valid moves above fraction. default: 0.5");
+  planner_des.push_back(lbkpiece);
+
+  OMPLPlannerDescription bkpiece("BKPIECE", "geometric");
+  bkpiece.addParameter("range", "0.0",
+                       "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                       "setup()");
+  bkpiece.addParameter("border_fraction", "0.9", "Fraction of time focused on boarder default: 0.9");
+  bkpiece.addParameter("failed_expansion_score_factor", "0.5",
+                       "When extending motion fails, scale score by factor. "
+                       "default: 0.5");
+  bkpiece.addParameter("min_valid_path_fraction", "0.5", "Accept partially valid moves above fraction. default: 0.5");
+  planner_des.push_back(bkpiece);
+
+  OMPLPlannerDescription kpiece("KPIECE", "geometric");
+  kpiece.addParameter("range", "0.0",
+                      "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                      "setup()");
+  kpiece.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability. default: 0.05");
+  kpiece.addParameter("border_fraction", "0.9", "Fraction of time focused on boarder default: 0.9 (0.0,1.]");
+  kpiece.addParameter("failed_expansion_score_factor", "0.5",
+                      "When extending motion fails, scale score by factor. "
+                      "default: 0.5");
+  kpiece.addParameter("min_valid_path_fraction", "0.5", "Accept partially valid moves above fraction. default: 0.5");
+  planner_des.push_back(kpiece);
+
+  OMPLPlannerDescription rrt("RRT", "geometric");
+  rrt.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()");
+  rrt.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability? default: 0.05");
+  planner_des.push_back(rrt);
+
+  OMPLPlannerDescription rrt_connect("RRTConnect", "geometric");
+  rrt_connect.addParameter("range", "0.0",
+                           "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                           "setup()");
+  planner_des.push_back(rrt_connect);
+
+  OMPLPlannerDescription rr_tstar("RRTstar", "geometric");
+  rr_tstar.addParameter("range", "0.0",
+                        "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                        "setup()");
+  rr_tstar.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability? default: 0.05");
+  rr_tstar.addParameter("delay_collision_checking", "1",
+                        "Stop collision checking as soon as C-free parent found. "
+                        "default 1");
+  planner_des.push_back(rr_tstar);
+
+  OMPLPlannerDescription trrt("TRRT", "geometric");
+  trrt.addParameter("range", "0.0", "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()");
+  trrt.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability? default: 0.05");
+  trrt.addParameter("max_states_failed", "10", "when to start increasing temp. default: 10");
+  trrt.addParameter("temp_change_factor", "2.0", "how much to increase or decrease temp. default: 2.0");
+  trrt.addParameter("min_temperature", "10e-10", "lower limit of temp change. default: 10e-10");
+  trrt.addParameter("init_temperature", "10e-6", "initial temperature. default: 10e-6");
+  trrt.addParameter("frountier_threshold", "0.0",
+                    "dist new state to nearest neighbor to disqualify as frontier. "
+                    "default: 0.0 set in setup()");
+  trrt.addParameter("frountierNodeRatio", "0.1", "1/10, or 1 nonfrontier for every 10 frontier. default: 0.1");
+  trrt.addParameter("k_constant", "0.0", "value used to normalize expression. default: 0.0 set in setup()");
+  planner_des.push_back(trrt);
+
+  OMPLPlannerDescription prm("PRM", "geometric");
+  prm.addParameter("max_nearest_neighbors", "10", "use k nearest neighbors. default: 10");
+  planner_des.push_back(prm);
+
+  OMPLPlannerDescription pr_mstar("PRMstar", "geometric");  // no declares in code
+  planner_des.push_back(pr_mstar);
+
+  OMPLPlannerDescription fmt("FMT", "geometric");
+  fmt.addParameter("num_samples", "1000", "number of states that the planner should sample. default: 1000");
+  fmt.addParameter("radius_multiplier", "1.1", "multiplier used for the nearest neighbors search radius. default: 1.1");
+  fmt.addParameter("nearest_k", "1", "use Knearest strategy. default: 1");
+  fmt.addParameter("cache_cc", "1", "use collision checking cache. default: 1");
+  fmt.addParameter("heuristics", "0", "activate cost to go heuristics. default: 0");
+  fmt.addParameter("extended_fmt", "1",
+                   "activate the extended FMT*: adding new samples if planner does not finish "
+                   "successfully. default: 1");
+  planner_des.push_back(fmt);
+
+  OMPLPlannerDescription bfmt("BFMT", "geometric");
+  bfmt.addParameter("num_samples", "1000", "number of states that the planner should sample. default: 1000");
+  bfmt.addParameter("radius_multiplier", "1.0",
+                    "multiplier used for the nearest neighbors search radius. default: "
+                    "1.0");
+  bfmt.addParameter("nearest_k", "1", "use the Knearest strategy. default: 1");
+  bfmt.addParameter("balanced", "0",
+                    "exploration strategy: balanced true expands one tree every iteration. False will "
+                    "select the tree with lowest maximum cost to go. default: 1");
+  bfmt.addParameter("optimality", "1",
+                    "termination strategy: optimality true finishes when the best possible path is "
+                    "found. Otherwise, the algorithm will finish when the first feasible path is "
+                    "found. default: 1");
+  bfmt.addParameter("heuristics", "1", "activates cost to go heuristics. default: 1");
+  bfmt.addParameter("cache_cc", "1", "use the collision checking cache. default: 1");
+  bfmt.addParameter("extended_fmt", "1",
+                    "Activates the extended FMT*: adding new samples if planner does not finish "
+                    "successfully. default: 1");
+  planner_des.push_back(bfmt);
+
+  OMPLPlannerDescription pdst("PDST", "geometric");
+  rrt.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability? default: 0.05");
+  planner_des.push_back(pdst);
+
+  OMPLPlannerDescription stride("STRIDE", "geometric");
+  stride.addParameter("range", "0.0",
+                      "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                      "setup()");
+  stride.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability. default: 0.05");
+  stride.addParameter("use_projected_distance", "0",
+                      "whether nearest neighbors are computed based on distances in a "
+                      "projection of the state rather distances in the state space "
+                      "itself. default: 0");
+  stride.addParameter("degree", "16",
+                      "desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). "
+                      "default: 16");
+  stride.addParameter("max_degree", "18", "max degree of a node in the GNAT. default: 12");
+  stride.addParameter("min_degree", "12", "min degree of a node in the GNAT. default: 12");
+  stride.addParameter("max_pts_per_leaf", "6", "max points per leaf in the GNAT. default: 6");
+  stride.addParameter("estimated_dimension", "0.0", "estimated dimension of the free space. default: 0.0");
+  stride.addParameter("min_valid_path_fraction", "0.2", "Accept partially valid moves above fraction. default: 0.2");
+  planner_des.push_back(stride);
+
+  OMPLPlannerDescription bi_trrt("BiTRRT", "geometric");
+  bi_trrt.addParameter("range", "0.0",
+                       "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                       "setup()");
+  bi_trrt.addParameter("temp_change_factor", "0.1", "how much to increase or decrease temp. default: 0.1");
+  bi_trrt.addParameter("init_temperature", "100", "initial temperature. default: 100");
+  bi_trrt.addParameter("frountier_threshold", "0.0",
+                       "dist new state to nearest neighbor to disqualify as frontier. "
+                       "default: 0.0 set in setup()");
+  bi_trrt.addParameter("frountier_node_ratio", "0.1", "1/10, or 1 nonfrontier for every 10 frontier. default: 0.1");
+  bi_trrt.addParameter("cost_threshold", "1e300",
+                       "the cost threshold. Any motion cost that is not better will not be "
+                       "expanded. default: inf");
+  planner_des.push_back(bi_trrt);
+
+  OMPLPlannerDescription lbtrrt("LBTRRT", "geometric");
+  lbtrrt.addParameter("range", "0.0",
+                      "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                      "setup()");
+  lbtrrt.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability. default: 0.05");
+  lbtrrt.addParameter("epsilon", "0.4", "optimality approximation factor. default: 0.4");
+  planner_des.push_back(lbtrrt);
+
+  OMPLPlannerDescription bi_est("BiEST", "geometric");
+  bi_est.addParameter("range", "0.0",
+                      "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                      "setup()");
+  planner_des.push_back(bi_est);
+
+  OMPLPlannerDescription proj_est("ProjEST", "geometric");
+  proj_est.addParameter("range", "0.0",
+                        "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                        "setup()");
+  proj_est.addParameter("goal_bias", "0.05", "When close to goal select goal, with this probability. default: 0.05");
+  planner_des.push_back(proj_est);
+
+  OMPLPlannerDescription lazy_prm("LazyPRM", "geometric");
+  lazy_prm.addParameter("range", "0.0",
+                        "Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on "
+                        "setup()");
+  planner_des.push_back(lazy_prm);
+
+  OMPLPlannerDescription lazy_pr_mstar("LazyPRMstar", "geometric");  // no declares in code
+  planner_des.push_back(lazy_pr_mstar);
+
+  OMPLPlannerDescription spars("SPARS", "geometric");
+  spars.addParameter("stretch_factor", "3.0",
+                     "roadmap spanner stretch factor. multiplicative upper bound on path "
+                     "quality. It does not make sense to make this parameter more than 3. "
+                     "default: 3.0");
+  spars.addParameter("sparse_delta_fraction", "0.25",
+                     "delta fraction for connection distance. This value represents "
+                     "the visibility range of sparse samples. default: 0.25");
+  spars.addParameter("dense_delta_fraction", "0.001", "delta fraction for interface detection. default: 0.001");
+  spars.addParameter("max_failures", "1000", "maximum consecutive failure limit. default: 1000");
+  planner_des.push_back(spars);
+
+  OMPLPlannerDescription spar_stwo("SPARStwo", "geometric");
+  spar_stwo.addParameter("stretch_factor", "3.0",
+                         "roadmap spanner stretch factor. multiplicative upper bound on path "
+                         "quality. It does not make sense to make this parameter more than 3. "
+                         "default: 3.0");
+  spar_stwo.addParameter("sparse_delta_fraction", "0.25",
+                         "delta fraction for connection distance. This value represents "
+                         "the visibility range of sparse samples. default: 0.25");
+  spar_stwo.addParameter("dense_delta_fraction", "0.001", "delta fraction for interface detection. default: 0.001");
+  spar_stwo.addParameter("max_failures", "5000", "maximum consecutive failure limit. default: 5000");
+  planner_des.push_back(spar_stwo);
+
+  return planner_des;
+}
+
+// ******************************************************************************************
+// Helper function to write the FollowJointTrajectory for each planning group to ros_controller.yaml,
+// and erases the controller that have been written, to avoid mixing between FollowJointTrajectory
+// which are published under the namespace of 'controller_list' and other types of controllers.
+// ******************************************************************************************
+void MoveItConfigData::outputFollowJointTrajectoryYAML(YAML::Emitter& emitter,
+                                                       std::vector<ROSControlConfig>& ros_controllers_config_output)
+{
+  // Write default controllers
+  emitter << YAML::Key << "controller_list";
+  emitter << YAML::Value << YAML::BeginSeq;
+  {
+    for (std::vector<ROSControlConfig>::iterator controller_it = ros_controllers_config_output.begin();
+         controller_it != ros_controllers_config_output.end();)
+    {
+      // Depending on the controller type, fill the required data
+      if (controller_it->type_ == "FollowJointTrajectory")
+      {
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "name";
+        emitter << YAML::Value << controller_it->name_;
+        emitter << YAML::Key << "action_ns";
+        emitter << YAML::Value << "follow_joint_trajectory";
+        emitter << YAML::Key << "default";
+        emitter << YAML::Value << "True";
+        emitter << YAML::Key << "type";
+        emitter << YAML::Value << controller_it->type_;
+        // Write joints
+        emitter << YAML::Key << "joints";
+        {
+          if (controller_it->joints_.size() != 1)
+          {
+            emitter << YAML::Value << YAML::BeginSeq;
+
+            // Iterate through the joints
+            for (std::string& joint : controller_it->joints_)
+            {
+              emitter << joint;
+            }
+            emitter << YAML::EndSeq;
+          }
+          else
+          {
+            emitter << YAML::Value << YAML::BeginMap;
+            emitter << controller_it->joints_[0];
+            emitter << YAML::EndMap;
+          }
+        }
+        controller_it = ros_controllers_config_output.erase(controller_it);
+        emitter << YAML::EndMap;
+      }
+      else
+      {
+        controller_it++;
+      }
+    }
+    emitter << YAML::EndSeq;
+  }
+}
+
+// ******************************************************************************************
+// Helper function to get the default start pose for moveit_sim_hw_interface
+// ******************************************************************************************
+srdf::Model::GroupState MoveItConfigData::getDefaultStartPose()
+{
+  if (!srdf_->group_states_.empty())
+    return srdf_->group_states_[0];
+  else
+    return srdf::Model::GroupState{ .name_ = "todo_state_name", .group_ = "todo_group_name", .joint_values_ = {} };
+}
+
+// ******************************************************************************************
+// Output controllers config files
+// ******************************************************************************************
+bool MoveItConfigData::outputROSControllersYAML(const std::string& file_path)
+{
+  // Copy ros_control_config_ to a new vector to avoid modifying it
+  std::vector<ROSControlConfig> ros_controllers_config_output(ros_controllers_config_);
+
+  // Cache the joints' names.
+  std::vector<std::vector<std::string>> planning_groups;
+  std::vector<std::string> group_joints;
+
+  // We are going to write the joints names many times.
+  // Loop through groups to store the joints names in group_joints vector and reuse is.
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    // Get list of associated joints
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+    // Iterate through the joints and push into group_joints vector.
+    for (const moveit::core::JointModel* joint : joint_models)
+    {
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
+        continue;
+      else
+        group_joints.push_back(joint->getName());
+    }
+    // Push all the group joints into planning_groups vector.
+    planning_groups.push_back(group_joints);
+    group_joints.clear();
+  }
+
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  {
+    emitter << YAML::Comment("Simulation settings for using moveit_sim_controllers");
+    emitter << YAML::Key << "moveit_sim_hw_interface" << YAML::Value << YAML::BeginMap;
+    // MoveIt Simulation Controller settings for setting initial pose
+    {
+      // Use the first planning group if initial joint_model_group was not set, else write a default value
+      emitter << YAML::Key << "joint_model_group";
+      emitter << YAML::Value << getDefaultStartPose().group_;
+
+      // Use the first robot pose if initial joint_model_group_pose was not set, else write a default value
+      emitter << YAML::Key << "joint_model_group_pose";
+      emitter << YAML::Value << getDefaultStartPose().name_;
+
+      emitter << YAML::EndMap;
+    }
+    // Settings for ros_control control loop
+    emitter << YAML::Newline;
+    emitter << YAML::Comment("Settings for ros_control_boilerplate control loop");
+    emitter << YAML::Key << "generic_hw_control_loop" << YAML::Value << YAML::BeginMap;
+    {
+      emitter << YAML::Key << "loop_hz";
+      emitter << YAML::Value << "300";
+      emitter << YAML::Key << "cycle_time_error_threshold";
+      emitter << YAML::Value << "0.01";
+      emitter << YAML::EndMap;
+    }
+    // Settings for ros_control hardware interface
+    emitter << YAML::Newline;
+    emitter << YAML::Comment("Settings for ros_control hardware interface");
+    emitter << YAML::Key << "hardware_interface" << YAML::Value << YAML::BeginMap;
+    {
+      // Get list of all joints for the robot
+      const std::vector<const moveit::core::JointModel*>& joint_models = getRobotModel()->getJointModels();
+
+      emitter << YAML::Key << "joints";
+      {
+        if (joint_models.size() != 1)
+        {
+          emitter << YAML::Value << YAML::BeginSeq;
+          // Iterate through the joints
+          for (std::vector<const moveit::core::JointModel*>::const_iterator joint_it = joint_models.begin();
+               joint_it < joint_models.end(); ++joint_it)
+          {
+            if ((*joint_it)->isPassive() || (*joint_it)->getMimic() != nullptr ||
+                (*joint_it)->getType() == moveit::core::JointModel::FIXED)
+              continue;
+            else
+              emitter << (*joint_it)->getName();
+          }
+          emitter << YAML::EndSeq;
+        }
+        else
+        {
+          emitter << YAML::Value << YAML::BeginMap;
+          emitter << joint_models[0]->getName();
+          emitter << YAML::EndMap;
+        }
+      }
+      emitter << YAML::Key << "sim_control_mode";
+      emitter << YAML::Value << "1";
+      emitter << YAML::Comment("0: position, 1: velocity");
+      emitter << YAML::Newline;
+      emitter << YAML::EndMap;
+    }
+    // Joint State Controller
+    emitter << YAML::Comment("Publish all joint states");
+    emitter << YAML::Newline << YAML::Comment("Creates the /joint_states topic necessary in ROS");
+    emitter << YAML::Key << "joint_state_broadcaster" << YAML::Value << YAML::BeginMap;
+    {
+      emitter << YAML::Key << "type";
+      emitter << YAML::Value << "joint_state_broadcaster/JointStateBroadcaster";
+      emitter << YAML::Key << "publish_rate";
+      emitter << YAML::Value << "50";
+      emitter << YAML::EndMap;
+    }
+
+    // Writes Follow Joint Trajectory ROS controllers to ros_controller.yaml
+    outputFollowJointTrajectoryYAML(emitter, ros_controllers_config_output);
+
+    for (const auto& controller : ros_controllers_config_output)
+    {
+      emitter << YAML::Key << controller.name_;
+      emitter << YAML::Value << YAML::BeginMap;
+      emitter << YAML::Key << "type";
+      emitter << YAML::Value << controller.type_;
+
+      // Write joints
+      emitter << YAML::Key << "joints";
+      {
+        if (controller.joints_.size() != 1)
+        {
+          emitter << YAML::Value << YAML::BeginSeq;
+
+          // Iterate through the joints
+          for (const std::string& joint : controller.joints_)
+          {
+            emitter << joint;
+          }
+          emitter << YAML::EndSeq;
+        }
+        else
+        {
+          emitter << YAML::Value << YAML::BeginMap;
+          emitter << controller.joints_[0];
+          emitter << YAML::EndMap;
+        }
+      }
+      // Write gains as they are required for vel and effort controllers
+      emitter << YAML::Key << "gains";
+      emitter << YAML::Value << YAML::BeginMap;
+      {
+        // Iterate through the joints
+        for (const std::string& joint : controller.joints_)
+        {
+          emitter << YAML::Key << joint << YAML::Value << YAML::BeginMap;
+          emitter << YAML::Key << "p";
+          emitter << YAML::Value << "100";
+          emitter << YAML::Key << "d";
+          emitter << YAML::Value << "1";
+          emitter << YAML::Key << "i";
+          emitter << YAML::Value << "1";
+          emitter << YAML::Key << "i_clamp";
+          emitter << YAML::Value << "1" << YAML::EndMap;
+        }
+        emitter << YAML::EndMap;
+      }
+      emitter << YAML::EndMap;
+    }
+  }
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Output 3D Sensor configuration file
+// ******************************************************************************************
+bool MoveItConfigData::output3DSensorPluginYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+
+  emitter << YAML::Comment("The name of this file shouldn't be changed, or else the Setup Assistant won't detect it");
+  emitter << YAML::Key << "sensors";
+  emitter << YAML::Value << YAML::BeginSeq;
+
+  for (auto& sensors_plugin_config : sensors_plugin_config_parameter_list_)
+  {
+    emitter << YAML::BeginMap;
+
+    for (auto& parameter : sensors_plugin_config)
+    {
+      emitter << YAML::Key << parameter.first;
+      emitter << YAML::Value << parameter.second.getValue();
+    }
+    emitter << YAML::EndMap;
+  }
+
+  emitter << YAML::EndSeq;
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Output joint limits config files
+// ******************************************************************************************
+bool MoveItConfigData::outputJointLimitsYAML(const std::string& file_path)
+{
+  YAML::Emitter emitter;
+  emitter << YAML::Comment("joint_limits.yaml allows the dynamics properties specified in the URDF "
+                           "to be overwritten or augmented as needed");
+  emitter << YAML::Newline;
+
+  emitter << YAML::BeginMap;
+
+  emitter << YAML::Comment("For beginners, we downscale velocity and acceleration limits.") << YAML::Newline;
+  emitter << YAML::Comment("You can always specify higher scaling factors (<= 1.0) in your motion requests.");
+  emitter << YAML::Comment("Increase the values below to 1.0 to always move at maximum speed.");
+  emitter << YAML::Key << "default_velocity_scaling_factor";
+  emitter << YAML::Value << "0.1";
+
+  emitter << YAML::Key << "default_acceleration_scaling_factor";
+  emitter << YAML::Value << "0.1";
+
+  emitter << YAML::Newline << YAML::Newline;
+  emitter << YAML::Comment("Specific joint properties can be changed with the keys "
+                           "[max_position, min_position, max_velocity, max_acceleration]")
+          << YAML::Newline;
+  emitter << YAML::Comment("Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]");
+
+  emitter << YAML::Key << "joint_limits";
+  emitter << YAML::Value << YAML::BeginMap;
+
+  // Union all the joints in groups. Uses a custom comparator to allow the joints to be sorted by name
+  std::set<const moveit::core::JointModel*, JointModelCompare> joints;
+
+  // Loop through groups
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    // Get list of associated joints
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group.name_);
+
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getJointModels();
+
+    // Iterate through the joints
+    for (const moveit::core::JointModel* joint_model : joint_models)
+    {
+      // Check that this joint only represents 1 variable.
+      if (joint_model->getVariableCount() == 1)
+        joints.insert(joint_model);
+    }
+  }
+
+  // Add joints to yaml file, if no more than 1 dof
+  for (const moveit::core::JointModel* joint : joints)
+  {
+    emitter << YAML::Key << joint->getName();
+    emitter << YAML::Value << YAML::BeginMap;
+
+    const moveit::core::VariableBounds& b = joint->getVariableBounds()[0];
+
+    // Output property
+    emitter << YAML::Key << "has_velocity_limits";
+    if (b.velocity_bounded_)
+      emitter << YAML::Value << "true";
+    else
+      emitter << YAML::Value << "false";
+
+    // Output property
+    emitter << YAML::Key << "max_velocity";
+    emitter << YAML::Value << std::min(fabs(b.max_velocity_), fabs(b.min_velocity_));
+
+    // Output property
+    emitter << YAML::Key << "has_acceleration_limits";
+    if (b.acceleration_bounded_)
+      emitter << YAML::Value << "true";
+    else
+      emitter << YAML::Value << "false";
+
+    // Output property
+    emitter << YAML::Key << "max_acceleration";
+    emitter << YAML::Value << std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_));
+
+    emitter << YAML::EndMap;
+  }
+
+  emitter << YAML::EndMap;
+
+  std::ofstream output_stream(file_path.c_str(), std::ios_base::trunc);
+  if (!output_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for writing " << file_path);
+    return false;
+  }
+  output_stream << emitter.c_str();
+  output_stream.close();
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Set list of collision link pairs in SRDF; sorted; with optional filter
+// ******************************************************************************************
+
+class SortableDisabledCollision
+{
+public:
+  SortableDisabledCollision(const srdf::Model::DisabledCollision& dc)
+    : dc_(dc), key_(dc.link1_ < dc.link2_ ? (dc.link1_ + "|" + dc.link2_) : (dc.link2_ + "|" + dc.link1_))
+  {
+  }
+  operator const srdf::Model::DisabledCollision &() const
+  {
+    return dc_;
+  }
+  bool operator<(const SortableDisabledCollision& other) const
+  {
+    return key_ < other.key_;
+  }
+
+private:
+  const srdf::Model::DisabledCollision dc_;
+  const std::string key_;
+};
+
+void MoveItConfigData::setCollisionLinkPairs(const moveit_collisions_updater::LinkPairMap& link_pairs, size_t skip_mask)
+{
+  // Create temp disabled collision
+  srdf::Model::DisabledCollision dc;
+
+  std::set<SortableDisabledCollision> disabled_collisions;
+  disabled_collisions.insert(srdf_->disabled_collisions_.begin(), srdf_->disabled_collisions_.end());
+
+  // copy the data in this class's LinkPairMap datastructure to srdf::Model::DisabledCollision format
+  for (const std::pair<const std::pair<std::string, std::string>, LinkPairData>& link_pair : link_pairs)
+  {
+    // Only copy those that are actually disabled
+    if (link_pair.second.disable_check)
+    {
+      if ((1 << link_pair.second.reason) & skip_mask)
+        continue;
+
+      dc.link1_ = link_pair.first.first;
+      dc.link2_ = link_pair.first.second;
+      dc.reason_ = moveit_collisions_updater::disabledReasonToString(link_pair.second.reason);
+
+      disabled_collisions.insert(SortableDisabledCollision(dc));
+    }
+  }
+
+  srdf_->disabled_collisions_.assign(disabled_collisions.begin(), disabled_collisions.end());
+}
+
+// ******************************************************************************************
+// Decide the best two joints to be used for the projection evaluator
+// ******************************************************************************************
+std::string MoveItConfigData::decideProjectionJoints(const std::string& planning_group)
+{
+  std::string joint_pair = "";
+
+  // Retrieve pointer to the shared kinematic model
+  const moveit::core::RobotModelConstPtr& model = getRobotModel();
+
+  // Error check
+  if (!model->hasJointModelGroup(planning_group))
+    return joint_pair;
+
+  // Get the joint model group
+  const moveit::core::JointModelGroup* group = model->getJointModelGroup(planning_group);
+
+  // get vector of joint names
+  const std::vector<std::string>& joints = group->getJointModelNames();
+
+  if (joints.size() >= 2)
+  {
+    // Check that the first two joints have only 1 variable
+    if (group->getJointModel(joints[0])->getVariableCount() == 1 &&
+        group->getJointModel(joints[1])->getVariableCount() == 1)
+    {
+      // Just choose the first two joints.
+      joint_pair = "joints(" + joints[0] + "," + joints[1] + ")";
+    }
+  }
+
+  return joint_pair;
+}
+
+template <typename T>
+bool parse(const YAML::Node& node, const std::string& key, T& storage, const T& default_value = T())
+{
+  const YAML::Node& n = node[key];
+  bool valid = n;
+  storage = valid ? n.as<T>() : default_value;
+  return valid;
+}
+
+bool MoveItConfigData::inputOMPLYAML(const std::string& file_path)
+{
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for reading " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    YAML::Node doc = YAML::Load(input_stream);
+
+    // Loop through all groups
+    for (YAML::const_iterator group_it = doc.begin(); group_it != doc.end(); ++group_it)
+    {
+      // get group name
+      const std::string group_name = group_it->first.as<std::string>();
+
+      // compare group name found to list of groups in group_meta_data_
+      std::map<std::string, GroupMetaData>::iterator group_meta_it;
+      group_meta_it = group_meta_data_.find(group_name);
+      if (group_meta_it != group_meta_data_.end())
+      {
+        std::string planner;
+        parse(group_it->second, "default_planner_config", planner);
+        std::size_t pos = planner.find("kConfigDefault");
+        if (pos != std::string::npos)
+        {
+          planner = planner.substr(0, pos);
+        }
+        group_meta_data_[group_name].default_planner_ = planner;
+      }
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM(e.what());
+    return false;
+  }
+  return true;
+}
+
+// ******************************************************************************************
+// Input kinematics.yaml file
+// ******************************************************************************************
+bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
+{
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for reading " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    YAML::Node doc = YAML::Load(input_stream);
+
+    // Loop through all groups
+    for (YAML::const_iterator group_it = doc.begin(); group_it != doc.end(); ++group_it)
+    {
+      const std::string& group_name = group_it->first.as<std::string>();
+      const YAML::Node& group = group_it->second;
+
+      // Create new meta data
+      GroupMetaData meta_data;
+
+      parse(group, "kinematics_solver", meta_data.kinematics_solver_);
+      parse(group, "kinematics_solver_search_resolution", meta_data.kinematics_solver_search_resolution_,
+            DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION);
+      parse(group, "kinematics_solver_timeout", meta_data.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT);
+
+      // Assign meta data to vector
+      group_meta_data_[group_name] = meta_data;
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM(e.what());
+    return false;
+  }
+
+  return true;  // file created successfully
+}
+
+// ******************************************************************************************
+// Input planning_context.launch file
+// ******************************************************************************************
+bool MoveItConfigData::inputPlanningContextLaunch(const std::string& file_path)
+{
+  TiXmlDocument launch_document(file_path);
+  if (!launch_document.LoadFile())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Failed parsing " << file_path);
+    return false;
+  }
+
+  // find the kinematics section
+  TiXmlHandle doc(&launch_document);
+  TiXmlElement* kinematics_group = doc.FirstChild("launch").FirstChild("group").ToElement();
+  while (kinematics_group && kinematics_group->Attribute("ns") &&
+         kinematics_group->Attribute("ns") != std::string("$(arg robot_description)_kinematics"))
+  {
+    kinematics_group = kinematics_group->NextSiblingElement("group");
+  }
+  if (!kinematics_group)
+  {
+    RVIZ_COMMON_LOG_ERROR("<group ns=\"$(arg robot_description)_kinematics\"> not found");
+    return false;
+  }
+
+  // iterate over all <rosparam namespace="group" file="..."/> elements
+  // and if 'group' matches an existing group, copy the filename
+  for (TiXmlElement* kinematics_parameter_file = kinematics_group->FirstChildElement("rosparam");
+       kinematics_parameter_file; kinematics_parameter_file = kinematics_parameter_file->NextSiblingElement("rosparam"))
+  {
+    const char* ns = kinematics_parameter_file->Attribute("ns");
+    if (ns && (group_meta_data_.find(ns) != group_meta_data_.end()))
+    {
+      group_meta_data_[ns].kinematics_parameters_file_ = kinematics_parameter_file->Attribute("file");
+    }
+  }
+
+  return true;
+}
+
+// ******************************************************************************************
+// Helper function for parsing an individual ROSController from ros_controllers yaml file
+// ******************************************************************************************
+bool MoveItConfigData::parseROSController(const YAML::Node& controller)
+{
+  // Used in parsing ROS controllers
+  ROSControlConfig control_setting;
+
+  if (const YAML::Node& trajectory_controllers = controller)
+  {
+    for (const YAML::Node& trajectory_controller : trajectory_controllers)
+    {
+      // Controller node
+      if (const YAML::Node& controller_node = trajectory_controller)
+      {
+        if (const YAML::Node& joints = controller_node["joints"])
+        {
+          control_setting.joints_.clear();
+          for (YAML::const_iterator joint_it = joints.begin(); joint_it != joints.end(); ++joint_it)
+          {
+            control_setting.joints_.push_back(joint_it->as<std::string>());
+          }
+          if (!parse(controller_node, "name", control_setting.name_))
+          {
+            RVIZ_COMMON_LOG_ERROR_STREAM("Couldn't parse ros_controllers.yaml");
+            return false;
+          }
+          if (!parse(controller_node, "type", control_setting.type_))
+          {
+            RVIZ_COMMON_LOG_ERROR_STREAM("Couldn't parse ros_controllers.yaml");
+            return false;
+          }
+          // All required fields were parsed correctly
+          ros_controllers_config_.push_back(control_setting);
+        }
+        else
+        {
+          RVIZ_COMMON_LOG_ERROR_STREAM("Couldn't parse ros_controllers.yaml");
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// ******************************************************************************************
+// Helper function for parsing ROSControllers from ros_controllers yaml file
+// ******************************************************************************************
+bool MoveItConfigData::processROSControllers(std::ifstream& input_stream)
+{
+  // Used in parsing ROS controllers
+  ROSControlConfig control_setting;
+  YAML::Node controllers = YAML::Load(input_stream);
+
+  // Loop through all controllers
+  for (YAML::const_iterator controller_it = controllers.begin(); controller_it != controllers.end(); ++controller_it)
+  {
+    // Follow Joint Trajectory action controllers
+    if (controller_it->first.as<std::string>() == "controller_list")
+    {
+      if (!parseROSController(controller_it->second))
+        return false;
+    }
+    // Other settings found in the ros_controllers file
+    else
+    {
+      const std::string& controller_name = controller_it->first.as<std::string>();
+      control_setting.joints_.clear();
+
+      // Push joints if found in the controller
+      if (const YAML::Node& joints = controller_it->second["joints"])
+      {
+        if (joints.IsSequence())
+        {
+          for (YAML::const_iterator joint_it = joints.begin(); joint_it != joints.end(); ++joint_it)
+          {
+            control_setting.joints_.push_back(joint_it->as<std::string>());
+          }
+        }
+        else
+        {
+          control_setting.joints_.push_back(joints.as<std::string>());
+        }
+      }
+
+      // If the setting has joints then it is a controller that needs to be parsed
+      if (!control_setting.joints_.empty())
+      {
+        if (const YAML::Node& urdf_node = controller_it->second["type"])
+        {
+          control_setting.type_ = controller_it->second["type"].as<std::string>();
+          control_setting.name_ = controller_name;
+          ros_controllers_config_.push_back(control_setting);
+          control_setting.joints_.clear();
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// ******************************************************************************************
+// Input ros_controllers.yaml file
+// ******************************************************************************************
+bool MoveItConfigData::inputROSControllersYAML(const std::string& file_path)
+{
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    RVIZ_COMMON_LOG_WARNING_STREAM("Does not exist " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    processROSControllers(input_stream);
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM(e.what());
+    return false;
+  }
+
+  return true;  // file read successfully
+}
+
+// ******************************************************************************************
+// Add a Follow Joint Trajectory action Controller for each Planning Group
+// ******************************************************************************************
+bool MoveItConfigData::addDefaultControllers()
+{
+  if (srdf_->srdf_model_->getGroups().empty())
+    return false;
+  // Loop through groups
+  for (const srdf::Model::Group& group_it : srdf_->srdf_model_->getGroups())
+  {
+    ROSControlConfig group_controller;
+    // Get list of associated joints
+    const moveit::core::JointModelGroup* joint_model_group = getRobotModel()->getJointModelGroup(group_it.name_);
+    const std::vector<const moveit::core::JointModel*>& joint_models = joint_model_group->getActiveJointModels();
+
+    // Iterate through the joints
+    for (const moveit::core::JointModel* joint : joint_models)
+    {
+      if (joint->isPassive() || joint->getMimic() != nullptr || joint->getType() == moveit::core::JointModel::FIXED)
+        continue;
+      group_controller.joints_.push_back(joint->getName());
+    }
+    if (!group_controller.joints_.empty())
+    {
+      group_controller.name_ = group_it.name_ + "_controller";
+      group_controller.type_ = "FollowJointTrajectory";
+      addROSController(group_controller);
+    }
+  }
+  return true;
+}
+
+// ******************************************************************************************
+// Set package path; try to resolve path from package name if directory does not exist
+// ******************************************************************************************
+bool MoveItConfigData::setPackagePath(const std::string& pkg_path)
+{
+  std::string full_package_path;
+
+  // check that the folder exists
+  if (!fs::is_directory(pkg_path))
+  {
+    // does not exist, check if its a package
+    full_package_path = ament_index_cpp::get_package_share_directory(pkg_path);
+
+    // check that the folder exists
+    if (!fs::is_directory(full_package_path))
+    {
+      return false;
+    }
+  }
+  else
+  {
+    // they inputted a full path
+    full_package_path = pkg_path;
+  }
+
+  config_pkg_path_ = full_package_path;
+  return true;
+}
+
+// ******************************************************************************************
+// Extract the package/stack name from an absolute file path
+// Input:  path
+// Output: package name and relative path
+// ******************************************************************************************
+bool MoveItConfigData::extractPackageNameFromPath(const std::string& path, std::string& package_name,
+                                                  std::string& relative_filepath) const
+{
+  fs::path sub_path = path;  // holds the directory less one folder
+  fs::path relative_path;    // holds the path after the sub_path
+
+  bool package_found = false;
+
+  // truncate path step by step and check if it contains a package.xml
+  while (!sub_path.empty())
+  {
+    RVIZ_COMMON_LOG_DEBUG_STREAM("checking in " << sub_path.make_preferred().string());
+    if (fs::is_regular_file(sub_path / "package.xml"))
+    {
+      RVIZ_COMMON_LOG_DEBUG_STREAM("Found package.xml in " << sub_path.make_preferred().string());
+      package_found = true;
+      relative_filepath = relative_path.string();
+      package_name = sub_path.leaf().string();
+      break;
+    }
+    relative_path = sub_path.leaf() / relative_path;
+    sub_path.remove_leaf();
+  }
+
+  // Assign data to moveit_config_data
+  if (!package_found)
+  {
+    // No package name found, we must be outside ROS
+    return false;
+  }
+
+  RVIZ_COMMON_LOG_DEBUG_STREAM("Package name for file \"" << path << "\" is \"" << package_name << "\"");
+  return true;
+}
+
+// ******************************************************************************************
+// Resolve path to .setup_assistant file
+// ******************************************************************************************
+
+bool MoveItConfigData::getSetupAssistantYAMLPath(std::string& path)
+{
+  path = appendPaths(config_pkg_path_, ".setup_assistant");
+
+  // Check if the old package is a setup assistant package
+  return fs::is_regular_file(path);
+}
+
+// ******************************************************************************************
+// Make the full URDF path using the loaded .setup_assistant data
+// ******************************************************************************************
+bool MoveItConfigData::createFullURDFPath()
+{
+  boost::trim(urdf_pkg_name_);
+
+  // Check if a package name was provided
+  if (urdf_pkg_name_.empty() || urdf_pkg_name_ == "\"\"")
+  {
+    urdf_path_ = urdf_pkg_relative_path_;
+    urdf_pkg_name_.clear();
+  }
+  else
+  {
+    // Check that ROS can find the package
+    std::string robot_desc_pkg_path = ament_index_cpp::get_package_share_directory(urdf_pkg_name_);
+
+    if (robot_desc_pkg_path.empty())
+    {
+      urdf_path_.clear();
+      return false;
+    }
+
+    // Append the relative URDF url path
+    urdf_path_ = appendPaths(robot_desc_pkg_path, urdf_pkg_relative_path_);
+  }
+
+  // Check that this file exits -------------------------------------------------
+  return fs::is_regular_file(urdf_path_);
+}
+
+// ******************************************************************************************
+// Make the full SRDF path using the loaded .setup_assistant data
+// ******************************************************************************************
+bool MoveItConfigData::createFullSRDFPath(const std::string& package_path)
+{
+  srdf_path_ = appendPaths(package_path, srdf_pkg_relative_path_);
+
+  return fs::is_regular_file(srdf_path_);
+}
+
+// ******************************************************************************************
+// Input .setup_assistant file - contains data used for the MoveIt Setup Assistant
+// ******************************************************************************************
+bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
+{
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for reading " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    const YAML::Node& doc = YAML::Load(input_stream);
+
+    // Get title node
+    if (const YAML::Node& title_node = doc["moveit_collisions_updater_config"])
+    {
+      // URDF Properties
+      if (const YAML::Node& urdf_node = title_node["URDF"])
+      {
+        if (!parse(urdf_node, "package", urdf_pkg_name_))
+          return false;  // if we do not find this value we cannot continue
+
+        if (!parse(urdf_node, "relative_path", urdf_pkg_relative_path_))
+          return false;  // if we do not find this value we cannot continue
+
+        parse(urdf_node, "xacro_args", xacro_args_);
+      }
+      // SRDF Properties
+      if (const YAML::Node& srdf_node = title_node["SRDF"])
+      {
+        if (!parse(srdf_node, "relative_path", srdf_pkg_relative_path_))
+          return false;  // if we do not find this value we cannot continue
+      }
+      // Package generation time
+      if (const YAML::Node& config_node = title_node["CONFIG"])
+      {
+        parse(config_node, "author_name", author_name_);
+        parse(config_node, "author_email", author_email_);
+        parse(config_node, "generated_timestamp", config_pkg_generated_timestamp_);
+      }
+      return true;
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM(e.what());
+  }
+
+  return false;  // if it gets to this point an error has occurred
+}
+
+// ******************************************************************************************
+// Input sensors_3d yaml file
+// ******************************************************************************************
+bool MoveItConfigData::input3DSensorsYAML(const std::string& default_file_path, const std::string& file_path)
+{
+  // Load default parameters file
+  std::ifstream default_input_stream(default_file_path.c_str());
+  if (!default_input_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for reading " << default_file_path);
+    return false;
+  }
+
+  // Parse default parameters values
+  try
+  {
+    const YAML::Node& doc = YAML::Load(default_input_stream);
+
+    // Get sensors node
+    if (const YAML::Node& sensors_node = doc["sensors"])
+    {
+      // Make sue that the sensors are written as a sequence
+      if (sensors_node.IsSequence())
+      {
+        GenericParameter sensor_param;
+        std::map<std::string, GenericParameter> sensor_map;
+
+        // Loop over the sensors available in the file
+        for (const YAML::Node& sensor : sensors_node)
+        {
+          if (const YAML::Node& sensor_node = sensor)
+          {
+            for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
+            {
+              sensor_param.setName(sensor_it->first.as<std::string>());
+              sensor_param.setValue(sensor_it->second.as<std::string>());
+
+              // Set the key as the parameter name to make accessing it easier
+              sensor_map[sensor_it->first.as<std::string>()] = sensor_param;
+            }
+            sensors_plugin_config_parameter_list_.push_back(sensor_map);
+          }
+        }
+      }
+    }
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Error parsing default sensors yaml: " << e.what());
+  }
+
+  // Is there a sensors config in the package?
+  if (file_path.empty())
+  {
+    return true;
+  }
+
+  // Load file
+  std::ifstream input_stream(file_path.c_str());
+  if (!input_stream.good())
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Unable to open file for reading " << file_path);
+    return false;
+  }
+
+  // Begin parsing
+  try
+  {
+    const YAML::Node& doc = YAML::Load(input_stream);
+    // Get sensors node
+    const YAML::Node& sensors_node = doc["sensors"];
+
+    // Make sure that the sensors are written as a sequence
+    if (sensors_node && sensors_node.IsSequence())
+    {
+      GenericParameter sensor_param;
+      std::map<std::string, GenericParameter> sensor_map;
+      bool empty_node = true;
+
+      // Loop over the sensors available in the file
+      for (const YAML::Node& sensor : sensors_node)
+      {
+        if (const YAML::Node& sensor_node = sensor)
+        {
+          for (YAML::const_iterator sensor_it = sensor_node.begin(); sensor_it != sensor_node.end(); ++sensor_it)
+          {
+            empty_node = false;
+            sensor_param.setName(sensor_it->first.as<std::string>());
+            sensor_param.setValue(sensor_it->second.as<std::string>());
+
+            // Set the key as the parameter name to make accessing it easier
+            sensor_map[sensor_it->first.as<std::string>()] = sensor_param;
+          }
+          // Don't push empty nodes
+          if (!empty_node)
+            sensors_plugin_config_parameter_list_.push_back(sensor_map);
+        }
+      }
+    }
+    return true;
+  }
+  catch (YAML::ParserException& e)  // Catch errors
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Error parsing sensors yaml: " << e.what());
+  }
+
+  return false;  // if it gets to this point an error has occurred
+}
+
+// ******************************************************************************************
+// Helper Function for joining a file path and a file name, or two file paths, etc, in a cross-platform way
+// ******************************************************************************************
+std::string MoveItConfigData::appendPaths(const std::string& path1, const std::string& path2)
+{
+  fs::path result = path1;
+  result /= path2;
+  return result.make_preferred().string();
+}
+
+srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
+{
+  // Find the group we are editing based on the goup name string
+  srdf::Model::Group* searched_group = nullptr;  // used for holding our search results
+
+  for (srdf::Model::Group& group : srdf_->groups_)
+  {
+    if (group.name_ == name)  // string match
+    {
+      searched_group = &group;  // convert to pointer from iterator
+      break;                    // we are done searching
+    }
+  }
+
+  // Check if subgroup was found
+  if (searched_group == nullptr)  // not found
+  {
+    RVIZ_COMMON_LOG_ERROR_STREAM("An internal error has occurred while searching for groups. Group '"
+                                 << name
+                                 << "' was not found "
+                                    "in the SRDF.");
+    exit(-1);
+  }
+
+  return searched_group;
+}
+
+// ******************************************************************************************
+// Find ROS controller by name
+// ******************************************************************************************
+ROSControlConfig* MoveItConfigData::findROSControllerByName(const std::string& controller_name)
+{
+  // Find the ROSController we are editing based on the ROSController name string
+  ROSControlConfig* searched_ros_controller = nullptr;  // used for holding our search results
+
+  for (ROSControlConfig& ros_control_config : ros_controllers_config_)
+  {
+    if (ros_control_config.name_ == controller_name)  // string match
+    {
+      searched_ros_controller = &ros_control_config;  // convert to pointer from iterator
+      break;                                          // we are done searching
+    }
+  }
+
+  return searched_ros_controller;
+}
+
+// ******************************************************************************************
+// Deletes a ROS controller by name
+// ******************************************************************************************
+bool MoveItConfigData::deleteROSController(const std::string& controller_name)
+{
+  for (std::vector<ROSControlConfig>::iterator controller_it = ros_controllers_config_.begin();
+       controller_it != ros_controllers_config_.end(); ++controller_it)
+  {
+    if (controller_it->name_ == controller_name)  // string match
+    {
+      ros_controllers_config_.erase(controller_it);
+      // we are done searching
+      return true;
+    }
+  }
+  return false;
+}
+
+// ******************************************************************************************
+// Adds a ROS controller to ros_controllers_config_ vector
+// ******************************************************************************************
+bool MoveItConfigData::addROSController(const ROSControlConfig& new_controller)
+{
+  // Used for holding our search results
+  ROSControlConfig* searched_ros_controller = nullptr;
+
+  // Find if there is an existing controller with the same name
+  searched_ros_controller = findROSControllerByName(new_controller.name_);
+
+  if (searched_ros_controller && searched_ros_controller->type_ == new_controller.type_)
+    return false;
+
+  ros_controllers_config_.push_back(new_controller);
+  return true;
+}
+
+// ******************************************************************************************
+// Gets ros_controllers_config_ vector
+// ******************************************************************************************
+std::vector<ROSControlConfig>& MoveItConfigData::getROSControllers()
+{
+  return ros_controllers_config_;
+}
+
+// ******************************************************************************************
+// Used to add a sensor plugin configuration parameter to the sensor plugin configuration parameter list
+// ******************************************************************************************
+void MoveItConfigData::addGenericParameterToSensorPluginConfig(const std::string& name, const std::string& value,
+                                                               const std::string& /*comment*/)
+{
+  // Use index 0 since we only write one plugin
+  GenericParameter new_parameter;
+  new_parameter.setName(name);
+  new_parameter.setValue(value);
+  sensors_plugin_config_parameter_list_[0][name] = new_parameter;
+}
+
+// ******************************************************************************************
+// Used to get sensor plugin configuration parameter list
+// ******************************************************************************************
+std::vector<std::map<std::string, GenericParameter>> MoveItConfigData::getSensorPluginConfig()
+{
+  return sensors_plugin_config_parameter_list_;
+}
+
+// ******************************************************************************************
+// Used to clear sensor plugin configuration parameter list
+// ******************************************************************************************
+void MoveItConfigData::clearSensorPluginConfig()
+{
+  for (std::map<std::string, GenericParameter>& param_id : sensors_plugin_config_parameter_list_)
+  {
+    param_id.clear();
+  }
+}
+
+}  // namespace moveit_collisions_updater


### PR DESCRIPTION
### Description

Copied the collisions_updater from the moviet_settup_assistent to its own package and then ported the code to ROS2.  I didn't modify any of the code in the tools.  Just updated the collision_updater.cpp file to replace the ROS1 code and also updated the CMake to Colcon.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
