### PR TITLE
Fix the servo executable name

### DIFF
--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -142,7 +142,7 @@ def generate_launch_description():
     # As opposed to a node component, this may be necessary (for example) if Servo is running on a different PC
     servo_node = Node(
         package="moveit_servo",
-        executable="servo_server_node",
+        executable="servo_node_main",
         parameters=[
             servo_params,
             robot_description,


### PR DESCRIPTION
Fix the Servo executable name which changed in #649. You can verify by checking [moveit_servo/CMakeLists](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/CMakeLists.txt).

This gets the tutorial back to a working state for the `main` branch of MoveIt2.
