### PR TITLE
Fix Ruckig smoothing infinite loop

### DIFF
--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -212,7 +212,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       for (size_t waypoint_idx = 1; waypoint_idx < num_waypoints; ++waypoint_idx)
       {
         trajectory.setWayPointDurationFromPrevious(
-            waypoint_idx, DURATION_EXTENSION_FRACTION * trajectory.getWayPointDurationFromPrevious(waypoint_idx));
+            waypoint_idx, duration_extension_factor * trajectory.getWayPointDurationFromPrevious(waypoint_idx));
         // TODO(andyz): re-calculate waypoint velocity and acceleration here?
       }
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -84,15 +84,12 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   robot_trajectory::RobotTrajectory requested_trajectory(trajectory.getRobotModel(), trajectory.getGroup());
   for (size_t waypoint_idx = 0; waypoint_idx < num_waypoints - 1; ++waypoint_idx)
   {
+    const auto current_waypoint_ptr = trajectory.getWayPointPtr(waypoint_idx);
     bool identical_waypoint = checkForIdenticalWaypoints(
-        *trajectory.getWayPointPtr(waypoint_idx), *trajectory.getWayPointPtr(waypoint_idx + 1), trajectory.getGroup());
-    if (identical_waypoint)
+        *current_waypoint_ptr, *trajectory.getWayPointPtr(waypoint_idx + 1), trajectory.getGroup());
+    if (!identical_waypoint)
     {
-      continue;
-    }
-    else
-    {
-      requested_trajectory.addSuffixWayPoint(trajectory.getWayPoint(waypoint_idx),
+      requested_trajectory.addSuffixWayPoint(*current_waypoint_ptr,
                                              trajectory.getWayPointDurationFromPrevious(waypoint_idx));
     }
   }


### PR DESCRIPTION
For identical waypoints, Ruckig smoothing could get stuck in an infinite loop. The reason was, the `continue` went to the next iteration of `while`, instead of continuing to the next waypoint.

Also, I didn't have to copy the waypoint here since we just checked it was identical. We can leave it as it was.

`*next_waypoint = trajectory.getWayPoint(waypoint_idx);`