### PR TITLE
Change servo parameters to use ros2 interfaces for parameters

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -75,7 +75,10 @@ include_directories(
 ###################
 
 # This library provides a way of loading parameters for servo
-add_library(${SERVO_PARAM_LIB_NAME} SHARED src/servo_parameters.cpp)
+add_library(${SERVO_PARAM_LIB_NAME} SHARED
+  src/servo_parameters.cpp
+  src/parameter_descriptor_builder.cpp
+)
 set_target_properties(${SERVO_PARAM_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${SERVO_PARAM_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
@@ -1,0 +1,123 @@
+// Copyright 2021 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <rcl_interfaces/msg/floating_point_range.hpp>
+#include <rcl_interfaces/msg/integer_range.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+#include <rcl_interfaces/msg/parameter_type.hpp>
+#include <string>
+
+namespace moveit_servo
+{
+class ParameterDescriptorBuilder
+{
+  rcl_interfaces::msg::ParameterDescriptor msg_;
+
+public:
+  /**
+   * @brief      Rcl_interfaces::msg::parameterdescriptor conversion operator.
+   */
+  operator rcl_interfaces::msg::ParameterDescriptor() const
+  {
+    return msg_;
+  }
+
+  /**
+   * @brief      Set the type
+   *
+   * @param[in]  type  The type
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& type(uint8_t type);
+
+  /**
+   * @brief      Set the description string
+   *
+   * @param[in]  description  The description
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& description(std::string description);
+
+  /**
+   * @brief      Set the additional constraints string (a description of any additional constraints which cannot be
+   * expressed with the available parameter constraints)
+   *
+   * @param[in]  additional_constraints  The additional constraints
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& additionalConstraints(std::string additional_constraints);
+
+  /**
+   * @brief      Sets the read only flag
+   *
+   * @param[in]  read_only  The read only flag
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& readOnly(bool read_only);
+
+  /**
+   * @brief      Set the dynamic typing flag (rolling only)
+   *
+   * @param[in]  dynamic_typing  The dynamic typing flag
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& dynamicTyping(bool dynamic_typing);
+
+  /**
+   * @brief      Set floating point range
+   *
+   * @param[in]  from_value  The from value
+   * @param[in]  to_value    To value
+   * @param[in]  step        The step
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& floatingPointRange(double from_value = std::numeric_limits<double>::min(),
+                                                 double to_value = std::numeric_limits<double>::max(), double step = 0);
+
+  /**
+   * @brief      Set the integer range
+   *
+   * @param[in]  from_value  The from value
+   * @param[in]  to_value    To value
+   * @param[in]  step        The step
+   *
+   * @return     Reference to this object
+   */
+  ParameterDescriptorBuilder& integerRange(int64_t from_value = std::numeric_limits<int64_t>::min(),
+                                           int64_t to_value = std::numeric_limits<int64_t>::max(), int64_t step = 0);
+};
+
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
@@ -26,6 +26,14 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+/* Author    : Tyler Weaver
+   Desc      : Creates a parameter descriptor message used to describe parameters
+   Title     : parameter_descriptor_builder.hpp
+   Project   : moveit_servo
+*/
+
+// TODO(823): Move this into a separate message_builder package
+
 #pragma once
 
 #include <rcl_interfaces/msg/floating_point_range.hpp>

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -42,6 +42,7 @@
 #include <thread>
 #include <vector>
 
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <rclcpp/rclcpp.hpp>
 
 namespace moveit_servo
@@ -59,47 +60,49 @@ struct ServoParameters
   // ROS Parameters
   // Note that all of these are effectively const because the only way to create one of these
   //  is as a shared_ptr to a constant struct.
-  bool use_gazebo;
-  std::string status_topic;
+  bool use_gazebo{ false };
+  std::string status_topic{ "~/status" };
   // Properties of incoming commands
-  std::string cartesian_command_in_topic;
-  std::string joint_command_in_topic;
-  std::string robot_link_command_frame;
-  std::string command_in_type;
-  double linear_scale;
-  double rotational_scale;
-  double joint_scale;
+  std::string cartesian_command_in_topic{ "~/delta_twist_cmds" };
+  std::string joint_command_in_topic{ "~/delta_joint_cmds" };
+  std::string robot_link_command_frame{ "panda_link0" };
+  std::string command_in_type{ "unitless" };
+  double linear_scale{ 0.4 };
+  double rotational_scale{ 0.8 };
+  double joint_scale{ 0.5 };
   // Properties of outgoing commands
-  std::string command_out_topic;
-  double publish_period;
-  std::string command_out_type;
-  bool publish_joint_positions;
-  bool publish_joint_velocities;
-  bool publish_joint_accelerations;
+  std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
+  double publish_period{ 0.034 };
+  std::string command_out_type{ "trajectory_msgs/JointTrajectory" };
+  bool publish_joint_positions{ true };
+  bool publish_joint_velocities{ true };
+  bool publish_joint_accelerations{ false };
   // Plugins for smoothing outgoing commands
-  std::string joint_topic;
-  std::string smoothing_filter_plugin_name;
+  std::string joint_topic{ "/joint_states" };
+  std::string smoothing_filter_plugin_name{ "online_signal_smoothing::ButterworthFilterPlugin" };
   // MoveIt properties
-  std::string move_group_name;
-  std::string planning_frame;
-  std::string ee_frame_name;
-  bool is_primary_planning_scene_monitor;
-  std::string monitored_planning_scene_topic;
+  std::string move_group_name{ "panda_arm" };
+  std::string planning_frame{ "panda_link0" };
+  std::string ee_frame_name{ "panda_link8" };
+  bool is_primary_planning_scene_monitor = { true };
+  std::string monitored_planning_scene_topic{
+    planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC
+  };
   // Stopping behaviour
-  double incoming_command_timeout;
-  int num_outgoing_halt_msgs_to_publish;
-  bool halt_all_joints_in_joint_mode;
-  bool halt_all_joints_in_cartesian_mode;
+  double incoming_command_timeout{ 0.1 };
+  int num_outgoing_halt_msgs_to_publish{ 4 };
+  bool halt_all_joints_in_joint_mode{ true };
+  bool halt_all_joints_in_cartesian_mode{ true };
   // Configure handling of singularities and joint limits
-  double lower_singularity_threshold;
-  double hard_stop_singularity_threshold;
-  double joint_limit_margin;
-  bool low_latency_mode;
+  double lower_singularity_threshold{ 17.0 };
+  double hard_stop_singularity_threshold{ 30.0 };
+  double joint_limit_margin{ 0.1 };
+  bool low_latency_mode{ false };
   // Collision checking
-  bool check_collisions;
-  double collision_check_rate;
-  double self_collision_proximity_threshold;
-  double scene_collision_proximity_threshold;
+  bool check_collisions{ true };
+  double collision_check_rate{ 10.0 };
+  double self_collision_proximity_threshold{ 0.01 };
+  double scene_collision_proximity_threshold{ 0.02 };
 
   /**
    * Declares, reads, and validates parameters used for moveit_servo
@@ -113,8 +116,8 @@ struct ServoParameters
    * @param dynamic_parameters Enable dynamic parameter handling. (default: true)
    * @return std::shared_ptr<ServoParameters> if all parameters were loaded and verified successfully, nullptr otherwise
    */
-  static SharedConstPtr makeServoParameters(const rclcpp::Node::SharedPtr& node, const rclcpp::Logger& logger,
-                                            std::string ns = "moveit_servo", bool dynamic_parameters = true);
+  static SharedConstPtr makeServoParameters(const rclcpp::Node::SharedPtr& node, std::string ns = "moveit_servo",
+                                            bool dynamic_parameters = true);
 
   /**
    * Register a callback for a parameter set event.
@@ -123,56 +126,43 @@ struct ServoParameters
    * @param name Name of parameter (key used for callback in map)
    * @param callback function to call when parameter is changed
    */
-  void registerSetParameterCallback(const std::string name, SetParameterCallbackType callback) const
+  [[nodiscard]] bool registerSetParameterCallback(const std::string name, SetParameterCallbackType callback) const
   {
-    const std::lock_guard<std::mutex> guard(callback_mutex_);
-    set_parameter_callbacks_[name].push_back(callback);
+    if (callback_handler_)
+    {
+      const std::lock_guard<std::mutex> guard{ callback_handler_->mutex_ };
+      callback_handler_->set_parameter_callbacks_[name].push_back(callback);
+      return true;
+    }
+    return false;
   }
+  static ServoParameters get(const std::string& ns,
+                             const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters);
+  static std::optional<ServoParameters> validate(ServoParameters parameters);
 
 private:
   // Private constructor because we only want this object to be created through the builder method makeServoParameters
-  ServoParameters(const rclcpp::Logger& logger, std::string ns) : ns(ns), logger_(logger)
+  ServoParameters()
   {
   }
-  const rclcpp::Logger& logger_;
 
-  // callback handler for the on set parameters callback
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handler_;
+  struct CallbackHandler
+  {
+    // callback handler for the on set parameters callback
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handler_;
 
-  // mutable so the callback can be registered objects that have const versions of this struct
-  mutable std::mutex callback_mutex_;
-  mutable std::map<std::string, std::vector<SetParameterCallbackType>> set_parameter_callbacks_;
+    // mutable so the callback can be registered objects that have const versions of this struct
+    mutable std::mutex mutex_;
+    mutable std::map<std::string, std::vector<SetParameterCallbackType>> set_parameter_callbacks_;
 
-  // For registering with add_on_set_parameters_callback after initializing data
-  rcl_interfaces::msg::SetParametersResult setParametersCallback(std::vector<rclcpp::Parameter> parameters);
+    // For registering with add_on_set_parameters_callback after initializing data
+    rcl_interfaces::msg::SetParametersResult setParametersCallback(const std::vector<rclcpp::Parameter>& parameters);
+  };
+
+  std::shared_ptr<CallbackHandler> callback_handler_;
+
+  static void declare(const std::string& ns,
+                      const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters);
 };
-
-// Helper template for declaring and getting ros param
-// Must be declared here to ensure template class is built for required templates when included.
-// (The CPP file can't just be included because not everything there is templated, so you'd get duplicate symbols)
-template <typename T>
-void declareOrGetParam(T& output_value, const std::string& param_name, const rclcpp::Node::SharedPtr& node,
-                       const rclcpp::Logger& logger, const T default_value = T{})
-{
-  try
-  {
-    if (node->has_parameter(param_name))
-    {
-      node->get_parameter<T>(param_name, output_value);
-    }
-    else
-    {
-      output_value = node->declare_parameter<T>(param_name, default_value);
-    }
-  }
-  catch (const rclcpp::exceptions::InvalidParameterTypeException& e)
-  {
-    RCLCPP_WARN_STREAM(logger, "InvalidParameterTypeException(" << param_name << "): " << e.what());
-    RCLCPP_ERROR_STREAM(logger, "Error getting parameter \'" << param_name << "\', check parameter type in YAML file");
-    throw e;
-  }
-
-  RCLCPP_INFO_STREAM(logger, "Found parameter - " << param_name << ": " << output_value);
-}
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
   executor.add_node(node);
   std::thread executor_thread([&executor]() { executor.spin(); });
 
-  auto servo_parameters = moveit_servo::ServoParameters::makeServoParameters(node, LOGGER);
+  auto servo_parameters = moveit_servo::ServoParameters::makeServoParameters(node);
 
   if (servo_parameters == nullptr)
   {

--- a/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
+++ b/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/* Author    : Tyler Weaver
+   Desc      : Creates a parameter descriptor message used to describe parameters
+   Title     : parameter_descriptor_builder.cpp
+   Project   : moveit_servo
+*/
+
+#include "moveit_servo/parameter_descriptor_builder.hpp"
+
+namespace moveit_servo
+{
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::type(uint8_t type)
+{
+  msg_.type = type;
+  return *this;
+}
+
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::description(std::string description)
+{
+  msg_.description = description;
+  return *this;
+}
+
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::additionalConstraints(std::string additional_constraints)
+{
+  msg_.additional_constraints = additional_constraints;
+  return *this;
+}
+
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::readOnly(bool read_only)
+{
+  msg_.read_only = read_only;
+  return *this;
+}
+
+// In rolling (not in Foxy)
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::dynamicTyping(bool dynamic_typing)
+{
+  msg_.dynamic_typing = dynamic_typing;
+  return *this;
+}
+
+ParameterDescriptorBuilder&
+ParameterDescriptorBuilder::floatingPointRange(double from_value /*= std::numeric_limits<double>::min()*/,
+                                               double to_value /*= std::numeric_limits<double>::max()*/,
+                                               double step /*= 0*/)
+{
+  msg_.floating_point_range.resize(1);
+  msg_.floating_point_range[0].from_value = from_value;
+  msg_.floating_point_range[0].to_value = to_value;
+  msg_.floating_point_range[0].step = step;
+  return *this;
+}
+
+ParameterDescriptorBuilder&
+ParameterDescriptorBuilder::integerRange(int64_t from_value /*= std::numeric_limits<int64_t>::min()*/,
+                                         int64_t to_value /*= std::numeric_limits<int64_t>::max()*/,
+                                         int64_t step /*= 0*/)
+{
+  msg_.integer_range.resize(1);
+  msg_.integer_range[0].from_value = from_value;
+  msg_.integer_range[0].to_value = to_value;
+  msg_.integer_range[0].step = step;
+  return *this;
+}
+
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -42,6 +42,32 @@ namespace
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.pose_tracking");
 constexpr size_t LOG_THROTTLE_PERIOD = 10;  // sec
+
+// Helper template for declaring and getting ros param
+template <typename T>
+void declareOrGetParam(T& output_value, const std::string& param_name, const rclcpp::Node::SharedPtr& node,
+                       const rclcpp::Logger& logger, const T default_value = T{})
+{
+  try
+  {
+    if (node->has_parameter(param_name))
+    {
+      node->get_parameter<T>(param_name, output_value);
+    }
+    else
+    {
+      output_value = node->declare_parameter<T>(param_name, default_value);
+    }
+  }
+  catch (const rclcpp::exceptions::InvalidParameterTypeException& e)
+  {
+    RCLCPP_WARN_STREAM(logger, "InvalidParameterTypeException(" << param_name << "): " << e.what());
+    RCLCPP_ERROR_STREAM(logger, "Error getting parameter \'" << param_name << "\', check parameter type in YAML file");
+    throw e;
+  }
+
+  RCLCPP_INFO_STREAM(logger, "Found parameter - " << param_name << ": " << output_value);
+}
 }  // namespace
 
 namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -103,9 +103,13 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
   , smoothing_loader_("moveit_core", "online_signal_smoothing::SmoothingBaseClass")
 {
   // Register callback for changes in robot_link_command_frame
-  parameters_->registerSetParameterCallback(parameters->ns + ".robot_link_command_frame",
-                                            std::bind(&ServoCalcs::robotLinkCommandFrameCallback, this,
-                                                      std::placeholders::_1));
+  bool callback_success = parameters_->registerSetParameterCallback(
+      parameters->ns + ".robot_link_command_frame",
+      std::bind(&ServoCalcs::robotLinkCommandFrameCallback, this, std::placeholders::_1));
+  if (!callback_success)
+  {
+    throw std::runtime_error("Failed to register setParameterCallback");
+  }
 
   // MoveIt Setup
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -71,7 +71,7 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
   node_->get_parameter_or("robot_description_name", robot_description_name, robot_description_name);
 
   // Get the servo parameters
-  auto servo_parameters = moveit_servo::ServoParameters::makeServoParameters(node_, LOGGER);
+  auto servo_parameters = moveit_servo::ServoParameters::makeServoParameters(node_);
   if (servo_parameters == nullptr)
   {
     RCLCPP_ERROR(LOGGER, "Failed to load the servo parameters");

--- a/moveit_ros/moveit_servo/src/servo_node_main.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node_main.cpp
@@ -44,7 +44,6 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
 
   rclcpp::NodeOptions options;
-  options.automatically_declare_parameters_from_overrides(true);
 
   auto servo_node = std::make_shared<moveit_servo::ServoNode>(options);
 

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -40,16 +40,22 @@
 */
 
 #include <moveit_servo/servo_parameters.h>
+#include <moveit_servo/parameter_descriptor_builder.hpp>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <rclcpp/rclcpp.hpp>
 #include <type_traits>
 
 namespace moveit_servo
 {
-rcl_interfaces::msg::SetParametersResult
-ServoParameters::setParametersCallback(std::vector<rclcpp::Parameter> parameters)
+namespace
 {
-  const std::lock_guard<std::mutex> guard(callback_mutex_);
+const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo_parameters");
+}
+
+rcl_interfaces::msg::SetParametersResult
+ServoParameters::CallbackHandler::setParametersCallback(const std::vector<rclcpp::Parameter>& parameters)
+{
+  const std::lock_guard<std::mutex> guard(mutex_);
   auto result = rcl_interfaces::msg::SetParametersResult();
   result.successful = true;
 
@@ -58,9 +64,9 @@ ServoParameters::setParametersCallback(std::vector<rclcpp::Parameter> parameters
     auto search = set_parameter_callbacks_.find(parameter.get_name());
     if (search != set_parameter_callbacks_.end())
     {
-      RCLCPP_INFO_STREAM(logger_, "setParametersCallback - "
-                                      << parameter.get_name() << "<" << parameter.get_type_name()
-                                      << ">: " << rclcpp::to_string(parameter.get_parameter_value()));
+      RCLCPP_INFO_STREAM(LOGGER, "setParametersCallback - "
+                                     << parameter.get_name() << "<" << parameter.get_type_name()
+                                     << ">: " << rclcpp::to_string(parameter.get_parameter_value()));
       for (const auto& callback : search->second)
       {
         result = callback(parameter);
@@ -77,175 +83,363 @@ ServoParameters::setParametersCallback(std::vector<rclcpp::Parameter> parameters
   return result;
 }
 
-ServoParameters::SharedConstPtr ServoParameters::makeServoParameters(const rclcpp::Node::SharedPtr& node,
-                                                                     const rclcpp::Logger& logger,
-                                                                     std::string ns, /* = "moveit_servo"*/
-                                                                     bool dynamic_parameters /* = true */)
+void ServoParameters::declare(const std::string& ns,
+                              const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters)
 {
-  auto parameters = std::shared_ptr<ServoParameters>(new ServoParameters(logger, ns));
+  using rclcpp::ParameterValue;
+  using rclcpp::ParameterType::PARAMETER_BOOL;
+  using rclcpp::ParameterType::PARAMETER_DOUBLE;
+  using rclcpp::ParameterType::PARAMETER_INTEGER;
+  using rclcpp::ParameterType::PARAMETER_STRING;
+  auto parameters = ServoParameters{};
 
-  // Get the parameters (organized same order as YAML file)
-  declareOrGetParam<bool>(parameters->use_gazebo, ns + ".use_gazebo", node, logger);
-  declareOrGetParam<std::string>(parameters->status_topic, ns + ".status_topic", node, logger);
-
+  // ROS Parameters
+  node_parameters->declare_parameter(
+      ns + ".use_gazebo", ParameterValue{ parameters.use_gazebo },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_BOOL)
+          .description("Whether the robot is started in a Gazebo simulation environment"));
+  node_parameters->declare_parameter(
+      ns + ".status_topic", ParameterValue{ parameters.status_topic },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Publish status to this topic"));
   // Properties of incoming commands
-  declareOrGetParam<std::string>(parameters->cartesian_command_in_topic, ns + ".cartesian_command_in_topic", node,
-                                 logger);
-  declareOrGetParam<std::string>(parameters->joint_command_in_topic, ns + ".joint_command_in_topic", node, logger);
-  declareOrGetParam<std::string>(parameters->robot_link_command_frame, ns + ".robot_link_command_frame", node, logger);
-  declareOrGetParam<std::string>(parameters->command_in_type, ns + ".command_in_type", node, logger);
-  declareOrGetParam<double>(parameters->linear_scale, ns + ".scale.linear", node, logger);
-  declareOrGetParam<double>(parameters->rotational_scale, ns + ".scale.rotational", node, logger);
-  declareOrGetParam<double>(parameters->joint_scale, ns + ".scale.joint", node, logger);
+  node_parameters->declare_parameter(
+      ns + ".cartesian_command_in_topic", ParameterValue{ parameters.cartesian_command_in_topic },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Topic for incoming Cartesian twist commands"));
+  node_parameters->declare_parameter(
+      ns + ".joint_command_in_topic", ParameterValue{ parameters.joint_command_in_topic },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Topic for incoming joint angle commands"));
+  node_parameters->declare_parameter(
+      ns + ".robot_link_command_frame", ParameterValue{ parameters.robot_link_command_frame },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_STRING)
+          .description("Commands must be given in the frame of a robot link. Usually either the base or end effector"));
+  node_parameters->declare_parameter(ns + ".command_in_type", ParameterValue{ parameters.command_in_type },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_STRING)
+                                         .description("\"unitless\"> in the range [-1:1], as if from joystick. "
+                                                      "\"speed_units\"> cmds are in m/s and rad/s"));
+  node_parameters->declare_parameter(ns + ".scale.linear", ParameterValue{ parameters.linear_scale },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Max linear velocity. Meters per publish_period. Unit is [m/s]. "
+                                                      "Only used for Cartesian commands."));
+  node_parameters->declare_parameter(ns + ".scale.rotational", ParameterValue{ parameters.rotational_scale },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Max angular velocity. Rads per publish_period. Unit is [rad/s]. "
+                                                      "Only used for Cartesian commands."));
+  node_parameters->declare_parameter(
+      ns + ".scale.joint", ParameterValue{ parameters.joint_scale },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint "
+                       "commands on joint_command_in_topic."));
 
   // Properties of outgoing commands
-  declareOrGetParam<std::string>(parameters->command_out_topic, ns + ".command_out_topic", node, logger);
-  declareOrGetParam<double>(parameters->publish_period, ns + ".publish_period", node, logger);
-  declareOrGetParam<std::string>(parameters->command_out_type, ns + ".command_out_type", node, logger);
-  declareOrGetParam<bool>(parameters->publish_joint_positions, ns + ".publish_joint_positions", node, logger);
-  declareOrGetParam<bool>(parameters->publish_joint_velocities, ns + ".publish_joint_velocities", node, logger);
-  declareOrGetParam<bool>(parameters->publish_joint_accelerations, ns + ".publish_joint_accelerations", node, logger);
-  declareOrGetParam<bool>(parameters->low_latency_mode, ns + ".low_latency_mode", node, logger);
+  node_parameters->declare_parameter(
+      ns + ".command_out_topic", ParameterValue{ parameters.command_out_topic },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Publish outgoing commands here"));
+  node_parameters->declare_parameter(
+      ns + ".publish_period", ParameterValue{ parameters.publish_period },
+      ParameterDescriptorBuilder{}.type(PARAMETER_DOUBLE).description("1/Nominal publish rate [seconds]"));
+  node_parameters->declare_parameter(
+      ns + ".command_out_type", ParameterValue{ parameters.command_out_type },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_STRING)
+          .description("What type of topic does your robot driver expect? Currently supported are "
+                       "std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory"));
+  node_parameters->declare_parameter(
+      ns + ".publish_joint_positions", ParameterValue{ parameters.publish_joint_positions },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_BOOL)
+          .description("What to publish? Can save some bandwidth as most robots only require positions or velocities"));
+  node_parameters->declare_parameter(
+      ns + ".publish_joint_velocities", ParameterValue{ parameters.publish_joint_velocities },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_BOOL)
+          .description("What to publish? Can save some bandwidth as most robots only require positions or velocities"));
+  node_parameters->declare_parameter(
+      ns + ".publish_joint_accelerations", ParameterValue{ parameters.publish_joint_accelerations },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_BOOL)
+          .description("What to publish? Can save some bandwidth as most robots only require positions or velocities"));
+  node_parameters->declare_parameter(ns + ".low_latency_mode", ParameterValue{ parameters.low_latency_mode },
+                                     ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Low latency mode"));
 
   // Incoming Joint State properties
-  declareOrGetParam<std::string>(parameters->joint_topic, ns + ".joint_topic", node, logger);
-  declareOrGetParam<std::string>(parameters->smoothing_filter_plugin_name, ns + ".smoothing_filter_plugin_name", node,
-                                 logger);
+  node_parameters->declare_parameter(ns + ".joint_topic", ParameterValue{ parameters.joint_topic },
+                                     ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Joint topic"));
+  node_parameters->declare_parameter(
+      ns + ".smoothing_filter_plugin_name", ParameterValue{ parameters.smoothing_filter_plugin_name },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Plugins for smoothing outgoing commands"));
 
   // MoveIt properties
-  declareOrGetParam<std::string>(parameters->move_group_name, ns + ".move_group_name", node, logger);
-  declareOrGetParam<std::string>(parameters->planning_frame, ns + ".planning_frame", node, logger);
-  declareOrGetParam<std::string>(parameters->ee_frame_name, ns + ".ee_frame_name", node, logger);
-  declareOrGetParam<bool>(parameters->is_primary_planning_scene_monitor, ns + ".is_primary_planning_scene_monitor",
-                          node, logger, true);
-  declareOrGetParam<std::string>(parameters->monitored_planning_scene_topic, ns + ".monitored_planning_scene_topic",
-                                 node, logger,
-                                 planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
+  node_parameters->declare_parameter(
+      ns + ".move_group_name", ParameterValue{ parameters.move_group_name },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Often 'manipulator' or 'arm'"));
+  node_parameters->declare_parameter(ns + ".planning_frame", ParameterValue{ parameters.planning_frame },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_STRING)
+                                         .description("The MoveIt planning frame. Often 'base_link' or 'world'"));
+  node_parameters->declare_parameter(ns + ".ee_frame_name", ParameterValue{ parameters.ee_frame_name },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_STRING)
+                                         .description("The name of the end effector link, used to return the EE pose"));
+  node_parameters->declare_parameter(
+      ns + ".is_primary_planning_scene_monitor", ParameterValue{ parameters.is_primary_planning_scene_monitor },
+      ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Is primary planning scene monitor"));
+  node_parameters->declare_parameter(
+      ns + ".monitored_planning_scene_topic", ParameterValue{ parameters.monitored_planning_scene_topic },
+      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Monitored planning scene topic"));
 
   // Stopping behaviour
-  declareOrGetParam<double>(parameters->incoming_command_timeout, ns + ".incoming_command_timeout", node, logger);
-  declareOrGetParam<int>(parameters->num_outgoing_halt_msgs_to_publish, ns + ".num_outgoing_halt_msgs_to_publish", node,
-                         logger);
-  declareOrGetParam<bool>(parameters->halt_all_joints_in_joint_mode, ns + ".halt_all_joints_in_joint_mode", node,
-                          logger, true);
-  declareOrGetParam<bool>(parameters->halt_all_joints_in_cartesian_mode, ns + ".halt_all_joints_in_cartesian_mode",
-                          node, logger, true);
+  node_parameters->declare_parameter(
+      ns + ".incoming_command_timeout", ParameterValue{ parameters.incoming_command_timeout },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("Stop servoing if X seconds elapse without a new command. If 0, republish commands forever even "
+                       "if the robot is stationary.Otherwise, specify num.to publish. Important because ROS may drop "
+                       "some messages and we need the robot to halt reliably."));
+  node_parameters->declare_parameter(
+      ns + ".num_outgoing_halt_msgs_to_publish", ParameterValue{ parameters.num_outgoing_halt_msgs_to_publish },
+      ParameterDescriptorBuilder{}.type(PARAMETER_INTEGER).description("Num outgoing halt msgs to publish"));
+  node_parameters->declare_parameter(
+      ns + ".halt_all_joints_in_joint_mode", ParameterValue{ parameters.halt_all_joints_in_joint_mode },
+      ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Halt all joints in joint mode"));
+  node_parameters->declare_parameter(
+      ns + ".halt_all_joints_in_cartesian_mode", ParameterValue{ parameters.halt_all_joints_in_cartesian_mode },
+      ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Halt all joints in cartesian mode"));
 
   // Configure handling of singularities and joint limits
-  declareOrGetParam<double>(parameters->lower_singularity_threshold, ns + ".lower_singularity_threshold", node, logger);
-  declareOrGetParam<double>(parameters->hard_stop_singularity_threshold, ns + ".hard_stop_singularity_threshold", node,
-                            logger);
-  declareOrGetParam<double>(parameters->joint_limit_margin, ns + ".joint_limit_margin", node, logger);
+  node_parameters->declare_parameter(
+      ns + ".lower_singularity_threshold", ParameterValue{ parameters.lower_singularity_threshold },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("Start decelerating when the condition number hits this (close to singularity)"));
+  node_parameters->declare_parameter(
+      ns + ".hard_stop_singularity_threshold", ParameterValue{ parameters.hard_stop_singularity_threshold },
+      ParameterDescriptorBuilder{}.type(PARAMETER_DOUBLE).description("Stop when the condition number hits this"));
+  node_parameters->declare_parameter(
+      ns + ".joint_limit_margin", ParameterValue{ parameters.joint_limit_margin },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("Added as a buffer to joint limits [radians]. If moving quickly, make this larger."));
 
   // Collision checking
-  declareOrGetParam<bool>(parameters->check_collisions, ns + ".check_collisions", node, logger);
-  declareOrGetParam<double>(parameters->collision_check_rate, ns + ".collision_check_rate", node, logger);
-  declareOrGetParam<double>(parameters->self_collision_proximity_threshold, ns + ".self_collision_proximity_threshold",
-                            node, logger);
-  declareOrGetParam<double>(parameters->scene_collision_proximity_threshold,
-                            ns + ".scene_collision_proximity_threshold", node, logger);
+  node_parameters->declare_parameter(ns + ".check_collisions", ParameterValue{ parameters.check_collisions },
+                                     ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Check collisions?"));
+  node_parameters->declare_parameter(
+      ns + ".collision_check_rate", ParameterValue(parameters.collision_check_rate),
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("[Hz] Collision-checking can easily bog down a CPU if done too often. Collision checking begins "
+                       "slowing down when nearer than a specified distance."));
+  node_parameters->declare_parameter(ns + ".self_collision_proximity_threshold",
+                                     ParameterValue{ parameters.self_collision_proximity_threshold },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Start decelerating when a self-collision is this far [m]"));
+  node_parameters->declare_parameter(ns + ".scene_collision_proximity_threshold",
+                                     ParameterValue{ parameters.scene_collision_proximity_threshold },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Start decelerating when a scene collision is this far [m]"));
+}
 
+ServoParameters ServoParameters::get(const std::string& ns,
+                                     const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters)
+{
+  auto parameters = ServoParameters{};
+
+  // ROS Parameters
+  parameters.use_gazebo = node_parameters->get_parameter(ns + ".use_gazebo").as_bool();
+  parameters.status_topic = node_parameters->get_parameter(ns + ".status_topic").as_string();
+
+  // Properties of incoming commands
+  parameters.cartesian_command_in_topic =
+      node_parameters->get_parameter(ns + ".cartesian_command_in_topic").as_string();
+  parameters.joint_command_in_topic = node_parameters->get_parameter(ns + ".joint_command_in_topic").as_string();
+  parameters.robot_link_command_frame = node_parameters->get_parameter(ns + ".robot_link_command_frame").as_string();
+  parameters.command_in_type = node_parameters->get_parameter(ns + ".command_in_type").as_string();
+  parameters.linear_scale = node_parameters->get_parameter(ns + ".scale.linear").as_double();
+  parameters.rotational_scale = node_parameters->get_parameter(ns + ".scale.rotational").as_double();
+  parameters.joint_scale = node_parameters->get_parameter(ns + ".scale.joint").as_double();
+
+  // Properties of outgoing commands
+  parameters.command_out_topic = node_parameters->get_parameter(ns + ".command_out_topic").as_string();
+  parameters.publish_period = node_parameters->get_parameter(ns + ".publish_period").as_double();
+  parameters.command_out_type = node_parameters->get_parameter(ns + ".command_out_type").as_string();
+  parameters.publish_joint_positions = node_parameters->get_parameter(ns + ".publish_joint_positions").as_bool();
+  parameters.publish_joint_velocities = node_parameters->get_parameter(ns + ".publish_joint_velocities").as_bool();
+  parameters.publish_joint_accelerations =
+      node_parameters->get_parameter(ns + ".publish_joint_accelerations").as_bool();
+  parameters.low_latency_mode = node_parameters->get_parameter(ns + ".low_latency_mode").as_bool();
+
+  // Incoming Joint State properties
+  parameters.joint_topic = node_parameters->get_parameter(ns + ".joint_topic").as_string();
+  parameters.smoothing_filter_plugin_name =
+      node_parameters->get_parameter(ns + ".smoothing_filter_plugin_name").as_string();
+
+  // MoveIt properties
+  parameters.move_group_name = node_parameters->get_parameter(ns + ".move_group_name").as_string();
+  parameters.planning_frame = node_parameters->get_parameter(ns + ".planning_frame").as_string();
+  parameters.ee_frame_name = node_parameters->get_parameter(ns + ".ee_frame_name").as_string();
+  parameters.is_primary_planning_scene_monitor =
+      node_parameters->get_parameter(ns + ".is_primary_planning_scene_monitor").as_bool();
+  parameters.monitored_planning_scene_topic =
+      node_parameters->get_parameter(ns + ".monitored_planning_scene_topic").as_string();
+
+  // Stopping behaviour
+  parameters.incoming_command_timeout = node_parameters->get_parameter(ns + ".incoming_command_timeout").as_double();
+  parameters.num_outgoing_halt_msgs_to_publish =
+      node_parameters->get_parameter(ns + ".num_outgoing_halt_msgs_to_publish").as_int();
+  parameters.halt_all_joints_in_joint_mode =
+      node_parameters->get_parameter(ns + ".halt_all_joints_in_joint_mode").as_bool();
+  parameters.halt_all_joints_in_cartesian_mode =
+      node_parameters->get_parameter(ns + ".halt_all_joints_in_cartesian_mode").as_bool();
+
+  // Configure handling of singularities and joint limits
+  parameters.lower_singularity_threshold =
+      node_parameters->get_parameter(ns + ".lower_singularity_threshold").as_double();
+  parameters.hard_stop_singularity_threshold =
+      node_parameters->get_parameter(ns + ".hard_stop_singularity_threshold").as_double();
+  parameters.joint_limit_margin = node_parameters->get_parameter(ns + ".joint_limit_margin").as_double();
+
+  // Collision checking
+  parameters.check_collisions = node_parameters->get_parameter(ns + ".check_collisions").as_bool();
+  parameters.collision_check_rate = node_parameters->get_parameter(ns + ".collision_check_rate").as_double();
+  parameters.self_collision_proximity_threshold =
+      node_parameters->get_parameter(ns + ".self_collision_proximity_threshold").as_double();
+  parameters.scene_collision_proximity_threshold =
+      node_parameters->get_parameter(ns + ".scene_collision_proximity_threshold").as_double();
+
+  return parameters;
+}
+
+std::optional<ServoParameters> ServoParameters::validate(ServoParameters parameters)
+{
   // Begin input checking
-  if (parameters->publish_period <= 0.)
+  if (parameters.publish_period <= 0.)
   {
-    RCLCPP_WARN(logger, "Parameter 'publish_period' should be "
+    RCLCPP_WARN(LOGGER, "Parameter 'publish_period' should be "
                         "greater than zero. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (parameters->num_outgoing_halt_msgs_to_publish < 0)
+  if (parameters.num_outgoing_halt_msgs_to_publish < 0)
   {
-    RCLCPP_WARN(logger, "Parameter 'num_outgoing_halt_msgs_to_publish' should be greater than zero. Check yaml file.");
-    return nullptr;
+    RCLCPP_WARN(LOGGER, "Parameter 'num_outgoing_halt_msgs_to_publish' should be greater than zero. Check yaml file.");
+    return std::nullopt;
   }
-  if (parameters->hard_stop_singularity_threshold <= parameters->lower_singularity_threshold)
+  if (parameters.hard_stop_singularity_threshold <= parameters.lower_singularity_threshold)
   {
-    RCLCPP_WARN(logger, "Parameter 'hard_stop_singularity_threshold' "
+    RCLCPP_WARN(LOGGER, "Parameter 'hard_stop_singularity_threshold' "
                         "should be greater than 'lower_singularity_threshold.' "
                         "Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if ((parameters->hard_stop_singularity_threshold <= 0.) || (parameters->lower_singularity_threshold <= 0.))
+  if ((parameters.hard_stop_singularity_threshold <= 0.) || (parameters.lower_singularity_threshold <= 0.))
   {
-    RCLCPP_WARN(logger, "Parameters 'hard_stop_singularity_threshold' "
+    RCLCPP_WARN(LOGGER, "Parameters 'hard_stop_singularity_threshold' "
                         "and 'lower_singularity_threshold' should be "
                         "greater than zero. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (parameters->smoothing_filter_plugin_name.empty())
+  if (parameters.smoothing_filter_plugin_name.empty())
   {
-    RCLCPP_WARN(logger, "A smoothing plugin is required.");
-    return nullptr;
+    RCLCPP_WARN(LOGGER, "A smoothing plugin is required.");
+    return std::nullopt;
   }
-  if (parameters->joint_limit_margin < 0.)
+  if (parameters.joint_limit_margin < 0.)
   {
-    RCLCPP_WARN(logger, "Parameter 'joint_limit_margin' should usually be  greater than or equal to zero, "
+    RCLCPP_WARN(LOGGER, "Parameter 'joint_limit_margin' should usually be  greater than or equal to zero, "
                         "although negative values can be used if the specified joint limits are actually soft. "
                         "Check yaml file.");
   }
-  if (parameters->command_in_type != "unitless" && parameters->command_in_type != "speed_units")
+  if (parameters.command_in_type != "unitless" && parameters.command_in_type != "speed_units")
   {
-    RCLCPP_WARN(logger, "command_in_type should be 'unitless' or "
+    RCLCPP_WARN(LOGGER, "command_in_type should be 'unitless' or "
                         "'speed_units'. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (parameters->command_out_type != "trajectory_msgs/JointTrajectory" &&
-      parameters->command_out_type != "std_msgs/Float64MultiArray")
+  if (parameters.command_out_type != "trajectory_msgs/JointTrajectory" &&
+      parameters.command_out_type != "std_msgs/Float64MultiArray")
   {
-    RCLCPP_WARN(logger, "Parameter command_out_type should be "
+    RCLCPP_WARN(LOGGER, "Parameter command_out_type should be "
                         "'trajectory_msgs/JointTrajectory' or "
                         "'std_msgs/Float64MultiArray'. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (!parameters->publish_joint_positions && !parameters->publish_joint_velocities &&
-      !parameters->publish_joint_accelerations)
+  if (!parameters.publish_joint_positions && !parameters.publish_joint_velocities &&
+      !parameters.publish_joint_accelerations)
   {
-    RCLCPP_WARN(logger, "At least one of publish_joint_positions / "
+    RCLCPP_WARN(LOGGER, "At least one of publish_joint_positions / "
                         "publish_joint_velocities / "
                         "publish_joint_accelerations must be true. Check "
                         "yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if ((parameters->command_out_type == "std_msgs/Float64MultiArray") && parameters->publish_joint_positions &&
-      parameters->publish_joint_velocities)
+  if ((parameters.command_out_type == "std_msgs/Float64MultiArray") && parameters.publish_joint_positions &&
+      parameters.publish_joint_velocities)
   {
-    RCLCPP_WARN(logger, "When publishing a std_msgs/Float64MultiArray, "
+    RCLCPP_WARN(LOGGER, "When publishing a std_msgs/Float64MultiArray, "
                         "you must select positions OR velocities.");
-    return nullptr;
+    return std::nullopt;
   }
   // Collision checking
-  if (parameters->self_collision_proximity_threshold <= 0.)
+  if (parameters.self_collision_proximity_threshold <= 0.)
   {
-    RCLCPP_WARN(logger, "Parameter 'self_collision_proximity_threshold' should be "
+    RCLCPP_WARN(LOGGER, "Parameter 'self_collision_proximity_threshold' should be "
                         "greater than zero. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (parameters->scene_collision_proximity_threshold <= 0.)
+  if (parameters.scene_collision_proximity_threshold <= 0.)
   {
-    RCLCPP_WARN(logger, "Parameter 'scene_collision_proximity_threshold' should be "
+    RCLCPP_WARN(LOGGER, "Parameter 'scene_collision_proximity_threshold' should be "
                         "greater than zero. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-  if (parameters->scene_collision_proximity_threshold < parameters->self_collision_proximity_threshold)
+  if (parameters.scene_collision_proximity_threshold < parameters.self_collision_proximity_threshold)
   {
-    RCLCPP_WARN(logger, "Parameter 'self_collision_proximity_threshold' should probably be less "
+    RCLCPP_WARN(LOGGER, "Parameter 'self_collision_proximity_threshold' should probably be less "
                         "than or equal to 'scene_collision_proximity_threshold'. Check yaml file.");
   }
-  if (parameters->collision_check_rate <= 0)
+  if (parameters.collision_check_rate <= 0)
   {
-    RCLCPP_WARN(logger, "Parameter 'collision_check_rate' should be "
+    RCLCPP_WARN(LOGGER, "Parameter 'collision_check_rate' should be "
                         "greater than zero. Check yaml file.");
-    return nullptr;
+    return std::nullopt;
   }
-
-  // register parameter change callback
-  if (dynamic_parameters)
-  {
-    using std::placeholders::_1;
-    parameters->on_set_parameters_callback_handler_ =
-        node->add_on_set_parameters_callback(std::bind(&ServoParameters::setParametersCallback, parameters.get(), _1));
-  }
-
   return parameters;
+}
+
+ServoParameters::SharedConstPtr ServoParameters::makeServoParameters(const rclcpp::Node::SharedPtr& node,
+                                                                     std::string ns, /* = "moveit_servo"*/
+                                                                     bool dynamic_parameters /* = true */)
+{
+  auto node_parameters = node->get_node_parameters_interface();
+
+  // Get the parameters
+  declare(ns, node_parameters);
+  auto parameters = validate(get(ns, node_parameters));
+
+  if (parameters)
+  {
+    auto parameters_ptr = std::make_shared<ServoParameters>(parameters.value());
+    parameters_ptr->callback_handler_ = std::make_shared<ServoParameters::CallbackHandler>();
+
+    // register parameter change callback
+    if (dynamic_parameters)
+    {
+      using std::placeholders::_1;
+      parameters_ptr->callback_handler_->on_set_parameters_callback_handler_ =
+          node->add_on_set_parameters_callback(std::bind(&ServoParameters::CallbackHandler::setParametersCallback,
+                                                         parameters_ptr->callback_handler_.get(), _1));
+    }
+
+    return parameters_ptr;
+  }
+  return nullptr;
 }
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -66,7 +66,7 @@ public:
     executor_->add_node(node_);
     executor_thread_ = std::thread([this]() { this->executor_->spin(); });
 
-    servo_parameters_ = moveit_servo::ServoParameters::makeServoParameters(node_, LOGGER);
+    servo_parameters_ = moveit_servo::ServoParameters::makeServoParameters(node_);
     ;
     if (servo_parameters_ == nullptr)
     {

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -84,7 +84,7 @@ public:
     , executor_(std::make_shared<rclcpp::executors::SingleThreadedExecutor>())
   {
     // read parameters and store them in shared pointer to constant
-    servo_parameters_ = moveit_servo::ServoParameters::makeServoParameters(node_, LOGGER, "moveit_servo", false);
+    servo_parameters_ = moveit_servo::ServoParameters::makeServoParameters(node_, "moveit_servo", false);
     if (servo_parameters_ == nullptr)
     {
       RCLCPP_FATAL(LOGGER, "Failed to load the servo parameters");

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.cpp
@@ -528,7 +528,7 @@ int main(int argc, char** argv)
   TEST_PSM->startStateMonitor();
 
   // read parameters and store them in shared pointer to constant
-  TEST_PARAMS = moveit_servo::ServoParameters::makeServoParameters(TEST_NODE, LOGGER);
+  TEST_PARAMS = moveit_servo::ServoParameters::makeServoParameters(TEST_NODE);
   if (TEST_PARAMS == nullptr)
   {
     RCLCPP_FATAL(LOGGER, "Failed to load the servo parameters");


### PR DESCRIPTION
### Description
Update servoParameters to use a new declare and get function that uses NodeParametersInterface to declare and get parameters. See #790

This PR  does the following:
- Sets default values for servo parameters based off of panda_simulated_config.yaml
- Replaces the getOrDeclareParam function with individual get and set functions
  - These 
- Adds parameter_descriptor_builder, which is used to create the messages used in setting up the descriptions for parameters


TODO:

- [x] When running the joystick servo example, declare will throw an error saying that the parameters are already declared. Not sure why this is happening yet, still working on this.
- [x] Build error with the set parameters callback

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)


[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
