### PR TITLE
Fix initialization of PSM publisher in servo

### DIFF
--- a/moveit_ros/moveit_servo/config/demo_rviz_config.rviz
+++ b/moveit_ros/moveit_servo/config/demo_rviz_config.rviz
@@ -46,7 +46,7 @@ Visualization Manager:
       Enabled: true
       Move Group Namespace: ""
       Name: PlanningScene
-      Planning Scene Topic: /moveit_servo/publish_planning_scene
+      Planning Scene Topic: /servo_node/publish_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 0.8999999761581421

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -86,7 +86,8 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
   planning_scene_monitor_->setPlanningScenePublishingFrequency(25);
   planning_scene_monitor_->getStateMonitor()->enableCopyDynamics(true);
   planning_scene_monitor_->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE,
-                                                        "~/publish_planning_scene");
+                                                        std::string(node_->get_fully_qualified_name()) +
+                                                            "/publish_planning_scene");
 
   // Create Servo
   servo_ = std::make_unique<moveit_servo::Servo>(node_, servo_parameters, planning_scene_monitor_);


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit2/issues/770

The bug was caused by me here: https://github.com/ros-planning/moveit2/commit/7e3fdcffbfef79d92a665d6ea2cd631befd872aa, I changed the topic name of the publish_planning_scene topic to be in the private namespace, what I meant to do was change it to be relative to the name of the node.  This PR fixes that so it has a topic name relative to the name of the servo node.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
