### PR TITLE
Sync from MoveIt1 (#2753)

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -537,9 +537,9 @@ class MoveGroupCommander(object):
         """ Specify which planning pipeline to use when motion planning (e.g. ompl, pilz_industrial_motion_planner) """
         self._g.set_planning_pipeline_id(planning_pipeline)
 
-    def get_planning_pipeline_id(self, planning_pipeline):
+    def get_planning_pipeline_id(self):
         """ Get the current planning_pipeline_id (e.g. ompl, pilz_industrial_motion_planner) """
-        self._g.get_planning_pipeline_id(planning_pipeline)
+        return self._g.get_planning_pipeline_id()
 
     def set_planner_id(self, planner_id):
         """ Specify which planner of the currently selected pipeline to use when motion planning (e.g. RRTConnect, LIN) """


### PR DESCRIPTION
- Add CI configuration for cross-platform CI
- CMakeLists.txt and package.xml fixes for cross-platform CI
- Fix windows compilation failures
- Rename near to seed
- Getter for name of CollisionDetectorAllocator
- Use rosdep in cross-platform CI
- Small cleanup, name job based on matrix.os as suggested by @rhaschke
- Add python2 dependency for < noetic, lint and rebase
- use infinity constant instead of divide by zero
- move to cmake gen headers
- Fix dumb bug (#2753)

### Description

I took the changes from the last commit.  The rest of them are here only for the git history.