### PR TITLE
Draft: Servo pipeline

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -86,6 +86,8 @@ ament_target_dependencies(${SERVO_PARAM_LIB_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS
 add_library(${SERVO_LIB_NAME} SHARED
   # These files are used to produce differential motion
   src/collision_check.cpp
+  src/detail/input_check_valid.cpp
+  src/detail/servo_pipeline.cpp
   src/enforce_limits.cpp
   src/servo.cpp
   src/servo_calcs.cpp
@@ -252,6 +254,26 @@ if(BUILD_TESTING)
     test/enforce_limits_tests.cpp
   )
   target_link_libraries(enforce_limits_tests ${SERVO_LIB_NAME})
+
+  # Input check valid
+  ament_add_gtest(input_check_valid_tests test/input_check_valid_tests.cpp)
+  target_link_libraries(input_check_valid_tests ${SERVO_LIB_NAME})
+
+  # Input resampler tests
+  ament_add_gtest(input_resampler_tests test/input_resampler_tests.cpp)
+  target_link_libraries(input_resampler_tests ${SERVO_LIB_NAME})
+
+  # Input stale command tests
+  ament_add_gtest(input_stale_command_tests test/input_stale_command_tests.cpp)
+  target_link_libraries(input_stale_command_tests ${SERVO_LIB_NAME})
+
+  # Input subscriber tests
+  ament_add_gtest(input_subscriber_tests test/input_subscriber_tests.cpp)
+  target_link_libraries(input_subscriber_tests ${SERVO_LIB_NAME})
+
+  # Servo pipeline tests
+  ament_add_gtest(servo_pipeline_tests test/servo_pipeline_tests.cpp)
+  target_link_libraries(servo_pipeline_tests ${SERVO_LIB_NAME})
 
 endif()
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
@@ -59,10 +59,11 @@ class InputCheckValid : public InputVisitor
 {
   rclcpp::Node::SharedPtr node_ = nullptr;
   std::string command_in_type_ = "unitless";
-  InputVisitor* next_ = nullptr;
+  std::shared_ptr<InputVisitor> next_ = nullptr;
 
 public:
-  InputCheckValid(rclcpp::Node::SharedPtr node, std::string_view command_in_type, InputVisitor* next)
+  InputCheckValid(const rclcpp::Node::SharedPtr& node, std::string_view command_in_type,
+                  const std::shared_ptr<InputVisitor>& next)
     : node_{ node }, command_in_type_{ command_in_type }, next_{ next }
   {
     assert(node_ != nullptr);

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
@@ -1,0 +1,78 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : input_check_valid.hpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <functional>
+#include <variant>
+#include <memory>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+/**
+ * @brief      Visitor that checks if the input is valid, only calling next if that is true
+ */
+class InputCheckValid : public InputVisitor
+{
+  rclcpp::Node::SharedPtr node_ = nullptr;
+  std::string command_in_type_ = "unitless";
+  InputVisitor* next_ = nullptr;
+
+public:
+  InputCheckValid(rclcpp::Node::SharedPtr node, std::string_view command_in_type, InputVisitor* next)
+    : node_{ node }, command_in_type_{ command_in_type }, next_{ next }
+  {
+    assert(node_ != nullptr);
+    assert(next_ != nullptr);
+  }
+  ~InputCheckValid() override = default;
+
+  void operator()(geometry_msgs::msg::TwistStamped command) override;
+  void operator()(control_msgs::msg::JointJog command) override;
+};
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_check_valid.hpp
@@ -70,8 +70,8 @@ public:
   }
   ~InputCheckValid() override = default;
 
-  void operator()(geometry_msgs::msg::TwistStamped command) override;
-  void operator()(control_msgs::msg::JointJog command) override;
+  void operator()(const geometry_msgs::msg::TwistStamped& command) override;
+  void operator()(const control_msgs::msg::JointJog& command) override;
 };
 
 }  // namespace detail

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_command.hpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/*      Title     : input_command.hpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+/**
+ * InputCommand type used by all Visitor callables
+ */
+using InputCommand = std::variant<geometry_msgs::msg::TwistStamped, control_msgs::msg::JointJog>;
+
+/**
+ * @brief Interface class for input visitors
+ */
+class InputVisitor
+{
+public:
+  virtual void operator()(geometry_msgs::msg::TwistStamped) = 0;
+  virtual void operator()(control_msgs::msg::JointJog) = 0;
+  virtual ~InputVisitor()
+  {
+  }
+};
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_command.hpp
@@ -58,8 +58,8 @@ using InputCommand = std::variant<geometry_msgs::msg::TwistStamped, control_msgs
 class InputVisitor
 {
 public:
-  virtual void operator()(geometry_msgs::msg::TwistStamped) = 0;
-  virtual void operator()(control_msgs::msg::JointJog) = 0;
+  virtual void operator()(const geometry_msgs::msg::TwistStamped&) = 0;
+  virtual void operator()(const control_msgs::msg::JointJog&) = 0;
   virtual ~InputVisitor()
   {
   }

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
@@ -88,19 +88,19 @@ public:
   }
   ~InputResampler() override = default;
 
-  void operator()(geometry_msgs::msg::TwistStamped command) override
+  void operator()(const geometry_msgs::msg::TwistStamped& command) override
   {
     operatorImpl(command);
   }
 
-  void operator()(control_msgs::msg::JointJog command) override
+  void operator()(const control_msgs::msg::JointJog& command) override
   {
     operatorImpl(command);
   }
 
 private:
   template <typename T>
-  void operatorImpl(T command)
+  void operatorImpl(const T& command)
   {
     {
       const std::lock_guard<std::mutex> lock(mutex_);

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
@@ -59,7 +59,7 @@ class InputResampler : public InputVisitor
 {
   rclcpp::Node::SharedPtr node_ = nullptr;
   rclcpp::Duration period_ = rclcpp::Duration::from_seconds(1);
-  InputVisitor* next_ = nullptr;
+  std::shared_ptr<InputVisitor> next_ = nullptr;
   rclcpp::TimerBase::SharedPtr timer_ = nullptr;
   std::mutex mutex_;
   InputCommand command_;
@@ -72,7 +72,8 @@ class InputResampler : public InputVisitor
   }
 
 public:
-  InputResampler(rclcpp::Node::SharedPtr node, const rclcpp::Duration& period, InputVisitor* next)
+  InputResampler(const rclcpp::Node::SharedPtr& node, const rclcpp::Duration& period,
+                 const std::shared_ptr<InputVisitor>& next)
     : node_{ node }, period_{ period }, next_{ next }
   {
     assert(node_ != nullptr);

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_resampler.hpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/*      Title     : input_resampler.hpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+/**
+ * @brief      Visitor that stores the the input command and then calls a visitor with a timer at a specified rate
+ */
+class InputResampler : public InputVisitor
+{
+  rclcpp::Node::SharedPtr node_ = nullptr;
+  rclcpp::Duration period_ = rclcpp::Duration::from_seconds(1);
+  InputVisitor* next_ = nullptr;
+  rclcpp::TimerBase::SharedPtr timer_ = nullptr;
+  std::mutex mutex_;
+  InputCommand command_;
+
+  // Create a copy of the message so we don't have to lock durring the call to visit
+  InputCommand getCommandCopy()
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return command_;
+  }
+
+public:
+  InputResampler(rclcpp::Node::SharedPtr node, const rclcpp::Duration& period, InputVisitor* next)
+    : node_{ node }, period_{ period }, next_{ next }
+  {
+    assert(node_ != nullptr);
+    assert(next_ != nullptr);
+  }
+  InputResampler(InputResampler&& other) noexcept
+    : node_{ std::move(other.node_) }
+    , period_{ other.period_ }
+    , next_{ other.next_ }
+    , timer_{ other.timer_ }
+    , command_{ other.command_ }
+  {
+  }
+  ~InputResampler() override = default;
+
+  void operator()(geometry_msgs::msg::TwistStamped command) override
+  {
+    operatorImpl(command);
+  }
+
+  void operator()(control_msgs::msg::JointJog command) override
+  {
+    operatorImpl(command);
+  }
+
+private:
+  template <typename T>
+  void operatorImpl(T command)
+  {
+    {
+      const std::lock_guard<std::mutex> lock(mutex_);
+      command_ = command;
+    }
+    if (timer_ == nullptr)
+    {
+      std::visit(*next_, getCommandCopy());
+      timer_ = node_->create_wall_timer(period_.to_chrono<std::chrono::milliseconds>(),
+                                        [&]() { std::visit(*next_, getCommandCopy()); });
+    }
+  }
+};
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
@@ -68,19 +68,21 @@ public:
   }
   ~TimestampNow() override = default;
 
-  void operator()(geometry_msgs::msg::TwistStamped command) override
+  void operator()(const geometry_msgs::msg::TwistStamped& command) override
   {
     operatorImpl(command);
   }
 
-  void operator()(control_msgs::msg::JointJog command) override
+  void operator()(const control_msgs::msg::JointJog& command) override
   {
     operatorImpl(command);
   }
 
 private:
+  // Note that this implementation template takes the input command by value
+  // because it mutates it before visiting the next step.
   template <typename T>
-  void operatorImpl(T& command)
+  void operatorImpl(T command)
   {
     command.header.stamp = node_->now();
     std::visit(*next_, InputCommand{ command });
@@ -107,19 +109,19 @@ public:
   }
   ~StaleCommandHalt() override = default;
 
-  void operator()(geometry_msgs::msg::TwistStamped command) override
+  void operator()(const geometry_msgs::msg::TwistStamped& command) override
   {
     operatorImpl(command);
   }
 
-  void operator()(control_msgs::msg::JointJog command) override
+  void operator()(const control_msgs::msg::JointJog& command) override
   {
     operatorImpl(command);
   }
 
 private:
   template <typename T>
-  void operatorImpl(T& command)
+  void operatorImpl(const T& command)
   {
     if (node_->now() - command.header.stamp > timeout_)
     {

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
@@ -1,0 +1,136 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : input_stale_command.hpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <functional>
+#include <variant>
+#include <memory>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+/**
+ * @brief      Visitor that sets the header.stamp to now and then calls the next visitor
+ */
+class TimestampNow : public InputVisitor
+{
+  rclcpp::Node::SharedPtr node_ = nullptr;
+  InputVisitor* next_ = nullptr;
+
+public:
+  TimestampNow(rclcpp::Node::SharedPtr node, InputVisitor* next) : node_{ node }, next_{ next }
+  {
+    assert(node_ != nullptr);
+    assert(next_ != nullptr);
+  }
+  ~TimestampNow() override = default;
+
+  void operator()(geometry_msgs::msg::TwistStamped command) override
+  {
+    operatorImpl(command);
+  }
+
+  void operator()(control_msgs::msg::JointJog command) override
+  {
+    operatorImpl(command);
+  }
+
+private:
+  template <typename T>
+  void operatorImpl(T& command)
+  {
+    command.header.stamp = node_->now();
+    std::visit(*next_, InputCommand{ command });
+  }
+};
+
+/**
+ * @brief      Visitor that if the message is stale it calls halt, otherwise it calls the next visitor
+ */
+class StaleCommandHalt : public InputVisitor
+{
+  rclcpp::Node::SharedPtr node_ = nullptr;
+  rclcpp::Duration timeout_;
+  std::function<void()> halt_;
+  InputVisitor* next_ = nullptr;
+
+public:
+  StaleCommandHalt(rclcpp::Node::SharedPtr node, const rclcpp::Duration& timeout, std::function<void()> halt,
+                   InputVisitor* next)
+    : node_{ node }, timeout_{ timeout }, halt_{ halt }, next_{ next }
+  {
+    assert(node_ != nullptr);
+    assert(next_ != nullptr);
+  }
+  ~StaleCommandHalt() override = default;
+
+  void operator()(geometry_msgs::msg::TwistStamped command) override
+  {
+    operatorImpl(command);
+  }
+
+  void operator()(control_msgs::msg::JointJog command) override
+  {
+    operatorImpl(command);
+  }
+
+private:
+  template <typename T>
+  void operatorImpl(T& command)
+  {
+    if (node_->now() - command.header.stamp > timeout_)
+    {
+      halt_();
+    }
+    else
+    {
+      std::visit(*next_, InputCommand{ command });
+    }
+  }
+};
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_stale_command.hpp
@@ -58,10 +58,11 @@ namespace detail
 class TimestampNow : public InputVisitor
 {
   rclcpp::Node::SharedPtr node_ = nullptr;
-  InputVisitor* next_ = nullptr;
+  std::shared_ptr<InputVisitor> next_ = nullptr;
 
 public:
-  TimestampNow(rclcpp::Node::SharedPtr node, InputVisitor* next) : node_{ node }, next_{ next }
+  TimestampNow(const rclcpp::Node::SharedPtr& node, const std::shared_ptr<InputVisitor>& next)
+    : node_{ node }, next_{ next }
   {
     assert(node_ != nullptr);
     assert(next_ != nullptr);
@@ -97,11 +98,11 @@ class StaleCommandHalt : public InputVisitor
   rclcpp::Node::SharedPtr node_ = nullptr;
   rclcpp::Duration timeout_;
   std::function<void()> halt_;
-  InputVisitor* next_ = nullptr;
+  std::shared_ptr<InputVisitor> next_ = nullptr;
 
 public:
-  StaleCommandHalt(rclcpp::Node::SharedPtr node, const rclcpp::Duration& timeout, std::function<void()> halt,
-                   InputVisitor* next)
+  StaleCommandHalt(const rclcpp::Node::SharedPtr& node, const rclcpp::Duration& timeout, std::function<void()> halt,
+                   const std::shared_ptr<InputVisitor>& next)
     : node_{ node }, timeout_{ timeout }, halt_{ halt }, next_{ next }
   {
     assert(node_ != nullptr);

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_subscriber.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_subscriber.hpp
@@ -63,7 +63,7 @@ class InputSubscriber
 
 public:
   InputSubscriber(const rclcpp::Node::SharedPtr& node, const std::string& twist_stamped_topic,
-                  const std::string& joint_jog_topic, InputVisitor* next)
+                  const std::string& joint_jog_topic, const std::shared_ptr<InputVisitor>& next)
   {
     assert(node != nullptr);
     assert(next != nullptr);

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/input_subscriber.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/input_subscriber.hpp
@@ -1,0 +1,80 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : input_subscriber.hpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#pragma once
+
+#include <functional>
+#include <variant>
+#include <memory>
+#include <string>
+#include <rclcpp/rclcpp.hpp>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+/**
+ * @brief      Subscribes to the two input topics and calls visitor on them
+ */
+class InputSubscriber
+{
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_ = nullptr;
+  rclcpp::Subscription<control_msgs::msg::JointJog>::SharedPtr joint_cmd_sub_ = nullptr;
+
+public:
+  InputSubscriber(const rclcpp::Node::SharedPtr& node, const std::string& twist_stamped_topic,
+                  const std::string& joint_jog_topic, InputVisitor* next)
+  {
+    assert(node != nullptr);
+    assert(next != nullptr);
+    twist_stamped_sub_ = node->create_subscription<geometry_msgs::msg::TwistStamped>(
+        twist_stamped_topic, rclcpp::SystemDefaultsQoS(),
+        [=](std::shared_ptr<geometry_msgs::msg::TwistStamped> msg) { std::visit(*next, InputCommand{ *msg }); });
+    joint_cmd_sub_ = node->create_subscription<control_msgs::msg::JointJog>(
+        joint_jog_topic, rclcpp::SystemDefaultsQoS(),
+        [=](std::shared_ptr<control_msgs::msg::JointJog> msg) { std::visit(*next, InputCommand{ *msg }); });
+  }
+};
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/detail/servo_pipeline.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/detail/servo_pipeline.hpp
@@ -52,7 +52,7 @@ namespace detail
 {
 class ServoPipeline
 {
-  std::vector<std::unique_ptr<InputVisitor>> input_visitors_;
+  std::vector<std::shared_ptr<InputVisitor>> input_visitors_;
   std::unique_ptr<InputSubscriber> input_subscriber_;
 
 public:
@@ -64,8 +64,9 @@ public:
    * @param halt function for sending a message that will stop the robot
    * @param next the next visitor to execute after the pipeline, normally ServoCalcs
    */
-  ServoPipeline(rclcpp::Node::SharedPtr node, std::shared_ptr<const moveit_servo::ServoParameters> parameters,
-                std::function<void()> halt, InputVisitor* next);
+  ServoPipeline(const rclcpp::Node::SharedPtr& node,
+                const std::shared_ptr<const moveit_servo::ServoParameters>& parameters, std::function<void()> halt,
+                const std::shared_ptr<InputVisitor>& next);
 };
 
 }  // namespace detail

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -43,8 +43,9 @@
 
 // Moveit2
 #include <moveit_servo/collision_check.h>
-#include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/servo_calcs.h>
+#include <moveit_servo/servo_parameters.h>
+#include <moveit_servo/detail/servo_pipeline.hpp>
 
 namespace moveit_servo
 {
@@ -56,11 +57,6 @@ class Servo
 public:
   Servo(const rclcpp::Node::SharedPtr& node, ServoParameters::SharedConstPtr parameters,
         planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor);
-
-  ~Servo();
-
-  /** \brief start servo node */
-  void start();
 
   /** \brief Pause or unpause processing servo commands while keeping the timers alive */
   void setPaused(bool paused);
@@ -100,6 +96,7 @@ private:
 
   ServoCalcs servo_calcs_;
   CollisionCheck collision_checker_;
+  detail::ServoPipeline servo_pipeline_;
 };
 
 // ServoPtr using alias

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -94,7 +94,7 @@ private:
   // The stored servo parameters
   ServoParameters::SharedConstPtr parameters_;
 
-  ServoCalcs servo_calcs_;
+  std::shared_ptr<ServoCalcs> servo_calcs_;
   CollisionCheck collision_checker_;
   detail::ServoPipeline servo_pipeline_;
 };

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -115,14 +115,14 @@ public:
    *
    * @param[in]  input_command  The input command
    */
-  void operator()(geometry_msgs::msg::TwistStamped input_command) override;
+  void operator()(const geometry_msgs::msg::TwistStamped& input_command) override;
 
   /**
    * @brief      Function call operator for input visitor.
    *
    * @param[in]  input_command  The input command
    */
-  void operator()(control_msgs::msg::JointJog input_command) override;
+  void operator()(const control_msgs::msg::JointJog& input_command) override;
 
   /**
    * @brief      Halt the robot arm
@@ -131,7 +131,7 @@ public:
 
 protected:
   /** \brief Do servoing calculations for Cartesian twist commands. */
-  bool cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
+  bool cartesianServoCalcs(geometry_msgs::msg::TwistStamped cmd,
                            trajectory_msgs::msg::JointTrajectory& joint_trajectory);
 
   /** \brief Do servoing calculations for direct commands to a joint. */

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.h
@@ -83,7 +83,5 @@ private:
   void unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                  std::shared_ptr<std_srvs::srv::Trigger::Response> response);
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr unpause_servo_service_;
-
-  bool is_initialized_;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -55,7 +55,7 @@ struct ServoParameters
   using SharedConstPtr = std::shared_ptr<const ServoParameters>;
 
   // Parameter namespace
-  const std::string ns;
+  std::string ns{ "moveit_servo" };
 
   // ROS Parameters
   // Note that all of these are effectively const because the only way to create one of these
@@ -141,11 +141,6 @@ struct ServoParameters
   static std::optional<ServoParameters> validate(ServoParameters parameters);
 
 private:
-  // Private constructor because we only want this object to be created through the builder method makeServoParameters
-  ServoParameters()
-  {
-  }
-
   struct CallbackHandler
   {
     // callback handler for the on set parameters callback

--- a/moveit_ros/moveit_servo/src/detail/input_check_valid.cpp
+++ b/moveit_ros/moveit_servo/src/detail/input_check_valid.cpp
@@ -62,7 +62,7 @@ constexpr auto ROS_LOG_THROTTLE_PERIOD = std::chrono::milliseconds(1000).count()
 using std::fabs;
 using std::isnan;
 
-void InputCheckValid::operator()(geometry_msgs::msg::TwistStamped command)
+void InputCheckValid::operator()(const geometry_msgs::msg::TwistStamped& command)
 {
   if (isnan(command.twist.linear.x) || isnan(command.twist.linear.y) || isnan(command.twist.linear.z) ||
       isnan(command.twist.angular.x) || isnan(command.twist.angular.y) || isnan(command.twist.angular.z))
@@ -91,7 +91,7 @@ void InputCheckValid::operator()(geometry_msgs::msg::TwistStamped command)
   std::visit(*next_, InputCommand{ command });
 }
 
-void InputCheckValid::operator()(control_msgs::msg::JointJog command)
+void InputCheckValid::operator()(const control_msgs::msg::JointJog& command)
 {
   for (double velocity : command.velocities)
   {

--- a/moveit_ros/moveit_servo/src/detail/input_check_valid.cpp
+++ b/moveit_ros/moveit_servo/src/detail/input_check_valid.cpp
@@ -1,0 +1,112 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*      Title     : input_check_valid.cpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/input_check_valid.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+namespace
+{
+const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.input_check_valid");
+constexpr auto ROS_LOG_THROTTLE_PERIOD = std::chrono::milliseconds(1000).count();
+}  // namespace
+
+using std::fabs;
+using std::isnan;
+
+void InputCheckValid::operator()(geometry_msgs::msg::TwistStamped command)
+{
+  if (isnan(command.twist.linear.x) || isnan(command.twist.linear.y) || isnan(command.twist.linear.z) ||
+      isnan(command.twist.angular.x) || isnan(command.twist.angular.y) || isnan(command.twist.angular.z))
+  {
+    rclcpp::Clock& clock = *node_->get_clock();
+    RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                "nan in incoming command. Skipping this datapoint.");
+    return;
+  }
+
+  // If incoming commands should be in the range [-1:1], check for |delta|>1
+  if (command_in_type_ == "unitless")
+  {
+    if ((fabs(command.twist.linear.x) > 1) || (fabs(command.twist.linear.y) > 1) ||
+        (fabs(command.twist.linear.z) > 1) || (fabs(command.twist.angular.x) > 1) ||
+        (fabs(command.twist.angular.y) > 1) || (fabs(command.twist.angular.z) > 1))
+    {
+      rclcpp::Clock& clock = *node_->get_clock();
+      RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                  "Component of incoming command is >1. Skipping this datapoint.");
+      return;
+    }
+  }
+
+  // All is good, visit the next one
+  std::visit(*next_, InputCommand{ command });
+}
+
+void InputCheckValid::operator()(control_msgs::msg::JointJog command)
+{
+  for (double velocity : command.velocities)
+  {
+    if (isnan(velocity))
+    {
+      rclcpp::Clock& clock = *node_->get_clock();
+      RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                  "nan in incoming command. Skipping this datapoint.");
+      return;
+    }
+  }
+
+  // All is good, visit the next one
+  std::visit(*next_, InputCommand{ command });
+}
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/detail/servo_pipeline.cpp
+++ b/moveit_ros/moveit_servo/src/detail/servo_pipeline.cpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, PickNik Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/*      Title     : servo_pipeline.cpp
+ *      Project   : moveit_servo
+ *      Created   : 11/06/2021
+ *      Author    : Tyler Weaver
+ */
+
+#include <functional>
+#include <memory>
+#include <moveit_servo/detail/input_check_valid.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <moveit_servo/detail/input_resampler.hpp>
+#include <moveit_servo/detail/input_stale_command.hpp>
+#include <moveit_servo/detail/input_subscriber.hpp>
+#include <moveit_servo/servo_parameters.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/servo_pipeline.hpp>
+
+namespace moveit_servo
+{
+namespace detail
+{
+ServoPipeline::ServoPipeline(rclcpp::Node::SharedPtr node,
+                             std::shared_ptr<const moveit_servo::ServoParameters> parameters,
+                             std::function<void()> halt, InputVisitor* next)
+{
+  assert(node != nullptr);
+  assert(parameters != nullptr);
+  assert(next != nullptr);
+
+  // The servo pipeline is constructed in reverse order.
+  // Starting with the last object and working in reverse.
+  // This is done because each step needs a pointer to the next step to be able to call it.
+
+  // The initial value of next is the visitor step after the last step in the servo pipeline.
+  // In the default, the happy path each step calls the next step in the chain after it does its thing.
+  // Note that after we construct each step we get a pointer to it in order to construct the next step.
+
+  // The reason these are unique_ptr inside of a vector is we hand a non-owning pointer to each one
+  //  to the step that precedes it.
+  // This means that the address of the pointer does not change if the ServoPipeline object is moved.
+
+  // This is the default case where we are not in low_latency_mode and we want to resample input.
+  //
+  // StaleCommandHalt
+  //   description: checks timeout and calls next if the message is not stale
+  //   failure: on timeout calls the halt function
+  // InputResampler
+  //   description: call StaleCommandHalt with stored input command at a set rate
+  // TimestampNow
+  //   descritption: sets the timestamp in header to now(), then calls InputResampler
+  //
+  // next is set to TimestampNow
+  if (!parameters->low_latency_mode)
+  {
+    next = input_visitors_
+               .emplace_back(std::make_unique<StaleCommandHalt>(
+                   node, rclcpp::Duration::from_seconds(parameters->incoming_command_timeout), halt, next))
+               .get();
+    next = input_visitors_
+               .emplace_back(std::make_unique<InputResampler>(
+                   node, rclcpp::Duration::from_seconds(parameters->publish_period), next))
+               .get();
+    next = input_visitors_.emplace_back(std::make_unique<TimestampNow>(node, next)).get();
+  }
+
+  // InputCheckValid
+  //   description: checks if the intput message is valid then calls next
+  //   failure: logs warning and does not call next
+  next = input_visitors_.emplace_back(std::make_unique<InputCheckValid>(node, parameters->command_in_type, next)).get();
+
+  // InputSubscriber
+  //   description: calls InputCheckValid with commands from ros subscribers
+  input_subscriber_ = std::make_unique<InputSubscriber>(node, parameters->cartesian_command_in_topic,
+                                                        parameters->joint_command_in_topic, next);
+}
+
+}  // namespace detail
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/detail/servo_pipeline.cpp
+++ b/moveit_ros/moveit_servo/src/detail/servo_pipeline.cpp
@@ -37,6 +37,7 @@
  *      Author    : Tyler Weaver
  */
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <moveit_servo/detail/input_check_valid.hpp>
@@ -89,8 +90,10 @@ ServoPipeline::ServoPipeline(const rclcpp::Node::SharedPtr& node,
   {
     next_step = input_visitors_.emplace_back(std::make_shared<StaleCommandHalt>(
         node, rclcpp::Duration::from_seconds(parameters->incoming_command_timeout), halt, next_step));
-    next_step = input_visitors_.emplace_back(
-        std::make_shared<InputResampler>(node, rclcpp::Duration::from_seconds(parameters->publish_period), next_step));
+    next_step = input_visitors_.emplace_back(std::make_shared<InputResampler>(
+        node,
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(parameters->publish_period)),
+        next_step));
     next_step = input_visitors_.emplace_back(std::make_shared<TimestampNow>(node, next_step));
   }
 

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -96,7 +96,6 @@ PoseTracking::PoseTracking(const rclcpp::Node::SharedPtr& node, const ServoParam
 
   // Use the C++ interface that Servo provides
   servo_ = std::make_unique<moveit_servo::Servo>(node_, servo_parameters_, planning_scene_monitor_);
-  servo_->start();
 
   // Connect to Servo ROS interfaces
   target_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -53,9 +53,9 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, ServoParameters::SharedConstPt
              planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor)
   : planning_scene_monitor_{ planning_scene_monitor }
   , parameters_{ parameters }
-  , servo_calcs_{ node, parameters, planning_scene_monitor_ }
+  , servo_calcs_{ std::make_shared<ServoCalcs>(node, parameters, planning_scene_monitor_) }
   , collision_checker_{ node, parameters, planning_scene_monitor_ }
-  , servo_pipeline_{ node, parameters, [&]() { servo_calcs_.halt(); }, &servo_calcs_ }
+  , servo_pipeline_{ node, parameters, [&]() { servo_calcs_->halt(); }, servo_calcs_ }
 {
   // Check collisions in this timer
   if (parameters_->check_collisions)
@@ -65,28 +65,28 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, ServoParameters::SharedConstPt
 
 void Servo::setPaused(bool paused)
 {
-  servo_calcs_.setPaused(paused);
+  servo_calcs_->setPaused(paused);
   collision_checker_.setPaused(paused);
 }
 
 bool Servo::getCommandFrameTransform(Eigen::Isometry3d& transform)
 {
-  return servo_calcs_.getCommandFrameTransform(transform);
+  return servo_calcs_->getCommandFrameTransform(transform);
 }
 
 bool Servo::getCommandFrameTransform(geometry_msgs::msg::TransformStamped& transform)
 {
-  return servo_calcs_.getCommandFrameTransform(transform);
+  return servo_calcs_->getCommandFrameTransform(transform);
 }
 
 bool Servo::getEEFrameTransform(Eigen::Isometry3d& transform)
 {
-  return servo_calcs_.getEEFrameTransform(transform);
+  return servo_calcs_->getEEFrameTransform(transform);
 }
 
 bool Servo::getEEFrameTransform(geometry_msgs::msg::TransformStamped& transform)
 {
-  return servo_calcs_.getEEFrameTransform(transform);
+  return servo_calcs_->getEEFrameTransform(transform);
 }
 
 const ServoParameters::SharedConstPtr& Servo::getParameters() const

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -347,7 +347,7 @@ bool ServoCalcs::pausedEarlyExit()
   return false;
 }
 
-void ServoCalcs::operator()(geometry_msgs::msg::TwistStamped input_command)
+void ServoCalcs::operator()(const geometry_msgs::msg::TwistStamped& input_command)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   updateState();
@@ -389,7 +389,7 @@ void ServoCalcs::operator()(geometry_msgs::msg::TwistStamped input_command)
   }
 }
 
-void ServoCalcs::operator()(control_msgs::msg::JointJog input_command)
+void ServoCalcs::operator()(const control_msgs::msg::JointJog& input_command)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   updateState();
@@ -465,7 +465,7 @@ rcl_interfaces::msg::SetParametersResult ServoCalcs::robotLinkCommandFrameCallba
 };
 
 // Perform the servoing calculations
-bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
+bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped cmd,
                                      trajectory_msgs::msg::JointTrajectory& joint_trajectory)
 {
   // Set uncontrolled dimensions to 0 in command frame

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -103,7 +103,7 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
 void ServoNode::startCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                         std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  servo_->start();
+  servo_->setPaused(false);
   response->success = true;
 }
 

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -251,6 +251,7 @@ ServoParameters ServoParameters::get(const std::string& ns,
                                      const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters)
 {
   auto parameters = ServoParameters{};
+  parameters.ns = ns;
 
   // ROS Parameters
   parameters.use_gazebo = node_parameters->get_parameter(ns + ".use_gazebo").as_bool();

--- a/moveit_ros/moveit_servo/test/input_check_valid_tests.cpp
+++ b/moveit_ros/moveit_servo/test/input_check_valid_tests.cpp
@@ -1,0 +1,154 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Stale Input Check Valid
+*/
+
+#include <cmath>
+#include <iostream>
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <gtest/gtest.h>
+#include <moveit_servo/detail/input_command.hpp>
+#include <moveit_servo/servo_parameters.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/input_check_valid.hpp>
+
+#include "input_visitors.hpp"
+
+namespace moveit_servo
+{
+using detail::InputCheckValid;
+using detail::InputCommand;
+
+TEST(InputCheckValidTests, DefaultTwistStamp)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+
+  // WHEN we visit with a default constructed TwistStamped
+  std::visit(input_check_valid, InputCommand{ TwistStamped{} });
+
+  // THEN we expect the visitor to have been called
+  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+}
+
+TEST(InputCheckValidTests, DefaultJointJog)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+
+  // WHEN we visit with a default constructed JointJog
+  std::visit(input_check_valid, InputCommand{ JointJog{} });
+
+  // THEN we expect the visitor to have been called
+  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+}
+
+TEST(InputCheckValidTests, InvalidUnitlessTwistStamp)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+
+  // WHEN we visit with a TwistStamped that is invlid in "unitless mode"
+  auto command = TwistStamped{};
+  command.twist.angular.z = 10.f;
+  std::visit(input_check_valid, InputCommand{ command });
+
+  // THEN we expect the visitor was not called
+  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+}
+
+TEST(InputCheckValidTests, ValidNotUnitlessTwistStamp)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "", &visitor);
+
+  // WHEN we visit with a TwistStamped that is invlid in "unitless mode"
+  auto command = TwistStamped{};
+  command.twist.angular.z = 10.f;
+  std::visit(input_check_valid, InputCommand{ command });
+
+  // THEN we expect the visitor was called
+  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+}
+
+TEST(InputCheckValidTests, NanTwistStamp)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+
+  // WHEN we visit with a TwistStamped containing a NaN
+  auto command = TwistStamped{};
+  command.twist.angular.z = NAN;
+  std::visit(input_check_valid, InputCommand{ command });
+
+  // THEN we expect the visitor was not called
+  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+}
+
+TEST(InputCheckValidTests, NanJointJog)
+{
+  // GIVEN a InputCheckValid with with a Visitor that counts
+  auto visitor = CountingVisitor{};
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+
+  // WHEN we visit with a JointJog containing a NaN
+  auto command = JointJog{};
+  command.velocities.push_back(NAN);
+  std::visit(input_check_valid, InputCommand{ command });
+
+  // THEN we expect the visitor was not called
+  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/input_check_valid_tests.cpp
+++ b/moveit_ros/moveit_servo/test/input_check_valid_tests.cpp
@@ -38,6 +38,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <variant>
 #include <control_msgs/msg/joint_jog.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -58,34 +59,34 @@ using detail::InputCommand;
 TEST(InputCheckValidTests, DefaultTwistStamp)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", visitor);
 
   // WHEN we visit with a default constructed TwistStamped
   std::visit(input_check_valid, InputCommand{ TwistStamped{} });
 
   // THEN we expect the visitor to have been called
-  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+  ASSERT_EQ(visitor->count, 1U) << "The visitor should have been called.";
 }
 
 TEST(InputCheckValidTests, DefaultJointJog)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", visitor);
 
   // WHEN we visit with a default constructed JointJog
   std::visit(input_check_valid, InputCommand{ JointJog{} });
 
   // THEN we expect the visitor to have been called
-  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+  ASSERT_EQ(visitor->count, 1U) << "The visitor should have been called.";
 }
 
 TEST(InputCheckValidTests, InvalidUnitlessTwistStamp)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", visitor);
 
   // WHEN we visit with a TwistStamped that is invlid in "unitless mode"
   auto command = TwistStamped{};
@@ -93,14 +94,14 @@ TEST(InputCheckValidTests, InvalidUnitlessTwistStamp)
   std::visit(input_check_valid, InputCommand{ command });
 
   // THEN we expect the visitor was not called
-  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+  ASSERT_EQ(visitor->count, 0U) << "The visitor should NOT have been called.";
 }
 
 TEST(InputCheckValidTests, ValidNotUnitlessTwistStamp)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "", visitor);
 
   // WHEN we visit with a TwistStamped that is invlid in "unitless mode"
   auto command = TwistStamped{};
@@ -108,14 +109,14 @@ TEST(InputCheckValidTests, ValidNotUnitlessTwistStamp)
   std::visit(input_check_valid, InputCommand{ command });
 
   // THEN we expect the visitor was called
-  ASSERT_EQ(visitor.count, 1U) << "The visitor should have been called.";
+  ASSERT_EQ(visitor->count, 1U) << "The visitor should have been called.";
 }
 
 TEST(InputCheckValidTests, NanTwistStamp)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", visitor);
 
   // WHEN we visit with a TwistStamped containing a NaN
   auto command = TwistStamped{};
@@ -123,14 +124,14 @@ TEST(InputCheckValidTests, NanTwistStamp)
   std::visit(input_check_valid, InputCommand{ command });
 
   // THEN we expect the visitor was not called
-  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+  ASSERT_EQ(visitor->count, 0U) << "The visitor should NOT have been called.";
 }
 
 TEST(InputCheckValidTests, NanJointJog)
 {
   // GIVEN a InputCheckValid with with a Visitor that counts
-  auto visitor = CountingVisitor{};
-  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", &visitor);
+  auto visitor = std::make_shared<CountingVisitor>();
+  auto input_check_valid = InputCheckValid(std::make_shared<rclcpp::Node>("test_node"), "unitless", visitor);
 
   // WHEN we visit with a JointJog containing a NaN
   auto command = JointJog{};
@@ -138,7 +139,7 @@ TEST(InputCheckValidTests, NanJointJog)
   std::visit(input_check_valid, InputCommand{ command });
 
   // THEN we expect the visitor was not called
-  ASSERT_EQ(visitor.count, 0U) << "The visitor should NOT have been called.";
+  ASSERT_EQ(visitor->count, 0U) << "The visitor should NOT have been called.";
 }
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/test/input_resampler_tests.cpp
+++ b/moveit_ros/moveit_servo/test/input_resampler_tests.cpp
@@ -1,0 +1,139 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Resampler Tests
+*/
+
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <gtest/gtest.h>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/input_resampler.hpp>
+
+#include "input_visitors.hpp"
+
+namespace moveit_servo
+{
+namespace
+{
+const auto MESSAGE_RECEIVED_EPSILON = 2U;
+}  // namespace
+
+using detail::InputCommand;
+using detail::InputResampler;
+
+TEST(InputReamplerTests, NoOutputVisit)
+{
+  // GIVEN a InputResampler with with a Visitor that counts output calls
+  auto visitor = CountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_0");
+  auto resampler = InputResampler(node, rclcpp::Duration::from_seconds(10), &visitor);
+
+  // WHEN we spin (without ever visiting the resampler)
+  rclcpp::spin_some(node);
+
+  // THEN we expect the count to still be 0
+  EXPECT_EQ(visitor.count, 0U) << "Visitor should not have been called";
+}
+
+TEST(InputReamplerTests, OneVisit)
+{
+  // GIVEN a InputResampler with with a Visitor that counts output calls
+  auto visitor = CountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_1");
+  auto resampler = InputResampler(node, rclcpp::Duration::from_seconds(10), &visitor);
+
+  // WHEN we visit the resampler with one message and spin
+  std::visit(resampler, InputCommand{ TwistStamped{} });
+  rclcpp::spin_some(node);
+
+  // THEN we expect the count to be one
+  EXPECT_EQ(visitor.count, 1U) << "Visitor should have only been called once";
+}
+
+TEST(InputReamplerTests, WaitForSomeOutput)
+{
+  // GIVEN a InputResampler with with a Visitor that counts output calls
+  auto visitor = CountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_2");
+  auto resampler = InputResampler(node, rclcpp::Duration::from_seconds(0.01), &visitor);
+
+  // WHEN we visit the resampler with one message and spin for some time
+  std::visit(resampler, InputCommand{ TwistStamped{} });
+  auto start = std::chrono::steady_clock::now();
+  while ((std::chrono::steady_clock::now() - start) < std::chrono::milliseconds(100))
+  {
+    rclcpp::spin_some(node);
+  }
+
+  // THEN we expect the callable count to be called about 10
+  EXPECT_NEAR(visitor.count, 10U, MESSAGE_RECEIVED_EPSILON) << "Count should have been called about 10 times";
+}
+
+TEST(InputReamplerTests, ReceivedEqualsSent)
+{
+  // GIVEN a InputResampler with Visitor that copies the received command into a local variant
+  auto visitor = ReceivedCommandVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_3");
+  auto resampler = InputResampler(node, rclcpp::Duration::from_seconds(10), &visitor);
+
+  // WHEN we visit the resampler with one message and spin
+  auto sent_msg = JointJog{};
+  std::visit(resampler, InputCommand{ sent_msg });
+  rclcpp::spin_some(node);
+
+  // THEN we expect the received command to be the same as the sent message
+  ASSERT_TRUE(std::holds_alternative<decltype(sent_msg)>(visitor.received_command))
+      << "Received command should be of the same type as sent message";
+  ASSERT_NO_THROW(std::get<JointJog>(visitor.received_command))
+      << "Received command variant should be of type JointJog";
+  EXPECT_EQ(std::get<JointJog>(visitor.received_command), sent_msg)
+      << "Received command variant should be equal to sent message";
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/input_stale_command_tests.cpp
+++ b/moveit_ros/moveit_servo/test/input_stale_command_tests.cpp
@@ -1,0 +1,186 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Stale Command Tests
+*/
+
+#include <iostream>
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <gtest/gtest.h>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/input_stale_command.hpp>
+
+#include "input_visitors.hpp"
+
+namespace moveit_servo
+{
+namespace
+{
+const auto TIME_EPSILON = 1e-1;
+}  // namespace
+
+using detail::InputCommand;
+using detail::StaleCommandHalt;
+using detail::TimestampNow;
+
+TEST(InputStaleCommandTests, TimeStampIsNearNowJointJog)
+{
+  // GIVEN a TimestampNow with with a Visitor that saves modified message locally
+  auto visitor = ReceivedCommandVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_0");
+  auto timestamp_now = TimestampNow(node, &visitor);
+
+  // WHEN we visit the timestamp_now with one message
+  auto sent_msg = JointJog{};
+  std::visit(timestamp_now, InputCommand{ sent_msg });
+
+  // THEN we expect the stamp to have changed
+  ASSERT_TRUE(std::holds_alternative<decltype(sent_msg)>(visitor.received_command))
+      << "Received command should be of the same type as sent message";
+  auto received_msg = std::get<JointJog>(visitor.received_command);
+  EXPECT_NE(received_msg.header.stamp, sent_msg.header.stamp)
+      << "Received message should have a different timestamp than sent one";
+  EXPECT_NEAR((node->now() - received_msg.header.stamp).seconds(), 0, TIME_EPSILON)
+      << "Time difference between now and received_msg should be close to 0";
+}
+
+TEST(InputStaleCommandTests, TimeStampIsNearNowTwistStamped)
+{
+  // GIVEN a TimestampNow with with a Visitor that saves modified message locally
+  auto visitor = ReceivedCommandVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_1");
+  auto timestamp_now = TimestampNow(node, &visitor);
+
+  // WHEN we visit the timestamp_now with one message
+  auto sent_msg = TwistStamped{};
+  std::visit(timestamp_now, InputCommand{ sent_msg });
+
+  // THEN we expect the stamp to have changed
+  ASSERT_TRUE(std::holds_alternative<decltype(sent_msg)>(visitor.received_command))
+      << "Received command should be of the same type as sent message";
+  auto received_msg = std::get<TwistStamped>(visitor.received_command);
+  EXPECT_NE(received_msg.header.stamp, sent_msg.header.stamp)
+      << "Received message should have a different timestamp than sent one";
+  EXPECT_NEAR((node->now() - received_msg.header.stamp).seconds(), 0, TIME_EPSILON)
+      << "Time difference between now and received_msg should be close to 0";
+}
+
+TEST(InputStaleCommandTests, HaltTwistStamped)
+{
+  // GIVEN a StaleCommandHalt with with a Visitor and halt function that counts calls
+  auto visitor = CountingVisitor{};
+  unsigned int halt_count{ 0 };
+  auto stale_command_halt = StaleCommandHalt(
+      std::make_shared<rclcpp::Node>("test_node_2"), rclcpp::Duration::from_seconds(1), [&]() { halt_count++; },
+      &visitor);
+
+  // WHEN we visit the stale_command_halt with one message that is default constructed
+  std::visit(stale_command_halt, InputCommand{ TwistStamped{} });
+
+  // THEN we expect the visitor count to still be 0 and the halt count should be 1
+  EXPECT_EQ(visitor.count, 0U) << "Visitor should not have been visited";
+  EXPECT_EQ(halt_count, 1U) << "Halt should have been called once";
+}
+
+TEST(InputStaleCommandTests, HaltJointJog)
+{
+  // GIVEN a StaleCommandHalt with with a Visitor and halt function that counts calls
+  auto visitor = CountingVisitor{};
+  unsigned int halt_count{ 0 };
+  auto stale_command_halt = StaleCommandHalt(
+      std::make_shared<rclcpp::Node>("test_node_3"), rclcpp::Duration::from_seconds(1), [&]() { halt_count++; },
+      &visitor);
+
+  // WHEN we visit the stale_command_halt with one message that is default constructed
+  std::visit(stale_command_halt, InputCommand{ JointJog{} });
+
+  // THEN we expect the visitor count to still be 0 and the halt count should be 1
+  EXPECT_EQ(visitor.count, 0U) << "Visitor should not have been visited";
+  EXPECT_EQ(halt_count, 1U) << "Halt should have been called once";
+}
+
+TEST(InputStaleCommandTests, NotStaleVisitTwistStamped)
+{
+  // GIVEN a StaleCommandHalt with with a Visitor and halt function that counts calls
+  auto visitor = CountingVisitor{};
+  unsigned int halt_count{ 0 };
+  auto node = std::make_shared<rclcpp::Node>("test_node_4");
+  auto stale_command_halt = StaleCommandHalt(
+      node, rclcpp::Duration::from_seconds(1), [&]() { halt_count++; }, &visitor);
+
+  // WHEN we visit the stale_command_halt with one message that has a current timestamp
+  auto sent_msg = TwistStamped{};
+  sent_msg.header.stamp = node->now();
+  std::visit(stale_command_halt, InputCommand{ sent_msg });
+
+  // THEN we expect the visitor count to be 1 and the halt count should be 0
+  EXPECT_EQ(visitor.count, 1U) << "Visitor should have been visited";
+  EXPECT_EQ(halt_count, 0U) << "Halt should not have been called once";
+}
+
+TEST(InputStaleCommandTests, NotStaleVisitJointJog)
+{
+  // GIVEN a StaleCommandHalt with with a Visitor and halt function that counts calls
+  auto visitor = CountingVisitor{};
+  unsigned int halt_count{ 0 };
+  auto node = std::make_shared<rclcpp::Node>("test_node_5");
+  auto stale_command_halt = StaleCommandHalt(
+      node, rclcpp::Duration::from_seconds(1), [&]() { halt_count++; }, &visitor);
+
+  // WHEN we visit the stale_command_halt with one message that has a current timestamp
+  auto sent_msg = JointJog{};
+  sent_msg.header.stamp = node->now();
+  std::visit(stale_command_halt, InputCommand{ sent_msg });
+
+  // THEN we expect the visitor count to be 1 and the halt count should be 0
+  EXPECT_EQ(visitor.count, 1U) << "Visitor should have been visited";
+  EXPECT_EQ(halt_count, 0U) << "Halt should not have been called once";
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/input_subscriber_tests.cpp
+++ b/moveit_ros/moveit_servo/test/input_subscriber_tests.cpp
@@ -1,0 +1,135 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Subscriber Tests
+*/
+
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <gtest/gtest.h>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/input_subscriber.hpp>
+
+#include "input_visitors.hpp"
+
+namespace moveit_servo
+{
+using detail::InputCommand;
+using detail::InputSubscriber;
+
+TEST(InputSubscriberTests, NoPublish)
+{
+  // GIVEN a InputSubscriber with with a Visitor that counts calls
+  auto visitor = CountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_0");
+  auto input_subscriber = InputSubscriber(node, "a", "b", &visitor);
+
+  // WHEN we spin (without ever publishing a message to either topic)
+  rclcpp::spin_some(node);
+
+  // THEN we expect the count to still be 0
+  EXPECT_EQ(visitor.count, 0U) << "Visitor should not have been visited";
+}
+
+TEST(InputSubscriberTests, TwistStampedVisit)
+{
+  // GIVEN a InputSubscriber with with a Visitor that counts calls to each type of topic
+  auto visitor = TypeCountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_1");
+  auto input_subscriber = InputSubscriber(node, "twist_stamped_topic", "joint_jog_topic", &visitor);
+  auto pub = node->create_publisher<TwistStamped>("twist_stamped_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin
+  pub->publish(TwistStamped{});
+  rclcpp::spin_some(node);
+
+  // THEN we expect the count of twist stamped to be 1 and the joint jog count to be 0
+  EXPECT_EQ(visitor.twist_stamped_count, 1U) << "Visitor count for twist stamped type should be 1";
+  EXPECT_EQ(visitor.joint_jog_count, 0U) << "Visitor count for joint jog type should be 0";
+}
+
+TEST(InputSubscriberTests, JointJogVisit)
+{
+  // GIVEN a InputSubscriber with with a Visitor that counts calls to each type of topic
+  auto visitor = TypeCountingVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_2");
+  auto input_subscriber = InputSubscriber(node, "twist_stamped_topic", "joint_jog_topic", &visitor);
+  auto pub = node->create_publisher<JointJog>("joint_jog_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin
+  pub->publish(JointJog{});
+  rclcpp::spin_some(node);
+
+  // THEN we expect the count of twist stamped to be 0 and the joint jog count to be 1
+  EXPECT_EQ(visitor.twist_stamped_count, 0U) << "Visitor count for twist stamped type should be 0";
+  EXPECT_EQ(visitor.joint_jog_count, 1U) << "Visitor count for joint jog type should be 1";
+}
+
+TEST(InputSubscriberTests, ReceivedEqualsSent)
+{
+  // GIVEN a InputSubscriber with with a Visitor that copies the received message into a local variant
+  auto visitor = ReceivedCommandVisitor{};
+  auto node = std::make_shared<rclcpp::Node>("test_node_3");
+  auto input_subscriber = InputSubscriber(node, "twist_stamped_topic", "joint_jog_topic", &visitor);
+  auto pub = node->create_publisher<JointJog>("joint_jog_topic", rclcpp::SystemDefaultsQoS());
+
+  // WHEN we publish a single message to it and spin
+  auto sent_msg = JointJog{};
+  pub->publish(sent_msg);
+  rclcpp::spin_some(node);
+
+  // THEN we expect the received command to be the same as the sent message
+  ASSERT_TRUE(std::holds_alternative<decltype(sent_msg)>(visitor.received_command))
+      << "Received command variant should be of the same type as sent message";
+  ASSERT_NO_THROW(std::get<JointJog>(visitor.received_command))
+      << "Received command variant should be of type JointJog";
+  EXPECT_EQ(std::get<JointJog>(visitor.received_command), sent_msg)
+      << "Received command variant should be equal to sent message";
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/input_visitors.hpp
+++ b/moveit_ros/moveit_servo/test/input_visitors.hpp
@@ -50,8 +50,8 @@ namespace moveit_servo
 class DoNothingVisitor : public detail::InputVisitor
 {
 public:
-  void operator()(TwistStamped /*unused*/) override{};
-  void operator()(JointJog /*unused*/) override{};
+  void operator()(const TwistStamped& /*unused*/) override{};
+  void operator()(const JointJog& /*unused*/) override{};
   ~DoNothingVisitor() override = default;
 };
 
@@ -59,11 +59,11 @@ class CountingVisitor : public detail::InputVisitor
 {
 public:
   unsigned int count = 0;
-  void operator()(TwistStamped /*unused*/) override
+  void operator()(const TwistStamped& /*unused*/) override
   {
     count++;
   };
-  void operator()(JointJog /*unused*/) override
+  void operator()(const JointJog& /*unused*/) override
   {
     count++;
   };
@@ -75,11 +75,11 @@ class TypeCountingVisitor : public detail::InputVisitor
 public:
   unsigned int twist_stamped_count = 0;
   unsigned int joint_jog_count = 0;
-  void operator()(TwistStamped /*unused*/) override
+  void operator()(const TwistStamped& /*unused*/) override
   {
     twist_stamped_count++;
   };
-  void operator()(JointJog /*unused*/) override
+  void operator()(const JointJog& /*unused*/) override
   {
     joint_jog_count++;
   };
@@ -90,11 +90,11 @@ class ReceivedCommandVisitor : public detail::InputVisitor
 {
 public:
   detail::InputCommand received_command;
-  void operator()(TwistStamped command) override
+  void operator()(const TwistStamped& command) override
   {
     received_command = command;
   };
-  void operator()(JointJog command) override
+  void operator()(const JointJog& command) override
   {
     received_command = command;
   };

--- a/moveit_ros/moveit_servo/test/input_visitors.hpp
+++ b/moveit_ros/moveit_servo/test/input_visitors.hpp
@@ -1,0 +1,104 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Visitor Mocks
+*/
+
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_servo/detail/input_command.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using control_msgs::msg::JointJog;
+using geometry_msgs::msg::TwistStamped;
+
+namespace moveit_servo
+{
+class DoNothingVisitor : public detail::InputVisitor
+{
+public:
+  void operator()(TwistStamped /*unused*/) override{};
+  void operator()(JointJog /*unused*/) override{};
+  ~DoNothingVisitor() override = default;
+};
+
+class CountingVisitor : public detail::InputVisitor
+{
+public:
+  unsigned int count = 0;
+  void operator()(TwistStamped /*unused*/) override
+  {
+    count++;
+  };
+  void operator()(JointJog /*unused*/) override
+  {
+    count++;
+  };
+  ~CountingVisitor() override = default;
+};
+
+class TypeCountingVisitor : public detail::InputVisitor
+{
+public:
+  unsigned int twist_stamped_count = 0;
+  unsigned int joint_jog_count = 0;
+  void operator()(TwistStamped /*unused*/) override
+  {
+    twist_stamped_count++;
+  };
+  void operator()(JointJog /*unused*/) override
+  {
+    joint_jog_count++;
+  };
+  ~TypeCountingVisitor() override = default;
+};
+
+class ReceivedCommandVisitor : public detail::InputVisitor
+{
+public:
+  detail::InputCommand received_command;
+  void operator()(TwistStamped command) override
+  {
+    received_command = command;
+  };
+  void operator()(JointJog command) override
+  {
+    received_command = command;
+  };
+  ~ReceivedCommandVisitor() override = default;
+};
+
+}  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/test/servo_pipeline_tests.cpp
+++ b/moveit_ros/moveit_servo/test/servo_pipeline_tests.cpp
@@ -1,0 +1,95 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Tyler Weaver
+   Desc:   Input Pipeline Tests
+*/
+
+#include <variant>
+#include <control_msgs/msg/joint_jog.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <gtest/gtest.h>
+#include <moveit_servo/detail/input_command.hpp>
+#include <moveit_servo/servo_parameters.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_servo/detail/servo_pipeline.hpp>
+
+#include "input_visitors.hpp"
+
+namespace moveit_servo
+{
+using detail::ServoPipeline;
+
+TEST(ServoPipelineTests, makeResampling)
+{
+  // GIVEN a ServoPipeline
+  auto node = std::make_shared<rclcpp::Node>("test_node_0");
+  auto next = DoNothingVisitor{};
+  auto parameters = std::make_shared<ServoParameters>();
+
+  // WHEN low_latency_mode set to false
+  parameters->low_latency_mode = false;
+
+  // THEN we expect ServoPipeline constructor to not throw
+  EXPECT_NO_THROW(auto servo_pipeline = ServoPipeline(
+                      node, parameters, []() {}, &next));
+}
+
+TEST(ServoPipelineTests, makeReactive)
+{
+  // GIVEN a ServoPipeline
+  auto node = std::make_shared<rclcpp::Node>("test_node_0");
+  auto next = DoNothingVisitor{};
+  auto parameters = std::make_shared<ServoParameters>();
+
+  // WHEN low_latency_mode set to true
+  parameters->low_latency_mode = true;
+
+  // THEN we expect ServoPipeline constructor to not throw
+  EXPECT_NO_THROW(auto servo_pipeline = ServoPipeline(
+                      node, parameters, []() {}, &next));
+}
+
+}  // namespace moveit_servo
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/moveit_ros/moveit_servo/test/servo_pipeline_tests.cpp
+++ b/moveit_ros/moveit_servo/test/servo_pipeline_tests.cpp
@@ -36,6 +36,7 @@
    Desc:   Input Pipeline Tests
 */
 
+#include <memory>
 #include <variant>
 #include <control_msgs/msg/joint_jog.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -56,7 +57,7 @@ TEST(ServoPipelineTests, makeResampling)
 {
   // GIVEN a ServoPipeline
   auto node = std::make_shared<rclcpp::Node>("test_node_0");
-  auto next = DoNothingVisitor{};
+  auto visitor = std::make_shared<DoNothingVisitor>();
   auto parameters = std::make_shared<ServoParameters>();
 
   // WHEN low_latency_mode set to false
@@ -64,14 +65,14 @@ TEST(ServoPipelineTests, makeResampling)
 
   // THEN we expect ServoPipeline constructor to not throw
   EXPECT_NO_THROW(auto servo_pipeline = ServoPipeline(
-                      node, parameters, []() {}, &next));
+                      node, parameters, []() {}, visitor));
 }
 
 TEST(ServoPipelineTests, makeReactive)
 {
   // GIVEN a ServoPipeline
   auto node = std::make_shared<rclcpp::Node>("test_node_0");
-  auto next = DoNothingVisitor{};
+  auto visitor = std::make_shared<DoNothingVisitor>();
   auto parameters = std::make_shared<ServoParameters>();
 
   // WHEN low_latency_mode set to true
@@ -79,7 +80,7 @@ TEST(ServoPipelineTests, makeReactive)
 
   // THEN we expect ServoPipeline constructor to not throw
   EXPECT_NO_THROW(auto servo_pipeline = ServoPipeline(
-                      node, parameters, []() {}, &next));
+                      node, parameters, []() {}, visitor));
 }
 
 }  // namespace moveit_servo


### PR DESCRIPTION
# Servo Input Pipeline Design

## C++17 features

To understand this pattern let me introduce you to two really nice features from C++17, `variant` and `Visitors` that are used by the `visit` function.  To use these features you just need to include this:

```c++
#include <variant>
```

### std::variant

This design starts with using some new features from C++17.  The first is the variant.  `input_command.hpp` defines this:

```c++
using InputCommand = std::variant<geometry_msgs::msg::TwistStamped, control_msgs::msg::JointJog>;
```

When you send a command to servo it is one of these two types.  It then does a handful of things that are not specific to the type of message received.  Specifically, the timestamp it was received is recorded, it is stored locally, then the loop is started at a rate with whichever message was newest.  Lastly, the timestamp of the message is tested against the stale command timeout to see if it is stale and servo should halt instead of continuing to move the robot arm.

At many places, the existing code has to test which message was last received.  This is simplified by using a variant.  A variant is a type-safe version of the union from C.  It is a type that can store one of the two types and has interfaces for executing code based on the types.  Here is a reference for a really nice guide with small examples showing what variant is: https://www.cppstories.com/2018/06/variant/

### Visitors and the std::visit function

The second C++17 feature needed for this pattern is a Visitor.  A visitor is an object that you can call visit on with a variant.  To understand what that means here is a simple example:

```c++
class PrintVisitor
{
  void operator()(int value) { cout << "int value: " << value; }
  void operator()(double value) { cout << "double value: " << value; }
};

int main()
{
  using IntOrDouble = std::variant<int, double>;
  auto a = IntOrDouble{ 2.5f };
  auto b = IntOrDouble{ 7 };

  auto print_visitor = PrintVisitor{};
  std::visit(print_visitor, a);
  std::visit(print_visitor, b);
  return 0;
} 
```

There are a couple of important C++ pieces of this.  

The first is the callable class PrintVisitor.  `operator()(variables...)` is an operator that says you can treat objects of this type like a function that takes `(variables...)`.  This is an explicit way of defining a callable class.  Lambdas are anonymous versions of this sort of class as they are objects that can store state and have a callable interface.

The second thing is the call to `visit`.  Visit just says call the callable function for the type of the variant passed into the second argument.  The compiler will check that the first argument has all the interfaces for all the possible types of the variant.  This whole concept came from functional programming and is enabled by the rich type system in C++.

These tools enable us to write code that says "do **this operation** on **this thing**" and allow the **thing** to be of different types and have different implementations for the type.

## Software design motivations and decisions

Here are some of the decisions and motivations behind these changes.

### How do these features fit in servo?

The input side of servo can take one of two types.  We want to respond to the last message we received.  When we had two different variables for the two types there needed to be a bunch of code to test which one was newest.  With a variant, there can be just one variable (the variant) and you just update and use that variable.

The second part of this is the visitor pattern.  Before this PR there is a logic in ServoCalcs that has to do with the simple logic of running the calculations at a set rate and making sure we halt when we have stale commands.  Because this logic was tightly coupled with the rest of ServoCalcs we had a bunch of code that can't be tested on its own.  By breaking out the various operations taken on the input values into separate objects that just call the next step with visit they can be tested easily separated from each other.

### SRP (Single responsibility principle)

One important rule for software design is that by breaking a problem into small modular pieces you can test them separately from each other and they are easier to write and understand.  There was a talk at cppcon this year that really inspired me to try to take this much more seriously.  One real advantage to this approach is that it produces code that is easier to understand and modify because each piece is much smaller.  The only real downside is that there are many more pieces now and you have more total code to read.

https://digital-medium-co-uk.zoom.us/rec/play/JMkXvgiWQKX5EJNuaHL-1Rh0F8FiFUwKYomrJF_wEgAtRaDVTHc_p_j3ZkbZ7dsGsLIYU5v4lP0GEMLm.8PJcMpJSgWDT8NJy?continueMode=true&_x_zm_rtaid=HjhEGiY3SZCHZAI7zLBnzQ.1637779957973.3b927e82802ef1b90907a73d94e9aed7&_x_zm_rhtaid=567

### Testing and why I didn't use dependency injection

The tests I wrote for the various pieces don't have dependency injection and do use some ROS features directly.  This greatly simplified the tests and reduced the boilerplate I had to write.  The large benefits to dependency injection comes from cases where the ROS features are complex and inherently unreliable.  By making the compromise that some of the tests take a bit longer to execute I was able to greatly simplify how much boilerplate code I had to write to add tests.  Everything has tradeoffs and dependency injection gives you much more performant and potentially much more reliable testing with the drawback of a bunch of boilerplate code and much more complex testing code.

## Design

Here I will lay out the various pieces, what they do, and my understanding of how they should work

### `input_command.hpp`

This header defines the variant type `InputCommand` that is the type used by the input of servo.
Secondly, there is the interface class `InputVisitor` that each visitor class will inherit from and implement the interface for calling `visit` on.  By using an interface class each class can have a pointer to the next step without caring what the type is because this interface guarantees it implements the functions needed to call visit on it.

### `input_subscriber.hpp`

This object has one purpose.  It contains the two subscribers to the input topics and in the callbacks uses visit to call the next step with an InputCommand variant.

### `input_stale_command.hpp`

This header contains two classes: `TimestampNow` and `StaleCommandHalt`.  `TimestampNow` is a peice of fixing the bug where stale commands don't stop servo.  This visitor just sets the header timestamp in the message to the output of `node->now()` and calls the next step.  The second one, `StaleCommandHalt` checks for the stale command timeout.  If the message is stale it calls the halt function it was passed and if not it calls the next step with the message.

Here is one place where the implementation differs from servo as it is now.  Right now servo expects the message timestamp to be set by the user of servo.  The downside to this is if a user forgets to do this or is replaying from a bagfile.  In both of those cases, it is very easy for the user to send a timestamp in their message that is not current.  This change makes so what servo cares about when it comes to stale messages is the time since it received the message instead of the time since the timestamp in the header of the message that was sent to servo.

### `input_resampler.hpp`

This is probably the most complex of the Visitors.  This one receives a message and stores it internally.  It has a timer that calls visit on the next step with the newest message it has received.  

Here is another important change from what was before.  Before as soon as you called to start the loop would start executing (even if we still haven't received a message).  This time where the loop is executing before the user sends a command is used to initialize the smoothing algorithm with the current state of the robot.

If previously a message was available on the first run of the loop there could be wild jumps because the smoothing filter was not yet initialized.  This was really unlikely to happen before but became obvious when I started testing this because in this case no calls are made to ServoCalcs until the user sends the first input.  To fix this I have the constructor of ServoCalcs waiting for a complete state of the robot and initializing the smoother.

Another edge case this helped me find is if a user pauses servo, moves the robot some other way, and then resumes servo.  This can also cause wild jumps if the smoother was not updated to the new position before executing the first command since the resume (this is because the previous state of the robot in servo was where it was before it was paused).  To fix this I am now also updating the smoother with the current state at the top of the function for halting on stale commands when paused (presumably the command will go stale when the user pauses).

### `input_pipeline.hpp`

This is what puts together all the various steps based on the configuration.  In the simplest case of `low_latency_mode` we only need an InputSubscriber that calls ServoCalcs directly.  This may seem like a bad idea because there is no handling of stale commands in this mode.  In my local testing, I've not been able to get the robot to keep moving if I stop sending commands.  I presume this is because there is a 1:1 relationship between input commands and output trajectories.  Once the trajectory is complete there is no new trajectory because there is no new input command and the robot stops.

In the more complex normal mode, the InputPipeline is a ResamplingInputPipeline that contains all the steps listed above connected together and eventually connected to ServoCalcs.

### `servo_calcs`

Here is where we were able to remove some code and other code had to just be moved around.

The first thing to note is that much of what was in the `start` function is now at the end of the constructor.  One part of this I'm not sure I like the interface to is the last two lines:

```c++
updateState();
resetLowPassFilters(original_joint_state_);
```

It is important to know that `updateState` calls a function that initializes `original_joint_state_` and that `resetLowPassFilters` is needed to initialize the values within the smoothing filters.

Next, I moved the code to publish the status and reset its value to NO_WARNING into a function because I now need to call it from several places.

After that is the new `updateState` function that updates the joint positions, current robot state, and the two tf frames we use for math.

The last of the helper functions I created is `publishJointTrajectory`.  This function prepares and publishes the output command.

One thing I don't like about these functions is they do much more than their name would imply.  For example `publishJointTrajectory` sets some values, selects between two different types of outputs, and then eventually publishes.  I made the choice to not try to refactor much of this as I wanted to limit the number of changes and felt that this was an OK compromise for now.

Lastly there are the two `operator()` functions and the `halt()` function.  These have the logic that was in the main loop before but is specific to the type of input they receive and in the case of halt, just create and publish the messages to halt the robot.  There is some copy-paste between these and eventually, I'd like to greatly reduce that but for now, that was one more thing I resisted trying to refactor more.  A bit upside to these three separate functions that do what the one main loop did is that there is much less nesting because the type we receive and the halt function stop us from having to check a bunch of bools and do a bunch of compares.

## Testing

A vast majority of the LOC in this change is test code.  These tests use various Visitor object mocks I created to capture the output of the various steps in `test/input_visitors.hpp`.  Each test follows a very specific pattern of `GIVEN / WHEN / THEN` from TDD (test-driven development) and each test is very simple and fast.  This sort of testing where there are many tiny tests means that if something doesn't work it is really obvious what is not working.  With large tests that test many things when they fail, they become hard to debug.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
