### PR TITLE
Sync with MoveIt

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,13 +4,13 @@ API changes in MoveIt releases
 
 ## ROS Rolling
 - ServoServer was renamed to ServoNode
-
-## ROS Noetic
 - `CollisionObject` messages are now defined with a `Pose`, and shapes and subframes are defined relative to the object's pose. This makes it easier to place objects with subframes and multiple shapes in the scene. This causes several changes:
     - `getFrameTransform()` now returns this pose instead of the first shape's pose.
     - The Rviz plugin's manipulation tab now uses the object's pose instead of the shape pose to evaluate if object's are in the region of interest.
     - Planning scene geometry text files (`.scene`) have changed format. Add a line `0 0 0 0 0 0 1` under each line with an asterisk to upgrade old files if required.
 - Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
+
+## ROS Noetic
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.
 - Planned trajectories are *slow* by default.
   The default values of the `velocity_scaling_factor` and `acceleration_scaling_factor` can now be customized and default to 0.1 instead of 1.0.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,11 @@ API changes in MoveIt releases
 - ServoServer was renamed to ServoNode
 
 ## ROS Noetic
+- `CollisionObject` messages are now defined with a `Pose`, and shapes and subframes are defined relative to the object's pose. This makes it easier to place objects with subframes and multiple shapes in the scene. This causes several changes:
+    - `getFrameTransform()` now returns this pose instead of the first shape's pose.
+    - The Rviz plugin's manipulation tab now uses the object's pose instead of the shape pose to evaluate if object's are in the region of interest.
+    - Planning scene geometry text files (`.scene`) have changed format. Add a line `0 0 0 0 0 0 1` under each line with an asterisk to upgrade old files if required.
+- Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.
 - Planned trajectories are *slow* by default.
   The default values of the `velocity_scaling_factor` and `acceleration_scaling_factor` can now be customized and default to 0.1 instead of 1.0.

--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
@@ -311,7 +311,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
   shapes.push_back(shapes::ShapeConstPtr(shape));
   poses.push_back(Eigen::Isometry3d::Identity());
   std::vector<std::string> touch_links;
-  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("box", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
 
   res = collision_detection::CollisionResult();
   this->cenv_->checkSelfCollision(req, res, robot_state, *this->acm_);
@@ -323,7 +323,7 @@ TYPED_TEST_P(CollisionDetectorTest, AttachedBodyTester)
   touch_links.push_back("r_gripper_palm_link");
   touch_links.push_back("r_gripper_motor_accelerometer_link");
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
-  robot_state.attachBody("box", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("box", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
   robot_state.update();
 
   res = collision_detection::CollisionResult();
@@ -374,7 +374,7 @@ TYPED_TEST_P(CollisionDetectorTest, DiffSceneTester)
   poses.push_back(Eigen::Isometry3d::Identity());
 
   std::vector<std::string> touch_links;
-  robot_state.attachBody("kinect", shapes, poses, touch_links, "r_gripper_palm_link");
+  robot_state.attachBody("kinect", poses[0], shapes, poses, touch_links, "r_gripper_palm_link");
 
   before = std::chrono::system_clock::now();
   new_cenv->checkSelfCollision(req, res, robot_state);
@@ -435,13 +435,16 @@ TYPED_TEST_P(CollisionDetectorTest, ConvertObjectToAttached)
   robot_state2.update();
 
   std::vector<std::string> touch_links;
-  robot_state1.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  Eigen::Isometry3d identity_transform{ Eigen::Isometry3d::Identity() };
+  robot_state1.attachBody("kinect", identity_transform, object->shapes_, object->shape_poses_, touch_links,
+                          "r_gripper_palm_link");
 
   EigenSTL::vector_Isometry3d other_poses;
   other_poses.push_back(pos2);
 
   // This creates a new set of constant properties for the attached body, which happens to be the same as the one above;
-  robot_state2.attachBody("kinect", object->shapes_, object->shape_poses_, touch_links, "r_gripper_palm_link");
+  robot_state2.attachBody("kinect", identity_transform, object->shapes_, object->shape_poses_, touch_links,
+                          "r_gripper_palm_link");
 
   // going to take a while, but that's fine
   res = collision_detection::CollisionResult();

--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -77,7 +77,7 @@ public:
   /** \brief A representation of an object */
   struct Object
   {
-    Object(const std::string& id) : id_(id)
+    Object(const std::string& object_id) : id_(object_id)
     {
     }
 
@@ -86,29 +86,34 @@ public:
     /** \brief The id for this object */
     std::string id_;
 
+    /** \brief The object's pose. All shapes and subframes are defined relative to this frame.
+     *  This frame is returned when getTransform() is called with the object's name. */
+    Eigen::Isometry3d pose_;
+
     /** \brief All the shapes making up this object.
      *
-     * The pose of each Shape is stored in the corresponding element of the shape_poses_ array.
-     *
-     * @note Although the code generally supports having multiple
-     * shapes per object, there are many cases where it is better to
-     * have only a single shape per object.  For instance
-     * planning_scene::PlanningScene::getFrameTransform() will
-     * return the pose of an Object.  As defined here, the pose of a
-     * multi-shaped object is ambiguous, so getFrameTransform() just
-     * returns the pose of the first Shape in the object. */
+     * The pose of each Shape is stored in the corresponding element of the shape_poses_ array. */
     std::vector<shapes::ShapeConstPtr> shapes_;
 
-    /** \brief The poses of the corresponding entries in shapes_.
+    /** \brief The poses of the corresponding entries in shapes_, relative to the object pose.
      *
      * @copydetails shapes_ */
     EigenSTL::vector_Isometry3d shape_poses_;
 
-    /** \brief Transforms to subframes on the object.
+    /** \brief The poses of the corresponding entries in shapes_, relative to the world frame.
+     *
+     * @copydetails shapes_ */
+    EigenSTL::vector_Isometry3d global_shape_poses_;
+
+    /** \brief Transforms from the object pose to subframes on the object.
      *  Use them to define points of interest on an object to plan with
      *  (e.g. screwdriver/tip, kettle/spout, mug/base).
      */
     moveit::core::FixedTransformsMap subframe_poses_;
+
+    /** \brief Transforms from the world frame to the object subframes.
+     */
+    moveit::core::FixedTransformsMap global_subframe_poses_;
   };
 
   /** \brief Get the list of Object ids */
@@ -135,9 +140,9 @@ public:
     return objects_.size();
   }
   /** find changes for a named object */
-  const_iterator find(const std::string& id) const
+  const_iterator find(const std::string& object_id) const
   {
-    return objects_.find(id);
+    return objects_.find(object_id);
   }
 
   /** \brief Check if a particular object exists in the collision world*/
@@ -150,36 +155,68 @@ public:
   /** \brief Get the transform to an object or subframe with given name.
    * If name does not exist, a std::runtime_error is thrown.
    * A subframe name needs to be prefixed with the object's name separated by a slash.
+   * The transform is global (relative to the world origin).
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getTransform(const std::string& name) const;
 
   /** \brief Get the transform to an object or subframe with given name.
    * If name does not exist, returns an identity transform and sets frame_found to false.
    * A subframe name needs to be prefixed with the object's name separated by a slash.
+   * The transform is global (relative to the world origin).
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getTransform(const std::string& name, bool& frame_found) const;
 
+  /** \brief Get the global transform to a shape of an object with multiple shapes.
+   * shape_number is the index of the object (counting from 0) and needs to be valid. */
+  const Eigen::Isometry3d& getGlobalShapeTransform(const std::string& object_id, int shape_index) const;
+
+  /** \brief Get the global transform to a shape of an object with multiple shapes.
+   * shape_number is the index of the object (counting from 0) and needs to be valid. */
+  const EigenSTL::vector_Isometry3d& getGlobalShapeTransforms(const std::string& object_id) const;
+
+  /** \brief Add a pose and shapes to an object in the map.
+   * This function makes repeated calls to addToObjectInternal() to add the
+   * shapes one by one.*/
+  void addToObject(const std::string& object_id, const Eigen::Isometry3d& pose,
+                   const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses);
+
   /** \brief Add shapes to an object in the map.
    * This function makes repeated calls to addToObjectInternal() to add the
-   * shapes one by one.
-   *  \note This function does NOT call the addToObject() variant that takes
-   * a single shape and a single pose as input. */
+   * shapes one by one. */
   void addToObject(const std::string& object_id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                   const EigenSTL::vector_Isometry3d& poses);
+                   const EigenSTL::vector_Isometry3d& shape_poses);
+
+  /** \brief Add a pose and shape to an object.
+   * If the object already exists, this call will add the shape to the object
+   * at the specified pose. Otherwise, the object is created and the
+   * specified shape is added. This calls addToObjectInternal().
+   * shape_pose is defined relative to the object's pose, not to the world frame. */
+  void addToObject(const std::string& object_id, const Eigen::Isometry3d& pose, const shapes::ShapeConstPtr& shape,
+                   const Eigen::Isometry3d& shape_pose);
 
   /** \brief Add a shape to an object.
    * If the object already exists, this call will add the shape to the object
    * at the specified pose. Otherwise, the object is created and the
-   * specified shape is added. This calls addToObjectInternal(). */
-  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& pose);
+   * specified shape is added. This calls addToObjectInternal().
+   * shape_pose is defined relative to the object's pose, not to the world frame. */
+  void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
+                   const Eigen::Isometry3d& shape_pose);
 
   /** \brief Update the pose of a shape in an object. Shape equality is
    * verified by comparing pointers. Returns true on success. */
   bool moveShapeInObject(const std::string& object_id, const shapes::ShapeConstPtr& shape,
-                         const Eigen::Isometry3d& pose);
+                         const Eigen::Isometry3d& shape_pose);
 
-  /** \brief Move all shapes in an object according to the given transform specified in world frame */
+  /** \brief Move the object pose (thus moving all shapes and subframes in the object)
+   * according to the given transform specified in world frame.
+   * The transform is relative to and changes the object pose. It does not replace it.
+   */
   bool moveObject(const std::string& object_id, const Eigen::Isometry3d& transform);
+
+  /** \brief Move the object pose (thus moving all shapes and subframes in the object)
+   * to the given transform specified in world frame. The transform replaces the old pose.
+   */
+  bool moveObjectAbsolute(const std::string& object_id, const Eigen::Isometry3d& transform);
 
   /** \brief Remove shape from object.
    * Shape equality is verified by comparing pointers. Ownership of the
@@ -195,8 +232,11 @@ public:
    * Returns true on success and false if no such object was found. */
   bool removeObject(const std::string& object_id);
 
-  /** \brief Set subframes on an object. */
+  /** \brief Set subframes on an object. The frames are relative to the object pose. */
   bool setSubframesOfObject(const std::string& object_id, const moveit::core::FixedTransformsMap& subframe_poses);
+
+  /** \brief Set the pose of an object. The pose is specified in the world frame. */
+  bool setObjectPose(const std::string& object_id, const Eigen::Isometry3d& pose);
 
   /** \brief Clear all objects.
    * If there are no other pointers to corresponding instances of Objects,
@@ -282,7 +322,10 @@ private:
 
   /* Add a shape with no checking */
   virtual void addToObjectInternal(const ObjectPtr& obj, const shapes::ShapeConstPtr& shape,
-                                   const Eigen::Isometry3d& pose);
+                                   const Eigen::Isometry3d& shape_pose);
+
+  /** \brief Updates the global shape and subframe poses. */
+  void updateGlobalPosesInternal(ObjectPtr& obj, bool update_shape_poses = true, bool update_subframe_poses = true);
 
   /** The objects maintained in the world */
   std::map<std::string, ObjectPtr> objects_;

--- a/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
+++ b/moveit_core/collision_detection_bullet/src/collision_env_bullet.cpp
@@ -256,8 +256,8 @@ void CollisionEnvBullet::addToManager(const World::Object* obj)
   }
 
   collision_detection_bullet::CollisionObjectWrapperPtr cow(new collision_detection_bullet::CollisionObjectWrapper(
-      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_, obj->shape_poses_, collision_object_types,
-      false));
+      obj->id_, collision_detection::BodyType::WORLD_OBJECT, obj->shapes_,
+      getWorld()->getGlobalShapeTransforms(obj->id_), collision_object_types, false));
 
   manager_->addCollisionObject(cow);
   manager_CCD_->addCollisionObject(cow->clone());

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -49,6 +49,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <memory>
+#include <type_traits>
 
 namespace collision_detection
 {
@@ -680,24 +681,6 @@ FCLShapeCache& GetShapeCache()
   return cache;
 }
 
-template <typename T1, typename T2>
-struct IfSameType
-{
-  enum
-  {
-    VALUE = 0
-  };
-};
-
-template <typename T>
-struct IfSameType<T, T>
-{
-  enum
-  {
-    VALUE = 1
-  };
-};
-
 /** \brief Templated helper function creating new collision geometry out of general object using an arbitrary bounding
  *  volume (BV).
  *
@@ -738,7 +721,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
   // attached objects could have previously been World::Object; we try to move them
   // from their old cache to the new one, if possible. the code is not pretty, but should help
   // when we attach/detach objects that are in the world
-  if (IfSameType<T, moveit::core::AttachedBody>::VALUE == 1)
+  if (std::is_same<T, moveit::core::AttachedBody>::value)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
     FCLShapeCache& othercache = GetShapeCache<BV, World::Object>();
@@ -771,7 +754,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
       // world objects could have previously been attached objects; we try to move them
       // from their old cache to the new one, if possible. the code is not pretty, but should help
       // when we attach/detach objects that are in the world
-      if (IfSameType<T, World::Object>::VALUE == 1)
+      if (std::is_same<T, World::Object>::value)
   {
     // get the cache that corresponds to objects; maybe this attached object used to be a world object
     FCLShapeCache& othercache = GetShapeCache<BV, moveit::core::AttachedBody>();

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -187,7 +187,8 @@ void CollisionEnvFCL::constructFCLObjectWorld(const World::Object* obj, FCLObjec
     FCLGeometryConstPtr g = createCollisionGeometry(obj->shapes_[i], obj);
     if (g)
     {
-      auto co = new fcl::CollisionObjectd(g->collision_geometry_, transform2fcl(obj->shape_poses_[i]));
+      auto co = new fcl::CollisionObjectd(g->collision_geometry_,
+                                          transform2fcl(getWorld()->getGlobalShapeTransform(obj->id_, i)));
       fcl_obj.collision_objects_.push_back(FCLCollisionObjectPtr(co));
       fcl_obj.collision_geometry_.push_back(g);
     }

--- a/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_common_distance_field.cpp
@@ -101,7 +101,7 @@ PosedBodyPointDecompositionVectorPtr getCollisionObjectPointDecomposition(const 
     PosedBodyPointDecompositionPtr pbd(
         new PosedBodyPointDecomposition(getBodyDecompositionCacheEntry(obj.shapes_[i], resolution)));
     ret->addToVector(pbd);
-    ret->updatePose(ret->getSize() - 1, obj.shape_poses_[i]);
+    ret->updatePose(ret->getSize() - 1, obj.global_shape_poses_[i]);
   }
   return ret;
 }

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -1753,8 +1753,8 @@ void CollisionEnvDistanceField::updateDistanceObject(const std::string& id, Dist
       else
       {
         BodyDecompositionConstPtr bd = getBodyDecompositionCacheEntry(shape, resolution_);
-
-        shape_points.push_back(std::make_shared<PosedBodyPointDecomposition>(bd, object->shape_poses_[i]));
+        shape_points.push_back(
+            std::make_shared<PosedBodyPointDecomposition>(bd, getWorld()->getGlobalShapeTransform(id, i)));
       }
 
       add_points.insert(add_points.end(), shape_points.back()->getCollisionPoints().begin(),

--- a/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
+++ b/moveit_core/collision_distance_field/test/test_collision_distance_field.cpp
@@ -289,6 +289,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   // deletes shape
   cenv_->getWorld()->removeObject("box");
 
+  const auto identity = Eigen::Isometry3d::Identity();
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Isometry3d poses;
   shapes.push_back(shapes::ShapeConstPtr(new shapes::Box(.25, .25, .25)));
@@ -296,7 +297,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   std::set<std::string> touch_links;
   trajectory_msgs::msg::JointTrajectory empty_state;
   moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
 
   robot_state.attachBody(attached_body);
 
@@ -311,7 +312,7 @@ TEST_F(DistanceFieldCollisionDetectionTester, AttachedBodyTester)
   shapes[0] = std::make_shared<shapes::Box>(.1, .1, .1);
 
   moveit::core::AttachedBody* attached_body_1 = new moveit::core::AttachedBody(
-      robot_state.getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_state.getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
   robot_state.attachBody(attached_body_1);
 
   res = collision_detection::CollisionResult();

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -355,6 +355,7 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
       {
         const collision_detection::World::Object& obj = *world_->getObject(it.first);
         scene->world_->removeObject(obj.id_);
+        scene->world_->setObjectPose(obj.id_, obj.pose_);
         scene->world_->addToObject(obj.id_, obj.shapes_, obj.shape_poses_);
         if (hasObjectColor(it.first))
           scene->setObjectColor(it.first, getObjectColor(it.first));
@@ -650,10 +651,11 @@ private:
 
 bool PlanningScene::getCollisionObjectMsg(moveit_msgs::msg::CollisionObject& collision_obj, const std::string& ns) const
 {
+  collision_detection::CollisionEnv::ObjectConstPtr obj = world_->getObject(ns);
   collision_obj.header.frame_id = getPlanningFrame();
+  collision_obj.pose = tf2::toMsg(obj->pose_);
   collision_obj.id = ns;
   collision_obj.operation = moveit_msgs::msg::CollisionObject::ADD;
-  collision_detection::CollisionEnv::ObjectConstPtr obj = world_->getObject(ns);
   if (!obj)
     return false;
   ShapeVisitorAddToCollisionObject sv(&collision_obj);
@@ -1229,7 +1231,7 @@ void PlanningScene::processOctomapMsg(const octomap_msgs::msg::OctomapWithPose& 
 
   const Eigen::Isometry3d& t = getFrameTransform(map.header.frame_id);
   Eigen::Isometry3d p;
-  tf2::fromMsg(map.origin, p);
+  PlanningScene::poseMsgToEigen(map.origin, p);
   p = t * p;
   world_->addToObject(OCTOMAP_NS, shapes::ShapeConstPtr(new shapes::OcTree(om)), p);
 }
@@ -1330,14 +1332,14 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
     if (link_model)
     {
       // items to build the attached object from (filled from existing world object or message)
+      Eigen::Isometry3d object_pose_in_link;
       std::vector<shapes::ShapeConstPtr> shapes;
-      EigenSTL::vector_Isometry3d poses;
+      EigenSTL::vector_Isometry3d shape_poses;
       moveit::core::FixedTransformsMap subframe_poses;
 
-      // STEP 1: Get info about object from the world. First shapes, then subframes.
-      // TODO(felixvd): This code may be duplicated in robot_state/conversions.cpp
+      // STEP 1: Obtain info about object to be attached.
+      //         If it is in the world, message contents are ignored.
 
-      // STEP 1.1: Get shapes and poses from existing world object or message.
       collision_detection::CollisionEnv::ObjectConstPtr obj_in_world = world_->getObject(object.object.id);
       if (object.object.operation == moveit_msgs::msg::CollisionObject::ADD && object.object.primitives.empty() &&
           object.object.meshes.empty() && object.object.planes.empty())
@@ -1347,14 +1349,10 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
           RCLCPP_DEBUG(LOGGER, "Attaching world object '%s' to link '%s'", object.object.id.c_str(),
                        object.link_name.c_str());
 
-          // extract the shapes from the world
+          object_pose_in_link = robot_state_->getGlobalLinkTransform(link_model).inverse() * obj_in_world->pose_;
           shapes = obj_in_world->shapes_;
-          poses = obj_in_world->shape_poses_;
-
-          // Transform shape poses to the link frame
-          const Eigen::Isometry3d& inv_transform = robot_state_->getGlobalLinkTransform(link_model).inverse();
-          for (Eigen::Isometry3d& pose : poses)
-            pose = inv_transform * pose;
+          shape_poses = obj_in_world->shape_poses_;
+          subframe_poses = obj_in_world->subframe_poses_;
         }
         else
         {
@@ -1365,46 +1363,54 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
           return false;
         }
       }
-      else  // If object is not in the world, fill shapes and poses with the message contents
+      else  // If object is not in the world, use the message contents
       {
+        Eigen::Isometry3d header_frame_to_object_pose;
+        PlanningScene::poseMsgToEigen(object.object.pose, header_frame_to_object_pose);
+        // TODO(felixvd): Use _msgToAttachedBody from robot_state/conversions.cpp here and
+        //                make a helper function for the other branch (getAttachedBodyFromWorld)
+        const Eigen::Isometry3d world_to_header_frame = getFrameTransform(object.object.header.frame_id);
+        const Eigen::Isometry3d link_to_header_frame =
+            robot_state_->getGlobalLinkTransform(link_model).inverse() * world_to_header_frame;
+        object_pose_in_link = link_to_header_frame * header_frame_to_object_pose;
+
         for (std::size_t i = 0; i < object.object.primitives.size(); ++i)
         {
-          if (shapes::Shape* s = shapes::constructShapeFromMsg(object.object.primitives[i]))
+          if (shapes::Shape* shape = shapes::constructShapeFromMsg(object.object.primitives[i]))
           {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(object.object.primitive_poses[i], p);
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
+            Eigen::Isometry3d shape_pose;
+            PlanningScene::poseMsgToEigen(object.object.primitive_poses[i], shape_pose);
+            shapes.push_back(shapes::ShapeConstPtr(shape));
+            shape_poses.push_back(shape_pose);
           }
         }
         for (std::size_t i = 0; i < object.object.meshes.size(); ++i)
         {
-          if (shapes::Shape* s = shapes::constructShapeFromMsg(object.object.meshes[i]))
+          if (shapes::Shape* shape = shapes::constructShapeFromMsg(object.object.meshes[i]))
           {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(object.object.mesh_poses[i], p);
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
+            Eigen::Isometry3d shape_pose;
+            PlanningScene::poseMsgToEigen(object.object.mesh_poses[i], shape_pose);
+            shapes.push_back(shapes::ShapeConstPtr(shape));
+            shape_poses.push_back(shape_pose);
           }
         }
         for (std::size_t i = 0; i < object.object.planes.size(); ++i)
         {
-          if (shapes::Shape* s = shapes::constructShapeFromMsg(object.object.planes[i]))
+          if (shapes::Shape* shape = shapes::constructShapeFromMsg(object.object.planes[i]))
           {
-            Eigen::Isometry3d p;
-            tf2::fromMsg(object.object.plane_poses[i], p);
-            shapes.push_back(shapes::ShapeConstPtr(s));
-            poses.push_back(p);
+            Eigen::Isometry3d shape_pose;
+            PlanningScene::poseMsgToEigen(object.object.plane_poses[i], shape_pose);
+            shapes.push_back(shapes::ShapeConstPtr(shape));
+            shape_poses.push_back(shape_pose);
           }
         }
 
-        // Transform shape poses to link frame
-        if (object.object.header.frame_id != object.link_name)
+        Eigen::Isometry3d subframe_pose;
+        for (std::size_t i = 0; i < object.object.subframe_poses.size(); ++i)
         {
-          const Eigen::Isometry3d& transform = robot_state_->getGlobalLinkTransform(link_model).inverse() *
-                                               getFrameTransform(object.object.header.frame_id);
-          for (Eigen::Isometry3d& pose : poses)
-            pose = transform * pose;
+          PlanningScene::poseMsgToEigen(object.object.subframe_poses[i], subframe_pose);
+          std::string name = object.object.subframe_names[i];
+          subframe_poses[name] = subframe_pose;
         }
       }
 
@@ -1418,37 +1424,7 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
       if (!object.object.type.db.empty() || !object.object.type.key.empty())
         setObjectType(object.object.id, object.object.type);
 
-      // STEP 1.2: Get subframes from previous world object or the message
-      if (object.object.operation == moveit_msgs::msg::CollisionObject::ADD && obj_in_world &&
-          object.object.subframe_poses.empty())
-      {
-        subframe_poses = obj_in_world->subframe_poses_;
-        // Transform subframes to the link frame
-        const Eigen::Isometry3d& inv_transform = robot_state_->getGlobalLinkTransform(link_model).inverse();
-        for (auto& subframe : subframe_poses)
-          subframe.second = inv_transform * subframe.second;
-      }
-      else  // Populate subframes from message
-      {
-        Eigen::Isometry3d p;
-        for (std::size_t i = 0; i < object.object.subframe_poses.size(); ++i)
-        {
-          tf2::fromMsg(object.object.subframe_poses[i], p);
-          std::string name = object.object.subframe_names[i];
-          subframe_poses[name] = p;
-        }
-
-        // Transform subframes to the link frame
-        if (object.object.header.frame_id != object.link_name)
-        {
-          const Eigen::Isometry3d& transform = robot_state_->getGlobalLinkTransform(link_model).inverse() *
-                                               getFrameTransform(object.object.header.frame_id);
-          for (auto& subframe : subframe_poses)
-            subframe.second = transform * subframe.second;
-        }
-      }
-
-      // STEP 2: Remove the object from the world
+      // STEP 2: Remove the object from the world (if it existed)
       if (obj_in_world && world_->removeObject(object.object.id))
       {
         if (object.object.operation == moveit_msgs::msg::CollisionObject::ADD)
@@ -1470,16 +1446,23 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
                        "The robot state already had an object named '%s' attached to link '%s'. "
                        "The object was replaced.",
                        object.object.id.c_str(), object.link_name.c_str());
-        robot_state_->attachBody(object.object.id, shapes, poses, object.touch_links, object.link_name,
-                                 object.detach_posture, subframe_poses);
+        robot_state_->attachBody(object.object.id, object_pose_in_link, shapes, shape_poses, object.touch_links,
+                                 object.link_name, object.detach_posture, subframe_poses);
         RCLCPP_DEBUG(LOGGER, "Attached object '%s' to link '%s'", object.object.id.c_str(), object.link_name.c_str());
       }
       else  // APPEND: augment to existing attached object
       {
         const moveit::core::AttachedBody* ab = robot_state_->getAttachedBody(object.object.id);
+
+        bool pose_msg_is_populated = (object.object.pose.position.x == 0 && object.object.pose.position.y == 0 &&
+                                      object.object.pose.position.z == 0 && object.object.pose.orientation.x == 0 &&
+                                      object.object.pose.orientation.y == 0 && object.object.pose.orientation.z == 0 &&
+                                      object.object.pose.orientation.w == 0);
+        object_pose_in_link = pose_msg_is_populated ? ab->getPose() : object_pose_in_link;
+
         shapes.insert(shapes.end(), ab->getShapes().begin(), ab->getShapes().end());
-        poses.insert(poses.end(), ab->getFixedTransforms().begin(), ab->getFixedTransforms().end());
-        subframe_poses.insert(ab->getSubframeTransforms().begin(), ab->getSubframeTransforms().end());
+        shape_poses.insert(shape_poses.end(), ab->getShapePoses().begin(), ab->getShapePoses().end());
+        subframe_poses.insert(ab->getSubframes().begin(), ab->getSubframes().end());
         trajectory_msgs::msg::JointTrajectory detach_posture =
             object.detach_posture.joint_names.empty() ? ab->getDetachPosture() : object.detach_posture;
 
@@ -1488,9 +1471,9 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
                            std::make_move_iterator(object.touch_links.end()));
 
         robot_state_->clearAttachedBody(object.object.id);
-        robot_state_->attachBody(object.object.id, shapes, poses, touch_links, object.link_name, detach_posture,
-                                 subframe_poses);
-        RCLCPP_DEBUG(LOGGER, "Added shapes to object '%s' attached to link '%s'", object.object.id.c_str(),
+        robot_state_->attachBody(object.object.id, object_pose_in_link, shapes, shape_poses, touch_links,
+                                 object.link_name, detach_posture, subframe_poses);
+        RCLCPP_DEBUG(LOGGER, "Appended things to object '%s' attached to link '%s'", object.object.id.c_str(),
                      object.link_name.c_str());
       }
       return true;
@@ -1533,7 +1516,11 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
     // STEP 2+3: Remove the attached object(s) from the RobotState and put them in the world
     for (const moveit::core::AttachedBody* attached_body : attached_bodies)
     {
+      const std::vector<shapes::ShapeConstPtr>& shapes = attached_body->getShapes();
+      const EigenSTL::vector_Isometry3d& shape_poses = attached_body->getShapePoses();
       const std::string& name = attached_body->getName();
+      const Eigen::Isometry3d& pose = attached_body->getGlobalPose();
+
       if (world_->hasObject(name))
       {
         RCLCPP_WARN(LOGGER,
@@ -1543,8 +1530,8 @@ bool PlanningScene::processAttachedCollisionObjectMsg(const moveit_msgs::msg::At
       }
       else
       {
-        world_->addToObject(name, attached_body->getShapes(), attached_body->getGlobalCollisionBodyTransforms());
-        world_->setSubframesOfObject(name, attached_body->getSubframeTransforms());
+        world_->addToObject(name, pose, shapes, shape_poses);
+        world_->setSubframesOfObject(name, attached_body->getSubframes());
         RCLCPP_DEBUG(LOGGER, "Detached object '%s' from link '%s' and added it back in the collision world",
                      name.c_str(), object.link_name.c_str());
       }
@@ -1616,6 +1603,8 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::msg::CollisionO
     return false;
   }
 
+  // TODO (felixvd): Factor these 3 conditions out of here and processAttachedCollisionObject,
+  //                and fill the pose vectors with Identity transforms instead of stopping.
   if (object.primitives.size() != object.primitive_poses.size())
   {
     RCLCPP_ERROR(LOGGER, "Number of primitive shapes does not match number of poses "
@@ -1645,16 +1634,21 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::msg::CollisionO
   if (object.operation == moveit_msgs::msg::CollisionObject::ADD && world_->hasObject(object.id))
     world_->removeObject(object.id);
 
-  const Eigen::Isometry3d& object_frame_transform = getFrameTransform(object.header.frame_id);
+  const Eigen::Isometry3d& world_to_object_header_transform = getFrameTransform(object.header.frame_id);
+  Eigen::Isometry3d header_to_pose_transform;
+  PlanningScene::poseMsgToEigen(object.pose, header_to_pose_transform);
+  const Eigen::Isometry3d object_frame_transform = world_to_object_header_transform * header_to_pose_transform;
+
+  world_->setObjectPose(object.id, object_frame_transform);
 
   for (std::size_t i = 0; i < object.primitives.size(); ++i)
   {
     shapes::Shape* s = shapes::constructShapeFromMsg(object.primitives[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(object.primitive_poses[i], object_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
+      Eigen::Isometry3d shape_pose;
+      PlanningScene::poseMsgToEigen(object.primitive_poses[i], shape_pose);
+      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
     }
   }
   for (std::size_t i = 0; i < object.meshes.size(); ++i)
@@ -1662,9 +1656,9 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::msg::CollisionO
     shapes::Shape* s = shapes::constructShapeFromMsg(object.meshes[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(object.mesh_poses[i], object_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
+      Eigen::Isometry3d shape_pose;
+      PlanningScene::poseMsgToEigen(object.mesh_poses[i], shape_pose);
+      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
     }
   }
   for (std::size_t i = 0; i < object.planes.size(); ++i)
@@ -1672,22 +1666,22 @@ bool PlanningScene::processCollisionObjectAdd(const moveit_msgs::msg::CollisionO
     shapes::Shape* s = shapes::constructShapeFromMsg(object.planes[i]);
     if (s)
     {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(object.plane_poses[i], object_pose);
-      world_->addToObject(object.id, shapes::ShapeConstPtr(s), object_frame_transform * object_pose);
+      Eigen::Isometry3d shape_pose;
+      PlanningScene::poseMsgToEigen(object.plane_poses[i], shape_pose);
+      world_->addToObject(object.id, shapes::ShapeConstPtr(s), shape_pose);
     }
   }
   if (!object.type.key.empty() || !object.type.db.empty())
     setObjectType(object.id, object.type);
 
-  // Add subframes to the newly created (or possibly modified) object
-  moveit::core::FixedTransformsMap subframes = world_->getObject(object.id)->subframe_poses_;
-  Eigen::Isometry3d frame_pose;
+  // Add subframes
+  moveit::core::FixedTransformsMap subframes;
+  Eigen::Isometry3d subframe_pose;
   for (std::size_t i = 0; i < object.subframe_poses.size(); ++i)
   {
-    tf2::fromMsg(object.subframe_poses[i], frame_pose);
+    PlanningScene::poseMsgToEigen(object.subframe_poses[i], subframe_pose);
     std::string name = object.subframe_names[i];
-    subframes[name] = object_frame_transform * frame_pose;
+    subframes[name] = subframe_pose;
   }
   world_->setSubframesOfObject(object.id, subframes);
   return true;
@@ -1716,44 +1710,13 @@ bool PlanningScene::processCollisionObjectMove(const moveit_msgs::msg::Collision
       RCLCPP_WARN(LOGGER, "Move operation for object '%s' ignores the geometry specified in the message.",
                   object.id.c_str());
 
-    const Eigen::Isometry3d& t = getFrameTransform(object.header.frame_id);
-    EigenSTL::vector_Isometry3d new_poses;
-    for (const geometry_msgs::msg::Pose& primitive_pose : object.primitive_poses)
-    {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(primitive_pose, object_pose);
-      new_poses.push_back(t * object_pose);
-    }
-    for (const geometry_msgs::msg::Pose& mesh_pose : object.mesh_poses)
-    {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(mesh_pose, object_pose);
-      new_poses.push_back(t * object_pose);
-    }
-    for (const geometry_msgs::msg::Pose& plane_pose : object.plane_poses)
-    {
-      Eigen::Isometry3d object_pose;
-      PlanningScene::poseMsgToEigen(plane_pose, object_pose);
-      new_poses.push_back(t * object_pose);
-    }
+    const Eigen::Isometry3d& world_to_object_header_transform = getFrameTransform(object.header.frame_id);
+    Eigen::Isometry3d header_to_pose_transform;
 
-    collision_detection::World::ObjectConstPtr obj = world_->getObject(object.id);
+    PlanningScene::poseMsgToEigen(object.pose, header_to_pose_transform);
 
-    if (obj->shapes_.size() == new_poses.size())
-    {
-      std::vector<shapes::ShapeConstPtr> shapes = obj->shapes_;
-      obj.reset();
-      world_->removeObject(object.id);
-      world_->addToObject(object.id, shapes, new_poses);
-    }
-    else
-    {
-      RCLCPP_ERROR(LOGGER,
-                   "Number of supplied poses (%zu) for object '%s' does not match number of shapes (%zu). "
-                   "Not moving.",
-                   new_poses.size(), object.id.c_str(), obj->shapes_.size());
-      return false;
-    }
+    const Eigen::Isometry3d object_frame_transform = world_to_object_header_transform * header_to_pose_transform;
+    world_->setObjectPose(object.id, object_frame_transform);
     return true;
   }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -60,10 +60,10 @@ public:
   /** \brief Construct an attached body for a specified \e link.
    *
    * The name of this body is \e id and it consists of \e shapes that attach to the link by the transforms
-   * \e attach_trans. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
-  AttachedBody(const LinkModel* link, const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-               const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
-               const trajectory_msgs::msg::JointTrajectory& attach_posture,
+   * \e shape_poses. The set of links that are allowed to be touched by this object is specified by \e touch_links. */
+  AttachedBody(const LinkModel* link, const std::string& id, const Eigen::Isometry3d& pose,
+               const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+               const std::set<std::string>& touch_links, const trajectory_msgs::msg::JointTrajectory& attach_posture,
                const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
   ~AttachedBody();
@@ -72,6 +72,18 @@ public:
   const std::string& getName() const
   {
     return id_;
+  }
+
+  /** \brief Get the pose of the attached body relative to the parent link */
+  const Eigen::Isometry3d& getPose() const
+  {
+    return pose_;
+  }
+
+  /** \brief Get the pose of the attached body, relative to the world */
+  const Eigen::Isometry3d& getGlobalPose() const
+  {
+    return global_pose_;
   }
 
   /** \brief Get the name of the link this body is attached to */
@@ -92,6 +104,13 @@ public:
     return shapes_;
   }
 
+  /** \brief Get the shape poses (the transforms to the shapes of this body, relative to the pose). The returned
+   *  transforms are guaranteed to be valid isometries. */
+  const EigenSTL::vector_Isometry3d& getShapePoses() const
+  {
+    return shape_poses_;
+  }
+
   /** \brief Get the links that the attached body is allowed to touch */
   const std::set<std::string>& getTouchLinks() const
   {
@@ -99,8 +118,7 @@ public:
   }
 
   /** \brief Return the posture that is necessary for the object to be released, (if any). This is useful for example
-     when storing
-      the configuration of a gripper holding an object */
+     when storing the configuration of a gripper holding an object */
   const trajectory_msgs::msg::JointTrajectory& getDetachPosture() const
   {
     return detach_posture_;
@@ -108,14 +126,22 @@ public:
 
   /** \brief Get the fixed transforms (the transforms to the shapes of this body, relative to the link). The returned
    *  transforms are guaranteed to be valid isometries. */
-  const EigenSTL::vector_Isometry3d& getFixedTransforms() const
+  const EigenSTL::vector_Isometry3d& getShapePosesInLinkFrame() const
   {
-    return attach_trans_;
+    return shape_poses_in_link_frame_;
   }
 
-  /** \brief Get subframes of this object (relative to the link). The returned transforms are guaranteed to be valid
-   *  isometries. */
-  const moveit::core::FixedTransformsMap& getSubframeTransforms() const
+  /** \brief Get the fixed transforms (the transforms to the shapes of this body, relative to the link). The returned
+   *  transforms are guaranteed to be valid isometries.
+   * Deprecated. Use getShapePosesInLinkFrame instead. */
+  [[deprecated]] const EigenSTL::vector_Isometry3d& getFixedTransforms() const
+  {
+    return shape_poses_in_link_frame_;
+  }
+
+  /** \brief Get subframes of this object (relative to the object pose). The returned transforms are guaranteed to be
+   * valid isometries. */
+  const moveit::core::FixedTransformsMap& getSubframes() const
   {
     return subframe_poses_;
   }
@@ -140,14 +166,21 @@ public:
     subframe_poses_ = subframe_poses;
   }
 
-  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
+  /** \brief Get the fixed transform to a named subframe on this body (relative to the body's pose)
    *
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
-  /** \brief Get the fixed transform to a named subframe on this body.
+  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
+   *
+   * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
+   * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
+   * The returned transform is guaranteed to be a valid isometry. */
+  const Eigen::Isometry3d& getSubframeTransformInLinkFrame(const std::string& frame_name, bool* found = nullptr) const;
+
+  /** \brief Get the fixed transform to a named subframe on this body, relative to the world frame.
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
    * The returned transform is guaranteed to be a valid isometry. */
@@ -159,8 +192,8 @@ public:
    * name is "screwdriver"). */
   bool hasSubframeTransform(const std::string& frame_name) const;
 
-  /** \brief Get the global transforms for the collision bodies. The returned transforms are guaranteed to be valid
-   *  isometries. */
+  /** \brief Get the global transforms (in world frame) for the collision bodies. The returned transforms are
+   *  guaranteed to be valid isometries. */
   const EigenSTL::vector_Isometry3d& getGlobalCollisionBodyTransforms() const
   {
     return global_collision_body_transforms_;
@@ -182,11 +215,23 @@ private:
   /** \brief string id for reference */
   std::string id_;
 
+  /** \brief The transform from the parent link to the attached body's pose*/
+  Eigen::Isometry3d pose_;
+
+  /** \brief The transform from the model frame to the attached body's pose  */
+  Eigen::Isometry3d global_pose_;
+
   /** \brief The geometries of the attached body */
   std::vector<shapes::ShapeConstPtr> shapes_;
 
-  /** \brief The constant transforms applied to the link (needs to be specified by user) */
-  EigenSTL::vector_Isometry3d attach_trans_;
+  /** \brief The transforms from the object's pose to the object's geometries*/
+  EigenSTL::vector_Isometry3d shape_poses_;
+
+  /** \brief The transforms from the link to the object's geometries*/
+  EigenSTL::vector_Isometry3d shape_poses_in_link_frame_;
+
+  /** \brief The global transforms for the attached bodies (computed by forward kinematics) */
+  EigenSTL::vector_Isometry3d global_collision_body_transforms_;
 
   /** \brief The set of links this body is allowed to touch */
   std::set<std::string> touch_links_;
@@ -195,10 +240,7 @@ private:
       the configuration of a gripper holding an object */
   trajectory_msgs::msg::JointTrajectory detach_posture_;
 
-  /** \brief The global transforms for these attached bodies (computed by forward kinematics) */
-  EigenSTL::vector_Isometry3d global_collision_body_transforms_;
-
-  /** \brief Transforms to subframes on the object. Transforms are relative to the link. */
+  /** \brief Transforms to subframes on the object, relative to the object's pose. */
   moveit::core::FixedTransformsMap subframe_poses_;
 
   /** \brief Transforms to subframes on the object, relative to the model frame. */

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1563,8 +1563,9 @@ public:
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
+   * @param pose The pose associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param attach_trans The desired transform between this link and the attached body
+   * @param shape_poses The transforms between the object pose and the attached body's shapes
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
@@ -1577,16 +1578,17 @@ public:
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
-                  const std::string& link_name,
+  void attachBody(const std::string& id, const Eigen::Isometry3d& pose,
+                  const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+                  const std::set<std::string>& touch_links, const std::string& link_name,
                   const trajectory_msgs::msg::JointTrajectory& detach_posture = trajectory_msgs::msg::JointTrajectory(),
                   const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap());
 
   /** @brief Add an attached body to a link
    * @param id The string id associated with the attached body
+   * @param pose The pose associated with the attached body
    * @param shapes The shapes that make up the attached body
-   * @param attach_trans The desired transform between this link and the attached body
+   * @param shape_poses The transforms between the object pose and the attached body's shapes
    * @param touch_links The set of links that the attached body is allowed to touch
    * @param link_name The link to attach to
    * @param detach_posture The posture of the gripper when placing the object
@@ -1599,14 +1601,14 @@ public:
    * from a planning_scene::PlanningScene), you will likely need to remove the
    * corresponding object from that world to avoid having collisions
    * detected against it. */
-  void attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
-                  const EigenSTL::vector_Isometry3d& shape_poses, const std::vector<std::string>& touch_links,
-                  const std::string& link_name,
+  void attachBody(const std::string& id, const Eigen::Isometry3d& pose,
+                  const std::vector<shapes::ShapeConstPtr>& shapes, const EigenSTL::vector_Isometry3d& shape_poses,
+                  const std::vector<std::string>& touch_links, const std::string& link_name,
                   const trajectory_msgs::msg::JointTrajectory& detach_posture = trajectory_msgs::msg::JointTrajectory(),
                   const moveit::core::FixedTransformsMap& subframe_poses = moveit::core::FixedTransformsMap())
   {
     std::set<std::string> touch_links_set(touch_links.begin(), touch_links.end());
-    attachBody(id, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
+    attachBody(id, pose, shapes, shape_poses, touch_links_set, link_name, detach_posture, subframe_poses);
   }
 
   /** \brief Get all bodies attached to the model corresponding to this state */

--- a/moveit_core/robot_state/src/attached_body.cpp
+++ b/moveit_core/robot_state/src/attached_body.cpp
@@ -43,21 +43,23 @@ namespace moveit
 {
 namespace core
 {
-AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id,
+AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string& id, const Eigen::Isometry3d& pose,
                            const std::vector<shapes::ShapeConstPtr>& shapes,
-                           const EigenSTL::vector_Isometry3d& attach_trans, const std::set<std::string>& touch_links,
+                           const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                            const trajectory_msgs::msg::JointTrajectory& detach_posture,
                            const FixedTransformsMap& subframe_poses)
   : parent_link_model_(parent_link_model)
   , id_(id)
+  , pose_(pose)
   , shapes_(shapes)
-  , attach_trans_(attach_trans)
+  , shape_poses_(shape_poses)
   , touch_links_(touch_links)
   , detach_posture_(detach_posture)
   , subframe_poses_(subframe_poses)
   , global_subframe_poses_(subframe_poses)
 {
-  for (const auto& t : attach_trans_)
+  ASSERT_ISOMETRY(pose)  // unsanitized input, could contain a non-isometry
+  for (const auto& t : shape_poses_)
   {
     ASSERT_ISOMETRY(t)  // unsanitized input, could contain a non-isometry
   }
@@ -65,9 +67,21 @@ AttachedBody::AttachedBody(const LinkModel* parent_link_model, const std::string
   {
     ASSERT_ISOMETRY(t.second)  // unsanitized input, could contain a non-isometry
   }
-  global_collision_body_transforms_.resize(attach_trans.size());
+
+  // TODO(felixvd): These are initialized as identity because the parent link transform is not
+  //                known to the AttachedBody. Is computeTransform called before they are used?
+  //                Otherwise they will not be correct.
+  global_pose_.setIdentity();
+  global_collision_body_transforms_.resize(shape_poses.size());
   for (Eigen::Isometry3d& global_collision_body_transform : global_collision_body_transforms_)
     global_collision_body_transform.setIdentity();
+
+  shape_poses_in_link_frame_.clear();
+  shape_poses_in_link_frame_.reserve(shape_poses_.size());
+  for (const auto& shape_pose : shape_poses_)
+  {
+    shape_poses_in_link_frame_.push_back(pose_ * shape_pose);
+  }
 }
 
 AttachedBody::~AttachedBody() = default;
@@ -92,15 +106,16 @@ void AttachedBody::setScale(double scale)
 void AttachedBody::computeTransform(const Eigen::Isometry3d& parent_link_global_transform)
 {
   ASSERT_ISOMETRY(parent_link_global_transform)  // unsanitized input, could contain a non-isometry
+  global_pose_ = parent_link_global_transform * pose_;
 
   // update collision body transforms
   for (std::size_t i = 0; i < global_collision_body_transforms_.size(); ++i)
-    global_collision_body_transforms_[i] = parent_link_global_transform * attach_trans_[i];  // valid isometry
+    global_collision_body_transforms_[i] = global_pose_ * shape_poses_[i];  // valid isometry
 
   // update subframe transforms
   for (auto global = global_subframe_poses_.begin(), end = global_subframe_poses_.end(), local = subframe_poses_.begin();
        global != end; ++global, ++local)
-    global->second = parent_link_global_transform * local->second;  // valid isometry
+    global->second = global_pose_ * local->second;  // valid isometry
 }
 
 void AttachedBody::setPadding(double padding)

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -202,10 +202,11 @@ static void _attachedBodyToMsg(const AttachedBody& attached_body, moveit_msgs::m
     aco.touch_links.push_back(touch_link);
   aco.object.header.frame_id = aco.link_name;
   aco.object.id = attached_body.getName();
+  aco.object.pose = tf2::toMsg(attached_body.getPose());
 
   aco.object.operation = moveit_msgs::msg::CollisionObject::ADD;
   const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body.getShapes();
-  const EigenSTL::vector_Isometry3d& ab_tf = attached_body.getFixedTransforms();
+  const EigenSTL::vector_Isometry3d& shape_poses = attached_body.getShapePoses();
   ShapeVisitorAddToCollisionObject sv(&aco.object);
   aco.object.primitives.clear();
   aco.object.meshes.clear();
@@ -219,13 +220,13 @@ static void _attachedBodyToMsg(const AttachedBody& attached_body, moveit_msgs::m
     if (shapes::constructMsgFromShape(ab_shapes[j].get(), sm))
     {
       geometry_msgs::msg::Pose p;
-      p = tf2::toMsg(ab_tf[j]);
+      p = tf2::toMsg(shape_poses[j]);
       sv.addToObject(sm, p);
     }
   }
   aco.object.subframe_names.clear();
   aco.object.subframe_poses.clear();
-  for (const auto& frame_pair : attached_body.getSubframeTransforms())
+  for (const auto& frame_pair : attached_body.getSubframes())
   {
     aco.object.subframe_names.push_back(frame_pair.first);
     geometry_msgs::msg::Pose pose;
@@ -269,6 +270,9 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::msg::Att
       const LinkModel* lm = state.getLinkModel(aco.link_name);
       if (lm)
       {
+        Eigen::Isometry3d object_pose;
+        tf2::fromMsg(aco.object.pose, object_pose);
+
         std::vector<shapes::ShapeConstPtr> shapes;
         EigenSTL::vector_Isometry3d poses;
 
@@ -320,26 +324,23 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::msg::Att
         if (!Transforms::sameFrame(aco.object.header.frame_id, aco.link_name))
         {
           bool frame_found = false;
-          Eigen::Isometry3d t0;
-          t0 = state.getFrameTransform(aco.object.header.frame_id, &frame_found);
+          Eigen::Isometry3d world_to_header_frame;
+          world_to_header_frame = state.getFrameTransform(aco.object.header.frame_id, &frame_found);
           if (!frame_found)
           {
             if (tf && tf->canTransform(aco.object.header.frame_id))
-              t0 = tf->getTransform(aco.object.header.frame_id);
+              world_to_header_frame = tf->getTransform(aco.object.header.frame_id);
             else
             {
-              t0.setIdentity();
+              world_to_header_frame.setIdentity();
               RCLCPP_ERROR(LOGGER,
                            "Cannot properly transform from frame '%s'. "
                            "The pose of the attached body may be incorrect",
                            aco.object.header.frame_id.c_str());
             }
           }
-          Eigen::Isometry3d t = state.getGlobalLinkTransform(lm).inverse() * t0;
-          for (Eigen::Isometry3d& pose : poses)
-            pose = t * pose;
-          for (auto& subframe_pose : subframe_poses)
-            subframe_pose.second = t * subframe_pose.second;
+          Eigen::Isometry3d t = world_to_header_frame.inverse() * state.getGlobalLinkTransform(lm);
+          object_pose = object_pose * t;
         }
 
         if (shapes.empty())
@@ -354,8 +355,8 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::msg::Att
                          "The robot state already had an object named '%s' attached to link '%s'. "
                          "The object was replaced.",
                          aco.object.id.c_str(), aco.link_name.c_str());
-          state.attachBody(aco.object.id, shapes, poses, aco.touch_links, aco.link_name, aco.detach_posture,
-                           subframe_poses);
+          state.attachBody(aco.object.id, object_pose, shapes, poses, aco.touch_links, aco.link_name,
+                           aco.detach_posture, subframe_poses);
           RCLCPP_DEBUG(LOGGER, "Attached object '%s' to link '%s'", aco.object.id.c_str(), aco.link_name.c_str());
         }
       }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -180,9 +180,9 @@ void RobotState::copyFrom(const RobotState& other)
   // copy attached bodies
   clearAttachedBodies();
   for (const std::pair<const std::string, AttachedBody*>& it : other.attached_body_map_)
-    attachBody(it.second->getName(), it.second->getShapes(), it.second->getFixedTransforms(),
+    attachBody(it.second->getName(), it.second->getPose(), it.second->getShapes(), it.second->getShapePoses(),
                it.second->getTouchLinks(), it.second->getAttachedLinkName(), it.second->getDetachPosture(),
-               it.second->getSubframeTransforms());
+               it.second->getSubframes());
 }
 
 bool RobotState::checkJointTransforms(const JointModel* joint) const
@@ -966,13 +966,14 @@ void RobotState::attachBody(AttachedBody* attached_body)
     attached_body_update_callback_(attached_body, true);
 }
 
-void RobotState::attachBody(const std::string& id, const std::vector<shapes::ShapeConstPtr>& shapes,
+void RobotState::attachBody(const std::string& id, const Eigen::Isometry3d& pose,
+                            const std::vector<shapes::ShapeConstPtr>& shapes,
                             const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                             const std::string& link, const trajectory_msgs::msg::JointTrajectory& detach_posture,
                             const moveit::core::FixedTransformsMap& subframe_poses)
 {
   const LinkModel* l = robot_model_->getLinkModel(link);
-  attachBody(new AttachedBody(l, id, shapes, shape_poses, touch_links, detach_posture, subframe_poses));
+  attachBody(new AttachedBody(l, id, pose, shapes, shape_poses, touch_links, detach_posture, subframe_poses));
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies) const
@@ -1106,24 +1107,11 @@ const Eigen::Isometry3d& RobotState::getFrameInfo(const std::string& frame_id, c
   std::map<std::string, AttachedBody*>::const_iterator jt = attached_body_map_.find(frame_id);
   if (jt != attached_body_map_.end())
   {
-    const EigenSTL::vector_Isometry3d& tf = jt->second->getGlobalCollisionBodyTransforms();
-    if (tf.empty())
-    {
-      RCLCPP_ERROR(LOGGER, "Attached body '%s' has no geometry associated to it. No transform to return.",
-                   frame_id.c_str());
-      robot_link = nullptr;
-      frame_found = false;
-      return IDENTITY_TRANSFORM;
-    }
-    if (tf.size() > 1)
-      RCLCPP_DEBUG(LOGGER,
-                   "There are multiple geometries associated to attached body '%s'. "
-                   "Returning the transform for the first one.",
-                   frame_id.c_str());
+    const Eigen::Isometry3d& transform = jt->second->getGlobalPose();
     robot_link = jt->second->getAttachedLink();
     frame_found = true;
     BOOST_VERIFY(checkLinkTransforms());
-    return tf[0];
+    return transform;
   }
 
   // Check if an AttachedBody has a subframe with name frame_id
@@ -1662,15 +1650,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
         if (hasAttachedBody(pose_frame))
         {
           const AttachedBody* body = getAttachedBody(pose_frame);
-          const EigenSTL::vector_Isometry3d& ab_trans = body->getFixedTransforms();
-          if (ab_trans.size() != 1)
-          {
-            RCLCPP_ERROR(LOGGER, "Cannot use an attached body "
-                                 "with multiple geometries as a reference frame.");
-            return false;
-          }
           pose_frame = body->getAttachedLinkName();
-          pose = pose * ab_trans[0].inverse();
+          pose = pose * body->getPose().inverse();
         }
         if (pose_frame != solver_tip_frame)
         {
@@ -1875,14 +1856,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
       if (hasAttachedBody(pose_frame))
       {
         const AttachedBody* body = getAttachedBody(pose_frame);
-        const EigenSTL::vector_Isometry3d& ab_trans = body->getFixedTransforms();  // valid isometries by contract
-        if (ab_trans.size() != 1)
-        {
-          RCLCPP_ERROR(LOGGER, "Cannot use an attached body with multiple geometries as a reference frame.");
-          return false;
-        }
         pose_frame = body->getAttachedLinkName();
-        pose = pose * ab_trans[0].inverse();  // valid isometry
+        pose = pose * body->getPose().inverse();  // valid isometry
       }
       if (pose_frame != solver_tip_frame)
       {

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -230,16 +230,17 @@ TEST_F(LoadPlanningModelsPr2, FullTest)
   moveit::core::RobotState ks2(robot_model);
   ks2.setToDefaultValues();
 
+  const auto identity = Eigen::Isometry3d::Identity();
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Isometry3d poses;
   shapes::Shape* shape = new shapes::Box(.1, .1, .1);
   shapes.push_back(shapes::ShapeConstPtr(shape));
-  poses.push_back(Eigen::Isometry3d::Identity());
+  poses.push_back(identity);
   std::set<std::string> touch_links;
 
   trajectory_msgs::msg::JointTrajectory empty_state;
   moveit::core::AttachedBody* attached_body = new moveit::core::AttachedBody(
-      robot_model->getLinkModel("r_gripper_palm_link"), "box", shapes, poses, touch_links, empty_state);
+      robot_model->getLinkModel("r_gripper_palm_link"), "box", identity, shapes, poses, touch_links, empty_state);
   ks.attachBody(attached_body);
 
   std::vector<const moveit::core::AttachedBody*> attached_bodies_1;

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -72,6 +72,12 @@ public:
     return isValid(state, dist, verbose_);
   }
 
+  bool isValid(const ompl::base::State* state, double& dist, ompl::base::State* /*validState*/,
+               bool& /*validStateAvailable*/) const override
+  {
+    return isValid(state, dist, verbose_);
+  }
+
   virtual bool isValid(const ompl::base::State* state, bool verbose) const;
   virtual bool isValid(const ompl::base::State* state, double& dist, bool verbose) const;
 

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -72,7 +72,7 @@ struct OrderPlaceLocationQuality
 bool transformToEndEffectorGoal(const geometry_msgs::PoseStamped& goal_pose,
                                 const moveit::core::AttachedBody* attached_body, geometry_msgs::PoseStamped& place_pose)
 {
-  const EigenSTL::vector_Isometry3d& fixed_transforms = attached_body->getFixedTransforms();
+  const EigenSTL::vector_Isometry3d& fixed_transforms = attached_body->getShapePosesInLinkFrame();
   if (fixed_transforms.empty())
     return false;
 

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -65,7 +65,7 @@ TfPublisher::~TfPublisher()
 namespace
 {
 void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::core::FixedTransformsMap& subframes,
-                      const std::string& parent_object, const std::string& parent_frame, const rclcpp::Time& stamp)
+                      const std::string& parent_object, const rclcpp::Time& stamp)
 {
   geometry_msgs::msg::TransformStamped transform;
   for (auto& subframe : subframes)
@@ -73,7 +73,7 @@ void publishSubframes(tf2_ros::TransformBroadcaster& broadcaster, const moveit::
     transform = tf2::eigenToTransform(subframe.second);
     transform.child_frame_id = parent_object + "/" + subframe.first;
     transform.header.stamp = stamp;
-    transform.header.frame_id = parent_frame;
+    transform.header.frame_id = parent_object;
     broadcaster.sendTransform(transform);
   }
 }
@@ -96,14 +96,14 @@ void TfPublisher::publishPlanningSceneFrames()
       for (const auto& obj : *world)
       {
         std::string object_frame = prefix_ + obj.second->id_;
-        transform = tf2::eigenToTransform(obj.second->shape_poses_[0]);
+        transform = tf2::eigenToTransform(obj.second->pose_);
         transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = planning_frame;
         broadcaster.sendTransform(transform);
 
         const moveit::core::FixedTransformsMap& subframes = obj.second->subframe_poses_;
-        publishSubframes(broadcaster, subframes, object_frame, planning_frame, stamp);
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
 
       const moveit::core::RobotState& rs = locked_planning_scene->getCurrentState();
@@ -112,14 +112,14 @@ void TfPublisher::publishPlanningSceneFrames()
       for (const moveit::core::AttachedBody* attached_body : attached_collision_objects)
       {
         std::string object_frame = prefix_ + attached_body->getName();
-        transform = tf2::eigenToTransform(attached_body->getFixedTransforms()[0]);
+        transform = tf2::eigenToTransform(attached_body->getPose());
         transform.child_frame_id = object_frame;
         transform.header.stamp = stamp;
         transform.header.frame_id = attached_body->getAttachedLinkName();
         broadcaster.sendTransform(transform);
 
-        const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframeTransforms();
-        publishSubframes(broadcaster, subframes, object_frame, attached_body->getAttachedLinkName(), stamp);
+        const moveit::core::FixedTransformsMap& subframes = attached_body->getSubframes();
+        publishSubframes(broadcaster, subframes, object_frame, stamp);
       }
     }
 

--- a/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/demos/demo_scene.cpp
@@ -65,6 +65,7 @@ void sendKnife(const rclcpp::Node::SharedPtr& node)
   co.id = "knife";
   co.header.stamp = rclcpp::Clock().now();
   co.header.frame_id = aco.link_name;
+  co.pose.orientation.w = 1.0;
   co.operation = moveit_msgs::msg::CollisionObject::ADD;
   co.primitives.resize(1);
   co.primitives[0].type = shape_msgs::msg::SolidPrimitive::BOX;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -937,7 +937,7 @@ void PlanningSceneMonitor::excludeWorldObjectFromOctree(const collision_detectio
     occupancy_map_monitor::ShapeHandle h = octomap_monitor_->excludeShape(obj->shapes_[i]);
     if (h)
     {
-      collision_body_shape_handles_[obj->id_].push_back(std::make_pair(h, &obj->shape_poses_[i]));
+      collision_body_shape_handles_[obj->id_].push_back(std::make_pair(h, &obj->global_shape_poses_[i]));
       found = true;
     }
   }
@@ -1129,7 +1129,7 @@ bool PlanningSceneMonitor::getShapeTransformCache(const std::string& target_fram
       for (std::size_t k = 0; k < attached_body_shape_handle.second.size(); ++k)
         cache[attached_body_shape_handle.second[k].first] =
             transform *
-            attached_body_shape_handle.first->getFixedTransforms()[attached_body_shape_handle.second[k].second];
+            attached_body_shape_handle.first->getShapePosesInLinkFrame()[attached_body_shape_handle.second[k].second];
     }
     {
       tf_buffer_->canTransform(target_frame, scene_->getPlanningFrame(), target_time,

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -118,13 +118,13 @@ RDFLoader::RDFLoader(const std::string& urdf_string, const std::string& srdf_str
   auto umodel = std::make_unique<urdf::Model>();
   if (umodel->initString(urdf_string))
   {
-    srdf_ = std::make_shared<srdf::Model>();
-    if (!srdf_->initString(*urdf_, srdf_string))
+    auto smodel = std::make_shared<srdf::Model>();
+    if (!smodel->initString(*umodel, srdf_string))
     {
       RCLCPP_ERROR(LOGGER, "Unable to parse SRDF");
-      srdf_.reset();
     }
     urdf_ = std::move(umodel);
+    srdf_ = std::move(smodel);
   }
   else
   {

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -103,6 +103,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   moveit_msgs::CollisionObject box;
   box.id = "box";
   box.header.frame_id = "panda_hand";
+  box.pose.orientation.w = 1.0;
   box.primitives.resize(1);
   box.primitive_poses.resize(1);
   box.primitives[0].type = box.primitives[0].BOX;
@@ -126,6 +127,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   moveit_msgs::CollisionObject cylinder;
   cylinder.id = "cylinder";
   cylinder.header.frame_id = "panda_hand";
+  cylinder.pose.orientation.w = 1.0;
   cylinder.primitives.resize(1);
   cylinder.primitive_poses.resize(1);
   cylinder.primitives[0].type = box.primitives[0].CYLINDER;
@@ -168,6 +170,7 @@ TEST(TestPlanUsingSubframes, SubframesTests)
   att_coll_object.object.id = "cylinder";
   att_coll_object.link_name = "panda_hand";
   att_coll_object.object.operation = att_coll_object.object.ADD;
+  att_coll_object.object.pose.orientation.w = 1.0;
   planning_scene_interface.applyAttachedCollisionObject(att_coll_object);
 
   tf2::Quaternion target_orientation;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -327,6 +327,8 @@ private:
   rclcpp::Publisher<moveit_msgs::msg::PlanningSceneWorld>::SharedPtr planning_scene_world_publisher_;
 
   collision_detection::CollisionEnv::ObjectConstPtr scaled_object_;
+  moveit::core::FixedTransformsMap scaled_object_subframes_;
+  EigenSTL::vector_Isometry3d scaled_object_shape_poses_;
 
   std::vector<std::pair<std::string, bool> > known_collision_objects_;
   long unsigned int known_collision_objects_version_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -96,14 +96,11 @@ void MotionPlanningFrame::processDetectedObjects()
       object_ids.clear();
       for (const auto& object : *world)
       {
-        if (!object.second->shape_poses_.empty())
+        const auto& position = object.second->pose_.translation();
+        if (position.x() >= min_x && position.x() <= max_x && position.y() >= min_y && position.y() <= max_y &&
+            position.z() >= min_z && position.z() <= max_z)
         {
-          const auto& position = object.second->shape_poses_[0].translation();
-          if (position.x() >= min_x && position.x() <= max_x && position.y() >= min_y && position.y() <= max_y &&
-              position.z() >= min_z && position.z() <= max_z)
-          {
-            object_ids.push_back(object.first);
-          }
+          object_ids.push_back(object.first);
         }
       }
       if (!object_ids.empty())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -158,6 +158,7 @@ void MotionPlanningFrame::clearScene()
 
 void MotionPlanningFrame::sceneScaleChanged(int value)
 {
+  const double scaling_factor = (double)value / 100.0;  // The GUI slider gives percent values
   if (scaled_object_)
   {
     planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();
@@ -165,17 +166,23 @@ void MotionPlanningFrame::sceneScaleChanged(int value)
     {
       if (ps->getWorld()->hasObject(scaled_object_->id_))
       {
-        const moveit::core::FixedTransformsMap subframes = scaled_object_->subframe_poses_;  // Keep subframes
         ps->getWorldNonConst()->removeObject(scaled_object_->id_);
         for (std::size_t i = 0; i < scaled_object_->shapes_.size(); ++i)
         {
           shapes::Shape* s = scaled_object_->shapes_[i]->clone();
-          s->scale((double)value / 100.0);
-          ps->getWorldNonConst()->addToObject(scaled_object_->id_, shapes::ShapeConstPtr(s),
-                                              scaled_object_->shape_poses_[i]);
+          s->scale(scaling_factor);
+
+          Eigen::Isometry3d scaled_shape_pose = scaled_object_->shape_poses_[i];
+          scaled_shape_pose.translation() *= scaling_factor;
+
+          ps->getWorldNonConst()->addToObject(scaled_object_->id_, scaled_object_->pose_, shapes::ShapeConstPtr(s),
+                                              scaled_shape_pose);
         }
-        // TODO(felixvd): Scale subframes too
-        ps->getWorldNonConst()->setSubframesOfObject(scaled_object_->id_, subframes);
+        moveit::core::FixedTransformsMap scaled_subframes = scaled_object_->subframe_poses_;
+        for (auto& subframe_pair : scaled_subframes)
+          subframe_pair.second.translation() *= scaling_factor;
+
+        ps->getWorldNonConst()->setSubframesOfObject(scaled_object_->id_, scaled_subframes);
         setLocalSceneEdited();
         scene_marker_->processMessage(createObjectMarkerMsg(ps->getWorld()->getObject(scaled_object_->id_)));
         planning_display_->queueRenderSceneGeometry();
@@ -199,6 +206,8 @@ void MotionPlanningFrame::sceneScaleStartChange()
     if (ps)
     {
       scaled_object_ = ps->getWorld()->getObject(sel[0]->text().toStdString());
+      scaled_object_subframes_ = scaled_object_->subframe_poses_;
+      scaled_object_shape_poses_ = scaled_object_->shape_poses_;
     }
   }
 }
@@ -260,9 +269,9 @@ static QString decideStatusText(const moveit::core::AttachedBody* attached_body)
 {
   QString status_text = "'" + QString::fromStdString(attached_body->getName()) + "' is attached to '" +
                         QString::fromStdString(attached_body->getAttachedLinkName()) + "'.";
-  if (!attached_body->getSubframeTransforms().empty())
+  if (!attached_body->getSubframes().empty())
   {
-    status_text += subframe_poses_to_qstring(attached_body->getSubframeTransforms());
+    status_text += subframe_poses_to_qstring(attached_body->getSubframes());
   }
   return status_text;
 }
@@ -318,7 +327,7 @@ void MotionPlanningFrame::selectedCollisionObjectChanged()
 
           if (obj->shapes_.size() == 1)
           {
-            obj_pose = obj->shape_poses_[0];  // valid isometry by contract
+            obj_pose = obj->pose_;  // valid isometry by contract
             Eigen::Vector3d xyz = obj_pose.linear().eulerAngles(0, 1, 2);
             update_scene_marker = true;  // do the marker update outside locked scope to avoid deadlock
 
@@ -385,7 +394,7 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
   if (ps)
   {
     collision_detection::CollisionEnv::ObjectConstPtr obj = ps->getWorld()->getObject(sel[0]->text().toStdString());
-    if (obj && obj->shapes_.size() == 1)
+    if (obj)
     {
       Eigen::Isometry3d p;
       p.translation()[0] = ui_->object_x->value();
@@ -397,7 +406,7 @@ void MotionPlanningFrame::updateCollisionObjectPose(bool update_marker_position)
            Eigen::AngleAxisd(ui_->object_ry->value(), Eigen::Vector3d::UnitY()) *
            Eigen::AngleAxisd(ui_->object_rz->value(), Eigen::Vector3d::UnitZ()));
 
-      ps->getWorldNonConst()->moveShapeInObject(obj->id_, obj->shapes_[0], p);
+      ps->getWorldNonConst()->moveObjectAbsolute(obj->id_, p);
       planning_display_->queueRenderSceneGeometry();
       setLocalSceneEdited();
 
@@ -481,7 +490,7 @@ void MotionPlanningFrame::copySelectedCollisionObject()
       continue;
 
     // find a name for the copy
-    name = std::string("Copy of ").append(name);
+    name.insert(0, "Copy of ");
     if (ps->getWorld()->hasObject(name))
     {
       name += " ";
@@ -762,7 +771,11 @@ MotionPlanningFrame::createObjectMarkerMsg(const collision_detection::CollisionE
   double scale;
   shapes::computeShapeBoundingSphere(obj->shapes_[0].get(), center, scale);
   geometry_msgs::msg::PoseStamped shape_pose = tf2::toMsg(tf2::Stamped<Eigen::Isometry3d>(
-      obj->shape_poses_[0], std::chrono::system_clock::now(), planning_display_->getRobotModel()->getModelFrame()));
+      obj->pose_, std::chrono::system_clock::now(), planning_display_->getRobotModel()->getModelFrame()));
+  // TODO(felixvd): Consider where to place the object marker.
+  //                obj->pose*obj->shape_poses_[0] is backwards compatible, sits on the visible part of
+  //                the object, and is more difficult to implement now.
+  //                obj->pose is easier to implement and makes more sense.
   scale = (scale + center.cwiseAbs().maxCoeff()) * 2.0 * 1.2;  // add padding of 20% size
 
   // create an interactive marker msg for the given shape
@@ -837,10 +850,12 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
     if (obj)
     {
       known_collision_objects_[item->type()].first = item_text;
+      const Eigen::Isometry3d pose = obj->pose_;
       const moveit::core::FixedTransformsMap subframes = obj->subframe_poses_;  // Keep subframes
-      // TODO(felixvd): Scale the subframes with the object
+
       ps->getWorldNonConst()->removeObject(obj->id_);
       ps->getWorldNonConst()->addToObject(known_collision_objects_[item->type()].first, obj->shapes_, obj->shape_poses_);
+      ps->getWorldNonConst()->setObjectPose(obj->id_, pose);
       ps->getWorldNonConst()->setSubframesOfObject(obj->id_, subframes);
       if (scene_marker_)
       {
@@ -860,8 +875,8 @@ void MotionPlanningFrame::renameCollisionObject(QListWidgetItem* item)
       known_collision_objects_[item->type()].first = item_text;
       moveit::core::AttachedBody* new_ab =
           new moveit::core::AttachedBody(ab->getAttachedLink(), known_collision_objects_[item->type()].first,
-                                         ab->getShapes(), ab->getFixedTransforms(), ab->getTouchLinks(),
-                                         ab->getDetachPosture(), ab->getSubframeTransforms());
+                                         ab->getPose(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
+                                         ab->getDetachPosture(), ab->getSubframes());
       cs.clearAttachedBody(ab->getName());
       cs.attachBody(new_ab);
     }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -112,8 +112,11 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
       alpha = c.a;
     }
     for (std::size_t j = 0; j < object->shapes_.size(); ++j)
-      render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(), object->shape_poses_[j],
-                                  octree_voxel_rendering, octree_color_mode, color, alpha);
+    {
+      render_shapes_->renderShape(planning_scene_geometry_node_, object->shapes_[j].get(),
+                                  scene->getWorld()->getGlobalShapeTransform(id, j), octree_voxel_rendering,
+                                  octree_color_mode, color, alpha);
+    }
   }
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -138,7 +138,7 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
       continue;
     }
     Ogre::ColourValue rcolor(color.r, color.g, color.b);
-    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getFixedTransforms();
+    const EigenSTL::vector_Isometry3d& ab_t = attached_body->getShapePosesInLinkFrame();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)
     {


### PR DESCRIPTION
### Description

Sync the following commits from MoveIt with merge
```
* [2020-09-11] [b57628ff7] | Unify object scaling in Rviz {{Felix von Drigalski}} 
* [2020-09-12] [d6a714d16] | Add pose to AttachedBody and RobotState {{Felix von Drigalski}} 
* [2020-09-12] [6561fd372] | Add pose to CollisionObject and world {{Felix von Drigalski}} 
* [2020-06-07] [aa88879b5] | Renaming, housekeeping, migration notes {{Felix von Drigalski}} 
* [2021-08-14] [0defef0f2] | more fixes for the clang-tidy job (#2813) {{Michael Görner}} 
* [2021-08-12] [86174f367] | fix clang-tidy CI job (#2792) {{Michael Görner}} 
* [2021-08-11] [823788778] | Bugfix in RDFLoader (#2806) {{werner291}} 
* [2021-08-10] [f0271dc6a] | Merge pull request #2802 from v4hn/pr-master-fix-clang-issues {{Michael Görner}} 
* [2021-07-29] [4daba2636] | ompl: provide override for missing isValid method {{v4hn}} 
* [2021-07-29] [99d6da39d] | work around clang diagnostics warning {{v4hn}} 
```