### PR TITLE
Remove temporary prbt related CI fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,6 @@ jobs:
       CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"
       DOCKER_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: moveit2.repos $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
-      # TODO(#885): Fix circular test dependency with moveit_resources and remove it from the target workspace
-      TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#ros2
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -7,11 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_msgs
     version: ros2
-  # TODO(#885): Re-enable when circular dependency is fixed
-  # moveit_resources:
-  #   type: git
-  #   url: https://github.com/ros-planning/moveit_resources
-  #   version: ros2
+  moveit_resources:
+    type: git
+    url: https://github.com/ros-planning/moveit_resources
+    version: ros2
   warehouse_ros:
     type: git
     url: https://github.com/ros-planning/warehouse_ros


### PR DESCRIPTION
Depends on https://github.com/ros-planning/moveit_resources/pull/105, will fail until that gets merged. After adding a build guard to prbt packages we wouldn't need the hacky fixes anymore. This should fix the regular CI builds as well as docker builds