### PR TITLE
Docker - Temporarily move moveit_resources under target workspace due to #885

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -27,17 +27,16 @@ RUN \
         # Preferred build tools
         clang clang-format-10 clang-tidy clang-tools \
         ccache && \
-    #
+    # TODO(#885): Fix circular test dependency with moveit_resources and remove it from the target workspace
+    git clone https://github.com/ros-planning/moveit_resources -b ros2 src/moveit_resources && \
     # Fetch all dependencies from moveit2.repos
     vcs import src < src/moveit2/moveit2.repos && \
     if [ -r src/moveit2/moveit2_${ROS_DISTRO}.repos ] ; then vcs import src < src/moveit2/moveit2_${ROS_DISTRO}.repos ; fi && \
-    #
     # Download all dependencies of MoveIt
     rosdep update && \
     DEBIAN_FRONTEND=noninteractive \
     rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     # Remove the source code from this container
     rm -rf src && \
-    #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -19,7 +19,6 @@ RUN \
     # Update apt package list as previous containers clear the cache
     apt-get -q update && \
     apt-get -q -y dist-upgrade && \
-    #
     # Install some base dependencies
     apt-get -q install --no-install-recommends -y \
         # Some basic requirements


### PR DESCRIPTION
This should fix docker CI fails in main. I would be happy if someone (that has write access) can test this in a branch before merging.