### PR TITLE
Various Servo fixes, optional latency compensation parameter

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -11,10 +11,9 @@ scale:
   rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
-# This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
-# controller performance. It essentially increases the timestep when calculating the target pose, to move the target
-# pose farther away. [seconds]
-system_latency_compensation: 0.05
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -7,9 +7,9 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.4  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.8 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
-  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  linear:  0.4  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
 
 ## Properties of outgoing commands

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -11,6 +11,10 @@ scale:
   rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
+# This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
+# controller performance. It essentially increases the timestep when calculating the target pose, to move the target
+# pose farther away. [seconds]
+system_latency_compensation: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -11,9 +11,10 @@ scale:
   rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
+
 # This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
 # It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
-target_pose_lookahead_time: 0.05
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -7,9 +7,9 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.6  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.3 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
-  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  linear:  0.6  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
 
 ## Properties of outgoing commands

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -11,9 +11,10 @@ scale:
   rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
+
 # This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
 # It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
-target_pose_lookahead_time: 0.05
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -11,6 +11,10 @@ scale:
   rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
+# This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
+# controller performance. It essentially increases the timestep when calculating the target pose, to move the target
+# pose farther away. [seconds]
+system_latency_compensation: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -11,10 +11,9 @@ scale:
   rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
-# This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
-# controller performance. It essentially increases the timestep when calculating the target pose, to move the target
-# pose farther away. [seconds]
-system_latency_compensation: 0.05
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/include/moveit_servo/enforce_limits.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/enforce_limits.hpp
@@ -46,15 +46,11 @@
 namespace moveit_servo
 {
 /**
- * @brief      Scale the delta theta to match joint velocity/acceleration limits
- *
- * @param[in]  joint_model_group   The joint model group
- * @param[in]  publish_period      The publish period of servo (used for calculating joint velocity)
- * @param[in]  delta_theta         The delta theta input
- *
- * @return     The delta theta output
+ * @brief Decrease robot position change and velocity, if needed, to satisfy joint velocity limits
+ * @param joint_model_group Active joint group. Used to retrieve limits.
+ * @param joint_state The command that will go to the robot.
  */
-Eigen::ArrayXd enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, double publish_period,
-                                     const Eigen::ArrayXd& delta_theta);
+void enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const double publish_period,
+                           sensor_msgs::msg::JointState& joint_state);
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -148,11 +148,13 @@ protected:
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
+   * @return a vector of position deltas
    */
   Eigen::VectorXd scaleCartesianCommand(const geometry_msgs::msg::TwistStamped& command);
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
+   * @return a vector of position deltas
    */
   Eigen::VectorXd scaleJointCommand(const control_msgs::msg::JointJog& command);
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -148,15 +148,15 @@ protected:
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
-   * @return a vector of position deltas
+   * @return a vector of Cartesian deltas
    */
-  Eigen::VectorXd scaleCartesianCommand(const geometry_msgs::msg::TwistStamped& command);
+  Eigen::VectorXd scaleCartesianTwistToCartesianPositionDelta(const geometry_msgs::msg::TwistStamped& command);
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
-   * @return a vector of position deltas
+   * @return a vector of joint position deltas
    */
-  Eigen::VectorXd scaleJointCommand(const control_msgs::msg::JointJog& command);
+  Eigen::VectorXd scaleJointCommandToJointPositionDelta(const control_msgs::msg::JointJog& command);
 
   /** \brief Come to a halt in a smooth way. Apply a smoothing plugin, if one is configured.
    */

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -203,8 +203,7 @@ protected:
    * @param previous_vel Eigen vector of previous velocities being updated
    * @return Returns false if there is a problem, true otherwise
    */
-  bool applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state,
-                        Eigen::ArrayXd& previous_vel);
+  bool applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state);
 
   /** \brief Gazebo simulations have very strict message timestamp requirements.
    * Satisfy Gazebo by stuffing multiple messages into one.
@@ -336,7 +335,6 @@ protected:
 
   // Use ArrayXd type to enable more coefficient-wise operations
   Eigen::ArrayXd delta_theta_;
-  Eigen::ArrayXd prev_joint_velocity_;
 
   const int gazebo_redundant_message_count_ = 30;
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -70,7 +70,7 @@ struct ServoParameters
   double linear_scale{ 0.4 };
   double rotational_scale{ 0.8 };
   double joint_scale{ 0.5 };
-  double system_latency_compensation{ 0.0 };
+  double target_pose_lookahead_time{ 0.0 };
   // Properties of outgoing commands
   std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
   double publish_period{ 0.034 };

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -70,6 +70,7 @@ struct ServoParameters
   double linear_scale{ 0.4 };
   double rotational_scale{ 0.8 };
   double joint_scale{ 0.5 };
+  double system_latency_compensation{ 0.0 };
   // Properties of outgoing commands
   std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
   double publish_period{ 0.034 };

--- a/moveit_ros/moveit_servo/src/enforce_limits.cpp
+++ b/moveit_ros/moveit_servo/src/enforce_limits.cpp
@@ -47,7 +47,7 @@ namespace moveit_servo
 {
 namespace
 {
-double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model_group, const Eigen::ArrayXd& velocity)
+double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model_group, const Eigen::VectorXd& velocity)
 {
   std::size_t joint_delta_index{ 0 };
   double velocity_scaling_factor{ 1.0 };
@@ -73,16 +73,16 @@ void enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_grou
                            sensor_msgs::msg::JointState& joint_state)
 {
   // Get the velocity scaling factor
-  Eigen::ArrayXd velocity =
-      Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
+  Eigen::VectorXd velocity =
+      Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
   double velocity_scaling_factor = getVelocityScalingFactor(joint_model_group, velocity);
 
   // Take a smaller step if the velocity scaling factor is less than 1
   if (velocity_scaling_factor < 1)
   {
-    Eigen::ArrayXd velocity_residuals = (1 - velocity_scaling_factor) * velocity;
-    Eigen::ArrayXd positions =
-        Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.position.data(), joint_state.position.size());
+    Eigen::VectorXd velocity_residuals = (1 - velocity_scaling_factor) * velocity;
+    Eigen::VectorXd positions =
+        Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(joint_state.position.data(), joint_state.position.size());
     positions -= velocity_residuals * publish_period;
 
     velocity *= velocity_scaling_factor;

--- a/moveit_ros/moveit_servo/src/enforce_limits.cpp
+++ b/moveit_ros/moveit_servo/src/enforce_limits.cpp
@@ -78,7 +78,7 @@ Eigen::ArrayXd enforceVelocityLimits(const moveit::core::JointModelGroup* joint_
   // Get the velocity scaling factor
   double velocity_scaling_factor = getVelocityScalingFactor(joint_model_group, velocity);
 
-  // Scale the resulting detas to avoid violating limits.
+  // Scale the resulting deltas to avoid violating limits.
   return velocity_scaling_factor * velocity * publish_period;
 }
 

--- a/moveit_ros/moveit_servo/src/enforce_limits.cpp
+++ b/moveit_ros/moveit_servo/src/enforce_limits.cpp
@@ -69,17 +69,27 @@ double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model
 
 }  // namespace
 
-Eigen::ArrayXd enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, double publish_period,
-                                     const Eigen::ArrayXd& delta_theta)
+void enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const double publish_period,
+                           sensor_msgs::msg::JointState& joint_state)
 {
-  // Convert to joint angle velocities for checking and applying joint specific velocity limits.
-  Eigen::ArrayXd velocity = delta_theta / publish_period;
-
   // Get the velocity scaling factor
+  Eigen::ArrayXd velocity =
+      Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
   double velocity_scaling_factor = getVelocityScalingFactor(joint_model_group, velocity);
 
-  // Scale the resulting deltas to avoid violating limits.
-  return velocity_scaling_factor * velocity * publish_period;
+  // Take a smaller step if the velocity scaling factor is less than 1
+  if (velocity_scaling_factor < 1)
+  {
+    Eigen::ArrayXd velocity_residuals = (1 - velocity_scaling_factor) * velocity;
+    Eigen::ArrayXd positions =
+        Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.position.data(), joint_state.position.size());
+    positions -= velocity_residuals * publish_period;
+
+    velocity *= velocity_scaling_factor;
+    // Back to sensor_msgs type
+    joint_state.velocity = std::vector<double>(velocity.data(), velocity.data() + velocity.size());
+    joint_state.position = std::vector<double>(positions.data(), positions.data() + positions.size());
+  }
 }
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -195,25 +195,6 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
     std::exit(EXIT_FAILURE);
   }
 
-  // Load the smoothing plugin
-  try
-  {
-    smoother_ = smoothing_loader_.createSharedInstance(parameters_->smoothing_filter_plugin_name);
-  }
-  catch (pluginlib::PluginlibException& ex)
-  {
-    RCLCPP_ERROR(LOGGER, "Exception while loading the smoothing plugin '%s': '%s'",
-                 parameters_->smoothing_filter_plugin_name.c_str(), ex.what());
-    std::exit(EXIT_FAILURE);
-  }
-
-  // Initialize the smoothing plugin
-  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), num_joints_))
-  {
-    RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
-    std::exit(EXIT_FAILURE);
-  }
-
   // A matrix of all zeros is used to check whether matrices have been initialized
   Eigen::Matrix3d empty_matrix;
   empty_matrix.setZero();

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -638,7 +638,7 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   updated_filters_ = true;
 
   // Enforce SRDF velocity limits
-  delta_theta = enforceVelocityLimits(joint_model_group_, parameters_->publish_period, delta_theta);
+  enforceVelocityLimits(joint_model_group_, parameters_->publish_period, internal_joint_state_);
 
   // Enforce SRDF position limits, might halt if needed, set prev_vel to 0
   const auto joints_to_halt = enforcePositionLimits(internal_joint_state_);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -149,10 +149,6 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
       node_->create_subscription<std_msgs::msg::Float64>("~/collision_velocity_scale", rclcpp::SystemDefaultsQoS(),
                                                          std::bind(&ServoCalcs::collisionVelocityScaleCB, this, _1));
 
-  // Publish to collision_check for worst stop time
-  worst_case_stop_time_pub_ =
-      node_->create_publisher<std_msgs::msg::Float64>("~/worst_case_stop_time", rclcpp::SystemDefaultsQoS());
-
   // Publish freshly-calculated joints to the robot.
   // Put the outgoing msg in the right format (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
   if (parameters_->command_out_type == "trajectory_msgs/JointTrajectory")

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1002,9 +1002,9 @@ Eigen::VectorXd ServoCalcs::scaleCartesianTwistToCartesianPositionDelta(const ge
   result.setZero();  // Or the else case below leads to misery
 
   // Add a user-defined, constant delay to the timestep.
-  // This can help if the robot's low-level controllers are not very responsive, or to account for network latency.
-  // Effectively it moves the carrot farther ahead.
-  double timestep = parameters_->publish_period + parameters_->system_latency_compensation;
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
 
   // Apply user-defined scaling if inputs are unitless [-1:1]
   if (parameters_->command_in_type == "unitless")
@@ -1041,9 +1041,9 @@ Eigen::VectorXd ServoCalcs::scaleJointCommandToJointPositionDelta(const control_
   result.setZero();
 
   // Add a user-defined, constant delay to the timestep.
-  // This can help if the robot's low-level controllers are not very responsive, or to account for network latency.
-  // Effectively it moves the carrot farther ahead.
-  double timestep = parameters_->publish_period + parameters_->system_latency_compensation;
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
 
   std::size_t c;
   for (std::size_t m = 0; m < command.joint_names.size(); ++m)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1004,7 +1004,7 @@ bool ServoCalcs::checkValidCommand(const geometry_msgs::msg::TwistStamped& cmd)
   return true;
 }
 
-// Scale the incoming jog command
+// Scale the incoming jog command. Returns a vector of position deltas
 Eigen::VectorXd ServoCalcs::scaleCartesianCommand(const geometry_msgs::msg::TwistStamped& command)
 {
   Eigen::VectorXd result(6);

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -135,6 +135,12 @@ void ServoParameters::declare(const std::string& ns,
           .type(PARAMETER_DOUBLE)
           .description("Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint "
                        "commands on joint_command_in_topic."));
+  node_parameters->declare_parameter(ns + ".system_latency_compensation",
+                                     ParameterValue{ parameters.system_latency_compensation },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("A fudge factor to account for any latency in the system, e.g. "
+                                                      "network latency or poor low-level controller performance"));
 
   // Properties of outgoing commands
   node_parameters->declare_parameter(
@@ -265,6 +271,8 @@ ServoParameters ServoParameters::get(const std::string& ns,
   parameters.linear_scale = node_parameters->get_parameter(ns + ".scale.linear").as_double();
   parameters.rotational_scale = node_parameters->get_parameter(ns + ".scale.rotational").as_double();
   parameters.joint_scale = node_parameters->get_parameter(ns + ".scale.joint").as_double();
+  parameters.system_latency_compensation =
+      node_parameters->get_parameter(ns + ".system_latency_compensation").as_double();
 
   // Properties of outgoing commands
   parameters.command_out_topic = node_parameters->get_parameter(ns + ".command_out_topic").as_string();

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -122,19 +122,18 @@ void ServoParameters::declare(const std::string& ns,
   node_parameters->declare_parameter(ns + ".scale.linear", ParameterValue{ parameters.linear_scale },
                                      ParameterDescriptorBuilder{}
                                          .type(PARAMETER_DOUBLE)
-                                         .description("Max linear velocity. Meters per publish_period. Unit is [m/s]. "
+                                         .description("Max linear velocity. Unit is [m/s]. "
                                                       "Only used for Cartesian commands."));
   node_parameters->declare_parameter(ns + ".scale.rotational", ParameterValue{ parameters.rotational_scale },
                                      ParameterDescriptorBuilder{}
                                          .type(PARAMETER_DOUBLE)
-                                         .description("Max angular velocity. Rads per publish_period. Unit is [rad/s]. "
+                                         .description("Max angular velocity. Unit is [rad/s]. "
                                                       "Only used for Cartesian commands."));
-  node_parameters->declare_parameter(
-      ns + ".scale.joint", ParameterValue{ parameters.joint_scale },
-      ParameterDescriptorBuilder{}
-          .type(PARAMETER_DOUBLE)
-          .description("Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint "
-                       "commands on joint_command_in_topic."));
+  node_parameters->declare_parameter(ns + ".scale.joint", ParameterValue{ parameters.joint_scale },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Max joint angular/linear velocity. Only used for joint "
+                                                      "commands on joint_command_in_topic."));
   node_parameters->declare_parameter(
       ns + ".target_pose_lookahead_time", ParameterValue{ parameters.target_pose_lookahead_time },
       ParameterDescriptorBuilder{}

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -135,12 +135,12 @@ void ServoParameters::declare(const std::string& ns,
           .type(PARAMETER_DOUBLE)
           .description("Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint "
                        "commands on joint_command_in_topic."));
-  node_parameters->declare_parameter(ns + ".system_latency_compensation",
-                                     ParameterValue{ parameters.system_latency_compensation },
-                                     ParameterDescriptorBuilder{}
-                                         .type(PARAMETER_DOUBLE)
-                                         .description("A fudge factor to account for any latency in the system, e.g. "
-                                                      "network latency or poor low-level controller performance"));
+  node_parameters->declare_parameter(
+      ns + ".target_pose_lookahead_time", ParameterValue{ parameters.target_pose_lookahead_time },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("An optional parameter to smooth jitter due to latency in the system "
+                       "or low-level controller ramp up / ramp down"));
 
   // Properties of outgoing commands
   node_parameters->declare_parameter(
@@ -271,8 +271,8 @@ ServoParameters ServoParameters::get(const std::string& ns,
   parameters.linear_scale = node_parameters->get_parameter(ns + ".scale.linear").as_double();
   parameters.rotational_scale = node_parameters->get_parameter(ns + ".scale.rotational").as_double();
   parameters.joint_scale = node_parameters->get_parameter(ns + ".scale.joint").as_double();
-  parameters.system_latency_compensation =
-      node_parameters->get_parameter(ns + ".system_latency_compensation").as_double();
+  parameters.target_pose_lookahead_time =
+      node_parameters->get_parameter(ns + ".target_pose_lookahead_time").as_double();
 
   // Properties of outgoing commands
   parameters.command_out_topic = node_parameters->get_parameter(ns + ".command_out_topic").as_string();

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -417,6 +417,12 @@ std::optional<ServoParameters> ServoParameters::validate(ServoParameters paramet
                         "greater than zero. Check yaml file.");
     return std::nullopt;
   }
+  if (parameters.target_pose_lookahead_time < 0 || parameters.target_pose_lookahead_time > 0.1)
+  {
+    RCLCPP_WARN(LOGGER,
+                "Parameter 'target_pose_lookahead_time' should be greater than zero and typically less than 0.1s.");
+    return std::nullopt;
+  }
   return parameters;
 }
 

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -12,6 +12,10 @@ scale:
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
 
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
+
 ## Properties of outgoing commands
 low_latency_mode: false  # Set this to true to tie the output rate to the input rate
 publish_period: 0.01  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
@@ -12,6 +12,10 @@ scale:
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
 
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
+
 ## Properties of outgoing commands
 low_latency_mode: true  # Set this to true to tie the output rate to the input rate
 publish_period: 0.01  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
+++ b/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
@@ -78,8 +78,10 @@ protected:
 TEST_F(EnforceLimitsTests, VelocityScalingTest)
 {
   // Request velocities that are too fast
+  std::vector<double> joint_position{ 0, 0, 0, 0, 0, 0, 0 };
   std::vector<double> joint_velocity{ 0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
   sensor_msgs::msg::JointState joint_state;
+  joint_state.position = joint_position;
   joint_state.velocity = joint_velocity;
 
   moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);
@@ -92,8 +94,10 @@ TEST_F(EnforceLimitsTests, VelocityScalingTest)
 TEST_F(EnforceLimitsTests, NegativeJointAngleDeltasTest)
 {
   // Negative velocities exceeding the limit
+  std::vector<double> joint_position{ 0, 0, 0, 0, 0, 0, 0 };
   std::vector<double> joint_velocity{ 0, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 };
   sensor_msgs::msg::JointState joint_state;
+  joint_state.position = joint_position;
   joint_state.velocity = joint_velocity;
 
   moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);
@@ -106,8 +110,10 @@ TEST_F(EnforceLimitsTests, NegativeJointAngleDeltasTest)
 TEST_F(EnforceLimitsTests, LowJointVelocityDeltaTest)
 {
   // Final test with joint velocities that are acceptable
+  std::vector<double> joint_position{ 0, 0, 0, 0, 0, 0, 0 };
   std::vector<double> joint_velocity{ 0, 0.001, 0.001, -0.001, 0.001, 0.001, 0.001 };
   sensor_msgs::msg::JointState joint_state;
+  joint_state.position = joint_position;
   joint_state.velocity = joint_velocity;
 
   moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);

--- a/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
+++ b/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
@@ -44,20 +44,19 @@ namespace
 {
 constexpr double PUBLISH_PERIOD = 0.01;
 
-void checkVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const Eigen::ArrayXd& delta_theta)
+void checkVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const Eigen::ArrayXd& velocity)
 {
-  std::size_t joint_delta_index{ 0 };
+  std::size_t joint_index{ 0 };
   for (const moveit::core::JointModel* joint : joint_model_group->getActiveJointModels())
   {
     const auto& bounds = joint->getVariableBounds(joint->getName());
 
     if (bounds.velocity_bounded_)
     {
-      auto velocity = delta_theta(joint_delta_index) / PUBLISH_PERIOD;
-      EXPECT_GE(velocity, bounds.min_velocity_) << "Joint " << joint_delta_index << " violates velocity limit";
-      EXPECT_LE(velocity, bounds.max_velocity_) << "Joint " << joint_delta_index << " violates velocity limit";
+      EXPECT_GE(velocity(joint_index), bounds.min_velocity_) << "Joint " << joint_index << " violates velocity limit";
+      EXPECT_LE(velocity(joint_index), bounds.max_velocity_) << "Joint " << joint_index << " violates velocity limit";
     }
-    ++joint_delta_index;
+    ++joint_index;
   }
 }
 
@@ -78,61 +77,44 @@ protected:
 
 TEST_F(EnforceLimitsTests, VelocityScalingTest)
 {
-  // Request joint angle changes that are too fast given the control period.
-  Eigen::ArrayXd delta_theta(7);
-  delta_theta[0] = 0;  // rad
-  delta_theta[1] = 0.01;
-  delta_theta[2] = 0.02;
-  delta_theta[3] = 0.03;
-  delta_theta[4] = 0.04;
-  delta_theta[5] = 0.05;
-  delta_theta[6] = 0.06;
+  // Request velocities that are too fast
+  std::vector<double> joint_velocity{ 0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+  sensor_msgs::msg::JointState joint_state;
+  joint_state.velocity = joint_velocity;
 
-  // Store the original joint commands for comparison before applying velocity scaling.
-  auto result_delta_theta = moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, delta_theta);
+  moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);
 
-  // Test that we don't violate velocity limits
-  checkVelocityLimits(joint_model_group_, result_delta_theta);
+  Eigen::ArrayXd eigen_velocity =
+      Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
+  checkVelocityLimits(joint_model_group_, eigen_velocity);
 }
 
 TEST_F(EnforceLimitsTests, NegativeJointAngleDeltasTest)
 {
-  // Now, negative joint angle deltas. Some will result to velocities
-  // greater than the arm joint velocity limits.
-  Eigen::ArrayXd delta_theta(7);
-  delta_theta[0] = 0.01;  // rad
-  delta_theta[1] = -0.01;
-  delta_theta[2] = -0.02;
-  delta_theta[3] = -0.03;
-  delta_theta[4] = -0.04;
-  delta_theta[5] = -0.05;
-  delta_theta[6] = -0.06;
+  // Negative velocities exceeding the limit
+  std::vector<double> joint_velocity{ 0, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 };
+  sensor_msgs::msg::JointState joint_state;
+  joint_state.velocity = joint_velocity;
 
-  // Store the original joint commands for comparison before applying velocity scaling.
-  auto result_delta_theta = moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, delta_theta);
+  moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);
 
-  // Test that we don't violate velocity limits
-  checkVelocityLimits(joint_model_group_, result_delta_theta);
+  Eigen::ArrayXd eigen_velocity =
+      Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
+  checkVelocityLimits(joint_model_group_, eigen_velocity);
 }
 
 TEST_F(EnforceLimitsTests, LowJointVelocityDeltaTest)
 {
-  // Final test with joint angle deltas that will result in velocities
-  // below the lowest Panda arm joint velocity limit.
-  Eigen::ArrayXd delta_theta(7);
-  delta_theta[0] = 0;  // rad
-  delta_theta[1] = -0.013;
-  delta_theta[2] = 0.023;
-  delta_theta[3] = -0.004;
-  delta_theta[4] = 0.021;
-  delta_theta[5] = 0.012;
-  delta_theta[6] = 0.0075;
+  // Final test with joint velocities that are acceptable
+  std::vector<double> joint_velocity{ 0, 0.001, 0.001, -0.001, 0.001, 0.001, 0.001 };
+  sensor_msgs::msg::JointState joint_state;
+  joint_state.velocity = joint_velocity;
 
-  // Store the original joint commands for comparison before applying velocity scaling.
-  auto result_delta_theta = moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, delta_theta);
+  moveit_servo::enforceVelocityLimits(joint_model_group_, PUBLISH_PERIOD, joint_state);
 
-  // Test that we don't violate velocity limits
-  checkVelocityLimits(joint_model_group_, result_delta_theta);
+  Eigen::ArrayXd eigen_velocity =
+      Eigen::Map<Eigen::ArrayXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
+  checkVelocityLimits(joint_model_group_, eigen_velocity);
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
+++ b/moveit_ros/moveit_servo/test/enforce_limits_tests.cpp
@@ -119,6 +119,9 @@ TEST_F(EnforceLimitsTests, LowJointVelocityDeltaTest)
 
 int main(int argc, char** argv)
 {
+  rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }


### PR DESCRIPTION
These are all relatively minor bug fixes or documentation improvement except "Add optional latency compensation parameter".

The latency comp parameter was very useful in improving a UR5e's path tracking accuracy. @MarqRazz can attest to that.

If the latency comp parameter is not specified, it doesn't change the behavior at all.

Closes #696

Should be merged with https://github.com/ros-planning/moveit2/pull/886 so that the changes in motion speed make sense with the tutorial.

I lumped the latency parameter into one number because there are quite a few sources of latency that can be hard to quantify:

>      - joint_states publication rate
>      - ROS message transmission. I believe there are 2 message hops
>      - network latency
>      - a little bit of processing time
>      - whatever happens in the ros_control interface
>      - low-level controller execution

@MarqRazz here is a diagram to help understand (one case) where this helps. If there is a net latency of 30 ms (from when the Servo message is published to when the low-level controller executes), it can reduce the path-tracking error quite a bit. Thus the robot's low-level PID output is small --> the robot does not move very fast. In the perfect world where the latency is 0, the path-tracking accuracy will be much larger and the robot would move with the expected speed.

The first green circle is when Servo publishes. The dashed green line represents 30ms of latency. Red is when the low-level controller starts executing. The final purple dot is the end of the control period.

You can see that when latency is present, the difference between (purple-red) is much less.

![IMG_20211203_161358960](https://user-images.githubusercontent.com/11284393/144929133-c6e752ec-61e7-4bbc-bdbd-face5dfb6a0c.jpg)