### PR TITLE
Remove unused dependency from online_signal_smoothing cmake

### DIFF
--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -46,7 +46,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BUTTERWORTH_FILTER_LIB}_export.h DES
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(ros_testing REQUIRED)
 
   # Lowpass filter unit test
   ament_add_gtest(test_butterworth_filter test/test_butterworth_filter.cpp)


### PR DESCRIPTION
### Description

This fixes this error:

```
CMake Error at online_signal_smoothing/CMakeLists.txt:49 (find_package):
  By not providing "Findros_testing.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "ros_testing", but CMake did not find one.

  Could not find a package configuration file provided by "ros_testing" with
  any of the following names:

    ros_testingConfig.cmake
    ros_testing-config.cmake

  Add the installation prefix of "ros_testing" to CMAKE_PREFIX_PATH or set
  "ros_testing_DIR" to a directory containing one of the above files.  If
  "ros_testing" provides a separate development package or SDK, be sure it
  has been installed.
```