### PR TITLE
MoveitCpp - path constraints added from PlanningComponent

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -178,6 +178,9 @@ public:
   /** \brief Set the goal constraints generated from a named target state */
   bool setGoal(const std::string& named_target);
 
+  /** \brief Set the path constraints generated from a moveit msg Constraints */
+  bool setPathConstraints(const moveit_msgs::msg::Constraints& path_constraints);
+
   /** \brief Run a plan from start or current state to fulfill the last goal constraints provided by setGoal() using
    * default parameters. */
   PlanSolution plan();
@@ -205,6 +208,7 @@ private:
   // The start state used in the planning motion request
   moveit::core::RobotStatePtr considered_start_state_;
   std::vector<moveit_msgs::msg::Constraints> current_goal_constraints_;
+  moveit_msgs::msg::Constraints current_path_constraints_;
   PlanRequestParameters plan_request_parameters_;
   moveit_msgs::msg::WorkspaceParameters workspace_parameters_;
   bool workspace_parameters_set_ = false;

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -107,6 +107,12 @@ const std::string& PlanningComponent::getPlanningGroupName() const
   return group_name_;
 }
 
+bool PlanningComponent::setPathConstraints(const moveit_msgs::msg::Constraints& path_constraints)
+{
+  current_path_constraints_ = path_constraints;
+  return true;
+}
+
 PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParameters& parameters)
 {
   last_plan_solution_.reset(new PlanSolution());
@@ -154,6 +160,8 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
     return *last_plan_solution_;
   }
   req.goal_constraints = current_goal_constraints_;
+
+  req.path_constraints = current_path_constraints_;
 
   // Run planning attempt
   ::planning_interface::MotionPlanResponse res;


### PR DESCRIPTION
### Description

Reference to Issue https://github.com/ros-planning/moveit2/issues/751
Tested both with and without the SetPathConstraints
