### PR TITLE
Use emulated time in action-based controller

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -81,7 +81,7 @@ class ActionBasedControllerHandle : public ActionBasedControllerHandleBase
 public:
   ActionBasedControllerHandle(const rclcpp::Node::SharedPtr& node, const std::string& name, const std::string& ns,
                               const std::string& logger_name)
-    : ActionBasedControllerHandleBase(name, logger_name), done_(true), namespace_(ns)
+    : ActionBasedControllerHandleBase(name, logger_name), node_(node), done_(true), namespace_(ns)
   {
     // Creating the action client does not ensure that the action server is actually running. Executing trajectories
     // through the controller handle will fail if the server is not running when an action goal message is sent.
@@ -185,6 +185,12 @@ public:
   }
 
 protected:
+
+  /**
+   * @brief A pointer to the node, required to read parameters and get the time.
+   */
+  const rclcpp::Node::SharedPtr node_;
+
   /**
    * @brief Check if the controller's action server is ready to receive action goals.
    * @return True if the action server is ready, false if it is not ready or does not exist.

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -185,7 +185,6 @@ public:
   }
 
 protected:
-
   /**
    * @brief A pointer to the node, required to read parameters and get the time.
    */

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -138,10 +138,9 @@ public:
     }
     else
     {
-      const bool use_sim_time = node_->get_parameter("use_sim_time").as_bool();
-      if (use_sim_time)
+      std::future_status status;
+      if (node_->get_parameter("use_sim_time").as_bool())
       {
-        std::future_status status;
         const auto start = node_->now();
         do
         {
@@ -155,7 +154,7 @@ public:
       }
       else
       {
-        std::future_status status = result_future.wait_for(timeout.to_chrono<std::chrono::duration<double>>());
+        status = result_future.wait_for(timeout.to_chrono<std::chrono::duration<double>>());
         if (status == std::future_status::timeout)
         {
           RCLCPP_WARN(LOGGER, "waitForExecution timed out");

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -145,7 +145,6 @@ public:
         const auto start = node_->now();
         do
         {
-          RCLCPP_WARN(LOGGER, "waitForExecution, wait_for");
           status = result_future.wait_for(50ms);
           if ((status == std::future_status::timeout) and ((node_->now() - start) > timeout))
           {


### PR DESCRIPTION
Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

`future.wait_for()` should not be used with a time obtained from `node_->now()` because of the mix between simulated and system time. This PR fix the issue that the action server would time out with a very slow simulated time.

Note that for technical reasons (cf. below) I cannot compile `main` but that same changes compile when based on `foxy`.

PS: can someone point me to the documentation to test a PR on the `main` branch? I use Foxy and I'm struggling with compiling the `main` branch. The [documentation](https://moveit.ros.org/documentation/contributing/pullrequests/) states that I could base my PR on `foxy` but my last [PR](https://github.com/ros-planning/moveit2/pull/793#pullrequestreview-803865316) was rejected because of this.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
