### PR TITLE
Add backward_ros to moveit_common

### DIFF
--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -32,6 +32,9 @@ macro(moveit_package)
   find_package(ament_cmake REQUIRED)
   ament_package_xml()
 
+  # Enable backward_ros on every moveit package
+  find_package(backward_ros REQUIRED)
+
   if(NOT "${CMAKE_CXX_STANDARD}")
     set(CMAKE_CXX_STANDARD 17)
   endif()

--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -33,7 +33,7 @@ macro(moveit_package)
   ament_package_xml()
 
   # Enable backward_ros on every moveit package
-  find_package(backward_ros REQUIRED)
+  find_package(backward_ros QUIET)
 
   if(NOT "${CMAKE_CXX_STANDARD}")
     set(CMAKE_CXX_STANDARD 17)

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
### Description

This adds backward_ros to all moveit packages that use the moveit_common cmake function.  This is a really useful tool and building it in by default seems like a really nice feature.

https://github.com/pal-robotics/backward_ros/tree/foxy-devel
