### PR TITLE
WIP: Topic resampler for servo

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -245,10 +245,12 @@ if(BUILD_TESTING)
   add_ros_test(test/launch/test_basic_servo.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
   # Enforce limits unit tests
-  ament_add_gtest(enforce_limits_tests
-    test/enforce_limits_tests.cpp
-  )
+  ament_add_gtest(enforce_limits_tests test/enforce_limits_tests.cpp)
   target_link_libraries(enforce_limits_tests ${SERVO_LIB_NAME})
+
+  # Topic resampler tests
+  ament_add_gtest(topic_resampler_tests test/topic_resampler_tests.cpp)
+  target_link_libraries(topic_resampler_tests ${SERVO_LIB_NAME})
 
 endif()
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/topic_resampler.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/topic_resampler.hpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/*      Title     : topic_resampler.hpp
+ *      Project   : moveit_servo
+ *      Created   : 10/31/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <rclcpp/rclcpp.hpp>
+
+namespace moveit_servo
+{
+template <class MessageT>
+class TopicResampler
+{
+  rclcpp::Node::SharedPtr node_;
+  std::string topic_;
+  rclcpp::Duration period_;
+  std::function<void(std::shared_ptr<MessageT>)> callback_;
+  typename rclcpp::Subscription<MessageT>::SharedPtr sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::mutex mutex_;
+  std::shared_ptr<MessageT> msg_;
+
+public:
+  /**
+   * @brief      Constructs a new topic resampler
+   *
+   * @param[in]  node      The ROS node
+   * @param[in]  topic     The topic to subscribe to
+   * @param[in]  period    The period to call the callback
+   * @param[in]  callback  The callback to call
+   */
+  TopicResampler(rclcpp::Node::SharedPtr node, std::string topic, rclcpp::Duration period,
+                 std::function<void(std::shared_ptr<MessageT>)> callback)
+    : node_{ node }, topic_{ topic }, period_{ period }, callback_{ callback }
+  {
+    // Update the internal message state
+    auto update_msg = [&](std::shared_ptr<MessageT> msg) -> void {
+      const std::lock_guard<std::mutex> lock(mutex_);
+      msg_ = msg;
+    };
+
+    // Publish the message (call the output callback)
+    // Note that we make a deep copy of the message so we can call the callback outside
+    // of the scope of the lock_guard.  This ensures that while the callback is executing
+    // we don't have to hold the mutex and it won't block the subscriber.
+    auto publish_msg = [&]() -> void {
+      auto get_msg = [&]() -> std::shared_ptr<MessageT> {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        return std::make_shared<MessageT>(*msg_);
+      };
+      callback_(get_msg());
+    };
+
+    // This happens on the first callback, here we start the timer that publishes the message.
+    // The reason we wait until our first callback to do this is so that the timer does not call the
+    // callback with an uninitalized message.  This also changes the subscription to just call the
+    // update_msg lambda instead of the first_callback lambda.
+    auto first_callback = [&, update_msg, publish_msg](std::shared_ptr<MessageT> msg) -> void {
+      // Update the internal state and publish the first message
+      update_msg(msg);
+      publish_msg();
+
+      // Start the resampling by changing the subscriber to just update the message
+      sub_ = node_->create_subscription<MessageT>(topic_, rclcpp::SystemDefaultsQoS(), update_msg);
+      // and create a timer that publishes the message at the specified period
+      timer_ = node_->create_wall_timer(period_.to_chrono<std::chrono::milliseconds>(), publish_msg);
+    };
+
+    // Create the subscription for the first message
+    sub_ = node_->create_subscription<MessageT>(topic_, rclcpp::SystemDefaultsQoS(), first_callback);
+  }
+};
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_node_main.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node_main.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <moveit_servo/servo_node.h>
+#include <rclcpp/rclcpp.hpp>
 
 int main(int argc, char* argv[])
 {
@@ -48,7 +49,10 @@ int main(int argc, char* argv[])
 
   auto servo_node = std::make_shared<moveit_servo::ServoNode>(options);
 
-  rclcpp::spin(servo_node->get_node_base_interface());
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(servo_node->get_node_base_interface());
+  executor.spin();
 
   rclcpp::shutdown();
+  return 0;
 }

--- a/moveit_ros/moveit_servo/test/topic_resampler_tests.cpp
+++ b/moveit_ros/moveit_servo/test/topic_resampler_tests.cpp
@@ -1,0 +1,138 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Topic Resampler Tests
+*/
+
+#include <atomic>
+#include <rclcpp/rclcpp.hpp>
+#include <gtest/gtest.h>
+#include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/int8.hpp>
+#include <moveit_servo/topic_resampler.hpp>
+
+using std_msgs::msg::Bool;
+using std_msgs::msg::Int8;
+
+namespace moveit_servo
+{
+TEST(TopicResamplerTests, NoPublishTest)
+{
+  std::atomic<unsigned int> callback_count{ 0 };
+  auto callback = [&](std::shared_ptr<Bool> /*unused*/) { callback_count++; };
+
+  // GIVEN a topic resampler with a connected publisher
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto resampler = TopicResampler<Bool>(node, "test_topic", rclcpp::Duration::from_seconds(10), callback);
+
+  // WHEN we spin (without ever publishing a message to that topic)
+  rclcpp::spin_some(node);
+
+  // THEN we expect the callback count to still be 0
+  EXPECT_EQ(callback_count, 0U) << "Callback should not have been called";
+}
+
+TEST(TopicResamplerTests, OnePublishTest)
+{
+  std::atomic<unsigned int> callback_count{ 0 };
+  auto callback = [&](std::shared_ptr<Bool> /*unused*/) { callback_count++; };
+
+  // GIVEN a topic resampler with a connected publisher with a long period
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto resampler = TopicResampler<Bool>(node, "test_topic", rclcpp::Duration::from_seconds(10), callback);
+  auto pub = node->create_publisher<Bool>("test_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin
+  pub->publish(Bool());
+  rclcpp::spin_some(node);
+
+  // THEN we expect the callback count to be one
+  EXPECT_EQ(callback_count, 1U) << "Callback should have only been called once";
+}
+
+TEST(TopicResamplerTests, OneSecTest)
+{
+  std::atomic<unsigned int> callback_count{ 0 };
+  auto callback = [&](std::shared_ptr<Bool> /*unused*/) { callback_count++; };
+
+  // GIVEN a topic resampler with a connected publisher with a 1/10s period
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto resampler = TopicResampler<Bool>(node, "test_topic", rclcpp::Duration::from_seconds(0.1), callback);
+  auto pub = node->create_publisher<Bool>("test_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin for 1 second
+  pub->publish(Bool());
+  auto start = std::chrono::steady_clock::now();
+  while ((std::chrono::steady_clock::now() - start) < std::chrono::seconds(1))
+  {
+    rclcpp::spin_some(node);
+  }
+
+  // THEN we expect the callback count to be called about 10 times
+  EXPECT_NEAR(callback_count, 10U, 2U) << "Callback should have been called about 10 times";
+}
+
+TEST(TopicResamplerTests, SameMessageTest)
+{
+  auto returned_msg = std::make_shared<Int8>();
+  returned_msg->data = 0;
+  auto callback = [&](std::shared_ptr<Int8> msg) { returned_msg = msg; };
+
+  // GIVEN a topic resampler with a connected publisher
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto resampler = TopicResampler<Int8>(node, "test_topic", rclcpp::Duration::from_seconds(1), callback);
+  auto pub = node->create_publisher<Int8>("test_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin
+  auto sent_msg = Int8();
+  sent_msg.data = 10;
+  pub->publish(sent_msg);
+  rclcpp::spin_some(node);
+
+  // THEN we expect the message we received to have the same data
+  EXPECT_EQ(returned_msg->data, sent_msg.data) << "Returned data should be the same as the sent data";
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
### Description

This is a work in progress, do not review yet.  

The whole point of this is to decouple the logic of calculating output from the resampling of the rate of the input.

Servo has 2 modes currently, one where the output is can be a different (presumably higher and maybe more consistant) rate than the input and a `low-latency` mode where it is input driven (input -> calcs -> output).

The idea of this is to separate that logic from the calculation of output.  So in the mode where the output is a fixed rate it would work like this:

input subscriber -> TopicResampler
TopicResampler -> calculate output -> publish output

And, in the case of the `low-latency` mode it would just execute like this:

input subscriber -> calculate output -> publish output

This would move the configuration of the mode into the constructor and simplify the logic in ServoCalcs as it no longer has to be concerned with resampling the output.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
