### PR TITLE
Use a steady clock for timeout for IK

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -159,6 +159,8 @@ private:
   /// clip q_delta such that joint limits will not be violated
   void clipToJointLimits(const KDL::JntArray& q, KDL::JntArray& q_delta, Eigen::ArrayXd& weighting) const;
 
+  static rclcpp::Clock steady_clock_;
+
   bool initialized_;  ///< Internal variable that indicates whether solver is configured and ready
 
   unsigned int dimension_;                             ///< Dimension of the group

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -49,6 +49,8 @@ namespace kdl_kinematics_plugin
 {
 static rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_kdl_kinematics_plugin.kdl_kinematics_plugin");
 
+rclcpp::Clock KDLKinematicsPlugin::steady_clock_{ RCL_STEADY_TIME };
+
 KDLKinematicsPlugin::KDLKinematicsPlugin() : initialized_(false)
 {
 }
@@ -268,9 +270,7 @@ bool KDLKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
 
 bool KDLKinematicsPlugin::timedOut(const rclcpp::Time& start_time, double duration) const
 {
-  static rclcpp::Clock clock{ RCL_STEADY_TIME };
-
-  return ((clock.now() - start_time).seconds() >= duration);
+  return ((steady_clock_.now() - start_time).seconds() >= duration);
 }
 
 bool KDLKinematicsPlugin::getPositionIK(const geometry_msgs::msg::Pose& ik_pose,
@@ -325,9 +325,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose& ik_po
                                            moveit_msgs::msg::MoveItErrorCodes& error_code,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
-  static rclcpp::Clock clock{ RCL_STEADY_TIME };
-
-  rclcpp::Time start_time = clock.now();
+  const rclcpp::Time start_time = steady_clock_.now();
   if (!initialized_)
   {
     RCLCPP_ERROR(LOGGER, "kinematics solver not initialized");
@@ -413,13 +411,13 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose& ik_po
 
       // solution passed consistency check and solution callback
       error_code.val = error_code.SUCCESS;
-      RCLCPP_DEBUG_STREAM(LOGGER, "Solved after " << (clock.now() - start_time).seconds() << " < " << timeout
+      RCLCPP_DEBUG_STREAM(LOGGER, "Solved after " << (steady_clock_.now() - start_time).seconds() << " < " << timeout
                                                   << "s and " << attempt << " attempts");
       return true;
     }
   } while (!timedOut(start_time, timeout));
 
-  RCLCPP_DEBUG_STREAM(LOGGER, "IK timed out after " << (clock.now() - start_time).seconds() << " > " << timeout
+  RCLCPP_DEBUG_STREAM(LOGGER, "IK timed out after " << (steady_clock_.now() - start_time).seconds() << " > " << timeout
                                                     << "s and " << attempt << " attempts");
   error_code.val = error_code.TIMED_OUT;
   return false;

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -268,7 +268,9 @@ bool KDLKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
 
 bool KDLKinematicsPlugin::timedOut(const rclcpp::Time& start_time, double duration) const
 {
-  return ((node_->now() - start_time).seconds() >= duration);
+  static rclcpp::Clock clock{ RCL_STEADY_TIME };
+
+  return ((clock.now() - start_time).seconds() >= duration);
 }
 
 bool KDLKinematicsPlugin::getPositionIK(const geometry_msgs::msg::Pose& ik_pose,
@@ -323,7 +325,9 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose& ik_po
                                            moveit_msgs::msg::MoveItErrorCodes& error_code,
                                            const kinematics::KinematicsQueryOptions& options) const
 {
-  rclcpp::Time start_time = node_->now();
+  static rclcpp::Clock clock{ RCL_STEADY_TIME };
+
+  rclcpp::Time start_time = clock.now();
   if (!initialized_)
   {
     RCLCPP_ERROR(LOGGER, "kinematics solver not initialized");
@@ -409,13 +413,13 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose& ik_po
 
       // solution passed consistency check and solution callback
       error_code.val = error_code.SUCCESS;
-      RCLCPP_DEBUG_STREAM(LOGGER, "Solved after " << (node_->now() - start_time).seconds() << " < " << timeout
+      RCLCPP_DEBUG_STREAM(LOGGER, "Solved after " << (clock.now() - start_time).seconds() << " < " << timeout
                                                   << "s and " << attempt << " attempts");
       return true;
     }
   } while (!timedOut(start_time, timeout));
 
-  RCLCPP_DEBUG_STREAM(LOGGER, "IK timed out after " << (node_->now() - start_time).seconds() << " > " << timeout
+  RCLCPP_DEBUG_STREAM(LOGGER, "IK timed out after " << (clock.now() - start_time).seconds() << " > " << timeout
                                                     << "s and " << attempt << " attempts");
   error_code.val = error_code.TIMED_OUT;
   return false;


### PR DESCRIPTION
Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

The `searchPositionIK` can hang forever when using a simulated time because the time is stuck while waiting for this function to return. For this simple reason the function never times out. This was reported by @jmarsik, I'll let him write his full report here. Most of the work, i.e. isolating the cause, was done by him.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

I don't know how to write a test for this. It doesn't appear to be worth it.
