### PR TITLE
Enforce package.xml format 3 Schema

### DIFF
--- a/moveit/package.xml
+++ b/moveit/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit</name>
   <version>2.3.0</version>

--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_commander</name>
   <version>1.1.5</version>
   <description>Python interfaces to MoveIt</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -15,6 +13,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</buildtool_depend>

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_common</name>
   <version>2.3.0</version>
   <description>Common support functionality used throughout MoveIt</description>
-
-  <author email="lior.lustgarten@microsoft.com">Lior Lustgarten</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
   <license>BSD</license>
+
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="lior.lustgarten@microsoft.com">Lior Lustgarten</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_core</name>
   <version>2.3.0</version>
   <description>Core libraries used by MoveIt</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-  <author email="acorn.pooley@sri.com">Acorn Pooley</author>
-  <author email="dave@picknik.ai">Dave Coleman</author>
 
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -14,9 +11,15 @@
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
   <license>BSD</license>
+
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
+  <author email="acorn.pooley@sri.com">Acorn Pooley</author>
+  <author email="dave@picknik.ai">Dave Coleman</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>

--- a/moveit_demo_nodes/run_move_group/package.xml
+++ b/moveit_demo_nodes/run_move_group/package.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>run_move_group</name>
   <version>2.3.0</version>
   <description>Demo launch file for running a MoveGroup setup</description>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <license>BSD</license>
+  <author email="henningkayser@picknik.ai">Henning Kayser</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_demo_nodes/run_moveit_cpp/package.xml
+++ b/moveit_demo_nodes/run_moveit_cpp/package.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>run_moveit_cpp</name>
   <version>2.3.0</version>
-  <description>TODO: Package description</description>
-  <author email="henningkayser@picknik.ai">Henning Kayser</author>
+  <description>A minimal example implementation of a MoveItCpp application</description>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <license>BSD</license>
+  <author email="henningkayser@picknik.ai">Henning Kayser</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_demo_nodes/run_ompl_constrained_planning/package.xml
+++ b/moveit_demo_nodes/run_ompl_constrained_planning/package.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>run_ompl_constrained_planning</name>
   <version>2.3.0</version>
   <description>Demo ompl constrained planning capabilities</description>
-  <author email="boston@picknik.ai">Boston Cleek</author>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <license>BSD</license>
+  <author email="boston@picknik.ai">Boston Cleek</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_kinematics</name>
   <version>2.3.0</version>
   <description>Package for all inverse kinematics solvers in MoveIt</description>
-
-  <author email="dave@picknik.ai">Dave Coleman</author>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -19,6 +16,10 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
+
+  <author email="dave@picknik.ai">Dave Coleman</author>
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_planners</name>
   <version>2.3.0</version>
   <description>Meta package that installs all available planners for MoveIt</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="sachinc@willowgarage.com">Sachin Chitta</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -15,6 +13,9 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="sachinc@willowgarage.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -1,10 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_planners_ompl</name>
   <version>2.3.0</version>
   <description>MoveIt interface to OMPL</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -14,6 +13,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pilz_industrial_motion_planner</name>
   <version>1.1.5</version>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>pilz_industrial_motion_planner_testutils</name>
   <version>1.1.5</version>
   <description>Helper scripts and functionality to test industrial motion generation</description>
@@ -20,9 +21,9 @@
   <build_depend>moveit_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
 
-  <run_depend>moveit_core</run_depend>
-  <run_depend>moveit_msgs</run_depend>
-  <run_depend>moveit_commander</run_depend>
+  <exec_depend>moveit_core</exec_depend>
+  <exec_depend>moveit_msgs</exec_depend>
+  <exec_depend>moveit_commander</exec_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/moveit_planners/trajopt/package.xml
+++ b/moveit_planners/trajopt/package.xml
@@ -1,9 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_planners_trajopt</name>
   <version>1.1.0</version>
   <description>TrajOpt planning plugin, an optimization based motion planner </description>
-
-  <author email="omid.github@gmail.com">Omid Heidari</author>
 
   <maintainer email="omid.github@gmail.com">Omid Heidari</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -13,6 +13,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="omid.github@gmail.com">Omid Heidari</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/moveit_plugins/moveit_plugins/package.xml
+++ b/moveit_plugins/moveit_plugins/package.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_plugins</name>
   <version>2.3.0</version>
   <description>Metapackage for MoveIt plugins.</description>
-
-  <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
-  <author email="isucan@google.com">Ioan Sucan</author>
 
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -15,6 +13,9 @@
   <license>BSD</license>
 
   <url type="website">http://moveit.ros.org</url>
+
+  <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_plugins/moveit_ros_control_interface/package.xml
+++ b/moveit_plugins/moveit_ros_control_interface/package.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_control_interface</name>
   <version>2.3.0</version>
   <description>ros_control controller manager interface for MoveIt</description>
-
-  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
   <license>BSD</license>
+
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -1,10 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_simple_controller_manager</name>
   <version>2.3.0</version>
   <description>A generic, simple controller manager plugin for MoveIt.</description>
-
-  <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
-
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -15,6 +14,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -1,20 +1,20 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_benchmarks</name>
   <version>2.3.0</version>
-
   <description>Enhanced tools for benchmarks in MoveIt</description>
-
-  <author email="rluna@rice.edu">Ryan Luna</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+
+  <license>BSD</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
 
-  <license>BSD</license>
+  <author email="rluna@rice.edu">Ryan Luna</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_ros/manipulation/package.xml
+++ b/moveit_ros/manipulation/package.xml
@@ -1,11 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_manipulation</name>
   <version>1.1.5</version>
   <description>Components of MoveIt used for manipulation</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -16,6 +14,9 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -1,10 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_move_group</name>
   <version>2.3.0</version>
   <description>The move_group node for MoveIt</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -15,6 +14,9 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_ros</name>
   <version>2.3.0</version>
   <description>Components of MoveIt that use ROS</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-  <author email="acorn.pooley@sri.com">Acorn Pooley</author>
-  <author email="dave@picknik.ai">Dave Coleman</author>
-
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
@@ -18,6 +14,11 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
+  <author email="acorn.pooley@sri.com">Acorn Pooley</author>
+  <author email="dave@picknik.ai">Dave Coleman</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_servo</name>
   <version>2.3.0</version>
-
   <description>Provides real-time manipulator Cartesian and joint servoing.</description>
-
   <maintainer email="blakeanderson@utexas.edu">Blake Anderson</maintainer>
   <maintainer email="andyz@utexas.edu">Andy Zelenak</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_occupancy_map_monitor</name>
   <version>2.3.0</version>
   <description>Components of MoveIt connecting to occupancy map</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="jon.binney@gmail.com">Jon Binney</author>
-  <author email="gedikli@willowgarage.com">Suat Gedikli</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -17,6 +13,10 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="jon.binney@gmail.com">Jon Binney</author>
+  <author email="gedikli@willowgarage.com">Suat Gedikli</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -1,12 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_perception</name>
   <version>2.3.0</version>
   <description>Components of MoveIt connecting to perception</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="jon.binney@gmail.com">Jon Binney</author>
-  <author email="gedikli@willowgarage.com">Suat Gedikli</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -16,6 +13,10 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="jon.binney@gmail.com">Jon Binney</author>
+  <author email="gedikli@willowgarage.com">Suat Gedikli</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -1,11 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_planning</name>
   <version>2.3.0</version>
   <description>Planning components of MoveIt that use ROS</description>
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
@@ -16,6 +14,9 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_ros_planning_interface</name>
   <version>2.3.0</version>
   <description>Components of MoveIt that offer simpler interfaces to planning and execution</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
@@ -16,6 +14,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -1,10 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_robot_interaction</name>
   <version>2.3.0</version>
   <description>Components of MoveIt that offer interaction via interactive markers</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
@@ -15,6 +14,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -1,12 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_visualization</name>
   <version>2.3.0</version>
   <description>Components of MoveIt that offer visualization</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-  <author email="dave@picknik.ai">Dave Coleman</author>
-  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="jon.binney@gmail.com">Jon Binney</maintainer>
@@ -17,6 +14,10 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
+  <author email="dave@picknik.ai">Dave Coleman</author>
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -1,10 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_ros_warehouse</name>
   <version>2.3.0</version>
   <description>Components of MoveIt connecting to MongoDB</description>
-
-  <author email="isucan@google.com">Ioan Sucan</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
@@ -14,6 +13,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/moveit_runtime/package.xml
+++ b/moveit_runtime/package.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_runtime</name>
   <version>2.3.0</version>
   <description>moveit_runtime meta package contains MoveIt packages that are essential for its runtime (e.g. running MoveIt on robots).</description>
-
-  <author email="gm130s@gmail.com">Isaac I. Y. Saito</author>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
 
   <license>BSD</license>
+
   <url type="website">http://moveit.ros.org</url>
   <url type="website">http://wiki.ros.org/moveit_runtime</url>
+
+  <author email="gm130s@gmail.com">Isaac I. Y. Saito</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>moveit_core</exec_depend>

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -1,11 +1,9 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_setup_assistant</name>
   <version>1.1.5</version>
-
   <description>Generates a configuration package that makes it easy to use MoveIt</description>
-
-  <author email="dave@picknik.ai">Dave Coleman</author>
-
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
@@ -16,6 +14,8 @@
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="dave@picknik.ai">Dave Coleman</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
This fixes the formatting for all package.xml files and enforces the [format 3 ROS schema](http://download.ros.org/schema/package_format3.xsd).
#697 should be merged first, then I will switch the target to `main`.