### PR TITLE
Allow MoveItControllerManager to manage more controllers

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -157,17 +157,18 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
                        });
       }
 
+      // All controllers are added to the map of managed controllers, independent of whether they are currently active or not.
+      std::string absname = getAbsName(controller.name);
+      auto controller_it = managed_controllers_.insert(std::make_pair(absname, controller)).first;  // with namespace
+      // Get the names of the interfaces that would be claimed by this currently-inactive controller if it was activated.
+      auto& required_interfaces = controller_it->second.required_command_interfaces;
+      std::transform(required_interfaces.cbegin(), required_interfaces.cend(), required_interfaces.begin(),
+                     [](const std::string& required_interface) {
+                       return parseJointNameFromResource(required_interface);
+                     });
       // Instantiate a controller handle if one is available for this type of controller.
       if (loader_.isClassAvailable(controller.type))
       {
-        std::string absname = getAbsName(controller.name);
-        auto controller_it = managed_controllers_.insert(std::make_pair(absname, controller)).first;  // with namespace
-        // Get the names of the interfaces that would be claimed by this currently-inactive controller if it was activated.
-        auto& required_interfaces = controller_it->second.required_command_interfaces;
-        std::transform(required_interfaces.cbegin(), required_interfaces.cend(), required_interfaces.begin(),
-                       [](const std::string& required_interface) {
-                         return parseJointNameFromResource(required_interface);
-                       });
         allocate(absname, controller_it->second);
       }
     }

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -87,8 +87,12 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   std::string ns_;
   pluginlib::ClassLoader<ControllerHandleAllocator> loader_;
   typedef std::map<std::string, controller_manager_msgs::msg::ControllerState> ControllersMap;
+
+  /** @brief Controllers that can be activated and deactivated by this plugin. */
   ControllersMap managed_controllers_;
+  /** @brief Controllers that are currently active. */
   ControllersMap active_controllers_;
+
   typedef std::map<std::string, ControllerHandleAllocatorPtr> AllocatorsMap;
   AllocatorsMap allocators_;
 
@@ -141,8 +145,10 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
     const auto& result = result_future.get();
     for (const controller_manager_msgs::msg::ControllerState& controller : result->controller)
     {
+      // If the controller is active, add it to the map of active controllers.
       if (isActive(controller))
       {
+        // Get the names of the interfaces currently claimed by the active controller.
         auto& claimed_interfaces = active_controllers_.insert(std::make_pair(controller.name, controller))
                                        .first->second.claimed_interfaces;  // without namespace
         std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
@@ -150,14 +156,17 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
                          return parseJointNameFromResource(claimed_interface);
                        });
       }
+
+      // Instantiate a controller handle if one is available for this type of controller.
       if (loader_.isClassAvailable(controller.type))
       {
         std::string absname = getAbsName(controller.name);
         auto controller_it = managed_controllers_.insert(std::make_pair(absname, controller)).first;  // with namespace
-        auto& claimed_interfaces = controller_it->second.claimed_interfaces;
-        std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
-                       [](const std::string& claimed_interface) {
-                         return parseJointNameFromResource(claimed_interface);
+        // Get the names of the interfaces that would be claimed by this currently-inactive controller if it was activated.
+        auto& required_interfaces = controller_it->second.required_command_interfaces;
+        std::transform(required_interfaces.cbegin(), required_interfaces.cend(), required_interfaces.begin(),
+                       [](const std::string& required_interface) {
+                         return parseJointNameFromResource(required_interface);
                        });
         allocate(absname, controller_it->second);
       }
@@ -236,6 +245,9 @@ public:
         getAbsName("controller_manager/list_controllers"));
     switch_controller_service_ = node_->create_client<controller_manager_msgs::srv::SwitchController>(
         getAbsName("controller_manager/switch_controller"));
+
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
+    discover(true);
   }
   /**
    * \brief Find and return the pre-allocated handle for the given controller.
@@ -244,7 +256,7 @@ public:
    */
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     HandleMap::iterator it = handles_.find(name);
     if (it != handles_.end())
     {  // controller is is manager by this interface
@@ -259,7 +271,7 @@ public:
    */
   void getControllersList(std::vector<std::string>& names) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
     for (std::pair<const std::string, controller_manager_msgs::msg::ControllerState>& managed_controller :
@@ -275,7 +287,7 @@ public:
    */
   void getActiveControllers(std::vector<std::string>& names) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
     for (std::pair<const std::string, controller_manager_msgs::msg::ControllerState>& managed_controller :
@@ -287,19 +299,19 @@ public:
   }
 
   /**
-   * \brief Read resources from cached controller states
+   * \brief Read interface names required by each controller from the cached controller state info.
    * @param[in] name name of controller (with namespace)
    * @param[out] joints
    */
   void getControllerJoints(const std::string& name, std::vector<std::string>& joints) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     ControllersMap::iterator it = managed_controllers_.find(name);
     if (it != managed_controllers_.end())
     {
-      for (const auto& claimed_resource : it->second.claimed_interfaces)
+      for (const auto& required_resource : it->second.required_command_interfaces)
       {
-        joints.push_back(claimed_resource);
+        joints.push_back(required_resource);
       }
     }
   }
@@ -311,7 +323,7 @@ public:
    */
   ControllerState getControllerState(const std::string& name) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
     ControllerState c;
@@ -332,7 +344,7 @@ public:
    */
   bool switchControllers(const std::vector<std::string>& activate, const std::vector<std::string>& deactivate) override
   {
-    std::unique_lock<std::mutex> lock(controllers_mutex_);
+    std::scoped_lock<std::mutex> lock(controllers_mutex_);
     discover(true);
 
     typedef boost::bimap<std::string, std::string> resources_bimap;
@@ -360,15 +372,17 @@ public:
       }
     }
 
+    // For each controller to activate, find conflicts between the interfaces required by that controller and the
+    // interfaces claimed by currently-active controllers.
     for (const std::string& it : activate)
     {
       ControllersMap::iterator c = managed_controllers_.find(it);
       if (c != managed_controllers_.end())
       {  // controller belongs to this manager
         request->start_controllers.push_back(c->second.name);
-        for (const auto& claimed_resource : c->second.claimed_interfaces)
+        for (const auto& required_resource : c->second.required_command_interfaces)
         {
-          resources_bimap::right_const_iterator res = claimed_resources.right.find(claimed_resource);
+          resources_bimap::right_const_iterator res = claimed_resources.right.find(required_resource);
           if (res != claimed_resources.right.end())
           {                                                    // resource is claimed
             request->stop_controllers.push_back(res->second);  // add claiming controller to stop list
@@ -377,6 +391,9 @@ public:
         }
       }
     }
+
+    // Setting level to STRICT means that the controller switch will only be committed if all controllers are
+    // successfully activated or deactivated.
     request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
 
     if (!request->start_controllers.empty() || !request->stop_controllers.empty())

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -582,6 +582,10 @@ void TrajectoryExecutionManager::reloadControllerInformation()
           }
         }
   }
+  else
+  {
+    RCLCPP_ERROR(LOGGER, "Failed to reload controllers: `controller_manager_` does not exist.");
+  }
 }
 
 void TrajectoryExecutionManager::updateControllerState(const std::string& controller, const rclcpp::Duration& age)
@@ -1713,7 +1717,12 @@ bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::
       std::map<std::string, ControllerInformation>::const_iterator it = known_controllers_.find(controller);
       if (it == known_controllers_.end())
       {
-        RCLCPP_ERROR_STREAM(LOGGER, "Controller " << controller << " is not known");
+        std::stringstream stream;
+        for (const auto& controller : known_controllers_)
+        {
+          stream << " `" << controller.first << "`";
+        }
+        RCLCPP_WARN_STREAM(LOGGER, "Controller " << controller << " is not known. Known controllers: " << stream.str());
         return false;
       }
       if (!it->second.state_.active_)


### PR DESCRIPTION
### Description

Implements #726.

This depends on [ros2_control #544](https://github.com/ros-controls/ros2_control/pull/544) to work correctly, since that PR allows the ros2_control controller manager to list joints associated with currently-inactive controllers.

- Add controllers to the `managed_controllers_` list even if they do not have a corresponding manager plugin defined. This allows the `TrajectoryExecutionManager::ensureActiveControllers` function to activate a wider variety of controllers, such as streaming position or velocity controllers.
- Add controller discovery to the initialization function of `MoveItControllerManager` to make sure that info about the available controllers is always available. Previously this was tied to the manager's introspection functions.
- Add some logging to help understand failure cases.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
