### PR TITLE
Make controller management logic more tolerant of missing or late ros2_control nodes

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -85,17 +85,6 @@ public:
     last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
   }
 
-  bool isConnected() const
-  {
-    if (!controller_action_client_->action_server_is_ready())
-    {
-      RCLCPP_ERROR_STREAM(LOGGER, "Action client not connected: " << getActionName());
-      return false;
-    }
-
-    return true;
-  }
-
   bool cancelExecution() override
   {
     if (!controller_action_client_)
@@ -160,6 +149,11 @@ public:
   }
 
 protected:
+  bool isConnected() const
+  {
+    return controller_action_client_->action_server_is_ready();
+  }
+
   const rclcpp::Node::SharedPtr node_;
   std::string getActionName() const
   {

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -79,9 +79,11 @@ class ActionBasedControllerHandle : public ActionBasedControllerHandleBase
 public:
   ActionBasedControllerHandle(const rclcpp::Node::SharedPtr& node, const std::string& name, const std::string& ns,
                               const std::string& logger_name)
-    : ActionBasedControllerHandleBase(name, logger_name), node_(node), done_(true), namespace_(ns)
+    : ActionBasedControllerHandleBase(name, logger_name), done_(true), namespace_(ns)
   {
-    controller_action_client_ = rclcpp_action::create_client<T>(node_, getActionName());
+    // Creating the action client does not ensure that the action server is actually running. Executing trajectories
+    // through the controller handle will fail if the server is not running when an action goal message is sent.
+    controller_action_client_ = rclcpp_action::create_client<T>(node, getActionName());
     last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
   }
 
@@ -203,11 +205,6 @@ protected:
       last_exec_ = moveit_controller_manager::ExecutionStatus::FAILED;
     done_ = true;
   }
-
-  /**
-   * @brief Node used to create the action client.
-   */
-  const rclcpp::Node::SharedPtr node_;
 
   /**
    * @brief Status after last trajectory execution.

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -70,8 +70,8 @@ protected:
 MOVEIT_CLASS_FORWARD(
     ActionBasedControllerHandleBase);  // Defines ActionBasedControllerHandleBasePtr, ConstPtr, WeakPtr... etc
 
-/*
- * This is a simple base class, which handles all of the action creation/etc
+/**
+ * @brief Base class for controller handles that interact with a controller through a ROS action server.
  */
 template <typename T>
 class ActionBasedControllerHandle : public ActionBasedControllerHandleBase
@@ -85,6 +85,10 @@ public:
     last_exec_ = moveit_controller_manager::ExecutionStatus::SUCCEEDED;
   }
 
+  /**
+   * @brief Cancels trajectory execution by triggering the controller action server's cancellation callback.
+   * @return True if cancellation was accepted, false if cancellation failed.
+   */
   bool cancelExecution() override
   {
     if (!controller_action_client_)
@@ -104,9 +108,18 @@ public:
     return true;
   }
 
+  /**
+   * @brief Callback function to call when the result is received from the controller action server.
+   * @param wrapped_result
+   */
   virtual void
   controllerDoneCallback(const typename rclcpp_action::ClientGoalHandle<T>::WrappedResult& wrapped_result) = 0;
 
+  /**
+   * @brief Blocks waiting for the action result to be received.
+   * @param timeout Duration to wait for a result before failing. Default value indicates no timeout.
+   * @return True if a result was received, false on timeout.
+   */
   bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration::from_seconds(-1.0)) override
   {
     auto result_callback_done = std::make_shared<std::promise<bool>>();
@@ -149,12 +162,19 @@ public:
   }
 
 protected:
+  /**
+   * @brief Check if the controller's action server is ready to receive action goals.
+   * @return True if the action server is ready, false if it is not ready or does not exist.
+   */
   bool isConnected() const
   {
     return controller_action_client_->action_server_is_ready();
   }
 
-  const rclcpp::Node::SharedPtr node_;
+  /**
+   * @brief Get the full name of the action using the action namespace and base name.
+   * @return The action name.
+   */
   std::string getActionName() const
   {
     if (namespace_.empty())
@@ -163,6 +183,11 @@ protected:
       return name_ + "/" + namespace_;
   }
 
+  /**
+   * @brief Indicate that the controller handle is done executing the trajectory and set the controller manager handle's
+   * ExecutionStatus based on the received action ResultCode.
+   * @param rclcpp_action::ResultCode to convert to moveit_controller_manager::ExecutionStatus.
+   */
   void finishControllerExecution(const rclcpp_action::ResultCode& state)
   {
     RCLCPP_DEBUG_STREAM(LOGGER, "Controller " << name_ << " is done with state " << static_cast<int>(state));
@@ -179,21 +204,40 @@ protected:
     done_ = true;
   }
 
-  /* execution status */
+  /**
+   * @brief Node used to create the action client.
+   */
+  const rclcpp::Node::SharedPtr node_;
+
+  /**
+   * @brief Status after last trajectory execution.
+   */
   moveit_controller_manager::ExecutionStatus last_exec_;
+
+  /**
+   * @brief Indicates whether the controller handle is done executing its current trajectory.
+   */
   bool done_;
 
-  /* the controller namespace, for instance, topics will map to name/ns/goal,
-   * name/ns/result, etc */
+  /**
+   * @brief The controller namespace. The controller action server's topics will map to name/ns/goal, name/ns/result, etc.
+   */
   std::string namespace_;
 
-  /* the joints controlled by this controller */
+  /**
+   * @brief The joints controlled by this controller.
+   */
   std::vector<std::string> joints_;
 
-  /* action client */
+  /**
+   * @brief Action client to send trajectories to the controller's action server.
+   */
   typename rclcpp_action::Client<T>::SharedPtr controller_action_client_;
-  /* Current goal that have been sent to the action server */
+
+  /**
+   * @brief Current goal that has been sent to the action server.
+   */
   typename rclcpp_action::ClientGoalHandle<T>::SharedPtr current_goal_;
 };
 
-}  // end namespace moveit_simple_controller_manager
+}  // namespace moveit_simple_controller_manager

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -66,6 +66,12 @@ public:
     if (!controller_action_client_)
       return false;
 
+    if (!isConnected())
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, "Action client not connected to action server: " << getActionName());
+      return false;
+    }
+
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
       RCLCPP_ERROR(LOGGER, "Gripper cannot execute multi-dof trajectories.");

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -48,6 +48,12 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::ms
   if (!controller_action_client_)
     return false;
 
+  if (!isConnected())
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Action client not connected to action server: " << getActionName());
+    return false;
+  }
+
   if (done_)
     RCLCPP_INFO_STREAM(LOGGER, "sending trajectory to " << name_);
   else

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -47,18 +47,33 @@
 namespace
 {
 /**
- * @brief Compose a parameter name used to load controller configuration from a ROS parameter.
- * @param base_namespace Namespace in which to look up the parameter.
- * @param controller_name Name of the controller configured by this parameter.
- * @param param_name Specific name of the parameter.
- * @return std::string concatenating the parameters separated by the `.` character. For example:
+ * @brief Create a string by adding a provided separator character between each of a variable number of input arguments.
+ * @param separator Char to use as the separator.
+ * @param content Variable number of input arguments to concatentate.
+ * @return Concatenated result string.
+ */
+template <typename... T>
+std::string concatenateWithSeparator(char separator, T... content)
+{
+  std::string result;
+  (result.append(content).append({ separator }), ...);
+  result.erase(result.end() - 1);  // delete trailing separator
+  return result;
+}
+
+/**
+ * @brief Compose a parameter name used to load controller configuration from a ROS parameter by concatenating strings
+ * separated by the `.` character.
+ * @param strings One or more strings, each corresponding to a part of the full parameter name.
+ * @return std::string concatenating the input parameters separated by the `.` character. For example:
  * base_namespace.controller_name.param_name
  */
-std::string makeControllerParameterName(const std::string& base_namespace, const std::string& controller_name,
-                                        const std::string& param_name)
+template <typename... T>
+std::string makeParameterName(T... strings)
 {
-  return std::string(base_namespace).append(".").append(controller_name).append(".").append(param_name);
+  return concatenateWithSeparator<T...>('.', strings...);
 }
+
 }  // namespace
 
 namespace moveit_simple_controller_manager
@@ -75,13 +90,13 @@ public:
   void initialize(const rclcpp::Node::SharedPtr& node) override
   {
     node_ = node;
-    if (!node_->has_parameter(std::string(PARAM_BASE_NAME) += ".controller_names"))
+    if (!node_->has_parameter(makeParameterName(PARAM_BASE_NAME, "controller_names")))
     {
       RCLCPP_ERROR_STREAM(LOGGER, "No controller_names specified.");
       return;
     }
     rclcpp::Parameter controller_names_param;
-    node_->get_parameter(std::string(PARAM_BASE_NAME) += ".controller_names", controller_names_param);
+    node_->get_parameter(makeParameterName(PARAM_BASE_NAME, "controller_names"), controller_names_param);
     if (controller_names_param.get_type() != rclcpp::ParameterType::PARAMETER_STRING_ARRAY)
     {
       RCLCPP_ERROR(LOGGER, "Parameter controller_names should be specified as a string array");
@@ -91,11 +106,10 @@ public:
     /* actually create each controller */
     for (const std::string& controller_name : controller_names)
     {
-      const auto controller_param = PARAM_BASE_NAME + controller_name + ".";
       try
       {
         std::string action_ns;
-        const std::string& action_ns_param = makeControllerParameterName(PARAM_BASE_NAME, controller_name, "action_ns");
+        const std::string& action_ns_param = makeParameterName(PARAM_BASE_NAME, controller_name, "action_ns");
         if (!node_->get_parameter(action_ns_param, action_ns))
         {
           RCLCPP_ERROR_STREAM(LOGGER, "No action namespace specified for controller `"
@@ -104,15 +118,14 @@ public:
         }
 
         std::string type;
-        if (!node_->get_parameter(makeControllerParameterName(PARAM_BASE_NAME, controller_name, "type"), type))
+        if (!node_->get_parameter(makeParameterName(PARAM_BASE_NAME, controller_name, "type"), type))
         {
           RCLCPP_ERROR_STREAM(LOGGER, "No type specified for controller " << controller_name);
           continue;
         }
 
         std::vector<std::string> controller_joints;
-        if (!node_->get_parameter(makeControllerParameterName(PARAM_BASE_NAME, controller_name, "joints"),
-                                  controller_joints) ||
+        if (!node_->get_parameter(makeParameterName(PARAM_BASE_NAME, controller_name, "joints"), controller_joints) ||
             controller_joints.empty())
         {
           RCLCPP_ERROR_STREAM(LOGGER, "No joints specified for controller " << controller_name);
@@ -124,7 +137,7 @@ public:
         {
           new_handle = std::make_shared<GripperControllerHandle>(node_, controller_name, action_ns);
           bool parallel_gripper = false;
-          if (node_->get_parameter(std::string(PARAM_BASE_NAME) += ".parallel", parallel_gripper) && parallel_gripper)
+          if (node_->get_parameter(makeParameterName(PARAM_BASE_NAME, "parallel"), parallel_gripper) && parallel_gripper)
           {
             if (controller_joints.size() != 2)
             {
@@ -138,14 +151,14 @@ public:
           else
           {
             std::string command_joint;
-            if (!node_->get_parameter(std::string(PARAM_BASE_NAME) += ".command_joint", command_joint))
+            if (!node_->get_parameter(makeParameterName(PARAM_BASE_NAME, "command_joint"), command_joint))
               command_joint = controller_joints[0];
 
             static_cast<GripperControllerHandle*>(new_handle.get())->setCommandJoint(command_joint);
           }
 
           bool allow_failure;
-          node_->get_parameter_or(std::string(PARAM_BASE_NAME) += ".allow_failure", allow_failure, false);
+          node_->get_parameter_or(makeParameterName(PARAM_BASE_NAME, "allow_failure"), allow_failure, false);
           static_cast<GripperControllerHandle*>(new_handle.get())->allowFailure(allow_failure);
 
           RCLCPP_INFO_STREAM(LOGGER, "Added GripperCommand controller for " << controller_name);
@@ -169,8 +182,7 @@ public:
         }
 
         moveit_controller_manager::MoveItControllerManager::ControllerState state;
-        node_->get_parameter_or(makeControllerParameterName(PARAM_BASE_NAME, controller_name, "default"),
-                                state.default_, false);
+        node_->get_parameter_or(makeParameterName(PARAM_BASE_NAME, controller_name, "default"), state.default_, false);
         state.active_ = true;
 
         controller_states_[controller_name] = state;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1705,6 +1705,8 @@ bool TrajectoryExecutionManager::ensureActiveController(const std::string& contr
 
 bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::string>& controllers)
 {
+  reloadControllerInformation();
+
   updateControllersState(DEFAULT_CONTROLLER_INFORMATION_VALIDITY_AGE);
 
   if (manage_controllers_)


### PR DESCRIPTION
### Description

Two related fixes to avoid some troublesome situations that happen if ros2_control's ROS interface isn't available when MoveIt is initialized (such as if the ros2_control nodes take longer to finish launching than the MoveIt nodes):

- Reload information about controllers whenever `TrajectoryExecutionManager::ensureActiveControllers` is called. Previously, reloading controller info only happened when initializing the TrajectoryExecutionManager and when executing a trajectory. This sometimes caused situations where using `ensureActiveControllers` outside the scope of executing a trajectory failed because the info about the controllers was out of date.

- Allow controller handles derived from `ActionBasedControllerHandle` to completely initialize even if the action server they expect to interact with is not initially available. I removed the blocking connection timeout check in the class constructor and changed `isConnected` to check for the existence/readiness of the expected action server.

edit: This also changes how parameter names are created within the `MoveItSimpleControllerManager`, originally to comply with clang-tidy recommendations. I added a new parameter name creation function that saves us from manually concatenating strings with specific separators.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
