### PR TITLE
Fix CHOMP motion planner build on Windows

### DIFF
--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -6,6 +6,9 @@ add_library(${MOVEIT_LIB_NAME} SHARED
   src/collision_env_distance_field.cpp
   src/collision_env_hybrid.cpp
 )
+include(GenerateExportHeader)
+generate_export_header(${MOVEIT_LIB_NAME})
+target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
@@ -24,6 +27,7 @@ target_link_libraries(${MOVEIT_LIB_NAME}
 )
 
 install(DIRECTORY include/ DESTINATION include)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MOVEIT_LIB_NAME}_export.h DESTINATION include)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
@@ -39,10 +39,12 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_distance_field/collision_env_hybrid.h>
 
+#include "moveit_collision_distance_field_export.h"
+
 namespace collision_detection
 {
 /** \brief An allocator for Hybrid collision detectors */
-class CollisionDetectorAllocatorHybrid
+class MOVEIT_COLLISION_DISTANCE_FIELD_EXPORT CollisionDetectorAllocatorHybrid
   : public CollisionDetectorAllocatorTemplate<CollisionEnvHybrid, CollisionDetectorAllocatorHybrid>
 {
 public:


### PR DESCRIPTION
### Description

#836 broke the build on Windows because it uses a static variable, which requires manual visibility headers in order to be exported. This PR generates the visibility header and exports the static variable, which fixes the build. Here is a successful [CI build run](https://github.com/Ace314159/ros2-foxy-windows-packages/runs/4413276014?check_suite_focus=true).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
