### PR TITLE
Update version of pre-commit action

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,4 +19,4 @@ jobs:
     - uses: actions/setup-python@v2
     - name: Install clang-format-10
       run: sudo apt-get install clang-format-10
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
### Description

We will need to back-port this change everywhere that uses pre-commit github action: https://github.com/pre-commit/action

The latest version stopped working this morning.
