### PR TITLE
Call psm.providePlanningSceneService in servo init

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -81,6 +81,7 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
   // Set up planning_scene_monitor
   planning_scene_monitor_ = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(
       node_, robot_description_name, "planning_scene_monitor");
+  planning_scene_monitor_->providePlanningSceneService();
   planning_scene_monitor_->startStateMonitor(servo_parameters->joint_topic);
   planning_scene_monitor_->startSceneMonitor();
   planning_scene_monitor_->setPlanningScenePublishingFrequency(25);


### PR DESCRIPTION
### Description

Fixes this error that you see on startup of servo:

```
Failed to call service get_planning_scene, have you launched move_group or called psm.providePlanningSceneService()?
```

As pointed out here: https://github.com/ros-planning/moveit2/issues/770#issuecomment-957030659

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
