### PR TITLE
[foxy] Port CHOMP to MoveIt2

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -13,8 +13,11 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   Boost
 )
 
+message(WARNING "trac_ik found: " ${trac_ik_kinematics_plugin_FOUND})
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
+    message(WARNING "include dir: " ${trac_ik_kinematics_plugin_INCLUDE_DIRS})
+    message(WARNING "include dir: " ${trac_ik_kinematics_plugin_INCLUDE_DIRS})
 endif()
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(chomp_motion_planner REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS 
+set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   #moveit_ros_planning
   chomp_motion_planner
@@ -42,15 +42,15 @@ include_directories(
 
 set(MOVEIT_LIB_NAME moveit_chomp_interface)
 
-add_library(${MOVEIT_LIB_NAME} SHARED 
-  src/chomp_interface.cpp 
+add_library(${MOVEIT_LIB_NAME} SHARED
+  src/chomp_interface.cpp
   src/chomp_planning_context.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(${MOVEIT_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(moveit_chomp_planner_plugin SHARED src/chomp_plugin.cpp)
 ament_target_dependencies(moveit_chomp_planner_plugin ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(moveit_chomp_planner_plugin 
+target_link_libraries(moveit_chomp_planner_plugin
   #chomp_interface
   #moveit_planning_scene
   ${MOVEIT_LIB_NAME}

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -1,20 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(moveit_planners_chomp)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Common cmake code applied to all moveit packages
 find_package(moveit_common REQUIRED)
 moveit_package()
@@ -22,14 +8,12 @@ moveit_package()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(moveit_core REQUIRED)
-#find_package(moveit_ros_planning REQUIRED)
 find_package(chomp_motion_planner REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
-  #moveit_ros_planning
   chomp_motion_planner
   moveit_core
   pluginlib
@@ -51,8 +35,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 add_library(moveit_chomp_planner_plugin SHARED src/chomp_plugin.cpp)
 ament_target_dependencies(moveit_chomp_planner_plugin ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_chomp_planner_plugin
-  #chomp_interface
-  #moveit_planning_scene
   ${MOVEIT_LIB_NAME}
 )
 

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -1,72 +1,85 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5)
 project(moveit_planners_chomp)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
-# find catkin in isolation so that CATKIN_ENABLE_TESTING is defined
-find_package(catkin REQUIRED)
-if(CATKIN_ENABLE_TESTING)
-  set(CHOMP_TEST_DEPS moveit_ros_planning_interface)
-else()
-  set(CHOMP_TEST_DEPS)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(moveit_core REQUIRED)
+#find_package(moveit_ros_planning REQUIRED)
+find_package(chomp_motion_planner REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS 
+  moveit_core
+  #moveit_ros_planning
+  chomp_motion_planner
   moveit_core
   pluginlib
-  chomp_motion_planner
-  ${CHOMP_TEST_DEPS}
+  rclcpp
 )
 
-find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp moveit_core pluginlib
+include_directories(
+  include
 )
 
-include_directories(include)
-include_directories(SYSTEM
-  ${catkin_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
+set(MOVEIT_LIB_NAME moveit_chomp_interface)
+
+add_library(${MOVEIT_LIB_NAME} SHARED 
+  src/chomp_interface.cpp 
+  src/chomp_planning_context.cpp)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+ament_target_dependencies(${MOVEIT_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+add_library(moveit_chomp_planner_plugin SHARED src/chomp_plugin.cpp)
+ament_target_dependencies(moveit_chomp_planner_plugin ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_chomp_planner_plugin 
+  #chomp_interface
+  #moveit_planning_scene
+  ${MOVEIT_LIB_NAME}
 )
 
-add_library(${PROJECT_NAME} src/chomp_interface.cpp src/chomp_planning_context.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-add_library(chomp_planner_plugin src/chomp_plugin.cpp)
-set_target_properties(chomp_planner_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(chomp_planner_plugin ${PROJECT_NAME} ${catkin_LIBRARIES})
-
-install(FILES chomp_interface_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-install(DIRECTORY include/chomp_interface/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(
+  TARGETS ${MOVEIT_LIB_NAME} moveit_chomp_planner_plugin
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
-install(TARGETS ${PROJECT_NAME} chomp_planner_plugin
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
 
-if(CATKIN_ENABLE_TESTING)
-  # additional test dependencies
-  find_package(rostest REQUIRED)
-  add_rostest_gtest(chomp_moveit_test
-    test/chomp_moveit.test
-    test/chomp_moveit_test.cpp)
-  target_link_libraries(chomp_moveit_test
-    ${catkin_LIBRARIES}
-    ${rostest_LIBRARIES})
+pluginlib_export_plugin_description_file(moveit_core chomp_interface_plugin_description.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
 endif()
+
+ament_package()

--- a/moveit_planners/chomp/chomp_interface/chomp_interface_plugin_description.xml
+++ b/moveit_planners/chomp/chomp_interface/chomp_interface_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libchomp_planner_plugin">
+<library path="moveit_chomp_planner_plugin">
   <class name="chomp_interface/CHOMPPlanner" type="chomp_interface::CHOMPPlannerManager" base_class_type="planning_interface::PlannerManager">
     <description>
     The CHOMP motion planner plugin.

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -36,29 +36,29 @@
 
 #pragma once
 
-#include <chomp_motion_planner/chomp_planner.h>
 #include <chomp_motion_planner/chomp_parameters.h>
-#include <ros/ros.h>
+#include <chomp_motion_planner/chomp_planner.h>
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace chomp_interface
 {
-MOVEIT_CLASS_FORWARD(CHOMPInterface)  // Defines CHOMPInterfacePtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(CHOMPInterface);  // Defines CHOMPInterfacePtr, ConstPtr, WeakPtr... etc
 
 class CHOMPInterface : public chomp::ChompPlanner
 {
 public:
-  CHOMPInterface(const ros::NodeHandle& nh = ros::NodeHandle("~"));
+  //CHOMPInterface();
+  CHOMPInterface(const rclcpp::Node::SharedPtr nh);
+  //CHOMPInterface(const rclcpp::Node& nh = rclcpp::Node("~"));
 
-  const chomp::ChompParameters& getParams() const
-  {
-    return params_;
-  }
+  const chomp::ChompParameters & getParams() const { return params_; }
 
 protected:
   /** @brief Configure everything using the param server */
   void loadParams();
 
-  ros::NodeHandle nh_;  /// The ROS node handle
+  std::shared_ptr<rclcpp::Node> nh_;  /// The ROS node handle
 
   chomp::ChompParameters params_;
 };

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -48,11 +48,14 @@ MOVEIT_CLASS_FORWARD(CHOMPInterface);  // Defines CHOMPInterfacePtr, ConstPtr, W
 class CHOMPInterface : public chomp::ChompPlanner
 {
 public:
-  //CHOMPInterface();
+  // CHOMPInterface();
   CHOMPInterface(const rclcpp::Node::SharedPtr nh);
-  //CHOMPInterface(const rclcpp::Node& nh = rclcpp::Node("~"));
+  // CHOMPInterface(const rclcpp::Node& nh = rclcpp::Node("~"));
 
-  const chomp::ChompParameters & getParams() const { return params_; }
+  const chomp::ChompParameters& getParams() const
+  {
+    return params_;
+  }
 
 protected:
   /** @brief Configure everything using the param server */

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -48,9 +48,7 @@ MOVEIT_CLASS_FORWARD(CHOMPInterface);  // Defines CHOMPInterfacePtr, ConstPtr, W
 class CHOMPInterface : public chomp::ChompPlanner
 {
 public:
-  // CHOMPInterface();
-  CHOMPInterface(const rclcpp::Node::SharedPtr nh);
-  // CHOMPInterface(const rclcpp::Node& nh = rclcpp::Node("~"));
+  CHOMPInterface(const rclcpp::Node::SharedPtr node);
 
   const chomp::ChompParameters& getParams() const
   {
@@ -61,7 +59,7 @@ protected:
   /** @brief Configure everything using the param server */
   void loadParams();
 
-  std::shared_ptr<rclcpp::Node> nh_;  /// The ROS node handle
+  std::shared_ptr<rclcpp::Node> node_;  /// The ROS node
 
   chomp::ChompParameters params_;
 };

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -43,21 +43,19 @@
 
 namespace chomp_interface
 {
-MOVEIT_CLASS_FORWARD(
-  CHOMPPlanningContext);  // Defines CHOMPPlanningContextPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(CHOMPPlanningContext);  // Defines CHOMPPlanningContextPtr, ConstPtr, WeakPtr... etc
 
 class CHOMPPlanningContext : public planning_interface::PlanningContext
 {
 public:
-  bool solve(planning_interface::MotionPlanResponse & res) override;
-  bool solve(planning_interface::MotionPlanDetailedResponse & res) override;
+  bool solve(planning_interface::MotionPlanResponse& res) override;
+  bool solve(planning_interface::MotionPlanDetailedResponse& res) override;
 
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(
-    const std::string & name, const std::string & group,
-    const moveit::core::RobotModelConstPtr & model, rclcpp::Node::SharedPtr nh);
+  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
+                       rclcpp::Node::SharedPtr nh);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -36,24 +36,28 @@
 
 #pragma once
 
-#include <moveit/planning_interface/planning_interface.h>
 #include <chomp_interface/chomp_interface.h>
+#include <moveit/planning_interface/planning_interface.h>
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace chomp_interface
 {
-MOVEIT_CLASS_FORWARD(CHOMPPlanningContext)  // Defines CHOMPPlanningContextPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(
+  CHOMPPlanningContext);  // Defines CHOMPPlanningContextPtr, ConstPtr, WeakPtr... etc
 
 class CHOMPPlanningContext : public planning_interface::PlanningContext
 {
 public:
-  bool solve(planning_interface::MotionPlanResponse& res) override;
-  bool solve(planning_interface::MotionPlanDetailedResponse& res) override;
+  bool solve(planning_interface::MotionPlanResponse & res) override;
+  bool solve(planning_interface::MotionPlanDetailedResponse & res) override;
 
   void clear() override;
   bool terminate() override;
 
-  CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
-                       ros::NodeHandle& nh);
+  CHOMPPlanningContext(
+    const std::string & name, const std::string & group,
+    const moveit::core::RobotModelConstPtr & model, rclcpp::Node::SharedPtr nh);
 
   ~CHOMPPlanningContext() override = default;
 
@@ -64,4 +68,4 @@ private:
   moveit::core::RobotModelConstPtr robot_model_;
 };
 
-} /* namespace chomp_interface */
+}  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -1,28 +1,31 @@
-<package format="2">
+<?xml version="2.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>moveit_planners_chomp</name>
-  <description>The interface for using CHOMP within MoveIt</description>
-
   <version>1.1.5</version>
+  <description>The interface for using CHOMP within MoveIt</description>
   <author email="gjones@willowgarage.com">Gil Jones</author>
 
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
   <maintainer email="dave@picknik.ai">Dave Coleman</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
-  <depend>roscpp</depend>
+  <depend>chomp_motion_planner</depend>
   <depend>moveit_core</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
-  <depend>chomp_motion_planner</depend>
+  <depend>rclcpp</depend>
 
-  <test_depend>moveit_ros_planning_interface</test_depend>
-  <test_depend>rostest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <moveit_core plugin="${prefix}/chomp_interface_plugin_description.xml"/>
   </export>
-
 </package>

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -9,7 +9,6 @@
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
   <maintainer email="dave@picknik.ai">Dave Coleman</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
-  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
 

--- a/moveit_planners/chomp/chomp_interface/plugin_description.xml
+++ b/moveit_planners/chomp/chomp_interface/plugin_description.xml
@@ -1,5 +1,7 @@
-<library path="lib/libchomp_planner_plugin">
-  <class name="chomp_interface_ros/CHOMPPlanner" type="chomp_interface_ros::CHOMPPlanner" base_class_type="planning_interface::Planner">
+<!--<library path="lib/libchomp_planner_plugin">-->
+<library path="moveit_planners_chomp">
+  <class name="chomp_interface/CHOMPPlanner" type="chomp_interface::CHOMPPlannerManager" base_class_type="planning_interface::PlannerManager">
+  <!--<class name="chomp_interface/CHOMPPlanner" type="chomp_interface::CHOMPPlanner" base_class_type="planning_interface::Planner">-->
     <description>
     </description>
   </class>

--- a/moveit_planners/chomp/chomp_interface/plugin_description.xml
+++ b/moveit_planners/chomp/chomp_interface/plugin_description.xml
@@ -1,7 +1,5 @@
-<!--<library path="lib/libchomp_planner_plugin">-->
 <library path="moveit_planners_chomp">
   <class name="chomp_interface/CHOMPPlanner" type="chomp_interface::CHOMPPlannerManager" base_class_type="planning_interface::PlannerManager">
-  <!--<class name="chomp_interface/CHOMPPlanner" type="chomp_interface::CHOMPPlanner" base_class_type="planning_interface::Planner">-->
     <description>
     </description>
   </class>

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -40,45 +40,45 @@ namespace chomp_interface
 {
 rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
 
-CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr nh) : ChompPlanner(), nh_(nh)
+CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr node) : ChompPlanner(), node_(node)
 {
   loadParams();
 }
 
 void CHOMPInterface::loadParams()
 {
-  nh_->get_parameter_or("chomp.planning_time_limit", params_.planning_time_limit_, 10.0);
-  nh_->get_parameter_or("chomp.max_iterations", params_.max_iterations_, 200);
-  nh_->get_parameter_or("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
+  node_->get_parameter_or("chomp.planning_time_limit", params_.planning_time_limit_, 10.0);
+  node_->get_parameter_or("chomp.max_iterations", params_.max_iterations_, 200);
+  node_->get_parameter_or("chomp.max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
 
-  nh_->get_parameter_or("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
-  nh_->get_parameter_or("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
-  nh_->get_parameter_or("chomp.learning_rate", params_.learning_rate_, 0.01);
+  node_->get_parameter_or("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
+  node_->get_parameter_or("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
+  node_->get_parameter_or("chomp.learning_rate", params_.learning_rate_, 0.01);
 
-  // nh_->param("add_randomness", params_.add_randomness_, false);
-  nh_->get_parameter_or("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
-  nh_->get_parameter_or("chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
-  nh_->get_parameter_or("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
-  // nh_->param("hmc_discretization", params_.hmc_discretization_, 0.01);
-  // nh_->param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
-  // nh_->param("hmc_annealing_factor", params_.hmc_annealing_factor_, 0.99);
-  // nh_->param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
-  nh_->get_parameter_or("chomp.ridge_factor", params_.ridge_factor_, 0.0);
-  nh_->get_parameter_or("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_, false);
-  nh_->get_parameter_or("chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
+  // node_->param("add_randomness", params_.add_randomness_, false);
+  node_->get_parameter_or("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
+  node_->get_parameter_or("chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
+  node_->get_parameter_or("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
+  // node_->param("hmc_discretization", params_.hmc_discretization_, 0.01);
+  // node_->param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
+  // node_->param("hmc_annealing_factor", params_.hmc_annealing_factor_, 0.99);
+  // node_->param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
+  node_->get_parameter_or("chomp.ridge_factor", params_.ridge_factor_, 0.0);
+  node_->get_parameter_or("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_, false);
+  node_->get_parameter_or("chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
 
-  nh_->get_parameter_or("chomp.joint_update_limit", params_.joint_update_limit_, 0.1);
+  node_->get_parameter_or("chomp.joint_update_limit", params_.joint_update_limit_, 0.1);
   // TODO: remove this warning after 06/2022
-  if (!nh_->has_parameter("collision_clearance") && nh_->has_parameter("collision_clearence"))
+  if (!node_->has_parameter("chomp.collision_clearance") && node_->has_parameter("chomp.collision_clearence"))
     RCLCPP_WARN(LOGGER, "The param 'collision_clearence' has been renamed to 'collision_clearance', please update "
                         "your config!");
-  nh_->get_parameter_or("chomp.collision_clearance", params_.min_clearance_, 0.2);
-  nh_->get_parameter_or("chomp.collision_threshold", params_.collision_threshold_, 0.07);
-  // nh_->param("random_jump_amount", params_.random_jump_amount_, 1.0);
-  nh_->get_parameter_or("chomp.use_stochastic_descent", params_.use_stochastic_descent_, true);
+  node_->get_parameter_or("chomp.collision_clearance", params_.min_clearance_, 0.2);
+  node_->get_parameter_or("chomp.collision_threshold", params_.collision_threshold_, 0.07);
+  // node_->param("random_jump_amount", params_.random_jump_amount_, 1.0);
+  node_->get_parameter_or("chomp.use_stochastic_descent", params_.use_stochastic_descent_, true);
   params_.trajectory_initialization_method_ = "quintic-spline";
   std::string method;
-  if (nh_->get_parameter("chomp.trajectory_initialization_method", method) &&
+  if (node_->get_parameter("chomp.trajectory_initialization_method", method) &&
       !params_.setTrajectoryInitializationMethod(method))
   {
     RCLCPP_ERROR(LOGGER,
@@ -86,7 +86,7 @@ void CHOMPInterface::loadParams()
                  "instead.",
                  method, params_.trajectory_initialization_method_);
   }
-  nh_->get_parameter_or("chomp.enable_failure_recovery", params_.enable_failure_recovery_, false);
-  nh_->get_parameter_or("chomp.max_recovery_attempts", params_.max_recovery_attempts_, 5);
+  node_->get_parameter_or("chomp.enable_failure_recovery", params_.enable_failure_recovery_, false);
+  node_->get_parameter_or("chomp.max_recovery_attempts", params_.max_recovery_attempts_, 5);
 }
 }  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -49,8 +49,7 @@ void CHOMPInterface::loadParams()
 {
   nh_->get_parameter_or("chomp.planning_time_limit", params_.planning_time_limit_, 10.0);
   nh_->get_parameter_or("chomp.max_iterations", params_.max_iterations_, 200);
-  nh_->get_parameter_or(
-    "max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
+  nh_->get_parameter_or("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
 
   nh_->get_parameter_or("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
   nh_->get_parameter_or("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
@@ -58,8 +57,7 @@ void CHOMPInterface::loadParams()
 
   // nh_->param("add_randomness", params_.add_randomness_, false);
   nh_->get_parameter_or("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
-  nh_->get_parameter_or(
-    "chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
+  nh_->get_parameter_or("chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
   nh_->get_parameter_or("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
   // nh_->param("hmc_discretization", params_.hmc_discretization_, 0.01);
   // nh_->param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
@@ -67,30 +65,26 @@ void CHOMPInterface::loadParams()
   // nh_->param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
   nh_->get_parameter_or("chomp.ridge_factor", params_.ridge_factor_, 0.0);
   nh_->get_parameter_or("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_, false);
-  nh_->get_parameter_or(
-    "chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
+  nh_->get_parameter_or("chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
 
   nh_->get_parameter_or("chomp.joint_update_limit", params_.joint_update_limit_, 0.1);
   // TODO: remove this warning after 06/2022
   if (!nh_->has_parameter("collision_clearance") && nh_->has_parameter("collision_clearence"))
-    RCLCPP_WARN(
-      LOGGER,
-      "The param 'collision_clearence' has been renamed to 'collision_clearance', please update "
-      "your config!");
+    RCLCPP_WARN(LOGGER, "The param 'collision_clearence' has been renamed to 'collision_clearance', please update "
+                        "your config!");
   nh_->get_parameter_or("chomp.collision_clearance", params_.min_clearance_, 0.2);
   nh_->get_parameter_or("chomp.collision_threshold", params_.collision_threshold_, 0.07);
   // nh_->param("random_jump_amount", params_.random_jump_amount_, 1.0);
   nh_->get_parameter_or("chomp.use_stochastic_descent", params_.use_stochastic_descent_, true);
   params_.trajectory_initialization_method_ = "quintic-spline";
   std::string method;
-  if (
-    nh_->get_parameter("chomp.trajectory_initialization_method", method) &&
-    !params_.setTrajectoryInitializationMethod(method)) {
-    RCLCPP_ERROR(
-      LOGGER,
-      "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default '%s' "
-      "instead.",
-      method, params_.trajectory_initialization_method_);
+  if (nh_->get_parameter("chomp.trajectory_initialization_method", method) &&
+      !params_.setTrajectoryInitializationMethod(method))
+  {
+    RCLCPP_ERROR(LOGGER,
+                 "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default '%s' "
+                 "instead.",
+                 method, params_.trajectory_initialization_method_);
   }
   nh_->get_parameter_or("chomp.enable_failure_recovery", params_.enable_failure_recovery_, false);
   nh_->get_parameter_or("chomp.max_recovery_attempts", params_.max_recovery_attempts_, 5);

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -38,48 +38,61 @@
 
 namespace chomp_interface
 {
-CHOMPInterface::CHOMPInterface(const ros::NodeHandle& nh) : ChompPlanner(), nh_(nh)
+rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
+
+CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr nh) : ChompPlanner(), nh_(nh)
 {
   loadParams();
 }
 
 void CHOMPInterface::loadParams()
 {
-  nh_.param("planning_time_limit", params_.planning_time_limit_, 10.0);
-  nh_.param("max_iterations", params_.max_iterations_, 200);
-  nh_.param("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
-  nh_.param("smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
-  nh_.param("obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
-  nh_.param("learning_rate", params_.learning_rate_, 0.01);
+  nh_->get_parameter_or("chomp.planning_time_limit", params_.planning_time_limit_, 10.0);
+  nh_->get_parameter_or("chomp.max_iterations", params_.max_iterations_, 200);
+  nh_->get_parameter_or(
+    "max_iterations_after_collision_free", params_.max_iterations_after_collision_free_, 5);
 
-  // nh_.param("add_randomness", params_.add_randomness_, false);
-  nh_.param("smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
-  nh_.param("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
-  nh_.param("smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
-  // nh_.param("hmc_discretization", params_.hmc_discretization_, 0.01);
-  // nh_.param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
-  // nh_.param("hmc_annealing_factor", params_.hmc_annealing_factor_, 0.99);
-  // nh_.param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
-  nh_.param("ridge_factor", params_.ridge_factor_, 0.0);
-  nh_.param("use_pseudo_inverse", params_.use_pseudo_inverse_, false);
-  nh_.param("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
+  nh_->get_parameter_or("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_, 0.1);
+  nh_->get_parameter_or("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_, 1.0);
+  nh_->get_parameter_or("chomp.learning_rate", params_.learning_rate_, 0.01);
 
-  nh_.param("joint_update_limit", params_.joint_update_limit_, 0.1);
+  // nh_->param("add_randomness", params_.add_randomness_, false);
+  nh_->get_parameter_or("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_, 0.0);
+  nh_->get_parameter_or(
+    "chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_, 1.0);
+  nh_->get_parameter_or("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_, 0.0);
+  // nh_->param("hmc_discretization", params_.hmc_discretization_, 0.01);
+  // nh_->param("hmc_stochasticity", params_.hmc_stochasticity_, 0.01);
+  // nh_->param("hmc_annealing_factor", params_.hmc_annealing_factor_, 0.99);
+  // nh_->param("use_hamiltonian_monte_carlo", params_.use_hamiltonian_monte_carlo_, false);
+  nh_->get_parameter_or("chomp.ridge_factor", params_.ridge_factor_, 0.0);
+  nh_->get_parameter_or("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_, false);
+  nh_->get_parameter_or(
+    "chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_, 1e-4);
+
+  nh_->get_parameter_or("chomp.joint_update_limit", params_.joint_update_limit_, 0.1);
   // TODO: remove this warning after 06/2022
-  if (!nh_.hasParam("collision_clearance") && nh_.hasParam("collision_clearence"))
-    ROS_WARN("The param 'collision_clearence' has been renamed to 'collision_clearance', please update your config!");
-  nh_.param("collision_clearance", params_.min_clearance_, 0.2);
-  nh_.param("collision_threshold", params_.collision_threshold_, 0.07);
-  // nh_.param("random_jump_amount", params_.random_jump_amount_, 1.0);
-  nh_.param("use_stochastic_descent", params_.use_stochastic_descent_, true);
-  {
-    params_.trajectory_initialization_method_ = "quintic-spline";
-    std::string method;
-    if (nh_.getParam("trajectory_initialization_method", method) && !params_.setTrajectoryInitializationMethod(method))
-      ROS_ERROR_STREAM("Attempted to set trajectory_initialization_method to invalid value '"
-                       << method << "'. Using default '" << params_.trajectory_initialization_method_ << "' instead.");
+  if (!nh_->has_parameter("collision_clearance") && nh_->has_parameter("collision_clearence"))
+    RCLCPP_WARN(
+      LOGGER,
+      "The param 'collision_clearence' has been renamed to 'collision_clearance', please update "
+      "your config!");
+  nh_->get_parameter_or("chomp.collision_clearance", params_.min_clearance_, 0.2);
+  nh_->get_parameter_or("chomp.collision_threshold", params_.collision_threshold_, 0.07);
+  // nh_->param("random_jump_amount", params_.random_jump_amount_, 1.0);
+  nh_->get_parameter_or("chomp.use_stochastic_descent", params_.use_stochastic_descent_, true);
+  params_.trajectory_initialization_method_ = "quintic-spline";
+  std::string method;
+  if (
+    nh_->get_parameter("chomp.trajectory_initialization_method", method) &&
+    !params_.setTrajectoryInitializationMethod(method)) {
+    RCLCPP_ERROR(
+      LOGGER,
+      "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default '%s' "
+      "instead.",
+      method, params_.trajectory_initialization_method_);
   }
-  nh_.param("enable_failure_recovery", params_.enable_failure_recovery_, false);
-  nh_.param("max_recovery_attempts", params_.max_recovery_attempts_, 5);
+  nh_->get_parameter_or("chomp.enable_failure_recovery", params_.enable_failure_recovery_, false);
+  nh_->get_parameter_or("chomp.max_recovery_attempts", params_.max_recovery_attempts_, 5);
 }
 }  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -35,32 +35,36 @@
 /* Author: Chittaranjan Srinivas Swaminathan */
 
 #include <chomp_interface/chomp_planning_context.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit/robot_state/conversions.h>
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+
+#include "rclcpp/rclcpp.hpp"
 
 namespace chomp_interface
 {
-CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::string& group,
-                                           const moveit::core::RobotModelConstPtr& model, ros::NodeHandle& nh)
-  : planning_interface::PlanningContext(name, group), robot_model_(model)
+rclcpp::Logger LOGGER3 = rclcpp::get_logger("chomp_optimizer");
+
+CHOMPPlanningContext::CHOMPPlanningContext(
+  const std::string & name, const std::string & group,
+  const moveit::core::RobotModelConstPtr & model, rclcpp::Node::SharedPtr nh)
+: planning_interface::PlanningContext(name, group), robot_model_(model)
 {
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface(nh));
 }
 
-bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
+bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse & res)
 {
   return chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res);
 }
 
-bool CHOMPPlanningContext::solve(planning_interface::MotionPlanResponse& res)
+bool CHOMPPlanningContext::solve(planning_interface::MotionPlanResponse & res)
 {
   planning_interface::MotionPlanDetailedResponse res_detailed;
   bool planning_success = solve(res_detailed);
 
   res.error_code_ = res_detailed.error_code_;
 
-  if (planning_success)
-  {
+  if (planning_success) {
     res.trajectory_ = res_detailed.trajectory_[0];
     res.planning_time_ = res_detailed.processing_time_[0];
   }
@@ -74,8 +78,6 @@ bool CHOMPPlanningContext::terminate()
   return true;
 }
 
-void CHOMPPlanningContext::clear()
-{
-}
+void CHOMPPlanningContext::clear() {}
 
-} /* namespace chomp_interface */
+}  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -44,27 +44,27 @@ namespace chomp_interface
 {
 rclcpp::Logger LOGGER3 = rclcpp::get_logger("chomp_optimizer");
 
-CHOMPPlanningContext::CHOMPPlanningContext(
-  const std::string & name, const std::string & group,
-  const moveit::core::RobotModelConstPtr & model, rclcpp::Node::SharedPtr nh)
-: planning_interface::PlanningContext(name, group), robot_model_(model)
+CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::string& group,
+                                           const moveit::core::RobotModelConstPtr& model, rclcpp::Node::SharedPtr nh)
+  : planning_interface::PlanningContext(name, group), robot_model_(model)
 {
   chomp_interface_ = CHOMPInterfacePtr(new CHOMPInterface(nh));
 }
 
-bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse & res)
+bool CHOMPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
   return chomp_interface_->solve(planning_scene_, request_, chomp_interface_->getParams(), res);
 }
 
-bool CHOMPPlanningContext::solve(planning_interface::MotionPlanResponse & res)
+bool CHOMPPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 {
   planning_interface::MotionPlanDetailedResponse res_detailed;
   bool planning_success = solve(res_detailed);
 
   res.error_code_ = res_detailed.error_code_;
 
-  if (planning_success) {
+  if (planning_success)
+  {
     res.trajectory_ = res_detailed.trajectory_[0];
     res.planning_time_ = res_detailed.processing_time_[0];
   }
@@ -78,6 +78,8 @@ bool CHOMPPlanningContext::terminate()
   return true;
 }
 
-void CHOMPPlanningContext::clear() {}
+void CHOMPPlanningContext::clear()
+{
+}
 
 }  // namespace chomp_interface

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -54,7 +54,6 @@ public:
 
   bool initialize(const moveit::core::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
                   const std::string& parameter_namespace) override
-  // bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
     std::string actual_ns;
     if (parameter_namespace.empty())

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -48,42 +48,49 @@ rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
 class CHOMPPlannerManager : public planning_interface::PlannerManager
 {
 public:
-  CHOMPPlannerManager() : planning_interface::PlannerManager() {}
+  CHOMPPlannerManager() : planning_interface::PlannerManager()
+  {
+  }
 
-  bool initialize(
-    const moveit::core::RobotModelConstPtr & model, const rclcpp::Node::SharedPtr & node,
-    const std::string & parameter_namespace) override
-  //bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
+                  const std::string& parameter_namespace) override
+  // bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
     std::string actual_ns;
-    if (parameter_namespace.empty()) {
+    if (parameter_namespace.empty())
+    {
       actual_ns = "~";
-    } else {
+    }
+    else
+    {
       actual_ns = parameter_namespace;
     }
     std::shared_ptr<rclcpp::Node> nh_ptr = std::make_shared<rclcpp::Node>(actual_ns);
 
-    for (const std::string & group : model->getJointModelGroupNames()) {
-      planning_contexts_[group] = CHOMPPlanningContextPtr(
-        new CHOMPPlanningContext("chomp_planning_context", group, model, nh_ptr));
+    for (const std::string& group : model->getJointModelGroupNames())
+    {
+      planning_contexts_[group] =
+          CHOMPPlanningContextPtr(new CHOMPPlanningContext("chomp_planning_context", group, model, nh_ptr));
     }
     return true;
   }
 
-  planning_interface::PlanningContextPtr getPlanningContext(
-    const planning_scene::PlanningSceneConstPtr & planning_scene,
-    const planning_interface::MotionPlanRequest & req,
-    moveit_msgs::msg::MoveItErrorCodes & error_code) const override
+  planning_interface::PlanningContextPtr
+  getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                     const planning_interface::MotionPlanRequest& req,
+                     moveit_msgs::msg::MoveItErrorCodes& error_code) const override
   {
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
 
-    if (req.group_name.empty()) {
+    if (req.group_name.empty())
+    {
       RCLCPP_ERROR(LOGGER, "No group specified to plan for");
       error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GROUP_NAME;
       return planning_interface::PlanningContextPtr();
     }
 
-    if (!planning_scene) {
+    if (!planning_scene)
+    {
       RCLCPP_ERROR(LOGGER, "No planning scene supplied as input");
       error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
       return planning_interface::PlanningContextPtr();
@@ -94,23 +101,26 @@ public:
     ps->allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorHybrid::create());
 
     // retrieve and configure existing context
-    const CHOMPPlanningContextPtr & context = planning_contexts_.at(req.group_name);
+    const CHOMPPlanningContextPtr& context = planning_contexts_.at(req.group_name);
     context->setPlanningScene(ps);
     context->setMotionPlanRequest(req);
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
     return context;
   }
 
-  bool canServiceRequest(const planning_interface::MotionPlanRequest & /*req*/) const override
+  bool canServiceRequest(const planning_interface::MotionPlanRequest& /*req*/) const override
   {
     // TODO: this is a dummy implementation
     //      capabilities.dummy = false;
     return true;
   }
 
-  std::string getDescription() const override { return "CHOMP"; }
+  std::string getDescription() const override
+  {
+    return "CHOMP";
+  }
 
-  void getPlanningAlgorithms(std::vector<std::string> & algs) const override
+  void getPlanningAlgorithms(std::vector<std::string>& algs) const override
   {
     algs.resize(1);
     algs[0] = "CHOMP";

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -32,54 +32,59 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <chomp_interface/chomp_planning_context.h>
+#include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_model/robot_model.h>
-#include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
-#include <chomp_interface/chomp_planning_context.h>
 
 #include <pluginlib/class_list_macros.hpp>
+#include <vector>
 
 namespace chomp_interface
 {
+rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
+
 class CHOMPPlannerManager : public planning_interface::PlannerManager
 {
 public:
-  CHOMPPlannerManager() : planning_interface::PlannerManager()
-  {
-  }
+  CHOMPPlannerManager() : planning_interface::PlannerManager() {}
 
-  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
+  bool initialize(
+    const moveit::core::RobotModelConstPtr & model, const rclcpp::Node::SharedPtr & node,
+    const std::string & parameter_namespace) override
+  //bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
-    ros::NodeHandle nh("~");
-    if (!ns.empty())
-      nh = ros::NodeHandle(ns);
+    std::string actual_ns;
+    if (parameter_namespace.empty()) {
+      actual_ns = "~";
+    } else {
+      actual_ns = parameter_namespace;
+    }
+    std::shared_ptr<rclcpp::Node> nh_ptr = std::make_shared<rclcpp::Node>(actual_ns);
 
-    for (const std::string& group : model->getJointModelGroupNames())
-    {
-      planning_contexts_[group] =
-          CHOMPPlanningContextPtr(new CHOMPPlanningContext("chomp_planning_context", group, model, nh));
+    for (const std::string & group : model->getJointModelGroupNames()) {
+      planning_contexts_[group] = CHOMPPlanningContextPtr(
+        new CHOMPPlanningContext("chomp_planning_context", group, model, nh_ptr));
     }
     return true;
   }
 
-  planning_interface::PlanningContextPtr
-  getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                     const planning_interface::MotionPlanRequest& req,
-                     moveit_msgs::msg::MoveItErrorCodes& error_code) const override
+  planning_interface::PlanningContextPtr getPlanningContext(
+    const planning_scene::PlanningSceneConstPtr & planning_scene,
+    const planning_interface::MotionPlanRequest & req,
+    moveit_msgs::msg::MoveItErrorCodes & error_code) const override
   {
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
 
-    if (req.group_name.empty())
-    {
-      ROS_ERROR("No group specified to plan for");
+    if (req.group_name.empty()) {
+      RCLCPP_ERROR(LOGGER, "No group specified to plan for");
       error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GROUP_NAME;
       return planning_interface::PlanningContextPtr();
     }
 
-    if (!planning_scene)
-    {
-      ROS_ERROR("No planning scene supplied as input");
+    if (!planning_scene) {
+      RCLCPP_ERROR(LOGGER, "No planning scene supplied as input");
       error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
       return planning_interface::PlanningContextPtr();
     }
@@ -89,26 +94,23 @@ public:
     ps->allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorHybrid::create());
 
     // retrieve and configure existing context
-    const CHOMPPlanningContextPtr& context = planning_contexts_.at(req.group_name);
+    const CHOMPPlanningContextPtr & context = planning_contexts_.at(req.group_name);
     context->setPlanningScene(ps);
     context->setMotionPlanRequest(req);
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
     return context;
   }
 
-  bool canServiceRequest(const planning_interface::MotionPlanRequest& /*req*/) const override
+  bool canServiceRequest(const planning_interface::MotionPlanRequest & /*req*/) const override
   {
     // TODO: this is a dummy implementation
     //      capabilities.dummy = false;
     return true;
   }
 
-  std::string getDescription() const override
-  {
-    return "CHOMP";
-  }
+  std::string getDescription() const override { return "CHOMP"; }
 
-  void getPlanningAlgorithms(std::vector<std::string>& algs) const override
+  void getPlanningAlgorithms(std::vector<std::string> & algs) const override
   {
     algs.resize(1);
     algs[0] = "CHOMP";
@@ -120,4 +122,4 @@ protected:
 
 }  // namespace chomp_interface
 
-PLUGINLIB_EXPORT_CLASS(chomp_interface::CHOMPPlannerManager, planning_interface::PlannerManager);
+PLUGINLIB_EXPORT_CLASS(chomp_interface::CHOMPPlannerManager, planning_interface::PlannerManager)

--- a/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
+++ b/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
@@ -46,14 +46,16 @@ public:
   moveit::planning_interface::MoveGroupInterface::Plan my_plan_;
 
 public:
-  CHOMPMoveitTest() : move_group_("arm") {}
+  CHOMPMoveitTest() : move_group_("arm")
+  {
+  }
 };
 
 // TEST CASES
 TEST_F(CHOMPMoveitTest, jointSpaceGoodGoal)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
-  move_group_.setJointValueTarget(std::vector<double>({1.0, 1.0}));
+  move_group_.setJointValueTarget(std::vector<double>({ 1.0, 1.0 }));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_GT(my_plan_.trajectory_.joint_trajectory.points.size(), 0u);
@@ -64,7 +66,7 @@ TEST_F(CHOMPMoveitTest, jointSpaceBadGoal)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
   // joint2 is limited to [-PI/2, PI/2]
-  move_group_.setJointValueTarget(std::vector<double>({100.0, 2 * M_PI / 3.0}));
+  move_group_.setJointValueTarget(std::vector<double>({ 100.0, 2 * M_PI / 3.0 }));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::INVALID_ROBOT_STATE);
@@ -87,7 +89,7 @@ TEST_F(CHOMPMoveitTest, cartesianGoal)
 
 TEST_F(CHOMPMoveitTest, noStartState)
 {
-  move_group_.setJointValueTarget(std::vector<double>({0.2, 0.2}));
+  move_group_.setJointValueTarget(std::vector<double>({ 0.2, 0.2 }));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::SUCCESS);
@@ -96,13 +98,13 @@ TEST_F(CHOMPMoveitTest, noStartState)
 TEST_F(CHOMPMoveitTest, collisionAtEndOfPath)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
-  move_group_.setJointValueTarget(std::vector<double>({M_PI / 2.0, 0}));
+  move_group_.setJointValueTarget(std::vector<double>({ M_PI / 2.0, 0 }));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::INVALID_MOTION_PLAN);
 }
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "chomp_moveit_test");

--- a/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
+++ b/moveit_planners/chomp/chomp_interface/test/chomp_moveit_test.cpp
@@ -34,11 +34,10 @@
 
 /// \author Bence Magyar
 
-#include <ros/ros.h>
 #include <gtest/gtest.h>
-
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <ros/ros.h>
 
 class CHOMPMoveitTest : public ::testing::Test
 {
@@ -47,16 +46,14 @@ public:
   moveit::planning_interface::MoveGroupInterface::Plan my_plan_;
 
 public:
-  CHOMPMoveitTest() : move_group_("arm")
-  {
-  }
+  CHOMPMoveitTest() : move_group_("arm") {}
 };
 
 // TEST CASES
 TEST_F(CHOMPMoveitTest, jointSpaceGoodGoal)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
-  move_group_.setJointValueTarget(std::vector<double>({ 1.0, 1.0 }));
+  move_group_.setJointValueTarget(std::vector<double>({1.0, 1.0}));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_GT(my_plan_.trajectory_.joint_trajectory.points.size(), 0u);
@@ -67,7 +64,7 @@ TEST_F(CHOMPMoveitTest, jointSpaceBadGoal)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
   // joint2 is limited to [-PI/2, PI/2]
-  move_group_.setJointValueTarget(std::vector<double>({ 100.0, 2 * M_PI / 3.0 }));
+  move_group_.setJointValueTarget(std::vector<double>({100.0, 2 * M_PI / 3.0}));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::INVALID_ROBOT_STATE);
@@ -90,7 +87,7 @@ TEST_F(CHOMPMoveitTest, cartesianGoal)
 
 TEST_F(CHOMPMoveitTest, noStartState)
 {
-  move_group_.setJointValueTarget(std::vector<double>({ 0.2, 0.2 }));
+  move_group_.setJointValueTarget(std::vector<double>({0.2, 0.2}));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::SUCCESS);
@@ -99,13 +96,13 @@ TEST_F(CHOMPMoveitTest, noStartState)
 TEST_F(CHOMPMoveitTest, collisionAtEndOfPath)
 {
   move_group_.setStartState(*(move_group_.getCurrentState()));
-  move_group_.setJointValueTarget(std::vector<double>({ M_PI / 2.0, 0 }));
+  move_group_.setJointValueTarget(std::vector<double>({M_PI / 2.0, 0}));
 
   moveit::planning_interface::MoveItErrorCode error_code = move_group_.plan(my_plan_);
   EXPECT_EQ(error_code.val, moveit::planning_interface::MoveItErrorCode::INVALID_MOTION_PLAN);
 }
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "chomp_moveit_test");

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(moveit_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS 
+set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   rclcpp
   trajectory_msgs
@@ -36,7 +36,7 @@ include_directories(
   include
 )
 
-add_library(${PROJECT_NAME} SHARED 
+add_library(${PROJECT_NAME} SHARED
   src/chomp_cost.cpp
   src/chomp_parameters.cpp
   src/chomp_trajectory.cpp

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -1,20 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(chomp_motion_planner)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Common cmake code applied to all moveit packages
 find_package(moveit_common REQUIRED)
 moveit_package()

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -1,26 +1,42 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5)
 project(chomp_motion_planner)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS 
   moveit_core
+  rclcpp
+  trajectory_msgs
+  visualization_msgs
 )
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+include_directories(
+  include
 )
 
-include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED 
   src/chomp_cost.cpp
   src/chomp_parameters.cpp
   src/chomp_trajectory.cpp
@@ -28,15 +44,24 @@ add_library(${PROJECT_NAME}
   src/chomp_planner.cpp
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
+install(DIRECTORY include/ DESTINATION include)
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_EXPORT_DEPENDS})
+
+ament_package()

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
@@ -49,21 +49,18 @@ namespace chomp
 class ChompCost
 {
 public:
-  ChompCost(
-    const ChompTrajectory & trajectory, int joint_number,
-    const std::vector<double> & derivative_costs, double ridge_factor = 0.0);
+  ChompCost(const ChompTrajectory& trajectory, int joint_number, const std::vector<double>& derivative_costs,
+            double ridge_factor = 0.0);
   virtual ~ChompCost();
 
   template <typename Derived>
-  void getDerivative(
-    const Eigen::MatrixXd::ColXpr & joint_trajectory,
-    Eigen::MatrixBase<Derived> & derivative) const;
+  void getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory, Eigen::MatrixBase<Derived>& derivative) const;
 
-  const Eigen::MatrixXd & getQuadraticCostInverse() const;
+  const Eigen::MatrixXd& getQuadraticCostInverse() const;
 
-  const Eigen::MatrixXd & getQuadraticCost() const;
+  const Eigen::MatrixXd& getQuadraticCost() const;
 
-  double getCost(const Eigen::MatrixXd::ColXpr & joint_trajectory) const;
+  double getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const;
 
   double getMaxQuadCostInvValue() const;
 
@@ -75,21 +72,27 @@ private:
   // Eigen::VectorXd linear_cost_;
   Eigen::MatrixXd quad_cost_inv_;
 
-  Eigen::MatrixXd getDiffMatrix(int size, const double * diff_rule) const;
+  Eigen::MatrixXd getDiffMatrix(int size, const double* diff_rule) const;
 };
 
 template <typename Derived>
-void ChompCost::getDerivative(
-  const Eigen::MatrixXd::ColXpr & joint_trajectory, Eigen::MatrixBase<Derived> & derivative) const
+void ChompCost::getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory,
+                              Eigen::MatrixBase<Derived>& derivative) const
 {
   derivative = (quad_cost_full_ * (2.0 * joint_trajectory));
 }
 
-inline const Eigen::MatrixXd & ChompCost::getQuadraticCostInverse() const { return quad_cost_inv_; }
+inline const Eigen::MatrixXd& ChompCost::getQuadraticCostInverse() const
+{
+  return quad_cost_inv_;
+}
 
-inline const Eigen::MatrixXd & ChompCost::getQuadraticCost() const { return quad_cost_; }
+inline const Eigen::MatrixXd& ChompCost::getQuadraticCost() const
+{
+  return quad_cost_;
+}
 
-inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr & joint_trajectory) const
+inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const
 {
   return joint_trajectory.dot(quad_cost_full_ * joint_trajectory);
 }

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
@@ -36,8 +36,9 @@
 
 #pragma once
 
-#include <eigen3/Eigen/Core>
 #include <chomp_motion_planner/chomp_trajectory.h>
+
+#include <eigen3/Eigen/Core>
 #include <vector>
 
 namespace chomp
@@ -48,18 +49,21 @@ namespace chomp
 class ChompCost
 {
 public:
-  ChompCost(const ChompTrajectory& trajectory, int joint_number, const std::vector<double>& derivative_costs,
-            double ridge_factor = 0.0);
+  ChompCost(
+    const ChompTrajectory & trajectory, int joint_number,
+    const std::vector<double> & derivative_costs, double ridge_factor = 0.0);
   virtual ~ChompCost();
 
   template <typename Derived>
-  void getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory, Eigen::MatrixBase<Derived>& derivative) const;
+  void getDerivative(
+    const Eigen::MatrixXd::ColXpr & joint_trajectory,
+    Eigen::MatrixBase<Derived> & derivative) const;
 
-  const Eigen::MatrixXd& getQuadraticCostInverse() const;
+  const Eigen::MatrixXd & getQuadraticCostInverse() const;
 
-  const Eigen::MatrixXd& getQuadraticCost() const;
+  const Eigen::MatrixXd & getQuadraticCost() const;
 
-  double getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const;
+  double getCost(const Eigen::MatrixXd::ColXpr & joint_trajectory) const;
 
   double getMaxQuadCostInvValue() const;
 
@@ -71,27 +75,21 @@ private:
   // Eigen::VectorXd linear_cost_;
   Eigen::MatrixXd quad_cost_inv_;
 
-  Eigen::MatrixXd getDiffMatrix(int size, const double* diff_rule) const;
+  Eigen::MatrixXd getDiffMatrix(int size, const double * diff_rule) const;
 };
 
 template <typename Derived>
-void ChompCost::getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory,
-                              Eigen::MatrixBase<Derived>& derivative) const
+void ChompCost::getDerivative(
+  const Eigen::MatrixXd::ColXpr & joint_trajectory, Eigen::MatrixBase<Derived> & derivative) const
 {
   derivative = (quad_cost_full_ * (2.0 * joint_trajectory));
 }
 
-inline const Eigen::MatrixXd& ChompCost::getQuadraticCostInverse() const
-{
-  return quad_cost_inv_;
-}
+inline const Eigen::MatrixXd & ChompCost::getQuadraticCostInverse() const { return quad_cost_inv_; }
 
-inline const Eigen::MatrixXd& ChompCost::getQuadraticCost() const
-{
-  return quad_cost_;
-}
+inline const Eigen::MatrixXd & ChompCost::getQuadraticCost() const { return quad_cost_; }
 
-inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const
+inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr & joint_trajectory) const
 {
   return joint_trajectory.dot(quad_cost_full_ * joint_trajectory);
 }

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -159,7 +159,7 @@ private:
   double stochasticity_factor_;
 
   std::vector<int> state_is_in_collision_; /**< Array containing a boolean about collision info for each point in the
-                                                             trajectory */
+                                                                            trajectory */
   std::vector<std::vector<int> > point_is_in_collision_;
   bool is_collision_free_;
   double worst_collision_cost_state_;

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -36,13 +36,13 @@
 
 #pragma once
 
+#include <chomp_motion_planner/chomp_cost.h>
 #include <chomp_motion_planner/chomp_parameters.h>
 #include <chomp_motion_planner/chomp_trajectory.h>
-#include <chomp_motion_planner/chomp_cost.h>
 #include <chomp_motion_planner/multivariate_gaussian.h>
-#include <moveit/robot_model/robot_model.h>
-#include <moveit/planning_scene/planning_scene.h>
 #include <moveit/collision_distance_field/collision_env_hybrid.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/robot_model/robot_model.h>
 
 #include <Eigen/Core>
 #include <Eigen/StdVector>
@@ -53,9 +53,10 @@ namespace chomp
 class ChompOptimizer
 {
 public:
-  ChompOptimizer(ChompTrajectory* trajectory, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                 const std::string& planning_group, const ChompParameters* parameters,
-                 const moveit::core::RobotState& start_state);
+  ChompOptimizer(
+    ChompTrajectory * trajectory, const planning_scene::PlanningSceneConstPtr & planning_scene,
+    const std::string & planning_group, const ChompParameters * parameters,
+    const moveit::core::RobotState & start_state);
 
   virtual ~ChompOptimizer();
 
@@ -70,15 +71,9 @@ public:
     // Nothing for now.
   }
 
-  bool isInitialized() const
-  {
-    return initialized_;
-  }
+  bool isInitialized() const { return initialized_; }
 
-  bool isCollisionFree() const
-  {
-    return is_collision_free_;
-  }
+  bool isCollisionFree() const { return is_collision_free_; }
 
 private:
   inline double getPotential(double field_distance, double radius, double clearance)
@@ -88,27 +83,26 @@ private:
     if (d >= clearance)  // everything is fine
     {
       return 0.0;
-    }
-    else if (d >= 0.0)  // transition phase, no collision yet
+    } else if (d >= 0.0)  // transition phase, no collision yet
     {
       const double diff = (d - clearance);
       const double gradient_magnitude = diff / clearance;
       return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
-    }
-    else  // d < 0.0: collision
+    } else                                     // d < 0.0: collision
     {
       return -d + 0.5 * clearance;  // linearly increase, starting from 0.5 * clearance
     }
   }
   template <typename Derived>
-  void getJacobian(int trajectoryPoint, Eigen::Vector3d& collision_point_pos, std::string& jointName,
-                   Eigen::MatrixBase<Derived>& jacobian) const;
+  void getJacobian(
+    int trajectoryPoint, Eigen::Vector3d & collision_point_pos, std::string & jointName,
+    Eigen::MatrixBase<Derived> & jacobian) const;
 
   // void getRandomState(const moveit::core::RobotState& currentState,
   //                     const std::string& group_name,
   //                     Eigen::VectorXd& state_vec);
 
-  void setRobotStateFromPoint(ChompTrajectory& group_trajectory, int i);
+  void setRobotStateFromPoint(ChompTrajectory & group_trajectory, int i);
 
   // collision_proximity::CollisionProximitySpace::TrajectorySafety checkCurrentIterValidity();
 
@@ -121,16 +115,16 @@ private:
   int iteration_;
   unsigned int collision_free_iteration_;
 
-  ChompTrajectory* full_trajectory_;
-  const moveit::core::RobotModelConstPtr& robot_model_;
+  ChompTrajectory * full_trajectory_;
+  const moveit::core::RobotModelConstPtr & robot_model_;
   std::string planning_group_;
-  const ChompParameters* parameters_;
+  const ChompParameters * parameters_;
   ChompTrajectory group_trajectory_;
   planning_scene::PlanningSceneConstPtr planning_scene_;
   moveit::core::RobotState state_;
   moveit::core::RobotState start_state_;
-  const moveit::core::JointModelGroup* joint_model_group_;
-  const collision_detection::CollisionEnvHybrid* hy_env_;
+  const moveit::core::JointModelGroup * joint_model_group_;
+  const collision_detection::CollisionEnvHybrid * hy_env_;
 
   std::vector<ChompCost> joint_costs_;
   collision_detection::GroupStateRepresentationPtr gsr_;
@@ -158,7 +152,8 @@ private:
   std::vector<MultivariateGaussian> multivariate_gaussian_;
   double stochasticity_factor_;
 
-  std::vector<int> state_is_in_collision_; /**< Array containing a boolean about collision info for each point in the
+  std::vector<int>
+    state_is_in_collision_; /**< Array containing a boolean about collision info for each point in the
                                               trajectory */
   std::vector<std::vector<int> > point_is_in_collision_;
   bool is_collision_free_;
@@ -179,23 +174,21 @@ private:
   std::vector<std::string> joint_names_;
   std::map<std::string, std::map<std::string, bool> > joint_parent_map_;
 
-  inline bool isParent(const std::string& childLink, const std::string& parentLink) const
+  inline bool isParent(const std::string & childLink, const std::string & parentLink) const
   {
-    if (childLink == parentLink)
-    {
+    if (childLink == parentLink) {
       return true;
     }
 
-    if (joint_parent_map_.find(childLink) == joint_parent_map_.end())
-    {
+    if (joint_parent_map_.find(childLink) == joint_parent_map_.end()) {
       // ROS_ERROR("%s was not in joint parent map! for lookup of %s", childLink.c_str(), parentLink.c_str());
       return false;
     }
-    const std::map<std::string, bool>& parents = joint_parent_map_.at(childLink);
+    const std::map<std::string, bool> & parents = joint_parent_map_.at(childLink);
     return (parents.find(parentLink) != parents.end() && parents.at(parentLink));
   }
 
-  void registerParents(const moveit::core::JointModel* model);
+  void registerParents(const moveit::core::JointModel * model);
   void initialize();
   void calculateSmoothnessIncrements();
   void calculateCollisionIncrements();

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -53,10 +53,9 @@ namespace chomp
 class ChompOptimizer
 {
 public:
-  ChompOptimizer(
-    ChompTrajectory * trajectory, const planning_scene::PlanningSceneConstPtr & planning_scene,
-    const std::string & planning_group, const ChompParameters * parameters,
-    const moveit::core::RobotState & start_state);
+  ChompOptimizer(ChompTrajectory* trajectory, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                 const std::string& planning_group, const ChompParameters* parameters,
+                 const moveit::core::RobotState& start_state);
 
   virtual ~ChompOptimizer();
 
@@ -71,9 +70,15 @@ public:
     // Nothing for now.
   }
 
-  bool isInitialized() const { return initialized_; }
+  bool isInitialized() const
+  {
+    return initialized_;
+  }
 
-  bool isCollisionFree() const { return is_collision_free_; }
+  bool isCollisionFree() const
+  {
+    return is_collision_free_;
+  }
 
 private:
   inline double getPotential(double field_distance, double radius, double clearance)
@@ -83,26 +88,27 @@ private:
     if (d >= clearance)  // everything is fine
     {
       return 0.0;
-    } else if (d >= 0.0)  // transition phase, no collision yet
+    }
+    else if (d >= 0.0)  // transition phase, no collision yet
     {
       const double diff = (d - clearance);
       const double gradient_magnitude = diff / clearance;
       return 0.5 * gradient_magnitude * diff;  // 0.5 * (d - clearance)^2 / clearance
-    } else                                     // d < 0.0: collision
+    }
+    else  // d < 0.0: collision
     {
       return -d + 0.5 * clearance;  // linearly increase, starting from 0.5 * clearance
     }
   }
   template <typename Derived>
-  void getJacobian(
-    int trajectoryPoint, Eigen::Vector3d & collision_point_pos, std::string & jointName,
-    Eigen::MatrixBase<Derived> & jacobian) const;
+  void getJacobian(int trajectoryPoint, Eigen::Vector3d& collision_point_pos, std::string& jointName,
+                   Eigen::MatrixBase<Derived>& jacobian) const;
 
   // void getRandomState(const moveit::core::RobotState& currentState,
   //                     const std::string& group_name,
   //                     Eigen::VectorXd& state_vec);
 
-  void setRobotStateFromPoint(ChompTrajectory & group_trajectory, int i);
+  void setRobotStateFromPoint(ChompTrajectory& group_trajectory, int i);
 
   // collision_proximity::CollisionProximitySpace::TrajectorySafety checkCurrentIterValidity();
 
@@ -115,16 +121,16 @@ private:
   int iteration_;
   unsigned int collision_free_iteration_;
 
-  ChompTrajectory * full_trajectory_;
-  const moveit::core::RobotModelConstPtr & robot_model_;
+  ChompTrajectory* full_trajectory_;
+  const moveit::core::RobotModelConstPtr& robot_model_;
   std::string planning_group_;
-  const ChompParameters * parameters_;
+  const ChompParameters* parameters_;
   ChompTrajectory group_trajectory_;
   planning_scene::PlanningSceneConstPtr planning_scene_;
   moveit::core::RobotState state_;
   moveit::core::RobotState start_state_;
-  const moveit::core::JointModelGroup * joint_model_group_;
-  const collision_detection::CollisionEnvHybrid * hy_env_;
+  const moveit::core::JointModelGroup* joint_model_group_;
+  const collision_detection::CollisionEnvHybrid* hy_env_;
 
   std::vector<ChompCost> joint_costs_;
   collision_detection::GroupStateRepresentationPtr gsr_;
@@ -152,9 +158,8 @@ private:
   std::vector<MultivariateGaussian> multivariate_gaussian_;
   double stochasticity_factor_;
 
-  std::vector<int>
-    state_is_in_collision_; /**< Array containing a boolean about collision info for each point in the
-                                              trajectory */
+  std::vector<int> state_is_in_collision_; /**< Array containing a boolean about collision info for each point in the
+                                                             trajectory */
   std::vector<std::vector<int> > point_is_in_collision_;
   bool is_collision_free_;
   double worst_collision_cost_state_;
@@ -174,21 +179,23 @@ private:
   std::vector<std::string> joint_names_;
   std::map<std::string, std::map<std::string, bool> > joint_parent_map_;
 
-  inline bool isParent(const std::string & childLink, const std::string & parentLink) const
+  inline bool isParent(const std::string& childLink, const std::string& parentLink) const
   {
-    if (childLink == parentLink) {
+    if (childLink == parentLink)
+    {
       return true;
     }
 
-    if (joint_parent_map_.find(childLink) == joint_parent_map_.end()) {
+    if (joint_parent_map_.find(childLink) == joint_parent_map_.end())
+    {
       // ROS_ERROR("%s was not in joint parent map! for lookup of %s", childLink.c_str(), parentLink.c_str());
       return false;
     }
-    const std::map<std::string, bool> & parents = joint_parent_map_.at(childLink);
+    const std::map<std::string, bool>& parents = joint_parent_map_.at(childLink);
     return (parents.find(parentLink) != parents.end() && parents.at(parentLink));
   }
 
-  void registerParents(const moveit::core::JointModel * model);
+  void registerParents(const moveit::core::JointModel* model);
   void initialize();
   void calculateSmoothnessIncrements();
   void calculateCollisionIncrements();

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -34,9 +34,10 @@
 
 /* Author: Mrinal Kalakrishnan */
 
-#pragma once
+#include <string>
+#include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#pragma once
 
 namespace chomp
 {

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -54,8 +54,7 @@ public:
    * @param planning_time_limit
    * @param max_iterations
    */
-  void setRecoveryParams(
-    double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations);
+  void setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations);
 
   /**
    * sets a valid trajectory initialization method
@@ -64,58 +63,46 @@ public:
   bool setTrajectoryInitializationMethod(std::string method);
 
 public:
-  double
-    planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
-  int
-    max_iterations_;  /// maximum number of iterations that the planner can take to find a good solution while
-                      /// optimization
-  int
-    max_iterations_after_collision_free_;  /// maximum iterations to be performed after a collision free path is
-                                           /// found.
-  double
-    smoothness_cost_weight_;  /// smoothness_cost_weight parameters controls its weight in the final cost that
-                              /// CHOMP is actually optimizing over
-  double
-    obstacle_cost_weight_;  /// controls the weight to be given to obstacles towards the final cost CHOMP optimizes
-                            /// over
-  double
-    learning_rate_;  /// learning rate used by the optimizer to find the local / global minima while reducing the
-                     /// total cost
+  double planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
+  int max_iterations_;          /// maximum number of iterations that the planner can take to find a good solution while
+                                /// optimization
+  int max_iterations_after_collision_free_;  /// maximum iterations to be performed after a collision free path is
+                                             /// found.
+  double smoothness_cost_weight_;  /// smoothness_cost_weight parameters controls its weight in the final cost that
+                                   /// CHOMP is actually optimizing over
+  double obstacle_cost_weight_;  /// controls the weight to be given to obstacles towards the final cost CHOMP optimizes
+                                 /// over
+  double learning_rate_;  /// learning rate used by the optimizer to find the local / global minima while reducing the
+                          /// total cost
 
   double smoothness_cost_velocity_;      /// variables associated with the cost in velocity
   double smoothness_cost_acceleration_;  /// variables associated with the cost in acceleration
   double smoothness_cost_jerk_;          /// variables associated with the cost in jerk
   // bool add_randomness_;
   // bool use_hamiltonian_monte_carlo_;
-  bool
-    use_stochastic_descent_;  /// set this to true/false if you want to use stochastic descent while optimizing the
-                              /// cost.
+  bool use_stochastic_descent_;  /// set this to true/false if you want to use stochastic descent while optimizing the
+                                 /// cost.
 
   // double hmc_stochasticity_;
   // double hmc_discretization_;
   // double hmc_annealing_factor_;
-  double
-    ridge_factor_;  /// the noise added to the diagnal of the total quadratic cost matrix in the objective function
+  double ridge_factor_;  /// the noise added to the diagnal of the total quadratic cost matrix in the objective function
   bool use_pseudo_inverse_;             /// enable pseudo inverse calculations or not.
   double pseudo_inverse_ridge_factor_;  /// set the ridge factor if pseudo inverse is enabled
 
-  double joint_update_limit_;  /// set the update limit for the robot joints
-  double min_clearance_;  /// the minimum distance that needs to be maintained to avoid obstacles
-  double
-    collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
+  double joint_update_limit_;   /// set the update limit for the robot joints
+  double min_clearance_;        /// the minimum distance that needs to be maintained to avoid obstacles
+  double collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
   bool filter_mode_;
   // double random_jump_amount_;
 
   static const std::vector<std::string> VALID_INITIALIZATION_METHODS;
-  std::string
-    trajectory_initialization_method_;  /// trajectory initialization method to be specified
+  std::string trajectory_initialization_method_;  /// trajectory initialization method to be specified
 
-  bool
-    enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
-                               /// an initial path is not found with the specified chomp parameters
-  int
-    max_recovery_attempts_;  /// this the maximum recovery attempts to find a collision free path after an initial
-                             /// failure to find a solution
+  bool enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
+                                  /// an initial path is not found with the specified chomp parameters
+  int max_recovery_attempts_;     /// this the maximum recovery attempts to find a collision free path after an initial
+                                  /// failure to find a solution
 };
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include <ros/ros.h>
+#include "rclcpp/rclcpp.hpp"
 
 namespace chomp
 {
@@ -54,7 +54,8 @@ public:
    * @param planning_time_limit
    * @param max_iterations
    */
-  void setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations);
+  void setRecoveryParams(
+    double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations);
 
   /**
    * sets a valid trajectory initialization method
@@ -63,46 +64,58 @@ public:
   bool setTrajectoryInitializationMethod(std::string method);
 
 public:
-  double planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
-  int max_iterations_;          /// maximum number of iterations that the planner can take to find a good solution while
-                                /// optimization
-  int max_iterations_after_collision_free_;  /// maximum iterations to be performed after a collision free path is
-                                             /// found.
-  double smoothness_cost_weight_;  /// smoothness_cost_weight parameters controls its weight in the final cost that
-                                   /// CHOMP is actually optimizing over
-  double obstacle_cost_weight_;  /// controls the weight to be given to obstacles towards the final cost CHOMP optimizes
-                                 /// over
-  double learning_rate_;  /// learning rate used by the optimizer to find the local / global minima while reducing the
-                          /// total cost
+  double
+    planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
+  int
+    max_iterations_;  /// maximum number of iterations that the planner can take to find a good solution while
+                      /// optimization
+  int
+    max_iterations_after_collision_free_;  /// maximum iterations to be performed after a collision free path is
+                                           /// found.
+  double
+    smoothness_cost_weight_;  /// smoothness_cost_weight parameters controls its weight in the final cost that
+                              /// CHOMP is actually optimizing over
+  double
+    obstacle_cost_weight_;  /// controls the weight to be given to obstacles towards the final cost CHOMP optimizes
+                            /// over
+  double
+    learning_rate_;  /// learning rate used by the optimizer to find the local / global minima while reducing the
+                     /// total cost
 
   double smoothness_cost_velocity_;      /// variables associated with the cost in velocity
   double smoothness_cost_acceleration_;  /// variables associated with the cost in acceleration
   double smoothness_cost_jerk_;          /// variables associated with the cost in jerk
   // bool add_randomness_;
   // bool use_hamiltonian_monte_carlo_;
-  bool use_stochastic_descent_;  /// set this to true/false if you want to use stochastic descent while optimizing the
-                                 /// cost.
+  bool
+    use_stochastic_descent_;  /// set this to true/false if you want to use stochastic descent while optimizing the
+                              /// cost.
 
   // double hmc_stochasticity_;
   // double hmc_discretization_;
   // double hmc_annealing_factor_;
-  double ridge_factor_;  /// the noise added to the diagnal of the total quadratic cost matrix in the objective function
+  double
+    ridge_factor_;  /// the noise added to the diagnal of the total quadratic cost matrix in the objective function
   bool use_pseudo_inverse_;             /// enable pseudo inverse calculations or not.
   double pseudo_inverse_ridge_factor_;  /// set the ridge factor if pseudo inverse is enabled
 
-  double joint_update_limit_;   /// set the update limit for the robot joints
-  double min_clearance_;        /// the minimum distance that needs to be maintained to avoid obstacles
-  double collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
+  double joint_update_limit_;  /// set the update limit for the robot joints
+  double min_clearance_;  /// the minimum distance that needs to be maintained to avoid obstacles
+  double
+    collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
   bool filter_mode_;
   // double random_jump_amount_;
 
   static const std::vector<std::string> VALID_INITIALIZATION_METHODS;
-  std::string trajectory_initialization_method_;  /// trajectory initialization method to be specified
+  std::string
+    trajectory_initialization_method_;  /// trajectory initialization method to be specified
 
-  bool enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
-                                  /// an initial path is not found with the specified chomp parameters
-  int max_recovery_attempts_;     /// this the maximum recovery attempts to find a collision free path after an initial
-                                  /// failure to find a solution
+  bool
+    enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
+                               /// an initial path is not found with the specified chomp parameters
+  int
+    max_recovery_attempts_;  /// this the maximum recovery attempts to find a collision free path after an initial
+                             /// failure to find a solution
 };
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -50,20 +50,17 @@ public:
   ChompPlanner() = default;
   virtual ~ChompPlanner() = default;
 
-  bool solve(
-    const planning_scene::PlanningSceneConstPtr & planning_scene,
-    const planning_interface::MotionPlanRequest & req, const ChompParameters & params,
-    planning_interface::MotionPlanDetailedResponse & res) const;
+  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+             const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
+             planning_interface::MotionPlanDetailedResponse& res) const;
 
-  bool computePoseIK(
-    const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
-    const std::string & link_name, const Eigen::Isometry3d & pose, const std::string & frame_id,
-    const std::map<std::string, double> & seed, std::map<std::string, double> & solution,
-    bool check_self_collision = true, const double timeout = 0.0) const;
+  bool computePoseIK(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
+                     const std::string& link_name, const Eigen::Isometry3d& pose, const std::string& frame_id,
+                     const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
+                     bool check_self_collision = true, const double timeout = 0.0) const;
 
-  bool isStateColliding(
-    const bool test_for_self_collision, const moveit::core::RobotModelConstPtr & robot_model,
-    moveit::core::RobotState * state, const moveit::core::JointModelGroup * const group,
-    const double * const ik_solution) const;
+  bool isStateColliding(const bool test_for_self_collision, const moveit::core::RobotModelConstPtr& robot_model,
+                        moveit::core::RobotState* state, const moveit::core::JointModelGroup* const group,
+                        const double* const ik_solution) const;
 };
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -40,6 +40,7 @@
 #include <moveit/planning_interface/planning_request.h>
 #include <moveit/planning_interface/planning_response.h>
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/robot_state/robot_state.h>
 
 namespace chomp
 {
@@ -49,8 +50,20 @@ public:
   ChompPlanner() = default;
   virtual ~ChompPlanner() = default;
 
-  bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-             const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
-             planning_interface::MotionPlanDetailedResponse& res) const;
+  bool solve(
+    const planning_scene::PlanningSceneConstPtr & planning_scene,
+    const planning_interface::MotionPlanRequest & req, const ChompParameters & params,
+    planning_interface::MotionPlanDetailedResponse & res) const;
+
+  bool computePoseIK(
+    const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
+    const std::string & link_name, const Eigen::Isometry3d & pose, const std::string & frame_id,
+    const std::map<std::string, double> & seed, std::map<std::string, double> & solution,
+    bool check_self_collision = true, const double timeout = 0.0) const;
+
+  bool isStateColliding(
+    const bool test_for_self_collision, const moveit::core::RobotModelConstPtr & robot_model,
+    moveit::core::RobotState * state, const moveit::core::JointModelGroup * const group,
+    const double * const ik_solution) const;
 };
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_planner.h
@@ -53,14 +53,5 @@ public:
   bool solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
              const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
              planning_interface::MotionPlanDetailedResponse& res) const;
-
-  bool computePoseIK(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
-                     const std::string& link_name, const Eigen::Isometry3d& pose, const std::string& frame_id,
-                     const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                     bool check_self_collision = true, const double timeout = 0.0) const;
-
-  bool isStateColliding(const bool test_for_self_collision, const moveit::core::RobotModelConstPtr& robot_model,
-                        moveit::core::RobotState* state, const moveit::core::JointModelGroup* const group,
-                        const double* const ik_solution) const;
 };
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -36,15 +36,14 @@
 
 #pragma once
 
-#include <trajectory_msgs/JointTrajectory.h>
-#include <moveit/robot_model/robot_model.h>
 #include <chomp_motion_planner/chomp_utils.h>
+#include <moveit/robot_model/robot_model.h>
 
+#include <eigen3/Eigen/Core>
 #include <moveit_msgs/msg/motion_plan_detailed_response.hpp>
 #include <moveit_msgs/msg/motion_plan_request.hpp>
-
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <vector>
-#include <eigen3/Eigen/Core>
 
 namespace chomp
 {
@@ -57,30 +56,34 @@ public:
   /**
    * \brief Constructs a trajectory for a given robot model, trajectory duration, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, double duration, double discretization,
-                  const std::string& group_name);
+  ChompTrajectory(
+    const moveit::core::RobotModelConstPtr & robot_model, double duration, double discretization,
+    const std::string & group_name);
 
   /**
    * \brief Constructs a trajectory for a given robot model, number of trajectory points, and discretization
    */
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, size_t num_points, double discretization,
-                  const std::string& group_name);
+  ChompTrajectory(
+    const moveit::core::RobotModelConstPtr & robot_model, size_t num_points, double discretization,
+    const std::string & group_name);
 
   /**
    * \brief Creates a new containing only the joints of interest, and adds padding to the start
    * and end if needed, to have enough trajectory points for the differentiation rules
    */
-  ChompTrajectory(const ChompTrajectory& source_traj, const std::string& group_name, int diff_rule_length);
+  ChompTrajectory(
+    const ChompTrajectory & source_traj, const std::string & group_name, int diff_rule_length);
 
-  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
-                  const trajectory_msgs::JointTrajectory& traj);
+  ChompTrajectory(
+    const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
+    const trajectory_msgs::msg::JointTrajectory & traj);
 
   /**
    * \brief Destructor
    */
   virtual ~ChompTrajectory() = default;
 
-  double& operator()(size_t traj_point, size_t joint);
+  double & operator()(size_t traj_point, size_t joint);
 
   double operator()(size_t traj_point, size_t joint) const;
 
@@ -134,7 +137,7 @@ public:
    * produced by OMPL) and puts it into the appropriate trajectory format required for CHOMP
    * @param res
    */
-  bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory);
+  bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory & trajectory);
 
   /**
    * \brief This function assigns the given \a source RobotState to the row at index \a chomp_trajectory_point
@@ -143,8 +146,9 @@ public:
    * @param chomp_trajectory_point index of the chomp_trajectory's point (row)
    * @param group  JointModelGroup determining the joints to copy
    */
-  void assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source, size_t chomp_trajectory_point,
-                                                const moveit::core::JointModelGroup* group);
+  void assignCHOMPTrajectoryPointFromRobotState(
+    const moveit::core::RobotState & source, size_t chomp_trajectory_point,
+    const moveit::core::JointModelGroup * group);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
@@ -167,7 +171,7 @@ public:
   /**
    * \brief Gets the entire trajectory matrix
    */
-  Eigen::MatrixXd& getTrajectory();
+  Eigen::MatrixXd & getTrajectory();
 
   /**
    * \brief Gets the block of the trajectory which can be optimized
@@ -177,12 +181,13 @@ public:
   /**
    * \brief Gets the block of free (optimizable) trajectory for a single joint
    */
-  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(size_t joint);
+  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(
+    size_t joint);
 
   /**
    * \brief Updates the full trajectory (*this) from the group trajectory
    */
-  void updateFromGroupTrajectory(const ChompTrajectory& group_trajectory);
+  void updateFromGroupTrajectory(const ChompTrajectory & group_trajectory);
 
   /**
    * \brief Gets the index in the full trajectory which was copied to this group trajectory
@@ -193,7 +198,7 @@ public:
    * \brief Gets the joint velocities at the given trajectory point
    */
   template <typename Derived>
-  void getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities);
+  void getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived> & velocities);
 
   double getDuration() const;
 
@@ -206,14 +211,17 @@ private:
   double discretization_;            //< Discretization of the trajectory
   double duration_;                  //< Duration of the trajectory
   Eigen::MatrixXd trajectory_;       //< Storage for the actual trajectory
-  size_t start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
-  size_t end_index_;    //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
-  std::vector<size_t> full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
+  size_t
+    start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
+  size_t
+    end_index_;  //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
+  std::vector<size_t>
+    full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
 };
 
 ///////////////////////// inline functions follow //////////////////////
 
-inline double& ChompTrajectory::operator()(size_t traj_point, size_t joint)
+inline double & ChompTrajectory::operator()(size_t traj_point, size_t joint)
 {
   return trajectory_(traj_point, joint);
 }
@@ -233,25 +241,13 @@ inline Eigen::MatrixXd::ColXpr ChompTrajectory::getJointTrajectory(int joint)
   return trajectory_.col(joint);
 }
 
-inline size_t ChompTrajectory::getNumPoints() const
-{
-  return num_points_;
-}
+inline size_t ChompTrajectory::getNumPoints() const { return num_points_; }
 
-inline size_t ChompTrajectory::getNumFreePoints() const
-{
-  return (end_index_ - start_index_) + 1;
-}
+inline size_t ChompTrajectory::getNumFreePoints() const { return (end_index_ - start_index_) + 1; }
 
-inline size_t ChompTrajectory::getNumJoints() const
-{
-  return num_joints_;
-}
+inline size_t ChompTrajectory::getNumJoints() const { return num_joints_; }
 
-inline double ChompTrajectory::getDiscretization() const
-{
-  return discretization_;
-}
+inline double ChompTrajectory::getDiscretization() const { return discretization_; }
 
 inline void ChompTrajectory::setStartEndIndex(size_t start_index, size_t end_index)
 {
@@ -259,22 +255,14 @@ inline void ChompTrajectory::setStartEndIndex(size_t start_index, size_t end_ind
   end_index_ = end_index;
 }
 
-inline size_t ChompTrajectory::getStartIndex() const
-{
-  return start_index_;
-}
+inline size_t ChompTrajectory::getStartIndex() const { return start_index_; }
 
-inline size_t ChompTrajectory::getEndIndex() const
-{
-  return end_index_;
-}
+inline size_t ChompTrajectory::getEndIndex() const { return end_index_; }
 
-inline Eigen::MatrixXd& ChompTrajectory::getTrajectory()
-{
-  return trajectory_;
-}
+inline Eigen::MatrixXd & ChompTrajectory::getTrajectory() { return trajectory_; }
 
-inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> ChompTrajectory::getFreeTrajectoryBlock()
+inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic>
+ChompTrajectory::getFreeTrajectoryBlock()
 {
   return trajectory_.block(start_index_, 0, getNumFreePoints(), getNumJoints());
 }
@@ -291,19 +279,16 @@ inline size_t ChompTrajectory::getFullTrajectoryIndex(size_t i) const
 }
 
 template <typename Derived>
-void ChompTrajectory::getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities)
+void ChompTrajectory::getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived> & velocities)
 {
   velocities.setZero();
   double inv_time = 1.0 / discretization_;
 
-  for (int k = -DIFF_RULE_LENGTH / 2; k <= DIFF_RULE_LENGTH / 2; k++)
-  {
-    velocities += (inv_time * DIFF_RULES[0][k + DIFF_RULE_LENGTH / 2]) * trajectory_.row(traj_point + k).transpose();
+  for (int k = -DIFF_RULE_LENGTH / 2; k <= DIFF_RULE_LENGTH / 2; k++) {
+    velocities += (inv_time * DIFF_RULES[0][k + DIFF_RULE_LENGTH / 2]) *
+                  trajectory_.row(traj_point + k).transpose();
   }
 }
 
-inline double ChompTrajectory::getDuration() const
-{
-  return duration_;
-}
+inline double ChompTrajectory::getDuration() const { return duration_; }
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -56,34 +56,30 @@ public:
   /**
    * \brief Constructs a trajectory for a given robot model, trajectory duration, and discretization
    */
-  ChompTrajectory(
-    const moveit::core::RobotModelConstPtr & robot_model, double duration, double discretization,
-    const std::string & group_name);
+  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, double duration, double discretization,
+                  const std::string& group_name);
 
   /**
    * \brief Constructs a trajectory for a given robot model, number of trajectory points, and discretization
    */
-  ChompTrajectory(
-    const moveit::core::RobotModelConstPtr & robot_model, size_t num_points, double discretization,
-    const std::string & group_name);
+  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, size_t num_points, double discretization,
+                  const std::string& group_name);
 
   /**
    * \brief Creates a new containing only the joints of interest, and adds padding to the start
    * and end if needed, to have enough trajectory points for the differentiation rules
    */
-  ChompTrajectory(
-    const ChompTrajectory & source_traj, const std::string & group_name, int diff_rule_length);
+  ChompTrajectory(const ChompTrajectory& source_traj, const std::string& group_name, int diff_rule_length);
 
-  ChompTrajectory(
-    const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
-    const trajectory_msgs::msg::JointTrajectory & traj);
+  ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
+                  const trajectory_msgs::msg::JointTrajectory& traj);
 
   /**
    * \brief Destructor
    */
   virtual ~ChompTrajectory() = default;
 
-  double & operator()(size_t traj_point, size_t joint);
+  double& operator()(size_t traj_point, size_t joint);
 
   double operator()(size_t traj_point, size_t joint) const;
 
@@ -137,7 +133,7 @@ public:
    * produced by OMPL) and puts it into the appropriate trajectory format required for CHOMP
    * @param res
    */
-  bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory & trajectory);
+  bool fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory);
 
   /**
    * \brief This function assigns the given \a source RobotState to the row at index \a chomp_trajectory_point
@@ -146,9 +142,8 @@ public:
    * @param chomp_trajectory_point index of the chomp_trajectory's point (row)
    * @param group  JointModelGroup determining the joints to copy
    */
-  void assignCHOMPTrajectoryPointFromRobotState(
-    const moveit::core::RobotState & source, size_t chomp_trajectory_point,
-    const moveit::core::JointModelGroup * group);
+  void assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source, size_t chomp_trajectory_point,
+                                                const moveit::core::JointModelGroup* group);
 
   /**
    * \brief Sets the start and end index for the modifiable part of the trajectory
@@ -171,7 +166,7 @@ public:
   /**
    * \brief Gets the entire trajectory matrix
    */
-  Eigen::MatrixXd & getTrajectory();
+  Eigen::MatrixXd& getTrajectory();
 
   /**
    * \brief Gets the block of the trajectory which can be optimized
@@ -181,13 +176,12 @@ public:
   /**
    * \brief Gets the block of free (optimizable) trajectory for a single joint
    */
-  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(
-    size_t joint);
+  Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> getFreeJointTrajectoryBlock(size_t joint);
 
   /**
    * \brief Updates the full trajectory (*this) from the group trajectory
    */
-  void updateFromGroupTrajectory(const ChompTrajectory & group_trajectory);
+  void updateFromGroupTrajectory(const ChompTrajectory& group_trajectory);
 
   /**
    * \brief Gets the index in the full trajectory which was copied to this group trajectory
@@ -198,7 +192,7 @@ public:
    * \brief Gets the joint velocities at the given trajectory point
    */
   template <typename Derived>
-  void getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived> & velocities);
+  void getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities);
 
   double getDuration() const;
 
@@ -211,17 +205,14 @@ private:
   double discretization_;            //< Discretization of the trajectory
   double duration_;                  //< Duration of the trajectory
   Eigen::MatrixXd trajectory_;       //< Storage for the actual trajectory
-  size_t
-    start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
-  size_t
-    end_index_;  //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
-  std::vector<size_t>
-    full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
+  size_t start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
+  size_t end_index_;    //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
+  std::vector<size_t> full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
 };
 
 ///////////////////////// inline functions follow //////////////////////
 
-inline double & ChompTrajectory::operator()(size_t traj_point, size_t joint)
+inline double& ChompTrajectory::operator()(size_t traj_point, size_t joint)
 {
   return trajectory_(traj_point, joint);
 }
@@ -241,13 +232,25 @@ inline Eigen::MatrixXd::ColXpr ChompTrajectory::getJointTrajectory(int joint)
   return trajectory_.col(joint);
 }
 
-inline size_t ChompTrajectory::getNumPoints() const { return num_points_; }
+inline size_t ChompTrajectory::getNumPoints() const
+{
+  return num_points_;
+}
 
-inline size_t ChompTrajectory::getNumFreePoints() const { return (end_index_ - start_index_) + 1; }
+inline size_t ChompTrajectory::getNumFreePoints() const
+{
+  return (end_index_ - start_index_) + 1;
+}
 
-inline size_t ChompTrajectory::getNumJoints() const { return num_joints_; }
+inline size_t ChompTrajectory::getNumJoints() const
+{
+  return num_joints_;
+}
 
-inline double ChompTrajectory::getDiscretization() const { return discretization_; }
+inline double ChompTrajectory::getDiscretization() const
+{
+  return discretization_;
+}
 
 inline void ChompTrajectory::setStartEndIndex(size_t start_index, size_t end_index)
 {
@@ -255,14 +258,22 @@ inline void ChompTrajectory::setStartEndIndex(size_t start_index, size_t end_ind
   end_index_ = end_index;
 }
 
-inline size_t ChompTrajectory::getStartIndex() const { return start_index_; }
+inline size_t ChompTrajectory::getStartIndex() const
+{
+  return start_index_;
+}
 
-inline size_t ChompTrajectory::getEndIndex() const { return end_index_; }
+inline size_t ChompTrajectory::getEndIndex() const
+{
+  return end_index_;
+}
 
-inline Eigen::MatrixXd & ChompTrajectory::getTrajectory() { return trajectory_; }
+inline Eigen::MatrixXd& ChompTrajectory::getTrajectory()
+{
+  return trajectory_;
+}
 
-inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic>
-ChompTrajectory::getFreeTrajectoryBlock()
+inline Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic> ChompTrajectory::getFreeTrajectoryBlock()
 {
   return trajectory_.block(start_index_, 0, getNumFreePoints(), getNumJoints());
 }
@@ -279,16 +290,19 @@ inline size_t ChompTrajectory::getFullTrajectoryIndex(size_t i) const
 }
 
 template <typename Derived>
-void ChompTrajectory::getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived> & velocities)
+void ChompTrajectory::getJointVelocities(size_t traj_point, Eigen::MatrixBase<Derived>& velocities)
 {
   velocities.setZero();
   double inv_time = 1.0 / discretization_;
 
-  for (int k = -DIFF_RULE_LENGTH / 2; k <= DIFF_RULE_LENGTH / 2; k++) {
-    velocities += (inv_time * DIFF_RULES[0][k + DIFF_RULE_LENGTH / 2]) *
-                  trajectory_.row(traj_point + k).transpose();
+  for (int k = -DIFF_RULE_LENGTH / 2; k <= DIFF_RULE_LENGTH / 2; k++)
+  {
+    velocities += (inv_time * DIFF_RULES[0][k + DIFF_RULE_LENGTH / 2]) * trajectory_.row(traj_point + k).transpose();
   }
 }
 
-inline double ChompTrajectory::getDuration() const { return duration_; }
+inline double ChompTrajectory::getDuration() const
+{
+  return duration_;
+}
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
@@ -36,9 +36,10 @@
 
 #pragma once
 
-#include <iostream>
-#include <Eigen/Core>
 #include <moveit/planning_scene/planning_scene.h>
+
+#include <Eigen/Core>
+#include <iostream>
 
 namespace chomp
 {
@@ -46,17 +47,18 @@ static const int DIFF_RULE_LENGTH = 7;
 
 // the differentiation rules (centered at the center)
 static const double DIFF_RULES[3][DIFF_RULE_LENGTH] = {
-  { 0, 0, -2 / 6.0, -3 / 6.0, 6 / 6.0, -1 / 6.0, 0 },                       // velocity
-  { 0, -1 / 12.0, 16 / 12.0, -30 / 12.0, 16 / 12.0, -1 / 12.0, 0 },         // acceleration
-  { 0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0 }  // jerk
+  {0, 0, -2 / 6.0, -3 / 6.0, 6 / 6.0, -1 / 6.0, 0},                       // velocity
+  {0, -1 / 12.0, 16 / 12.0, -30 / 12.0, 16 / 12.0, -1 / 12.0, 0},         // acceleration
+  {0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0}  // jerk
 };
 
-static inline void robotStateToArray(const moveit::core::RobotState& state, const std::string& planning_group_name,
-                                     Eigen::MatrixXd::RowXpr joint_array)
+static inline void robotStateToArray(
+  const moveit::core::RobotState & state, const std::string & planning_group_name,
+  Eigen::MatrixXd::RowXpr joint_array)
 {
-  const moveit::core::JointModelGroup* group = state.getJointModelGroup(planning_group_name);
+  const moveit::core::JointModelGroup * group = state.getJointModelGroup(planning_group_name);
   size_t joint_index = 0;
-  for (const moveit::core::JointModel* jm : group->getActiveJointModels())
+  for (const moveit::core::JointModel * jm : group->getActiveJointModels())
     joint_array[joint_index++] = state.getVariablePosition(jm->getFirstVariableIndex());
 }
 
@@ -69,16 +71,14 @@ static inline double normalizeAnglePositive(double angle)
 static inline double normalizeAngle(double angle)
 {
   double a = normalizeAnglePositive(angle);
-  if (a > M_PI)
-    a -= 2.0 * M_PI;
+  if (a > M_PI) a -= 2.0 * M_PI;
   return a;
 }
 
 static inline double shortestAngularDistance(double start, double end)
 {
   double res = normalizeAnglePositive(normalizeAnglePositive(end) - normalizeAnglePositive(start));
-  if (res > M_PI)
-  {
+  if (res > M_PI) {
     res = -(2.0 * M_PI - res);
   }
   return normalizeAngle(res);

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_utils.h
@@ -47,18 +47,17 @@ static const int DIFF_RULE_LENGTH = 7;
 
 // the differentiation rules (centered at the center)
 static const double DIFF_RULES[3][DIFF_RULE_LENGTH] = {
-  {0, 0, -2 / 6.0, -3 / 6.0, 6 / 6.0, -1 / 6.0, 0},                       // velocity
-  {0, -1 / 12.0, 16 / 12.0, -30 / 12.0, 16 / 12.0, -1 / 12.0, 0},         // acceleration
-  {0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0}  // jerk
+  { 0, 0, -2 / 6.0, -3 / 6.0, 6 / 6.0, -1 / 6.0, 0 },                       // velocity
+  { 0, -1 / 12.0, 16 / 12.0, -30 / 12.0, 16 / 12.0, -1 / 12.0, 0 },         // acceleration
+  { 0, 1 / 12.0, -17 / 12.0, 46 / 12.0, -46 / 12.0, 17 / 12.0, -1 / 12.0 }  // jerk
 };
 
-static inline void robotStateToArray(
-  const moveit::core::RobotState & state, const std::string & planning_group_name,
-  Eigen::MatrixXd::RowXpr joint_array)
+static inline void robotStateToArray(const moveit::core::RobotState& state, const std::string& planning_group_name,
+                                     Eigen::MatrixXd::RowXpr joint_array)
 {
-  const moveit::core::JointModelGroup * group = state.getJointModelGroup(planning_group_name);
+  const moveit::core::JointModelGroup* group = state.getJointModelGroup(planning_group_name);
   size_t joint_index = 0;
-  for (const moveit::core::JointModel * jm : group->getActiveJointModels())
+  for (const moveit::core::JointModel* jm : group->getActiveJointModels())
     joint_array[joint_index++] = state.getVariablePosition(jm->getFirstVariableIndex());
 }
 
@@ -71,14 +70,16 @@ static inline double normalizeAnglePositive(double angle)
 static inline double normalizeAngle(double angle)
 {
   double a = normalizeAnglePositive(angle);
-  if (a > M_PI) a -= 2.0 * M_PI;
+  if (a > M_PI)
+    a -= 2.0 * M_PI;
   return a;
 }
 
 static inline double shortestAngularDistance(double start, double end)
 {
   double res = normalizeAnglePositive(normalizeAnglePositive(end) - normalizeAnglePositive(start));
-  if (res > M_PI) {
+  if (res > M_PI)
+  {
     res = -(2.0 * M_PI - res);
   }
   return normalizeAngle(res);

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
@@ -52,11 +52,10 @@ class MultivariateGaussian
 {
 public:
   template <typename Derived1, typename Derived2>
-  MultivariateGaussian(
-    const Eigen::MatrixBase<Derived1> & mean, const Eigen::MatrixBase<Derived2> & covariance);
+  MultivariateGaussian(const Eigen::MatrixBase<Derived1>& mean, const Eigen::MatrixBase<Derived2>& covariance);
 
   template <typename Derived>
-  void sample(Eigen::MatrixBase<Derived> & output);
+  void sample(Eigen::MatrixBase<Derived>& output);
 
 private:
   Eigen::VectorXd mean_;                /**< Mean of the gaussian distribution */
@@ -72,23 +71,24 @@ private:
 //////////////////////// template function definitions follow //////////////////////////////
 
 template <typename Derived1, typename Derived2>
-MultivariateGaussian::MultivariateGaussian(
-  const Eigen::MatrixBase<Derived1> & mean, const Eigen::MatrixBase<Derived2> & covariance)
-: mean_(mean),
-  covariance_(covariance),
-  covariance_cholesky_(covariance_.llt().matrixL()),
-  rng_(),
-  normal_dist_(0.0, 1.0),
-  gaussian_(rng_, normal_dist_)
+MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& mean,
+                                           const Eigen::MatrixBase<Derived2>& covariance)
+  : mean_(mean)
+  , covariance_(covariance)
+  , covariance_cholesky_(covariance_.llt().matrixL())
+  , rng_()
+  , normal_dist_(0.0, 1.0)
+  , gaussian_(rng_, normal_dist_)
 {
   rng_.seed(rand());
   size_ = mean.rows();
 }
 
 template <typename Derived>
-void MultivariateGaussian::sample(Eigen::MatrixBase<Derived> & output)
+void MultivariateGaussian::sample(Eigen::MatrixBase<Derived>& output)
 {
-  for (int i = 0; i < size_; ++i) output(i) = gaussian_();
+  for (int i = 0; i < size_; ++i)
+    output(i) = gaussian_();
   output = mean_ + covariance_cholesky_ * output;
 }
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
@@ -36,12 +36,12 @@
 
 #pragma once
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Cholesky>
-#include <boost/random/variate_generator.hpp>
-#include <boost/random/normal_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
 #include <cstdlib>
+#include <eigen3/Eigen/Cholesky>
+#include <eigen3/Eigen/Core>
 
 namespace chomp
 {
@@ -52,10 +52,11 @@ class MultivariateGaussian
 {
 public:
   template <typename Derived1, typename Derived2>
-  MultivariateGaussian(const Eigen::MatrixBase<Derived1>& mean, const Eigen::MatrixBase<Derived2>& covariance);
+  MultivariateGaussian(
+    const Eigen::MatrixBase<Derived1> & mean, const Eigen::MatrixBase<Derived2> & covariance);
 
   template <typename Derived>
-  void sample(Eigen::MatrixBase<Derived>& output);
+  void sample(Eigen::MatrixBase<Derived> & output);
 
 private:
   Eigen::VectorXd mean_;                /**< Mean of the gaussian distribution */
@@ -71,24 +72,23 @@ private:
 //////////////////////// template function definitions follow //////////////////////////////
 
 template <typename Derived1, typename Derived2>
-MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& mean,
-                                           const Eigen::MatrixBase<Derived2>& covariance)
-  : mean_(mean)
-  , covariance_(covariance)
-  , covariance_cholesky_(covariance_.llt().matrixL())
-  , rng_()
-  , normal_dist_(0.0, 1.0)
-  , gaussian_(rng_, normal_dist_)
+MultivariateGaussian::MultivariateGaussian(
+  const Eigen::MatrixBase<Derived1> & mean, const Eigen::MatrixBase<Derived2> & covariance)
+: mean_(mean),
+  covariance_(covariance),
+  covariance_cholesky_(covariance_.llt().matrixL()),
+  rng_(),
+  normal_dist_(0.0, 1.0),
+  gaussian_(rng_, normal_dist_)
 {
   rng_.seed(rand());
   size_ = mean.rows();
 }
 
 template <typename Derived>
-void MultivariateGaussian::sample(Eigen::MatrixBase<Derived>& output)
+void MultivariateGaussian::sample(Eigen::MatrixBase<Derived> & output)
 {
-  for (int i = 0; i < size_; ++i)
-    output(i) = gaussian_();
+  for (int i = 0; i < size_; ++i) output(i) = gaussian_();
   output = mean_ + covariance_cholesky_ * output;
 }
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -1,20 +1,31 @@
-<package format="2">
+<?xml version="2.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>chomp_motion_planner</name>
-  <description>chomp_motion_planner</description>
-
   <version>1.1.5</version>
+  <description>chomp_motion_planner</description>
+  
   <author email="gjones@willowgarage.com">Gil Jones</author>
   <author email="mail@mrinal.net">Mrinal Kalakrishnan</author>
-
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/chomp_motion_planner</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>moveit_core</build_depend>
+  <depend>moveit_core</depend>
+  <depend>rclcpp</depend>
+  <depend>trajectory_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -9,7 +9,6 @@
   <author email="mail@mrinal.net">Mrinal Kalakrishnan</author>
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
-  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
   <url>http://ros.org/wiki/chomp_motion_planner</url>

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -4,7 +4,7 @@
   <name>chomp_motion_planner</name>
   <version>1.1.5</version>
   <description>chomp_motion_planner</description>
-  
+
   <author email="gjones@willowgarage.com">Gil Jones</author>
   <author email="mail@mrinal.net">Mrinal Kalakrishnan</author>
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -36,6 +36,7 @@
 
 #include <chomp_motion_planner/chomp_cost.h>
 #include <chomp_motion_planner/chomp_utils.h>
+
 #include <eigen3/Eigen/LU>
 
 using namespace Eigen;
@@ -43,8 +44,9 @@ using namespace std;
 
 namespace chomp
 {
-ChompCost::ChompCost(const ChompTrajectory& trajectory, int /* joint_number */,
-                     const std::vector<double>& derivative_costs, double ridge_factor)
+ChompCost::ChompCost(
+  const ChompTrajectory & trajectory, int /* joint_number */,
+  const std::vector<double> & derivative_costs, double ridge_factor)
 {
   int num_vars_all = trajectory.getNumPoints();
   int num_vars_free = num_vars_all - 2 * (DIFF_RULE_LENGTH - 1);
@@ -53,8 +55,7 @@ ChompCost::ChompCost(const ChompTrajectory& trajectory, int /* joint_number */,
 
   // construct the quad cost for all variables, as a sum of squared differentiation matrices
   double multiplier = 1.0;
-  for (unsigned int i = 0; i < derivative_costs.size(); i++)
-  {
+  for (unsigned int i = 0; i < derivative_costs.size(); i++) {
     multiplier *= trajectory.getDiscretization();
     diff_matrix = getDiffMatrix(num_vars_all, &DIFF_RULES[i][0]);
     quad_cost_full_ += (derivative_costs[i] * multiplier) * (diff_matrix.transpose() * diff_matrix);
@@ -62,7 +63,8 @@ ChompCost::ChompCost(const ChompTrajectory& trajectory, int /* joint_number */,
   quad_cost_full_ += MatrixXd::Identity(num_vars_all, num_vars_all) * ridge_factor;
 
   // extract the quad cost just for the free variables:
-  quad_cost_ = quad_cost_full_.block(DIFF_RULE_LENGTH - 1, DIFF_RULE_LENGTH - 1, num_vars_free, num_vars_free);
+  quad_cost_ =
+    quad_cost_full_.block(DIFF_RULE_LENGTH - 1, DIFF_RULE_LENGTH - 1, num_vars_free, num_vars_free);
 
   // invert the matrix:
   quad_cost_inv_ = quad_cost_.inverse();
@@ -70,28 +72,21 @@ ChompCost::ChompCost(const ChompTrajectory& trajectory, int /* joint_number */,
   // cout << quad_cost_inv_ << endl;
 }
 
-Eigen::MatrixXd ChompCost::getDiffMatrix(int size, const double* diff_rule) const
+Eigen::MatrixXd ChompCost::getDiffMatrix(int size, const double * diff_rule) const
 {
   MatrixXd matrix = MatrixXd::Zero(size, size);
-  for (int i = 0; i < size; i++)
-  {
-    for (int j = -DIFF_RULE_LENGTH / 2; j <= DIFF_RULE_LENGTH / 2; j++)
-    {
+  for (int i = 0; i < size; i++) {
+    for (int j = -DIFF_RULE_LENGTH / 2; j <= DIFF_RULE_LENGTH / 2; j++) {
       int index = i + j;
-      if (index < 0)
-        continue;
-      if (index >= size)
-        continue;
+      if (index < 0) continue;
+      if (index >= size) continue;
       matrix(i, index) = diff_rule[j + DIFF_RULE_LENGTH / 2];
     }
   }
   return matrix;
 }
 
-double ChompCost::getMaxQuadCostInvValue() const
-{
-  return quad_cost_inv_.maxCoeff();
-}
+double ChompCost::getMaxQuadCostInvValue() const { return quad_cost_inv_.maxCoeff(); }
 
 void ChompCost::scale(double scale)
 {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_cost.cpp
@@ -44,9 +44,8 @@ using namespace std;
 
 namespace chomp
 {
-ChompCost::ChompCost(
-  const ChompTrajectory & trajectory, int /* joint_number */,
-  const std::vector<double> & derivative_costs, double ridge_factor)
+ChompCost::ChompCost(const ChompTrajectory& trajectory, int /* joint_number */,
+                     const std::vector<double>& derivative_costs, double ridge_factor)
 {
   int num_vars_all = trajectory.getNumPoints();
   int num_vars_free = num_vars_all - 2 * (DIFF_RULE_LENGTH - 1);
@@ -55,7 +54,8 @@ ChompCost::ChompCost(
 
   // construct the quad cost for all variables, as a sum of squared differentiation matrices
   double multiplier = 1.0;
-  for (unsigned int i = 0; i < derivative_costs.size(); i++) {
+  for (unsigned int i = 0; i < derivative_costs.size(); i++)
+  {
     multiplier *= trajectory.getDiscretization();
     diff_matrix = getDiffMatrix(num_vars_all, &DIFF_RULES[i][0]);
     quad_cost_full_ += (derivative_costs[i] * multiplier) * (diff_matrix.transpose() * diff_matrix);
@@ -63,8 +63,7 @@ ChompCost::ChompCost(
   quad_cost_full_ += MatrixXd::Identity(num_vars_all, num_vars_all) * ridge_factor;
 
   // extract the quad cost just for the free variables:
-  quad_cost_ =
-    quad_cost_full_.block(DIFF_RULE_LENGTH - 1, DIFF_RULE_LENGTH - 1, num_vars_free, num_vars_free);
+  quad_cost_ = quad_cost_full_.block(DIFF_RULE_LENGTH - 1, DIFF_RULE_LENGTH - 1, num_vars_free, num_vars_free);
 
   // invert the matrix:
   quad_cost_inv_ = quad_cost_.inverse();
@@ -72,21 +71,28 @@ ChompCost::ChompCost(
   // cout << quad_cost_inv_ << endl;
 }
 
-Eigen::MatrixXd ChompCost::getDiffMatrix(int size, const double * diff_rule) const
+Eigen::MatrixXd ChompCost::getDiffMatrix(int size, const double* diff_rule) const
 {
   MatrixXd matrix = MatrixXd::Zero(size, size);
-  for (int i = 0; i < size; i++) {
-    for (int j = -DIFF_RULE_LENGTH / 2; j <= DIFF_RULE_LENGTH / 2; j++) {
+  for (int i = 0; i < size; i++)
+  {
+    for (int j = -DIFF_RULE_LENGTH / 2; j <= DIFF_RULE_LENGTH / 2; j++)
+    {
       int index = i + j;
-      if (index < 0) continue;
-      if (index >= size) continue;
+      if (index < 0)
+        continue;
+      if (index >= size)
+        continue;
       matrix(i, index) = diff_rule[j + DIFF_RULE_LENGTH / 2];
     }
   }
   return matrix;
 }
 
-double ChompCost::getMaxQuadCostInvValue() const { return quad_cost_inv_.maxCoeff(); }
+double ChompCost::getMaxQuadCostInvValue() const
+{
+  return quad_cost_inv_.maxCoeff();
+}
 
 void ChompCost::scale(double scale)
 {

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -273,12 +273,12 @@ void ChompOptimizer::registerParents(const moveit::core::JointModel* model)
     {
       if (model->getParentLinkModel() == nullptr)
       {
-        RCLCPP_ERROR(LOGGER2, "Model %s not root but has NULL link model parent", model->getName());
+        RCLCPP_ERROR(LOGGER2, "Model %s not root but has NULL link model parent", model->getName().c_str());
         return;
       }
       else if (model->getParentLinkModel()->getParentJointModel() == nullptr)
       {
-        RCLCPP_ERROR(LOGGER2, "Model %s not root but has NULL joint model parent", model->getName());
+        RCLCPP_ERROR(LOGGER2, "Model %s not root but has NULL joint model parent", model->getName().c_str());
         return;
       }
       parent_model = model->getParentLinkModel()->getParentJointModel();

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -72,8 +72,8 @@ ChompParameters::ChompParameters()
 
 ChompParameters::~ChompParameters() = default;
 
-void ChompParameters::setRecoveryParams(
-  double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations)
+void ChompParameters::setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit,
+                                        int max_iterations)
 {
   this->learning_rate_ = learning_rate;
   this->ridge_factor_ = ridge_factor;
@@ -81,14 +81,14 @@ void ChompParameters::setRecoveryParams(
   this->max_iterations_ = max_iterations;
 }
 
-const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{
-  "quintic-spline", "linear", "cubic", "fillTrajectory"};
+const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{ "quintic-spline", "linear", "cubic",
+                                                                              "fillTrajectory" };
 
 bool ChompParameters::setTrajectoryInitializationMethod(std::string method)
 {
-  if (
-    std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
-    VALID_INITIALIZATION_METHODS.end()) {
+  if (std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
+      VALID_INITIALIZATION_METHODS.end())
+  {
     this->trajectory_initialization_method_ = std::move(method);
     return true;
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -72,8 +72,8 @@ ChompParameters::ChompParameters()
 
 ChompParameters::~ChompParameters() = default;
 
-void ChompParameters::setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit,
-                                        int max_iterations)
+void ChompParameters::setRecoveryParams(
+  double learning_rate, double ridge_factor, int planning_time_limit, int max_iterations)
 {
   this->learning_rate_ = learning_rate;
   this->ridge_factor_ = ridge_factor;
@@ -81,14 +81,14 @@ void ChompParameters::setRecoveryParams(double learning_rate, double ridge_facto
   this->max_iterations_ = max_iterations;
 }
 
-const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{ "quintic-spline", "linear", "cubic",
-                                                                              "fillTrajectory" };
+const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{
+  "quintic-spline", "linear", "cubic", "fillTrajectory"};
 
 bool ChompParameters::setTrajectoryInitializationMethod(std::string method)
 {
-  if (std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
-      VALID_INITIALIZATION_METHODS.end())
-  {
+  if (
+    std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
+    VALID_INITIALIZATION_METHODS.end()) {
     this->trajectory_initialization_method_ = std::move(method);
     return true;
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -36,6 +36,8 @@
 
 #include <chomp_motion_planner/chomp_parameters.h>
 
+#include <algorithm>
+
 namespace chomp
 {
 ChompParameters::ChompParameters()

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -50,13 +50,13 @@ namespace chomp
 {
 rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_planner");
 
-bool ChompPlanner::solve(
-  const planning_scene::PlanningSceneConstPtr & planning_scene,
-  const planning_interface::MotionPlanRequest & req, const ChompParameters & params,
-  planning_interface::MotionPlanDetailedResponse & res) const
+bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                         const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
+                         planning_interface::MotionPlanDetailedResponse& res) const
 {
   std::chrono::time_point<std::chrono::system_clock> start_time = std::chrono::system_clock::now();
-  if (!planning_scene) {
+  if (!planning_scene)
+  {
     RCLCPP_ERROR(LOGGER, "No planning scene initialized.");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
     return false;
@@ -64,10 +64,10 @@ bool ChompPlanner::solve(
 
   // get the specified start state
   moveit::core::RobotState start_state = planning_scene->getCurrentState();
-  moveit::core::robotStateMsgToRobotState(
-    planning_scene->getTransforms(), req.start_state, start_state);
+  moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
 
-  if (!start_state.satisfiesBounds()) {
+  if (!start_state.satisfiesBounds())
+  {
     RCLCPP_ERROR(LOGGER, "Start state violates joint limits");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
@@ -76,25 +76,22 @@ bool ChompPlanner::solve(
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
   robotStateToArray(start_state, req.group_name, trajectory.getTrajectoryPoint(0));
 
-  if (req.goal_constraints.size() != 1) {
-    RCLCPP_ERROR(
-      LOGGER, "Expecting exactly one goal constraint, got: %zd", req.goal_constraints.size());
+  if (req.goal_constraints.size() != 1)
+  {
+    RCLCPP_ERROR(LOGGER, "Expecting exactly one goal constraint, got: %zd", req.goal_constraints.size());
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
   // Convert to joint space goal.
   planning_interface::MotionPlanRequest req_mod;
-  if (
-    req.goal_constraints[0].joint_constraints.empty() ||
-    !req.goal_constraints[0].position_constraints.empty() ||
-    !req.goal_constraints[0].orientation_constraints.empty()) {
+  if (req.goal_constraints[0].joint_constraints.empty() || !req.goal_constraints[0].position_constraints.empty() ||
+      !req.goal_constraints[0].orientation_constraints.empty())
+  {
     RCLCPP_INFO(LOGGER, "Converting work-space to joint-space goal ...");
 
-    geometry_msgs::msg::Point p = req.goal_constraints.at(0)
-                                    .position_constraints.at(0)
-                                    .constraint_region.primitive_poses.at(0)
-                                    .position;
+    geometry_msgs::msg::Point p =
+        req.goal_constraints.at(0).position_constraints.at(0).constraint_region.primitive_poses.at(0).position;
     p.x -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.x;
     p.y -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.y;
     p.z -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.z;
@@ -110,16 +107,15 @@ bool ChompPlanner::solve(
     moveit::core::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
 
     std::map<std::string, double> start_joint_position;
-    for (std::size_t i = 0; i < req.start_state.joint_state.name.size(); ++i) {
-      start_joint_position[req.start_state.joint_state.name[i]] =
-        req.start_state.joint_state.position[i];
+    for (std::size_t i = 0; i < req.start_state.joint_state.name.size(); ++i)
+    {
+      start_joint_position[req.start_state.joint_state.name[i]] = req.start_state.joint_state.position[i];
     }
 
     std::map<std::string, double> goal_joint_position;
-    if (!computePoseIK(
-          robot_model, req.group_name,
-          req.goal_constraints.at(0).position_constraints.at(0).link_name, pose_eigen,
-          robot_model->getModelFrame(), start_joint_position, goal_joint_position)) {
+    if (!computePoseIK(robot_model, req.group_name, req.goal_constraints.at(0).position_constraints.at(0).link_name,
+                       pose_eigen, robot_model->getModelFrame(), start_joint_position, goal_joint_position))
+    {
       throw std::runtime_error("No IK solution for goal pose");
     }
 
@@ -127,18 +123,18 @@ bool ChompPlanner::solve(
     req_mod.goal_constraints.resize(1);
     req_mod.goal_constraints[0].joint_constraints.resize(goal_joint_position.size());
     const std::vector<std::string> joint_names =
-      robot_model->getJointModelGroup(req.group_name)->getActiveJointModelNames();
+        robot_model->getJointModelGroup(req.group_name)->getActiveJointModelNames();
     RCLCPP_INFO(LOGGER, "The joint space goal is:");
-    for (std::size_t i = 0; i < goal_joint_position.size(); ++i) {
+    for (std::size_t i = 0; i < goal_joint_position.size(); ++i)
+    {
       req_mod.goal_constraints[0].joint_constraints[i].joint_name = joint_names[i];
-      req_mod.goal_constraints[0].joint_constraints[i].position =
-        goal_joint_position[joint_names[i]];
-      RCLCPP_INFO(
-        LOGGER, "(%d) %s: %.3f", i,
-        req_mod.goal_constraints[0].joint_constraints[i].joint_name.c_str(),
-        req_mod.goal_constraints[0].joint_constraints[i].position);
+      req_mod.goal_constraints[0].joint_constraints[i].position = goal_joint_position[joint_names[i]];
+      RCLCPP_INFO(LOGGER, "(%d) %s: %.3f", i, req_mod.goal_constraints[0].joint_constraints[i].joint_name.c_str(),
+                  req_mod.goal_constraints[0].joint_constraints[i].position);
     }
-  } else {
+  }
+  else
+  {
     req_mod = req;
   }
 
@@ -153,30 +149,32 @@ bool ChompPlanner::solve(
 
   const size_t goal_index = trajectory.getNumPoints() - 1;
   moveit::core::RobotState goal_state(start_state);
-  for (const moveit_msgs::msg::JointConstraint & joint_constraint :
-       req_mod.goal_constraints[0].joint_constraints)
+  for (const moveit_msgs::msg::JointConstraint& joint_constraint : req_mod.goal_constraints[0].joint_constraints)
     goal_state.setVariablePosition(joint_constraint.joint_name, joint_constraint.position);
-  if (!goal_state.satisfiesBounds()) {
+  if (!goal_state.satisfiesBounds())
+  {
     RCLCPP_ERROR(LOGGER, "Goal state violates joint limits");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
   robotStateToArray(goal_state, req_mod.group_name, trajectory.getTrajectoryPoint(goal_index));
 
-  const moveit::core::JointModelGroup * model_group =
-    planning_scene->getRobotModel()->getJointModelGroup(req_mod.group_name);
+  const moveit::core::JointModelGroup* model_group =
+      planning_scene->getRobotModel()->getJointModelGroup(req_mod.group_name);
   // fix the goal to move the shortest angular distance for wrap-around joints:
-  for (size_t i = 0; i < model_group->getActiveJointModels().size(); i++) {
-    const moveit::core::JointModel * model = model_group->getActiveJointModels()[i];
-    const moveit::core::RevoluteJointModel * revolute_joint =
-      dynamic_cast<const moveit::core::RevoluteJointModel *>(model);
+  for (size_t i = 0; i < model_group->getActiveJointModels().size(); i++)
+  {
+    const moveit::core::JointModel* model = model_group->getActiveJointModels()[i];
+    const moveit::core::RevoluteJointModel* revolute_joint =
+        dynamic_cast<const moveit::core::RevoluteJointModel*>(model);
 
-    if (revolute_joint != nullptr) {
-      if (revolute_joint->isContinuous()) {
+    if (revolute_joint != nullptr)
+    {
+      if (revolute_joint->isContinuous())
+      {
         double start = (trajectory)(0, i);
         double end = (trajectory)(goal_index, i);
-        RCLCPP_INFO(
-          LOGGER, "Start is %s end %s short %f", start, end, shortestAngularDistance(start, end));
+        RCLCPP_INFO(LOGGER, "Start is %s end %s short %f", start, end, shortestAngularDistance(start, end));
         (trajectory)(goal_index, i) = start + shortestAngularDistance(start, end);
       }
     }
@@ -189,22 +187,23 @@ bool ChompPlanner::solve(
     trajectory.fillInLinearInterpolation();
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
-  else if (params.trajectory_initialization_method_.compare("fillTrajectory") == 0) {
-    if (!(trajectory.fillInFromTrajectory(*res.trajectory_[0]))) {
-      RCLCPP_ERROR(
-        LOGGER,
-        "Input trajectory has less than 2 points, "
-        "trajectory must contain at least start and goal state");
+  else if (params.trajectory_initialization_method_.compare("fillTrajectory") == 0)
+  {
+    if (!(trajectory.fillInFromTrajectory(*res.trajectory_[0])))
+    {
+      RCLCPP_ERROR(LOGGER, "Input trajectory has less than 2 points, "
+                           "trajectory must contain at least start and goal state");
       return false;
     }
-  } else {
+  }
+  else
+  {
     RCLCPP_ERROR(LOGGER, "invalid interpolation method specified in the chomp_planner file");
     return false;
   }
 
-  RCLCPP_INFO(
-    LOGGER, "CHOMP trajectory initialized using method: %s ",
-    (params.trajectory_initialization_method_).c_str());
+  RCLCPP_INFO(LOGGER, "CHOMP trajectory initialized using method: %s ",
+              (params.trajectory_initialization_method_).c_str());
 
   // optimize!
   std::chrono::time_point<std::chrono::system_clock> create_time = std::chrono::system_clock::now();
@@ -226,73 +225,74 @@ bool ChompPlanner::solve(
   ChompParameters params_nonconst = params;
 
   // while loop for replanning (recovery behaviour) if collision free optimized solution not found
-  while (true) {
-    if (replan_flag) {
+  while (true)
+  {
+    if (replan_flag)
+    {
       // increase learning rate in hope to find a successful path; increase ridge factor to avoid obstacles; add 5
       // additional secs in hope to find a solution; increase maximum iterations
-      params_nonconst.setRecoveryParams(
-        params_nonconst.learning_rate_ + 0.02, params_nonconst.ridge_factor_ + 0.002,
-        params_nonconst.planning_time_limit_ + 5, params_nonconst.max_iterations_ + 50);
+      params_nonconst.setRecoveryParams(params_nonconst.learning_rate_ + 0.02, params_nonconst.ridge_factor_ + 0.002,
+                                        params_nonconst.planning_time_limit_ + 5, params_nonconst.max_iterations_ + 50);
     }
 
     // initialize a ChompOptimizer object to load up the optimizer with default parameters or with updated parameters in
     // case of a recovery behaviour
-    optimizer.reset(new ChompOptimizer(
-      &trajectory, planning_scene, req.group_name, &params_nonconst, start_state));
-    if (!optimizer->isInitialized()) {
+    optimizer.reset(new ChompOptimizer(&trajectory, planning_scene, req.group_name, &params_nonconst, start_state));
+    if (!optimizer->isInitialized())
+    {
       RCLCPP_ERROR(LOGGER, "Could not initialize optimizer");
       res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
       return false;
     }
 
-    RCLCPP_DEBUG(
-      LOGGER, "Optimization took %f sec to create",
-      (std::chrono::system_clock::now() - create_time).count());
+    RCLCPP_DEBUG(LOGGER, "Optimization took %f sec to create", (std::chrono::system_clock::now() - create_time).count());
 
     bool optimization_result = optimizer->optimize();
 
     // replan with updated parameters if no solution is found
-    if (params_nonconst.enable_failure_recovery_) {
-      RCLCPP_INFO(
-        LOGGER,
-        "Planned with Chomp Parameters (learning_rate, ridge_factor, "
-        "planning_time_limit, max_iterations), attempt: # %d ",
-        (replan_count + 1));
-      RCLCPP_INFO(
-        LOGGER, "Learning rate: %f ridge factor: %f planning time limit: %f max_iterations %d ",
-        params_nonconst.learning_rate_, params_nonconst.ridge_factor_,
-        params_nonconst.planning_time_limit_, params_nonconst.max_iterations_);
+    if (params_nonconst.enable_failure_recovery_)
+    {
+      RCLCPP_INFO(LOGGER,
+                  "Planned with Chomp Parameters (learning_rate, ridge_factor, "
+                  "planning_time_limit, max_iterations), attempt: # %d ",
+                  (replan_count + 1));
+      RCLCPP_INFO(LOGGER, "Learning rate: %f ridge factor: %f planning time limit: %f max_iterations %d ",
+                  params_nonconst.learning_rate_, params_nonconst.ridge_factor_, params_nonconst.planning_time_limit_,
+                  params_nonconst.max_iterations_);
 
-      if (!optimization_result && replan_count < params_nonconst.max_recovery_attempts_) {
+      if (!optimization_result && replan_count < params_nonconst.max_recovery_attempts_)
+      {
         replan_count++;
         replan_flag = true;
-      } else {
+      }
+      else
+      {
         break;
       }
-    } else
+    }
+    else
       break;
   }  // end of while loop
 
   // resetting the CHOMP Parameters to the original values after a successful plan
-  params_nonconst.setRecoveryParams(
-    org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
+  params_nonconst.setRecoveryParams(org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
 
-  RCLCPP_DEBUG(
-    LOGGER, "Optimization actually took %f sec to run",
-    (std::chrono::system_clock::now() - create_time).count());
+  RCLCPP_DEBUG(LOGGER, "Optimization actually took %f sec to run",
+               (std::chrono::system_clock::now() - create_time).count());
   create_time = std::chrono::system_clock::now();
   // assume that the trajectory is now optimized, fill in the output structure:
 
   RCLCPP_DEBUG(LOGGER, "Output trajectory has %zd joints", trajectory.getNumJoints());
 
-  auto result = std::make_shared<robot_trajectory::RobotTrajectory>(
-    planning_scene->getRobotModel(), req.group_name);
+  auto result = std::make_shared<robot_trajectory::RobotTrajectory>(planning_scene->getRobotModel(), req.group_name);
   // fill in the entire trajectory
-  for (size_t i = 0; i < trajectory.getNumPoints(); i++) {
+  for (size_t i = 0; i < trajectory.getNumPoints(); i++)
+  {
     const Eigen::MatrixXd::RowXpr source = trajectory.getTrajectoryPoint(i);
     auto state = std::make_shared<moveit::core::RobotState>(start_state);
     size_t joint_index = 0;
-    for (const moveit::core::JointModel * jm : result->getGroup()->getActiveJointModels()) {
+    for (const moveit::core::JointModel* jm : result->getGroup()->getActiveJointModels())
+    {
       assert(jm->getVariableCount() == 1);
       state->setVariablePosition(jm->getFirstVariableIndex(), source[joint_index++]);
     }
@@ -302,22 +302,19 @@ bool ChompPlanner::solve(
   res.trajectory_.resize(1);
   res.trajectory_[0] = result;
 
-  RCLCPP_DEBUG(
-    LOGGER, "Bottom took %f sec to create",
-    (std::chrono::system_clock::now() - create_time).count());
-  RCLCPP_DEBUG(
-    LOGGER, "Serviced planning request in %f wall-seconds",
-    (std::chrono::system_clock::now() - start_time).count());
+  RCLCPP_DEBUG(LOGGER, "Bottom took %f sec to create", (std::chrono::system_clock::now() - create_time).count());
+  RCLCPP_DEBUG(LOGGER, "Serviced planning request in %f wall-seconds",
+               (std::chrono::system_clock::now() - start_time).count());
 
   res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
-  int count = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now() - start_time)
-                .count();
+  int count =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start_time).count();
   res.processing_time_.resize(1);
   res.processing_time_[0] = (double)count / 1000.0;
 
   // report planning failure if path has collisions
-  if (not optimizer->isCollisionFree()) {
+  if (not optimizer->isCollisionFree())
+  {
     RCLCPP_ERROR(LOGGER, "Motion plan is invalid.");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
@@ -325,46 +322,45 @@ bool ChompPlanner::solve(
 
   // check that final state is within goal tolerances
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
-  const moveit::core::RobotState & last_state = result->getLastWayPoint();
-  for (const moveit_msgs::msg::JointConstraint & constraint :
-       req.goal_constraints[0].joint_constraints) {
-    if (!jc.configure(constraint) || !jc.decide(last_state).satisfied) {
+  const moveit::core::RobotState& last_state = result->getLastWayPoint();
+  for (const moveit_msgs::msg::JointConstraint& constraint : req.goal_constraints[0].joint_constraints)
+  {
+    if (!jc.configure(constraint) || !jc.decide(last_state).satisfied)
+    {
       RCLCPP_ERROR(LOGGER, "Goal constraints are violated: %s", constraint.joint_name);
       res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::GOAL_CONSTRAINTS_VIOLATED;
       return false;
     }
   }
 
-  count = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now() - start_time)
-            .count();
+  count = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start_time).count();
   res.processing_time_.resize(1);
   res.processing_time_[0] = (double)count / 1000.0;
 
   return true;
 }
 
-bool ChompPlanner::computePoseIK(
-  const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
-  const std::string & link_name, const Eigen::Isometry3d & pose, const std::string & frame_id,
-  const std::map<std::string, double> & seed, std::map<std::string, double> & solution,
-  bool check_self_collision, const double timeout) const
+bool ChompPlanner::computePoseIK(const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name,
+                                 const std::string& link_name, const Eigen::Isometry3d& pose,
+                                 const std::string& frame_id, const std::map<std::string, double>& seed,
+                                 std::map<std::string, double>& solution, bool check_self_collision,
+                                 const double timeout) const
 {
-  if (!robot_model->hasJointModelGroup(group_name)) {
+  if (!robot_model->hasJointModelGroup(group_name))
+  {
     RCLCPP_ERROR(LOGGER, "Robot model has no planning group named as %s", group_name);
     return false;
   }
 
-  if (!robot_model->getJointModelGroup(group_name)->canSetStateFromIK(link_name)) {
-    RCLCPP_ERROR(
-      LOGGER, "No valid IK solver exists for %s in planning group %s", link_name, group_name);
+  if (!robot_model->getJointModelGroup(group_name)->canSetStateFromIK(link_name))
+  {
+    RCLCPP_ERROR(LOGGER, "No valid IK solver exists for %s in planning group %s", link_name, group_name);
     return false;
   }
 
-  if (frame_id != robot_model->getModelFrame()) {
-    RCLCPP_ERROR(
-      LOGGER, "Given frame (%s) is unequal to model frame(%s)", frame_id,
-      robot_model->getModelFrame());
+  if (frame_id != robot_model->getModelFrame())
+  {
+    RCLCPP_ERROR(LOGGER, "Given frame (%s) is unequal to model frame(%s)", frame_id, robot_model->getModelFrame());
     return false;
   }
 
@@ -376,33 +372,34 @@ bool ChompPlanner::computePoseIK(
 
   moveit::core::GroupStateValidityCallbackFn ik_constraint_function;
 
-  ik_constraint_function = std::bind(
-    &ChompPlanner::isStateColliding, this, check_self_collision, robot_model, std::placeholders::_1,
-    std::placeholders::_2, std::placeholders::_3);
+  ik_constraint_function = std::bind(&ChompPlanner::isStateColliding, this, check_self_collision, robot_model,
+                                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
   // Call Inverse Kinematics solver.
-  if (rstate.setFromIK(
-        robot_model->getJointModelGroup(group_name), pose, link_name, timeout,
-        ik_constraint_function)) {
+  if (rstate.setFromIK(robot_model->getJointModelGroup(group_name), pose, link_name, timeout, ik_constraint_function))
+  {
     // copy the solution
-    for (const std::string & joint_name :
-         robot_model->getJointModelGroup(group_name)->getActiveJointModelNames()) {
+    for (const std::string& joint_name : robot_model->getJointModelGroup(group_name)->getActiveJointModelNames())
+    {
       solution[joint_name] = rstate.getVariablePosition(joint_name);
       RCLCPP_ERROR(LOGGER, "%s: %.4f", joint_name.c_str(), solution[joint_name]);
     }
     return true;
-  } else {
+  }
+  else
+  {
     RCLCPP_ERROR(LOGGER, "Inverse kinematics found no solution.");
     return false;
   }
 }
 
-bool ChompPlanner::isStateColliding(
-  const bool test_for_self_collision, const moveit::core::RobotModelConstPtr & robot_model,
-  moveit::core::RobotState * rstate, const moveit::core::JointModelGroup * const group,
-  const double * const ik_solution) const
+bool ChompPlanner::isStateColliding(const bool test_for_self_collision,
+                                    const moveit::core::RobotModelConstPtr& robot_model,
+                                    moveit::core::RobotState* rstate, const moveit::core::JointModelGroup* const group,
+                                    const double* const ik_solution) const
 {
-  if (!test_for_self_collision) {
+  if (!test_for_self_collision)
+  {
     return true;
   }
 
@@ -411,8 +408,7 @@ bool ChompPlanner::isStateColliding(
   collision_detection::CollisionRequest collision_req;
   collision_req.group_name = group->getName();
   collision_detection::CollisionResult collision_res;
-  planning_scene::PlanningScene(robot_model)
-    .checkSelfCollision(collision_req, collision_res, *rstate);
+  planning_scene::PlanningScene(robot_model).checkSelfCollision(collision_req, collision_res, *rstate);
 
   return !collision_res.collision;
 }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -34,33 +34,41 @@
 
 /* Author: E. Gil Jones */
 
-#include <ros/ros.h>
+#include <chomp_motion_planner/chomp_optimizer.h>
 #include <chomp_motion_planner/chomp_planner.h>
 #include <chomp_motion_planner/chomp_trajectory.h>
-#include <chomp_motion_planner/chomp_optimizer.h>
 #include <moveit/robot_state/conversions.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
 
 namespace chomp
 {
-bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                         const planning_interface::MotionPlanRequest& req, const ChompParameters& params,
-                         planning_interface::MotionPlanDetailedResponse& res) const
+rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_planner");
+
+bool ChompPlanner::solve(
+  const planning_scene::PlanningSceneConstPtr & planning_scene,
+  const planning_interface::MotionPlanRequest & req, const ChompParameters & params,
+  planning_interface::MotionPlanDetailedResponse & res) const
 {
-  ros::WallTime start_time = ros::WallTime::now();
-  if (!planning_scene)
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "No planning scene initialized.");
+  std::chrono::time_point<std::chrono::system_clock> start_time = std::chrono::system_clock::now();
+  if (!planning_scene) {
+    RCLCPP_ERROR(LOGGER, "No planning scene initialized.");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
     return false;
   }
 
   // get the specified start state
   moveit::core::RobotState start_state = planning_scene->getCurrentState();
-  moveit::core::robotStateMsgToRobotState(planning_scene->getTransforms(), req.start_state, start_state);
+  moveit::core::robotStateMsgToRobotState(
+    planning_scene->getTransforms(), req.start_state, start_state);
 
-  if (!start_state.satisfiesBounds())
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Start state violates joint limits");
+  if (!start_state.satisfiesBounds()) {
+    RCLCPP_ERROR(LOGGER, "Start state violates joint limits");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
@@ -68,49 +76,107 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ChompTrajectory trajectory(planning_scene->getRobotModel(), 3.0, .03, req.group_name);
   robotStateToArray(start_state, req.group_name, trajectory.getTrajectoryPoint(0));
 
-  if (req.goal_constraints.size() != 1)
-  {
-    ROS_ERROR_NAMED("chomp_planner", "Expecting exactly one goal constraint, got: %zd", req.goal_constraints.size());
+  if (req.goal_constraints.size() != 1) {
+    RCLCPP_ERROR(
+      LOGGER, "Expecting exactly one goal constraint, got: %zd", req.goal_constraints.size());
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
     return false;
   }
 
-  if (req.goal_constraints[0].joint_constraints.empty() || !req.goal_constraints[0].position_constraints.empty() ||
-      !req.goal_constraints[0].orientation_constraints.empty())
-  {
-    ROS_ERROR_STREAM("Only joint-space goals are supported");
-    res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
-    return false;
+  // Convert to joint space goal.
+  planning_interface::MotionPlanRequest req_mod;
+  if (
+    req.goal_constraints[0].joint_constraints.empty() ||
+    !req.goal_constraints[0].position_constraints.empty() ||
+    !req.goal_constraints[0].orientation_constraints.empty()) {
+    RCLCPP_INFO(LOGGER, "Converting work-space to joint-space goal ...");
+
+    geometry_msgs::msg::Point p = req.goal_constraints.at(0)
+                                    .position_constraints.at(0)
+                                    .constraint_region.primitive_poses.at(0)
+                                    .position;
+    p.x -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.x;
+    p.y -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.y;
+    p.z -= req.goal_constraints.at(0).position_constraints.at(0).target_point_offset.z;
+
+    geometry_msgs::msg::Pose pose;
+    pose.position = p;
+    pose.orientation = req.goal_constraints.at(0).orientation_constraints.at(0).orientation;
+    tf2::Quaternion q;
+    tf2::fromMsg(pose.orientation, q);
+    pose.orientation = tf2::toMsg(q.normalize());
+    Eigen::Isometry3d pose_eigen;
+    tf2::fromMsg(pose, pose_eigen);
+    moveit::core::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
+
+    std::map<std::string, double> start_joint_position;
+    for (std::size_t i = 0; i < req.start_state.joint_state.name.size(); ++i) {
+      start_joint_position[req.start_state.joint_state.name[i]] =
+        req.start_state.joint_state.position[i];
+    }
+
+    std::map<std::string, double> goal_joint_position;
+    if (!computePoseIK(
+          robot_model, req.group_name,
+          req.goal_constraints.at(0).position_constraints.at(0).link_name, pose_eigen,
+          robot_model->getModelFrame(), start_joint_position, goal_joint_position)) {
+      throw std::runtime_error("No IK solution for goal pose");
+    }
+
+    req_mod.group_name = req.group_name;
+    req_mod.goal_constraints.resize(1);
+    req_mod.goal_constraints[0].joint_constraints.resize(goal_joint_position.size());
+    const std::vector<std::string> joint_names =
+      robot_model->getJointModelGroup(req.group_name)->getActiveJointModelNames();
+    RCLCPP_INFO(LOGGER, "The joint space goal is:");
+    for (std::size_t i = 0; i < goal_joint_position.size(); ++i) {
+      req_mod.goal_constraints[0].joint_constraints[i].joint_name = joint_names[i];
+      req_mod.goal_constraints[0].joint_constraints[i].position =
+        goal_joint_position[joint_names[i]];
+      RCLCPP_INFO(
+        LOGGER, "(%d) %s: %.3f", i,
+        req_mod.goal_constraints[0].joint_constraints[i].joint_name.c_str(),
+        req_mod.goal_constraints[0].joint_constraints[i].position);
+    }
+  } else {
+    req_mod = req;
   }
+
+  // if (
+  //   req.goal_constraints[0].joint_constraints.empty() ||
+  //   !req.goal_constraints[0].position_constraints.empty() ||
+  //   !req.goal_constraints[0].orientation_constraints.empty()) {
+  //   RCLCPP_ERROR(LOGGER, "Only joint-space goals are supported");
+  //   res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
+  //   return false;
+  // }
 
   const size_t goal_index = trajectory.getNumPoints() - 1;
   moveit::core::RobotState goal_state(start_state);
-  for (const moveit_msgs::JointConstraint& joint_constraint : req.goal_constraints[0].joint_constraints)
+  for (const moveit_msgs::msg::JointConstraint & joint_constraint :
+       req_mod.goal_constraints[0].joint_constraints)
     goal_state.setVariablePosition(joint_constraint.joint_name, joint_constraint.position);
-  if (!goal_state.satisfiesBounds())
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal state violates joint limits");
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
+  if (!goal_state.satisfiesBounds()) {
+    RCLCPP_ERROR(LOGGER, "Goal state violates joint limits");
+    res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
-  robotStateToArray(goal_state, req.group_name, trajectory.getTrajectoryPoint(goal_index));
+  robotStateToArray(goal_state, req_mod.group_name, trajectory.getTrajectoryPoint(goal_index));
 
-  const moveit::core::JointModelGroup* model_group =
-      planning_scene->getRobotModel()->getJointModelGroup(req.group_name);
+  const moveit::core::JointModelGroup * model_group =
+    planning_scene->getRobotModel()->getJointModelGroup(req_mod.group_name);
   // fix the goal to move the shortest angular distance for wrap-around joints:
-  for (size_t i = 0; i < model_group->getActiveJointModels().size(); i++)
-  {
-    const moveit::core::JointModel* model = model_group->getActiveJointModels()[i];
-    const moveit::core::RevoluteJointModel* revolute_joint =
-        dynamic_cast<const moveit::core::RevoluteJointModel*>(model);
+  for (size_t i = 0; i < model_group->getActiveJointModels().size(); i++) {
+    const moveit::core::JointModel * model = model_group->getActiveJointModels()[i];
+    const moveit::core::RevoluteJointModel * revolute_joint =
+      dynamic_cast<const moveit::core::RevoluteJointModel *>(model);
 
-    if (revolute_joint != nullptr)
-    {
-      if (revolute_joint->isContinuous())
-      {
+    if (revolute_joint != nullptr) {
+      if (revolute_joint->isContinuous()) {
         double start = (trajectory)(0, i);
         double end = (trajectory)(goal_index, i);
-        ROS_INFO_STREAM("Start is " << start << " end " << end << " short " << shortestAngularDistance(start, end));
+        RCLCPP_INFO(
+          LOGGER, "Start is %s end %s short %f", start, end, shortestAngularDistance(start, end));
         (trajectory)(goal_index, i) = start + shortestAngularDistance(start, end);
       }
     }
@@ -123,26 +189,25 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
     trajectory.fillInLinearInterpolation();
   else if (params.trajectory_initialization_method_.compare("cubic") == 0)
     trajectory.fillInCubicInterpolation();
-  else if (params.trajectory_initialization_method_.compare("fillTrajectory") == 0)
-  {
-    if (!(trajectory.fillInFromTrajectory(*res.trajectory_[0])))
-    {
-      ROS_ERROR_STREAM_NAMED("chomp_planner", "Input trajectory has less than 2 points, "
-                                              "trajectory must contain at least start and goal state");
+  else if (params.trajectory_initialization_method_.compare("fillTrajectory") == 0) {
+    if (!(trajectory.fillInFromTrajectory(*res.trajectory_[0]))) {
+      RCLCPP_ERROR(
+        LOGGER,
+        "Input trajectory has less than 2 points, "
+        "trajectory must contain at least start and goal state");
       return false;
     }
-  }
-  else
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "invalid interpolation method specified in the chomp_planner file");
+  } else {
+    RCLCPP_ERROR(LOGGER, "invalid interpolation method specified in the chomp_planner file");
     return false;
   }
 
-  ROS_INFO_NAMED("chomp_planner", "CHOMP trajectory initialized using method: %s ",
-                 (params.trajectory_initialization_method_).c_str());
+  RCLCPP_INFO(
+    LOGGER, "CHOMP trajectory initialized using method: %s ",
+    (params.trajectory_initialization_method_).c_str());
 
   // optimize!
-  ros::WallTime create_time = ros::WallTime::now();
+  std::chrono::time_point<std::chrono::system_clock> create_time = std::chrono::system_clock::now();
 
   int replan_count = 0;
   bool replan_flag = false;
@@ -161,74 +226,73 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   ChompParameters params_nonconst = params;
 
   // while loop for replanning (recovery behaviour) if collision free optimized solution not found
-  while (true)
-  {
-    if (replan_flag)
-    {
+  while (true) {
+    if (replan_flag) {
       // increase learning rate in hope to find a successful path; increase ridge factor to avoid obstacles; add 5
       // additional secs in hope to find a solution; increase maximum iterations
-      params_nonconst.setRecoveryParams(params_nonconst.learning_rate_ + 0.02, params_nonconst.ridge_factor_ + 0.002,
-                                        params_nonconst.planning_time_limit_ + 5, params_nonconst.max_iterations_ + 50);
+      params_nonconst.setRecoveryParams(
+        params_nonconst.learning_rate_ + 0.02, params_nonconst.ridge_factor_ + 0.002,
+        params_nonconst.planning_time_limit_ + 5, params_nonconst.max_iterations_ + 50);
     }
 
     // initialize a ChompOptimizer object to load up the optimizer with default parameters or with updated parameters in
     // case of a recovery behaviour
-    optimizer.reset(new ChompOptimizer(&trajectory, planning_scene, req.group_name, &params_nonconst, start_state));
-    if (!optimizer->isInitialized())
-    {
-      ROS_ERROR_STREAM_NAMED("chomp_planner", "Could not initialize optimizer");
+    optimizer.reset(new ChompOptimizer(
+      &trajectory, planning_scene, req.group_name, &params_nonconst, start_state));
+    if (!optimizer->isInitialized()) {
+      RCLCPP_ERROR(LOGGER, "Could not initialize optimizer");
       res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
       return false;
     }
 
-    ROS_DEBUG_NAMED("chomp_planner", "Optimization took %f sec to create", (ros::WallTime::now() - create_time).toSec());
+    RCLCPP_DEBUG(
+      LOGGER, "Optimization took %f sec to create",
+      (std::chrono::system_clock::now() - create_time).count());
 
     bool optimization_result = optimizer->optimize();
 
     // replan with updated parameters if no solution is found
-    if (params_nonconst.enable_failure_recovery_)
-    {
-      ROS_INFO_NAMED("chomp_planner",
-                     "Planned with Chomp Parameters (learning_rate, ridge_factor, "
-                     "planning_time_limit, max_iterations), attempt: # %d ",
-                     (replan_count + 1));
-      ROS_INFO_NAMED("chomp_planner", "Learning rate: %f ridge factor: %f planning time limit: %f max_iterations %d ",
-                     params_nonconst.learning_rate_, params_nonconst.ridge_factor_,
-                     params_nonconst.planning_time_limit_, params_nonconst.max_iterations_);
+    if (params_nonconst.enable_failure_recovery_) {
+      RCLCPP_INFO(
+        LOGGER,
+        "Planned with Chomp Parameters (learning_rate, ridge_factor, "
+        "planning_time_limit, max_iterations), attempt: # %d ",
+        (replan_count + 1));
+      RCLCPP_INFO(
+        LOGGER, "Learning rate: %f ridge factor: %f planning time limit: %f max_iterations %d ",
+        params_nonconst.learning_rate_, params_nonconst.ridge_factor_,
+        params_nonconst.planning_time_limit_, params_nonconst.max_iterations_);
 
-      if (!optimization_result && replan_count < params_nonconst.max_recovery_attempts_)
-      {
+      if (!optimization_result && replan_count < params_nonconst.max_recovery_attempts_) {
         replan_count++;
         replan_flag = true;
-      }
-      else
-      {
+      } else {
         break;
       }
-    }
-    else
+    } else
       break;
   }  // end of while loop
 
   // resetting the CHOMP Parameters to the original values after a successful plan
-  params_nonconst.setRecoveryParams(org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
+  params_nonconst.setRecoveryParams(
+    org_learning_rate, org_ridge_factor, org_planning_time_limit, org_max_iterations);
 
-  ROS_DEBUG_NAMED("chomp_planner", "Optimization actually took %f sec to run",
-                  (ros::WallTime::now() - create_time).toSec());
-  create_time = ros::WallTime::now();
+  RCLCPP_DEBUG(
+    LOGGER, "Optimization actually took %f sec to run",
+    (std::chrono::system_clock::now() - create_time).count());
+  create_time = std::chrono::system_clock::now();
   // assume that the trajectory is now optimized, fill in the output structure:
 
-  ROS_DEBUG_NAMED("chomp_planner", "Output trajectory has %zd joints", trajectory.getNumJoints());
+  RCLCPP_DEBUG(LOGGER, "Output trajectory has %zd joints", trajectory.getNumJoints());
 
-  auto result = std::make_shared<robot_trajectory::RobotTrajectory>(planning_scene->getRobotModel(), req.group_name);
+  auto result = std::make_shared<robot_trajectory::RobotTrajectory>(
+    planning_scene->getRobotModel(), req.group_name);
   // fill in the entire trajectory
-  for (size_t i = 0; i < trajectory.getNumPoints(); i++)
-  {
+  for (size_t i = 0; i < trajectory.getNumPoints(); i++) {
     const Eigen::MatrixXd::RowXpr source = trajectory.getTrajectoryPoint(i);
     auto state = std::make_shared<moveit::core::RobotState>(start_state);
     size_t joint_index = 0;
-    for (const moveit::core::JointModel* jm : result->getGroup()->getActiveJointModels())
-    {
+    for (const moveit::core::JointModel * jm : result->getGroup()->getActiveJointModels()) {
       assert(jm->getVariableCount() == 1);
       state->setVariablePosition(jm->getFirstVariableIndex(), source[joint_index++]);
     }
@@ -238,35 +302,119 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   res.trajectory_.resize(1);
   res.trajectory_[0] = result;
 
-  ROS_DEBUG_NAMED("chomp_planner", "Bottom took %f sec to create", (ros::WallTime::now() - create_time).toSec());
-  ROS_DEBUG_NAMED("chomp_planner", "Serviced planning request in %f wall-seconds",
-                  (ros::WallTime::now() - start_time).toSec());
+  RCLCPP_DEBUG(
+    LOGGER, "Bottom took %f sec to create",
+    (std::chrono::system_clock::now() - create_time).count());
+  RCLCPP_DEBUG(
+    LOGGER, "Serviced planning request in %f wall-seconds",
+    (std::chrono::system_clock::now() - start_time).count());
 
   res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+  int count = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now() - start_time)
+                .count();
   res.processing_time_.resize(1);
-  res.processing_time_[0] = (ros::WallTime::now() - start_time).toSec();
+  res.processing_time_[0] = (double)count / 1000.0;
 
   // report planning failure if path has collisions
-  if (not optimizer->isCollisionFree())
-  {
-    ROS_ERROR_STREAM_NAMED("chomp_planner", "Motion plan is invalid.");
+  if (not optimizer->isCollisionFree()) {
+    RCLCPP_ERROR(LOGGER, "Motion plan is invalid.");
     res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
 
   // check that final state is within goal tolerances
   kinematic_constraints::JointConstraint jc(planning_scene->getRobotModel());
-  const moveit::core::RobotState& last_state = result->getLastWayPoint();
-  for (const moveit_msgs::msg::JointConstraint& constraint : req.goal_constraints[0].joint_constraints)
-  {
-    if (!jc.configure(constraint) || !jc.decide(last_state).satisfied)
-    {
-      ROS_ERROR_STREAM_NAMED("chomp_planner", "Goal constraints are violated: " << constraint.joint_name);
+  const moveit::core::RobotState & last_state = result->getLastWayPoint();
+  for (const moveit_msgs::msg::JointConstraint & constraint :
+       req.goal_constraints[0].joint_constraints) {
+    if (!jc.configure(constraint) || !jc.decide(last_state).satisfied) {
+      RCLCPP_ERROR(LOGGER, "Goal constraints are violated: %s", constraint.joint_name);
       res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::GOAL_CONSTRAINTS_VIOLATED;
       return false;
     }
   }
 
+  count = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now() - start_time)
+            .count();
+  res.processing_time_.resize(1);
+  res.processing_time_[0] = (double)count / 1000.0;
+
   return true;
 }
+
+bool ChompPlanner::computePoseIK(
+  const moveit::core::RobotModelConstPtr & robot_model, const std::string & group_name,
+  const std::string & link_name, const Eigen::Isometry3d & pose, const std::string & frame_id,
+  const std::map<std::string, double> & seed, std::map<std::string, double> & solution,
+  bool check_self_collision, const double timeout) const
+{
+  if (!robot_model->hasJointModelGroup(group_name)) {
+    RCLCPP_ERROR(LOGGER, "Robot model has no planning group named as %s", group_name);
+    return false;
+  }
+
+  if (!robot_model->getJointModelGroup(group_name)->canSetStateFromIK(link_name)) {
+    RCLCPP_ERROR(
+      LOGGER, "No valid IK solver exists for %s in planning group %s", link_name, group_name);
+    return false;
+  }
+
+  if (frame_id != robot_model->getModelFrame()) {
+    RCLCPP_ERROR(
+      LOGGER, "Given frame (%s) is unequal to model frame(%s)", frame_id,
+      robot_model->getModelFrame());
+    return false;
+  }
+
+  moveit::core::RobotState rstate(robot_model);
+  // By setting the robot state to default values, we basically allow
+  // the user of this function to supply an incomplete or even empty seed.
+  rstate.setToDefaultValues();
+  rstate.setVariablePositions(seed);
+
+  moveit::core::GroupStateValidityCallbackFn ik_constraint_function;
+
+  ik_constraint_function = std::bind(
+    &ChompPlanner::isStateColliding, this, check_self_collision, robot_model, std::placeholders::_1,
+    std::placeholders::_2, std::placeholders::_3);
+
+  // Call Inverse Kinematics solver.
+  if (rstate.setFromIK(
+        robot_model->getJointModelGroup(group_name), pose, link_name, timeout,
+        ik_constraint_function)) {
+    // copy the solution
+    for (const std::string & joint_name :
+         robot_model->getJointModelGroup(group_name)->getActiveJointModelNames()) {
+      solution[joint_name] = rstate.getVariablePosition(joint_name);
+      RCLCPP_ERROR(LOGGER, "%s: %.4f", joint_name.c_str(), solution[joint_name]);
+    }
+    return true;
+  } else {
+    RCLCPP_ERROR(LOGGER, "Inverse kinematics found no solution.");
+    return false;
+  }
+}
+
+bool ChompPlanner::isStateColliding(
+  const bool test_for_self_collision, const moveit::core::RobotModelConstPtr & robot_model,
+  moveit::core::RobotState * rstate, const moveit::core::JointModelGroup * const group,
+  const double * const ik_solution) const
+{
+  if (!test_for_self_collision) {
+    return true;
+  }
+
+  rstate->setJointGroupPositions(group, ik_solution);
+  rstate->update();
+  collision_detection::CollisionRequest collision_req;
+  collision_req.group_name = group->getName();
+  collision_detection::CollisionResult collision_res;
+  planning_scene::PlanningScene(robot_model)
+    .checkSelfCollision(collision_req, collision_res, *rstate);
+
+  return !collision_res.collision;
+}
+
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -34,33 +34,39 @@
 
 /* Author: Mrinal Kalakrishnan */
 
-#include <ros/ros.h>
 #include <chomp_motion_planner/chomp_trajectory.h>
+
+#include "rclcpp/rclcpp.hpp"
 
 namespace chomp
 {
-ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, double duration,
-                                 double discretization, const std::string& group_name)
-  : ChompTrajectory(robot_model, static_cast<size_t>(duration / discretization) + 1, discretization, group_name)
+ChompTrajectory::ChompTrajectory(
+  const moveit::core::RobotModelConstPtr & robot_model, double duration, double discretization,
+  const std::string & group_name)
+: ChompTrajectory(
+    robot_model, static_cast<size_t>(duration / discretization) + 1, discretization, group_name)
 {
 }
 
-ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, size_t num_points,
-                                 double discretization, const std::string& group_name)
-  : planning_group_name_(group_name)
-  , num_points_(num_points)
-  , discretization_(discretization)
-  , duration_((num_points - 1) * discretization)
-  , start_index_(1)
-  , end_index_(num_points_ - 2)
+ChompTrajectory::ChompTrajectory(
+  const moveit::core::RobotModelConstPtr & robot_model, size_t num_points, double discretization,
+  const std::string & group_name)
+: planning_group_name_(group_name),
+  num_points_(num_points),
+  discretization_(discretization),
+  duration_((num_points - 1) * discretization),
+  start_index_(1),
+  end_index_(num_points_ - 2)
 {
-  const moveit::core::JointModelGroup* model_group = robot_model->getJointModelGroup(planning_group_name_);
+  const moveit::core::JointModelGroup * model_group =
+    robot_model->getJointModelGroup(planning_group_name_);
   num_joints_ = model_group->getActiveJointModels().size();
   init();
 }
 
-ChompTrajectory::ChompTrajectory(const ChompTrajectory& source_traj, const std::string& group_name, int diff_rule_length)
-  : planning_group_name_(group_name), discretization_(source_traj.discretization_)
+ChompTrajectory::ChompTrajectory(
+  const ChompTrajectory & source_traj, const std::string & group_name, int diff_rule_length)
+: planning_group_name_(group_name), discretization_(source_traj.discretization_)
 {
   num_joints_ = source_traj.getNumJoints();
 
@@ -80,39 +86,34 @@ ChompTrajectory::ChompTrajectory(const ChompTrajectory& source_traj, const std::
   full_trajectory_index_.resize(num_points_);
 
   // now copy the trajectories over:
-  for (size_t i = 0; i < num_points_; i++)
-  {
+  for (size_t i = 0; i < num_points_; i++) {
     int source_traj_point = i - start_extra;
-    if (source_traj_point < 0)
-      source_traj_point = 0;
+    if (source_traj_point < 0) source_traj_point = 0;
     if (static_cast<size_t>(source_traj_point) >= source_traj.num_points_)
       source_traj_point = source_traj.num_points_ - 1;
     full_trajectory_index_[i] = source_traj_point;
-    getTrajectoryPoint(i) = const_cast<ChompTrajectory&>(source_traj).getTrajectoryPoint(source_traj_point);
+    getTrajectoryPoint(i) =
+      const_cast<ChompTrajectory &>(source_traj).getTrajectoryPoint(source_traj_point);
   }
 }
 
-void ChompTrajectory::init()
-{
-  trajectory_.resize(num_points_, num_joints_);
-}
+void ChompTrajectory::init() { trajectory_.resize(num_points_, num_joints_); }
 
-void ChompTrajectory::updateFromGroupTrajectory(const ChompTrajectory& group_trajectory)
+void ChompTrajectory::updateFromGroupTrajectory(const ChompTrajectory & group_trajectory)
 {
   size_t num_vars_free = end_index_ - start_index_ + 1;
   trajectory_.block(start_index_, 0, num_vars_free, num_joints_) =
-      group_trajectory.trajectory_.block(group_trajectory.start_index_, 0, num_vars_free, num_joints_);
+    group_trajectory.trajectory_.block(
+      group_trajectory.start_index_, 0, num_vars_free, num_joints_);
 }
 
 void ChompTrajectory::fillInLinearInterpolation()
 {
   double start_index = start_index_ - 1;
   double end_index = end_index_ + 1;
-  for (size_t i = 0; i < num_joints_; i++)
-  {
+  for (size_t i = 0; i < num_joints_; i++) {
     double theta = ((*this)(end_index, i) - (*this)(start_index, i)) / (end_index - 1);
-    for (size_t j = start_index + 1; j < end_index; j++)
-    {
+    for (size_t j = start_index + 1; j < end_index; j++) {
       (*this)(j, i) = (*this)(start_index, i) + j * theta;
     }
   }
@@ -125,15 +126,13 @@ void ChompTrajectory::fillInCubicInterpolation()
   double dt = 0.001;
   std::vector<double> coeffs(4, 0);
   double total_time = (end_index - 1) * dt;
-  for (size_t i = 0; i < num_joints_; i++)
-  {
+  for (size_t i = 0; i < num_joints_; i++) {
     coeffs[0] = (*this)(start_index, i);
     coeffs[2] = (3 / (pow(total_time, 2))) * ((*this)(end_index, i) - (*this)(start_index, i));
     coeffs[3] = (-2 / (pow(total_time, 3))) * ((*this)(end_index, i) - (*this)(start_index, i));
 
     double t;
-    for (size_t j = start_index + 1; j < end_index; j++)
-    {
+    for (size_t j = start_index + 1; j < end_index; j++) {
       t = j * dt;
       (*this)(j, i) = coeffs[0] + coeffs[2] * pow(t, 2) + coeffs[3] * pow(t, 3);
     }
@@ -148,14 +147,12 @@ void ChompTrajectory::fillInMinJerk()
   td[0] = 1.0;
   td[1] = (end_index - start_index) * discretization_;
 
-  for (unsigned int i = 2; i <= 5; i++)
-    td[i] = td[i - 1] * td[1];
+  for (unsigned int i = 2; i <= 5; i++) td[i] = td[i - 1] * td[1];
 
   // calculate the spline coefficients for each joint:
   // (these are for the special case of zero start and end vel and acc)
   std::vector<double[6]> coeff(num_joints_);
-  for (size_t i = 0; i < num_joints_; i++)
-  {
+  for (size_t i = 0; i < num_joints_; i++) {
     double x0 = (*this)(start_index, i);
     double x1 = (*this)(end_index, i);
     coeff[i][0] = x0;
@@ -167,57 +164,51 @@ void ChompTrajectory::fillInMinJerk()
   }
 
   // now fill in the joint positions at each time step
-  for (size_t i = start_index + 1; i < end_index; i++)
-  {
+  for (size_t i = start_index + 1; i < end_index; i++) {
     double ti[6];  // powers of the time index point
     ti[0] = 1.0;
     ti[1] = (i - start_index) * discretization_;
-    for (unsigned int k = 2; k <= 5; k++)
-      ti[k] = ti[k - 1] * ti[1];
+    for (unsigned int k = 2; k <= 5; k++) ti[k] = ti[k - 1] * ti[1];
 
-    for (size_t j = 0; j < num_joints_; j++)
-    {
+    for (size_t j = 0; j < num_joints_; j++) {
       (*this)(i, j) = 0.0;
-      for (unsigned int k = 0; k <= 5; k++)
-      {
+      for (unsigned int k = 0; k <= 5; k++) {
         (*this)(i, j) += ti[k] * coeff[j][k];
       }
     }
   }
 }
 
-bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajectory& trajectory)
+bool ChompTrajectory::fillInFromTrajectory(const robot_trajectory::RobotTrajectory & trajectory)
 {
   // check if input trajectory has less than two states (start and goal), function returns false if condition is true
-  if (trajectory.getWayPointCount() < 2)
-    return false;
+  if (trajectory.getWayPointCount() < 2) return false;
 
   const size_t max_output_index = getNumPoints() - 1;
   const size_t max_input_index = trajectory.getWayPointCount() - 1;
 
-  const moveit::core::JointModelGroup* group = trajectory.getGroup();
+  const moveit::core::JointModelGroup * group = trajectory.getGroup();
   moveit::core::RobotState interpolated(trajectory.getRobotModel());
-  for (size_t i = 0; i <= max_output_index; i++)
-  {
+  for (size_t i = 0; i <= max_output_index; i++) {
     double fraction = static_cast<double>(i * max_input_index) / max_output_index;
     const size_t prev_idx = std::trunc(fraction);  // integer part
     fraction = fraction - prev_idx;                // fractional part
     const size_t next_idx = prev_idx == max_input_index ? prev_idx : prev_idx + 1;
-    trajectory.getWayPoint(prev_idx).interpolate(trajectory.getWayPoint(next_idx), fraction, interpolated, group);
+    trajectory.getWayPoint(prev_idx).interpolate(
+      trajectory.getWayPoint(next_idx), fraction, interpolated, group);
     assignCHOMPTrajectoryPointFromRobotState(interpolated, i, group);
   }
   return true;
 }
 
-void ChompTrajectory::assignCHOMPTrajectoryPointFromRobotState(const moveit::core::RobotState& source,
-                                                               size_t chomp_trajectory_point_index,
-                                                               const moveit::core::JointModelGroup* group)
+void ChompTrajectory::assignCHOMPTrajectoryPointFromRobotState(
+  const moveit::core::RobotState & source, size_t chomp_trajectory_point_index,
+  const moveit::core::JointModelGroup * group)
 {
   Eigen::MatrixXd::RowXpr target = getTrajectoryPoint(chomp_trajectory_point_index);
   assert(group->getActiveJointModels().size() == static_cast<size_t>(target.cols()));
   size_t joint_index = 0;
-  for (const moveit::core::JointModel* jm : group->getActiveJointModels())
-  {
+  for (const moveit::core::JointModel * jm : group->getActiveJointModels()) {
     assert(jm->getVariableCount() == 1);
     target[joint_index++] = source.getVariablePosition(jm->getFirstVariableIndex());
   }

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -36,8 +36,6 @@
 
 #include <chomp_motion_planner/chomp_trajectory.h>
 
-#include "rclcpp/rclcpp.hpp"
-
 namespace chomp
 {
 ChompTrajectory::ChompTrajectory(const moveit::core::RobotModelConstPtr& robot_model, double duration,

--- a/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(chomp_motion_planner REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS 
+set(THIS_PACKAGE_INCLUDE_DEPENDS
   chomp_motion_planner
   moveit_core
   pluginlib

--- a/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
@@ -1,31 +1,56 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_chomp_optimizer_adapter)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(catkin REQUIRED COMPONENTS
-  moveit_core
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(chomp_motion_planner REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(pluginlib REQUIRED)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS 
   chomp_motion_planner
+  moveit_core
   pluginlib
+  rclcpp
 )
 
-catkin_package()
-
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME} src/chomp_optimizer_adapter.cpp)
+add_library(${PROJECT_NAME} SHARED src/chomp_optimizer_adapter.cpp)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-install(FILES chomp_optimizer_adapter_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+pluginlib_export_plugin_description_file(moveit_core chomp_optimizer_adapter_plugin_description.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
@@ -1,20 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(moveit_chomp_optimizer_adapter)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # Common cmake code applied to all moveit packages
 find_package(moveit_common REQUIRED)
 moveit_package()

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -11,12 +11,17 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>
   <depend>chomp_motion_planner</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
+    <build_type>ament_cmake</build_type>
     <moveit_core plugin="${prefix}/chomp_optimizer_adapter_plugin_description.xml"/>
   </export>
 </package>

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -7,7 +7,6 @@
   <author email="raghavendersahdev@gmail.com">Raghavender Sahdev</author>
   <maintainer email="raghavendersahdev@gmail.com">Raghavender Sahdev</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
-  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
 

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -7,10 +7,11 @@
   <author email="raghavendersahdev@gmail.com">Raghavender Sahdev</author>
   <maintainer email="raghavendersahdev@gmail.com">Raghavender Sahdev</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
+  <maintainer email="andreas@botbuilt.com">atenpas</maintainer>
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>
 
   <depend>moveit_core</depend>

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -43,9 +43,9 @@
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 
-#include <class_loader/class_loader.hpp>
 #include <eigen3/Eigen/Core>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
+#include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <vector>
 
@@ -73,7 +73,7 @@ public:
       params_.max_iterations_ = 200;
       RCLCPP_DEBUG(LOGGER, "Param max_iterations was not set. Using default value: %s", params_.max_iterations_);
     }
-    if (!node->get_parameter("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
+    if (!node->get_parameter("chomp.max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
     {
       params_.max_iterations_after_collision_free_ = 5;
       RCLCPP_DEBUG(LOGGER, "Param max_iterations_after_collision_free was not set. Using default value: %s",
@@ -102,7 +102,7 @@ public:
       RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_velocity was not set. Using default value: %s",
                    params_.smoothness_cost_velocity_);
     }
-    if (!node->get_parameter("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
+    if (!node->get_parameter("chomp.smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
     {
       params_.smoothness_cost_acceleration_ = 1.0;
       RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_acceleration was not set. Using default value: %s",
@@ -137,7 +137,7 @@ public:
       RCLCPP_DEBUG(LOGGER, "Param joint_update_limit was not set. Using default value: %s", params_.joint_update_limit_);
     }
     // TODO: remove this warning after 06/2022
-    if (!node->has_parameter("min_clearance") && node->has_parameter("min_clearence"))
+    if (!node->has_parameter("chomp.min_clearance") && node->has_parameter("chomp.min_clearence"))
       RCLCPP_WARN(LOGGER, "The param 'min_clearence' has been renamed to 'min_clearance', please update your "
                           "config!");
     if (!node->get_parameter("chomp.min_clearance", params_.min_clearance_))

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -56,142 +56,138 @@ rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_planner");
 class OptimizerAdapter : public planning_request_adapter::PlanningRequestAdapter
 {
 public:
-  OptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter() {}
-
-  void initialize(
-    const rclcpp::Node::SharedPtr & node, const std::string & parameter_namespace) override
+  OptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter()
   {
-    if (!node->get_parameter("chomp.planning_time_limit", params_.planning_time_limit_)) {
+  }
+
+  void initialize(const rclcpp::Node::SharedPtr& node, const std::string& parameter_namespace) override
+  {
+    if (!node->get_parameter("chomp.planning_time_limit", params_.planning_time_limit_))
+    {
       params_.planning_time_limit_ = 10.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param planning_time_limit was not set. Using default value: %s",
-        params_.planning_time_limit_);
+      RCLCPP_DEBUG(LOGGER, "Param planning_time_limit was not set. Using default value: %s",
+                   params_.planning_time_limit_);
     }
-    if (!node->get_parameter("chomp.max_iterations", params_.max_iterations_)) {
+    if (!node->get_parameter("chomp.max_iterations", params_.max_iterations_))
+    {
       params_.max_iterations_ = 200;
-      RCLCPP_DEBUG(
-        LOGGER, "Param max_iterations was not set. Using default value: %s",
-        params_.max_iterations_);
+      RCLCPP_DEBUG(LOGGER, "Param max_iterations was not set. Using default value: %s", params_.max_iterations_);
     }
-    if (!node->get_parameter(
-          "max_iterations_after_collision_free", params_.max_iterations_after_collision_free_)) {
+    if (!node->get_parameter("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
+    {
       params_.max_iterations_after_collision_free_ = 5;
-      RCLCPP_DEBUG(
-        LOGGER, "Param max_iterations_after_collision_free was not set. Using default value: %s",
-        params_.max_iterations_after_collision_free_);
+      RCLCPP_DEBUG(LOGGER, "Param max_iterations_after_collision_free was not set. Using default value: %s",
+                   params_.max_iterations_after_collision_free_);
     }
-    if (!node->get_parameter("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_)) {
+    if (!node->get_parameter("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_))
+    {
       params_.smoothness_cost_weight_ = 0.1;
-      RCLCPP_DEBUG(
-        LOGGER, "Param smoothness_cost_weight was not set. Using default value: %s",
-        params_.smoothness_cost_weight_);
+      RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_weight was not set. Using default value: %s",
+                   params_.smoothness_cost_weight_);
     }
-    if (!node->get_parameter("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_)) {
+    if (!node->get_parameter("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_))
+    {
       params_.obstacle_cost_weight_ = 1.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param obstacle_cost_weight was not set. Using default value: %s",
-        params_.obstacle_cost_weight_);
+      RCLCPP_DEBUG(LOGGER, "Param obstacle_cost_weight was not set. Using default value: %s",
+                   params_.obstacle_cost_weight_);
     }
-    if (!node->get_parameter("chomp.learning_rate", params_.learning_rate_)) {
+    if (!node->get_parameter("chomp.learning_rate", params_.learning_rate_))
+    {
       params_.learning_rate_ = 0.01;
-      RCLCPP_DEBUG(
-        LOGGER, "Param learning_rate was not set. Using default value: %s", params_.learning_rate_);
+      RCLCPP_DEBUG(LOGGER, "Param learning_rate was not set. Using default value: %s", params_.learning_rate_);
     }
-    if (!node->get_parameter("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_)) {
+    if (!node->get_parameter("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_))
+    {
       params_.smoothness_cost_velocity_ = 0.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param smoothness_cost_velocity was not set. Using default value: %s",
-        params_.smoothness_cost_velocity_);
+      RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_velocity was not set. Using default value: %s",
+                   params_.smoothness_cost_velocity_);
     }
-    if (!node->get_parameter(
-          "smoothness_cost_acceleration", params_.smoothness_cost_acceleration_)) {
+    if (!node->get_parameter("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
+    {
       params_.smoothness_cost_acceleration_ = 1.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param smoothness_cost_acceleration was not set. Using default value: %s",
-        params_.smoothness_cost_acceleration_);
+      RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_acceleration was not set. Using default value: %s",
+                   params_.smoothness_cost_acceleration_);
     }
-    if (!node->get_parameter("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_)) {
+    if (!node->get_parameter("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_))
+    {
       params_.smoothness_cost_jerk_ = 0.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param smoothness_cost_jerk_ was not set. Using default value: %s",
-        params_.smoothness_cost_jerk_);
+      RCLCPP_DEBUG(LOGGER, "Param smoothness_cost_jerk_ was not set. Using default value: %s",
+                   params_.smoothness_cost_jerk_);
     }
-    if (!node->get_parameter("chomp.ridge_factor", params_.ridge_factor_)) {
+    if (!node->get_parameter("chomp.ridge_factor", params_.ridge_factor_))
+    {
       params_.ridge_factor_ = 0.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param ridge_factor_ was not set. Using default value: %s", params_.ridge_factor_);
+      RCLCPP_DEBUG(LOGGER, "Param ridge_factor_ was not set. Using default value: %s", params_.ridge_factor_);
     }
-    if (!node->get_parameter("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_)) {
+    if (!node->get_parameter("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_))
+    {
       params_.use_pseudo_inverse_ = 0.0;
-      RCLCPP_DEBUG(
-        LOGGER, "Param use_pseudo_inverse_ was not set. Using default value: %s",
-        params_.use_pseudo_inverse_);
+      RCLCPP_DEBUG(LOGGER, "Param use_pseudo_inverse_ was not set. Using default value: %s",
+                   params_.use_pseudo_inverse_);
     }
-    if (!node->get_parameter(
-          "chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_)) {
+    if (!node->get_parameter("chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_))
+    {
       params_.pseudo_inverse_ridge_factor_ = 1e-4;
-      RCLCPP_DEBUG(
-        LOGGER, "Param pseudo_inverse_ridge_factor was not set. Using default value: %s",
-        params_.pseudo_inverse_ridge_factor_);
+      RCLCPP_DEBUG(LOGGER, "Param pseudo_inverse_ridge_factor was not set. Using default value: %s",
+                   params_.pseudo_inverse_ridge_factor_);
     }
-    if (!node->get_parameter("chomp.joint_update_limit", params_.joint_update_limit_)) {
+    if (!node->get_parameter("chomp.joint_update_limit", params_.joint_update_limit_))
+    {
       params_.joint_update_limit_ = 0.1;
-      RCLCPP_DEBUG(
-        LOGGER, "Param joint_update_limit was not set. Using default value: %s",
-        params_.joint_update_limit_);
+      RCLCPP_DEBUG(LOGGER, "Param joint_update_limit was not set. Using default value: %s", params_.joint_update_limit_);
     }
     // TODO: remove this warning after 06/2022
     if (!node->has_parameter("min_clearance") && node->has_parameter("min_clearence"))
-      RCLCPP_WARN(
-        LOGGER,
-        "The param 'min_clearence' has been renamed to 'min_clearance', please update your "
-        "config!");
-    if (!node->get_parameter("chomp.min_clearance", params_.min_clearance_)) {
+      RCLCPP_WARN(LOGGER, "The param 'min_clearence' has been renamed to 'min_clearance', please update your "
+                          "config!");
+    if (!node->get_parameter("chomp.min_clearance", params_.min_clearance_))
+    {
       params_.min_clearance_ = 0.2;
-      RCLCPP_DEBUG(
-        LOGGER, "Param min_clearance was not set. Using default value: %s", params_.min_clearance_);
+      RCLCPP_DEBUG(LOGGER, "Param min_clearance was not set. Using default value: %s", params_.min_clearance_);
     }
-    if (!node->get_parameter("chomp.collision_threshold", params_.collision_threshold_)) {
+    if (!node->get_parameter("chomp.collision_threshold", params_.collision_threshold_))
+    {
       params_.collision_threshold_ = 0.07;
-      RCLCPP_DEBUG(
-        LOGGER, "Param collision_threshold_ was not set. Using default value: %s",
-        params_.collision_threshold_);
+      RCLCPP_DEBUG(LOGGER, "Param collision_threshold_ was not set. Using default value: %s",
+                   params_.collision_threshold_);
     }
-    if (!node->get_parameter("chomp.use_stochastic_descent", params_.use_stochastic_descent_)) {
+    if (!node->get_parameter("chomp.use_stochastic_descent", params_.use_stochastic_descent_))
+    {
       params_.use_stochastic_descent_ = true;
-      RCLCPP_DEBUG(
-        LOGGER, "Param use_stochastic_descent was not set. Using default value: %s",
-        params_.use_stochastic_descent_);
+      RCLCPP_DEBUG(LOGGER, "Param use_stochastic_descent was not set. Using default value: %s",
+                   params_.use_stochastic_descent_);
     }
     params_.trajectory_initialization_method_ = "quintic-spline";
     std::string method;
-    if (
-      node->get_parameter("chomp.trajectory_initialization_method", method) &&
-      !params_.setTrajectoryInitializationMethod(method)) {
-      RCLCPP_ERROR(
-        LOGGER,
-        "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default "
-        "'%s' instead.",
-        method, params_.trajectory_initialization_method_);
+    if (node->get_parameter("chomp.trajectory_initialization_method", method) &&
+        !params_.setTrajectoryInitializationMethod(method))
+    {
+      RCLCPP_ERROR(LOGGER,
+                   "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default "
+                   "'%s' instead.",
+                   method, params_.trajectory_initialization_method_);
     }
   }
 
-  std::string getDescription() const override { return "CHOMP Optimizer"; }
+  std::string getDescription() const override
+  {
+    return "CHOMP Optimizer";
+  }
 
-  bool adaptAndPlan(
-    const PlannerFn & planner, const planning_scene::PlanningSceneConstPtr & ps,
-    const planning_interface::MotionPlanRequest & req, planning_interface::MotionPlanResponse & res,
-    std::vector<std::size_t> & /*added_path_index*/) const override
+  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
+                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
+                    std::vector<std::size_t>& /*added_path_index*/) const override
   {
     RCLCPP_DEBUG(LOGGER, "CHOMP: adaptAndPlan ...");
 
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    if (!planner(ps, req, res)) return false;
+    if (!planner(ps, req, res))
+      return false;
 
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
-      collision_detection::CollisionDetectorAllocatorHybrid::create());
+        collision_detection::CollisionDetectorAllocatorHybrid::create());
 
     // create a writable planning scene
     planning_scene::PlanningScenePtr planning_scene = ps->diff();
@@ -204,7 +200,8 @@ public:
 
     bool planning_success = chomp_planner.solve(planning_scene, req, params_, res_detailed);
 
-    if (planning_success) {
+    if (planning_success)
+    {
       res.trajectory_ = res_detailed.trajectory_[0];
       res.planning_time_ += res_detailed.processing_time_[0];
     }
@@ -218,5 +215,4 @@ private:
 };
 }  // namespace chomp
 
-CLASS_LOADER_REGISTER_CLASS(
-  chomp::OptimizerAdapter, planning_request_adapter::PlanningRequestAdapter)
+CLASS_LOADER_REGISTER_CLASS(chomp::OptimizerAdapter, planning_request_adapter::PlanningRequestAdapter)

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -34,162 +34,168 @@
 
 /* Author: Raghavender Sahdev */
 
+#include <chomp_motion_planner/chomp_parameters.h>
+#include <chomp_motion_planner/chomp_planner.h>
+#include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
+#include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
 #include <moveit/robot_state/conversions.h>
-#include <moveit/trajectory_processing/trajectory_tools.h>
-#include <moveit_msgs/msg/robot_trajectory.hpp>
-#include <class_loader/class_loader.hpp>
-#include <ros/ros.h>
-
-#include <chomp_motion_planner/chomp_planner.h>
-#include <chomp_motion_planner/chomp_parameters.h>
-#include <moveit/planning_interface/planning_interface.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/trajectory_tools.h>
 
-#include <moveit/collision_distance_field/collision_detector_allocator_hybrid.h>
-
-#include <moveit/robot_state/conversions.h>
-
-#include <vector>
+#include <class_loader/class_loader.hpp>
 #include <eigen3/Eigen/Core>
+#include <moveit_msgs/msg/robot_trajectory.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <vector>
 
 namespace chomp
 {
+rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_planner");
+
 class OptimizerAdapter : public planning_request_adapter::PlanningRequestAdapter
 {
 public:
-  OptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter()
-  {
-  }
+  OptimizerAdapter() : planning_request_adapter::PlanningRequestAdapter() {}
 
-  void initialize(const ros::NodeHandle& nh) override
+  void initialize(
+    const rclcpp::Node::SharedPtr & node, const std::string & parameter_namespace) override
   {
-    if (!nh.getParam("planning_time_limit", params_.planning_time_limit_))
-    {
+    if (!node->get_parameter("chomp.planning_time_limit", params_.planning_time_limit_)) {
       params_.planning_time_limit_ = 10.0;
-      ROS_INFO_STREAM("Param planning_time_limit was not set. Using default value: " << params_.planning_time_limit_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param planning_time_limit was not set. Using default value: %s",
+        params_.planning_time_limit_);
     }
-    if (!nh.getParam("max_iterations", params_.max_iterations_))
-    {
+    if (!node->get_parameter("chomp.max_iterations", params_.max_iterations_)) {
       params_.max_iterations_ = 200;
-      ROS_INFO_STREAM("Param max_iterations was not set. Using default value: " << params_.max_iterations_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param max_iterations was not set. Using default value: %s",
+        params_.max_iterations_);
     }
-    if (!nh.getParam("max_iterations_after_collision_free", params_.max_iterations_after_collision_free_))
-    {
+    if (!node->get_parameter(
+          "max_iterations_after_collision_free", params_.max_iterations_after_collision_free_)) {
       params_.max_iterations_after_collision_free_ = 5;
-      ROS_INFO_STREAM("Param max_iterations_after_collision_free was not set. Using default value: "
-                      << params_.max_iterations_after_collision_free_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param max_iterations_after_collision_free was not set. Using default value: %s",
+        params_.max_iterations_after_collision_free_);
     }
-    if (!nh.getParam("smoothness_cost_weight", params_.smoothness_cost_weight_))
-    {
+    if (!node->get_parameter("chomp.smoothness_cost_weight", params_.smoothness_cost_weight_)) {
       params_.smoothness_cost_weight_ = 0.1;
-      ROS_INFO_STREAM(
-          "Param smoothness_cost_weight was not set. Using default value: " << params_.smoothness_cost_weight_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param smoothness_cost_weight was not set. Using default value: %s",
+        params_.smoothness_cost_weight_);
     }
-    if (!nh.getParam("obstacle_cost_weight", params_.obstacle_cost_weight_))
-    {
+    if (!node->get_parameter("chomp.obstacle_cost_weight", params_.obstacle_cost_weight_)) {
       params_.obstacle_cost_weight_ = 1.0;
-      ROS_INFO_STREAM("Param obstacle_cost_weight was not set. Using default value: " << params_.obstacle_cost_weight_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param obstacle_cost_weight was not set. Using default value: %s",
+        params_.obstacle_cost_weight_);
     }
-    if (!nh.getParam("learning_rate", params_.learning_rate_))
-    {
+    if (!node->get_parameter("chomp.learning_rate", params_.learning_rate_)) {
       params_.learning_rate_ = 0.01;
-      ROS_INFO_STREAM("Param learning_rate was not set. Using default value: " << params_.learning_rate_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param learning_rate was not set. Using default value: %s", params_.learning_rate_);
     }
-    if (!nh.getParam("smoothness_cost_velocity", params_.smoothness_cost_velocity_))
-    {
+    if (!node->get_parameter("chomp.smoothness_cost_velocity", params_.smoothness_cost_velocity_)) {
       params_.smoothness_cost_velocity_ = 0.0;
-      ROS_INFO_STREAM(
-          "Param smoothness_cost_velocity was not set. Using default value: " << params_.smoothness_cost_velocity_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param smoothness_cost_velocity was not set. Using default value: %s",
+        params_.smoothness_cost_velocity_);
     }
-    if (!nh.getParam("smoothness_cost_acceleration", params_.smoothness_cost_acceleration_))
-    {
+    if (!node->get_parameter(
+          "smoothness_cost_acceleration", params_.smoothness_cost_acceleration_)) {
       params_.smoothness_cost_acceleration_ = 1.0;
-      ROS_INFO_STREAM("Param smoothness_cost_acceleration was not set. Using default value: "
-                      << params_.smoothness_cost_acceleration_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param smoothness_cost_acceleration was not set. Using default value: %s",
+        params_.smoothness_cost_acceleration_);
     }
-    if (!nh.getParam("smoothness_cost_jerk", params_.smoothness_cost_jerk_))
-    {
+    if (!node->get_parameter("chomp.smoothness_cost_jerk", params_.smoothness_cost_jerk_)) {
       params_.smoothness_cost_jerk_ = 0.0;
-      ROS_INFO_STREAM("Param smoothness_cost_jerk_ was not set. Using default value: " << params_.smoothness_cost_jerk_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param smoothness_cost_jerk_ was not set. Using default value: %s",
+        params_.smoothness_cost_jerk_);
     }
-    if (!nh.getParam("ridge_factor", params_.ridge_factor_))
-    {
+    if (!node->get_parameter("chomp.ridge_factor", params_.ridge_factor_)) {
       params_.ridge_factor_ = 0.0;
-      ROS_INFO_STREAM("Param ridge_factor_ was not set. Using default value: " << params_.ridge_factor_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param ridge_factor_ was not set. Using default value: %s", params_.ridge_factor_);
     }
-    if (!nh.getParam("use_pseudo_inverse", params_.use_pseudo_inverse_))
-    {
+    if (!node->get_parameter("chomp.use_pseudo_inverse", params_.use_pseudo_inverse_)) {
       params_.use_pseudo_inverse_ = 0.0;
-      ROS_INFO_STREAM("Param use_pseudo_inverse_ was not set. Using default value: " << params_.use_pseudo_inverse_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param use_pseudo_inverse_ was not set. Using default value: %s",
+        params_.use_pseudo_inverse_);
     }
-    if (!nh.getParam("pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_))
-    {
+    if (!node->get_parameter(
+          "chomp.pseudo_inverse_ridge_factor", params_.pseudo_inverse_ridge_factor_)) {
       params_.pseudo_inverse_ridge_factor_ = 1e-4;
-      ROS_INFO_STREAM("Param pseudo_inverse_ridge_factor was not set. Using default value: "
-                      << params_.pseudo_inverse_ridge_factor_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param pseudo_inverse_ridge_factor was not set. Using default value: %s",
+        params_.pseudo_inverse_ridge_factor_);
     }
-    if (!nh.getParam("joint_update_limit", params_.joint_update_limit_))
-    {
+    if (!node->get_parameter("chomp.joint_update_limit", params_.joint_update_limit_)) {
       params_.joint_update_limit_ = 0.1;
-      ROS_INFO_STREAM("Param joint_update_limit was not set. Using default value: " << params_.joint_update_limit_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param joint_update_limit was not set. Using default value: %s",
+        params_.joint_update_limit_);
     }
     // TODO: remove this warning after 06/2022
-    if (!nh.hasParam("min_clearance") && nh.hasParam("min_clearence"))
-      ROS_WARN("The param 'min_clearence' has been renamed to 'min_clearance', please update your config!");
-    if (!nh.getParam("min_clearance", params_.min_clearance_))
-    {
+    if (!node->has_parameter("min_clearance") && node->has_parameter("min_clearence"))
+      RCLCPP_WARN(
+        LOGGER,
+        "The param 'min_clearence' has been renamed to 'min_clearance', please update your "
+        "config!");
+    if (!node->get_parameter("chomp.min_clearance", params_.min_clearance_)) {
       params_.min_clearance_ = 0.2;
-      ROS_INFO_STREAM("Param min_clearance was not set. Using default value: " << params_.min_clearance_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param min_clearance was not set. Using default value: %s", params_.min_clearance_);
     }
-    if (!nh.getParam("collision_threshold", params_.collision_threshold_))
-    {
+    if (!node->get_parameter("chomp.collision_threshold", params_.collision_threshold_)) {
       params_.collision_threshold_ = 0.07;
-      ROS_INFO_STREAM("Param collision_threshold_ was not set. Using default value: " << params_.collision_threshold_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param collision_threshold_ was not set. Using default value: %s",
+        params_.collision_threshold_);
     }
-    if (!nh.getParam("use_stochastic_descent", params_.use_stochastic_descent_))
-    {
+    if (!node->get_parameter("chomp.use_stochastic_descent", params_.use_stochastic_descent_)) {
       params_.use_stochastic_descent_ = true;
-      ROS_INFO_STREAM(
-          "Param use_stochastic_descent was not set. Using default value: " << params_.use_stochastic_descent_);
+      RCLCPP_DEBUG(
+        LOGGER, "Param use_stochastic_descent was not set. Using default value: %s",
+        params_.use_stochastic_descent_);
     }
-    // default
-    params_.trajectory_initialization_method_ = std::string("fillTrajectory");
-    std::string trajectory_initialization_method;
-    if (!nh.getParam("trajectory_initialization_method", trajectory_initialization_method))
-    {
-      ROS_INFO_STREAM("Param trajectory_initialization_method was not set. Using value: "
-                      << params_.trajectory_initialization_method_);
-    }
-    else if (!params_.setTrajectoryInitializationMethod(trajectory_initialization_method))
-    {
-      ROS_ERROR_STREAM("Param trajectory_initialization_method set to invalid value '"
-                       << trajectory_initialization_method << "'. Using '" << params_.trajectory_initialization_method_
-                       << "' instead.");
+    params_.trajectory_initialization_method_ = "quintic-spline";
+    std::string method;
+    if (
+      node->get_parameter("chomp.trajectory_initialization_method", method) &&
+      !params_.setTrajectoryInitializationMethod(method)) {
+      RCLCPP_ERROR(
+        LOGGER,
+        "Attempted to set trajectory_initialization_method to invalid value '%s'. Using default "
+        "'%s' instead.",
+        method, params_.trajectory_initialization_method_);
     }
   }
 
-  std::string getDescription() const override
-  {
-    return "CHOMP Optimizer";
-  }
+  std::string getDescription() const override { return "CHOMP Optimizer"; }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  bool adaptAndPlan(
+    const PlannerFn & planner, const planning_scene::PlanningSceneConstPtr & ps,
+    const planning_interface::MotionPlanRequest & req, planning_interface::MotionPlanResponse & res,
+    std::vector<std::size_t> & /*added_path_index*/) const override
   {
+    RCLCPP_DEBUG(LOGGER, "CHOMP: adaptAndPlan ...");
+
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    if (!planner(ps, req, res))
-      return false;
+    if (!planner(ps, req, res)) return false;
 
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(
-        collision_detection::CollisionDetectorAllocatorHybrid::create());
+      collision_detection::CollisionDetectorAllocatorHybrid::create());
 
     // create a writable planning scene
     planning_scene::PlanningScenePtr planning_scene = ps->diff();
-    ROS_DEBUG_STREAM("Configuring Planning Scene for CHOMP ...");
+    RCLCPP_DEBUG(LOGGER, "Configuring Planning Scene for CHOMP ...");
     planning_scene->allocateCollisionDetector(hybrid_cd);
 
     chomp::ChompPlanner chomp_planner;
@@ -198,8 +204,7 @@ public:
 
     bool planning_success = chomp_planner.solve(planning_scene, req, params_, res_detailed);
 
-    if (planning_success)
-    {
+    if (planning_success) {
       res.trajectory_ = res_detailed.trajectory_[0];
       res.planning_time_ += res_detailed.processing_time_[0];
     }
@@ -213,4 +218,5 @@ private:
 };
 }  // namespace chomp
 
-CLASS_LOADER_REGISTER_CLASS(chomp::OptimizerAdapter, planning_request_adapter::PlanningRequestAdapter);
+CLASS_LOADER_REGISTER_CLASS(
+  chomp::OptimizerAdapter, planning_request_adapter::PlanningRequestAdapter)


### PR DESCRIPTION
### Description

This PR makes [CHOMP](http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html) available in MoveIt2. CHOMP can be used as a stand-alone motion planner plugin (instead of OMPL) or as a post-processor for OMPL (where the seed trajectory for CHOMP is the output of OMPL).

<img src="https://user-images.githubusercontent.com/94128674/141846461-85d962b6-8fd6-4a42-a0a7-e4f7cb183b39.gif" width="500" title="rviz chomp demo" />

### Changes
- CHOMP parameters are loaded from the namespace "chomp"
- Pose goals are converted to joint space goals (instead of being rejected)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
