### PR TITLE
Get rid of "std::endl"

### DIFF
--- a/moveit_core/backtrace/include/moveit/backtrace/backtrace.h
+++ b/moveit_core/backtrace/include/moveit/backtrace/backtrace.h
@@ -48,17 +48,17 @@ void get_backtrace(std::ostream& out)
   void* array[500];
   size_t size = backtrace(array, 500);
   char** strings = backtrace_symbols((void* const*)array, size);
-  out << "Backtrace:" << std::endl;
+  out << "Backtrace: \n";
   for (size_t i = 0; i < size; ++i)
   {
-    out << "  " << strings[i] << std::endl;
+    out << "  " << strings[i] << '\n';
   }
   free(strings);
 }
 #else
 void get_backtrace(std::ostream& out)
 {
-  out << "Unable to get backtrace with the used compiler." << std::endl;
+  out << "Unable to get backtrace with the used compiler.\n";
 }
 #endif
 }  // namespace moveit

--- a/moveit_core/collision_detection/src/collision_matrix.cpp
+++ b/moveit_core/collision_detection/src/collision_matrix.cpp
@@ -400,7 +400,7 @@ void AllowedCollisionMatrix::print(std::ostream& out) const
       ss << std::setw(number_digits) << i;
       out << std::setw(3) << ss.str().c_str()[j];
     }
-    out << std::endl;
+    out << '\n';
   }
 
   for (std::size_t i = 0; i < names.size(); ++i)
@@ -417,7 +417,7 @@ void AllowedCollisionMatrix::print(std::ostream& out) const
       else
         out << std::setw(3) << '-';
     }
-    out << std::endl;
+    out << '\n';
   }
 }
 

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -242,7 +242,7 @@ public:
                                const Eigen::Isometry3d& new_relative_cylinder_pose)
   {
     // std::cerr << "Replacing " << collision_spheres_.size() << " with " <<
-    // new_collision_spheres.size() << std::endl;
+    // new_collision_spheres.size() << '\n';
     collision_spheres_ = new_collision_spheres;
     relative_cylinder_pose_ = new_relative_cylinder_pose;
   }

--- a/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
+++ b/moveit_core/collision_distance_field/src/collision_env_distance_field.cpp
@@ -504,7 +504,7 @@ bool CollisionEnvDistanceField::getIntraGroupCollisions(const collision_detectio
         }
         // std::cerr << "Bounding spheres for " << gsr->dfce_->link_names_[i] <<
         // " and " << gsr->dfce_->link_names_[j]
-        //           << " intersect" << std::endl;
+        //           << " intersect" << '\n';
       }
       int num_pair = -1;
       std::string name_1;
@@ -572,7 +572,7 @@ bool CollisionEnvDistanceField::getIntraGroupCollisions(const collision_detectio
           double dist = gradient.norm();
           // std::cerr << "Dist is " << dist << " rad " <<
           // (*collision_spheres_1)[k].radius_+(*collision_spheres_2)[l].radius_
-          // << std::endl;
+          // << '\n';
 
           if (dist < (*collision_spheres_1)[k].radius_ + (*collision_spheres_2)[l].radius_)
           {
@@ -805,14 +805,14 @@ DistanceFieldCacheEntryPtr CollisionEnvDistanceField::generateDistanceFieldCache
           // std::cerr << "Checking touch links for " << link_name << " and " <<
           // attached_bodies[j]->getName()
           //           << " num " << attached_bodies[j]->getTouchLinks().size()
-          //           << std::endl;
+          //           << '\n';
           // touch links take priority
           if (link_attached_bodies[j]->getTouchLinks().find(link_name) != link_attached_bodies[j]->getTouchLinks().end())
           {
             dfce->intra_group_collision_enabled_[i][att_count + dfce->link_names_.size()] = false;
             // std::cerr << "Setting intra group for " << link_name << " and
             // attached body " << link_attached_bodies[j]->getName() << " to
-            // false" << std::endl;
+            // false" << '\n';
           }
         }
       }
@@ -852,7 +852,7 @@ DistanceFieldCacheEntryPtr CollisionEnvDistanceField::generateDistanceFieldCache
         // TODO - allow for touch links to be attached bodies?
         // else {
         // std::cerr << "Setting not allowed for " << link_name << " and " <<
-        // dfce->link_names_[j] << std::endl;
+        // dfce->link_names_[j] << '\n';
         //}
       }
     }
@@ -1226,7 +1226,7 @@ void CollisionEnvDistanceField::getGroupStateRepresentation(const DistanceFieldC
     // const moveit::core::LinkModel* ls =
     // state.getLinkStateVector()[dfce->attached_body_link_state_indices_[i]];
     /// std::cerr << "Attached " << dfce->attached_body_names_[i] << " index "
-    /// << dfce->attached_body_link_state_indices_[i] << std::endl;
+    /// << dfce->attached_body_link_state_indices_[i] << '\n';
     gsr->attached_body_decompositions_.push_back(
         getAttachedBodySphereDecomposition(state.getAttachedBody(dfce->attached_body_names_[i]), resolution_));
     gsr->gradients_[i + dfce->link_names_.size()].types.resize(
@@ -1351,7 +1351,7 @@ bool CollisionEnvDistanceField::compareCacheEntryToAllowedCollisionMatrix(
             // " << dfce->link_names_[j]
             //           << " went from " <<
             //           dfce->intra_group_collision_enabled_[i][j] << " to " <<
-            //           intra_collision_enabled << std::endl;
+            //           intra_collision_enabled << '\n';
             return false;
           }
         }

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -262,7 +262,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
   theta4[1] = -acos_angle;
 
 #ifdef DEBUG
-  std::cout << "ComputeIK::theta3:" << numerator << "," << denominator << "," << std::endl << theta4[0] << std::endl;
+  std::cout << "ComputeIK::theta3:" << numerator << "," << denominator << ",\n" << theta4[0] << '\n';
 #endif
 
   for (double theta : theta4)
@@ -272,7 +272,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
     sint4 = sin(t4);
 
 #ifdef DEBUG
-    std::cout << "t4 " << t4 << std::endl;
+    std::cout << "t4 " << t4 << '\n';
 #endif
     if (std::isnan(t4))
       continue;
@@ -295,7 +295,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
         continue;
 
 #ifdef DEBUG
-      std::cout << "t2 " << t2 << std::endl;
+      std::cout << "t2 " << t2 << '\n';
 #endif
       sint2 = sin(t2);
       cost2 = cos(t2);
@@ -318,7 +318,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
         sint3 = sin(t3);
         cost3 = cos(t3);
 #ifdef DEBUG
-        std::cout << "t3 " << t3 << std::endl;
+        std::cout << "t3 " << t3 << '\n';
 #endif
         if (fabs((shoulder_upperarm_offset_ - shoulder_elbow_offset_ +
                   (shoulder_elbow_offset_ - shoulder_wrist_offset_) * cost4) *
@@ -395,14 +395,14 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
             continue;
 
 #ifdef DEBUG
-          std::cout << "t6 " << t6 << std::endl;
+          std::cout << "t6 " << t6 << '\n';
 #endif
           if (fabs(cos(t6) - grhs_local(0, 0)) > IK_EPS)
             continue;
 
           if (fabs(sin(t6)) < IK_EPS)
           {
-            //                std::cout << "Singularity" << std::endl;
+            //                std::cout << "Singularity" << '\n';
             theta5[0] = acos(grhs_local(1, 1)) / 2.0;
             theta7[0] = theta7[0];
             theta7[1] = M_PI + theta7[0];
@@ -416,13 +416,13 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
             theta5[1] = M_PI + theta5[0];
           }
 #ifdef DEBUG
-          std::cout << "theta1: " << t1 << std::endl;
-          std::cout << "theta2: " << t2 << std::endl;
-          std::cout << "theta3: " << t3 << std::endl;
-          std::cout << "theta4: " << t4 << std::endl;
-          std::cout << "theta5: " << t5 << std::endl;
-          std::cout << "theta6: " << t6 << std::endl;
-          std::cout << "theta7: " << t7 << std::endl << std::endl << std::endl;
+          std::cout << "theta1: " << t1 << '\n';
+          std::cout << "theta2: " << t2 << '\n';
+          std::cout << "theta3: " << t3 << '\n';
+          std::cout << "theta4: " << t4 << '\n';
+          std::cout << "theta5: " << t5 << '\n';
+          std::cout << "theta6: " << t6 << '\n';
+          std::cout << "theta7: " << t7 << '\n' << '\n' << '\n';
 #endif
           for (int lll = 0; lll < 2; lll++)
           {
@@ -434,8 +434,8 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
               continue;
 
 #ifdef DEBUG
-            std::cout << "t5" << t5 << std::endl;
-            std::cout << "t7" << t7 << std::endl;
+            std::cout << "t5" << t5 << '\n';
+            std::cout << "t7" << t7 << '\n';
 #endif
             if (fabs(sin(t6) * sin(t7) - grhs_local(0, 1)) > IK_EPS ||
                 fabs(cos(t7) * sin(t6) - grhs_local(0, 2)) > IK_EPS)
@@ -453,8 +453,8 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
 #ifdef DEBUG
             std::cout << "SOLN " << solution_ik[0] << " " << solution_ik[1] << " " << solution_ik[2] << " "
                       << solution_ik[3] << " " << solution_ik[4] << " " << solution_ik[5] << " " << solution_ik[6]
-                      << std::endl
-                      << std::endl;
+                      << '\n'
+                      << '\n';
 #endif
           }
         }
@@ -542,7 +542,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
     cost4 = cos(t4);
     sint4 = sin(t4);
 #ifdef DEBUG
-    std::cout << "t4 " << t4 << std::endl;
+    std::cout << "t4 " << t4 << '\n';
 #endif
     if (std::isnan(t4))
       continue;
@@ -558,7 +558,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
     {
       t2 = theta;
 #ifdef DEBUG
-      std::cout << "t2 " << t2 << std::endl;
+      std::cout << "t2 " << t2 << '\n';
 #endif
       if (!checkJointLimits(t2, 1))
       {
@@ -574,7 +574,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
       if (!solveCosineEqn(at, bt, ct, theta1[0], theta1[1]))
       {
 #ifdef DEBUG
-        std::cout << "could not solve cosine equation for t1" << std::endl;
+        std::cout << "could not solve cosine equation for t1" << '\n';
 #endif
         continue;
       }
@@ -583,7 +583,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
       {
         t1 = theta;
 #ifdef DEBUG
-        std::cout << "t1 " << t1 << std::endl;
+        std::cout << "t1 " << t1 << '\n';
 #endif
         if (!checkJointLimits(t1, 0))
         {
@@ -690,7 +690,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
         {
           t6 = theta6[mm];
 #ifdef DEBUG
-          std::cout << "t6 " << t6 << std::endl;
+          std::cout << "t6 " << t6 << '\n';
 #endif
           if (!checkJointLimits(t6, 5))
           {
@@ -702,7 +702,7 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
 
           if (fabs(sin(t6)) < IK_EPS)
           {
-            //                std::cout << "Singularity" << std::endl;
+            //                std::cout << "Singularity" << '\n';
             theta5[0] = acos(grhs_local(1, 1)) / 2.0;
             theta7[0] = theta5[0];
             //            theta7[1] = M_PI+theta7[0];
@@ -730,20 +730,20 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
             }
 
 #ifdef DEBUG
-            std::cout << "t5 " << t5 << std::endl;
-            std::cout << "t7 " << t7 << std::endl;
+            std::cout << "t5 " << t5 << '\n';
+            std::cout << "t7 " << t7 << '\n';
 #endif
             //           if(fabs(sin(t6)*sin(t7)-grhs_local(0,1)) > IK_EPS || fabs(cos(t7)*sin(t6)-grhs_local(0,2)) > IK_EPS)
             //  continue;
 
 #ifdef DEBUG
-            std::cout << "theta1: " << t1 << std::endl;
-            std::cout << "theta2: " << t2 << std::endl;
-            std::cout << "theta3: " << t3 << std::endl;
-            std::cout << "theta4: " << t4 << std::endl;
-            std::cout << "theta5: " << t5 << std::endl;
-            std::cout << "theta6: " << t6 << std::endl;
-            std::cout << "theta7: " << t7 << std::endl << std::endl << std::endl;
+            std::cout << "theta1: " << t1 << '\n';
+            std::cout << "theta2: " << t2 << '\n';
+            std::cout << "theta3: " << t3 << '\n';
+            std::cout << "theta4: " << t4 << '\n';
+            std::cout << "theta5: " << t5 << '\n';
+            std::cout << "theta6: " << t6 << '\n';
+            std::cout << "theta7: " << t7 << '\n' << '\n' << '\n';
 #endif
 
             solution_ik[0] = normalize_angle(t1 * angle_multipliers_[0]);
@@ -757,8 +757,8 @@ void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double
 #ifdef DEBUG
             std::cout << "SOLN " << solution_ik[0] << " " << solution_ik[1] << " " << solution_ik[2] << " "
                       << solution_ik[3] << " " << solution_ik[4] << " " << solution_ik[5] << " " << solution_ik[6]
-                      << std::endl
-                      << std::endl;
+                      << '\n'
+                      << '\n';
 #endif
           }
         }

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -96,7 +96,7 @@ inline bool solveCosineEqn(const double& a, const double& b, const double& c, do
   if (fabs(denom) < IK_EPS)  // should never happen, wouldn't make sense but make sure it is checked nonetheless
   {
 #ifdef DEBUG
-    std::cout << "denom: " << denom << std::endl;
+    std::cout << "denom: " << denom << '\n';
 #endif
     return false;
   }
@@ -104,7 +104,7 @@ inline bool solveCosineEqn(const double& a, const double& b, const double& c, do
   if (rhs_ratio < -1 || rhs_ratio > 1)
   {
 #ifdef DEBUG
-    std::cout << "rhs_ratio: " << rhs_ratio << std::endl;
+    std::cout << "rhs_ratio: " << rhs_ratio << '\n';
 #endif
     return false;
   }

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -477,11 +477,11 @@ void PropagationDistanceField::propagateNegative()
         if (new_distance_sq > max_distance_sq_)
           continue;
         // std::cout << "Looking at " << nloc.x() << " " << nloc.y() << " " << nloc.z() << " " << new_distance_sq << " "
-        // << neighbor->negative_distance_square_ << std::endl;
+        // << neighbor->negative_distance_square_ << '\n';
         if (new_distance_sq < neighbor->negative_distance_square_)
         {
           // std::cout << "Updating " << nloc.x() << " " << nloc.y() << " " << nloc.z() << " " << new_distance_sq <<
-          // std::endl;
+          // '\n';
           // update the neighboring voxel
           neighbor->negative_distance_square_ = new_distance_sq;
           neighbor->closest_negative_point_ = vptr->closest_negative_point_;
@@ -627,13 +627,13 @@ bool PropagationDistanceField::worldToGrid(double world_x, double world_y, doubl
 
 bool PropagationDistanceField::writeToStream(std::ostream& os) const
 {
-  os << "resolution: " << resolution_ << std::endl;
-  os << "size_x: " << size_x_ << std::endl;
-  os << "size_y: " << size_y_ << std::endl;
-  os << "size_z: " << size_z_ << std::endl;
-  os << "origin_x: " << origin_x_ << std::endl;
-  os << "origin_y: " << origin_y_ << std::endl;
-  os << "origin_z: " << origin_z_ << std::endl;
+  os << "resolution: " << resolution_ << '\n';
+  os << "size_x: " << size_x_ << '\n';
+  os << "size_y: " << size_y_ << '\n';
+  os << "size_z: " << size_z_ << '\n';
+  os << "origin_x: " << origin_x_ << '\n';
+  os << "origin_y: " << origin_y_ << '\n';
+  os << "origin_z: " << origin_z_ << '\n';
   // now the binary stuff
 
   // first writing to zlib compressed buffer
@@ -653,7 +653,7 @@ bool PropagationDistanceField::writeToStream(std::ostream& os) const
         {
           if (getCell(x, y, z + zi).distance_square_ == 0)
           {
-            // std::cout << "Marking obs cell " << x << " " << y << " " << z+zi << std::endl;
+            // std::cout << "Marking obs cell " << x << " " << y << " " << z+zi << '\n';
             bs[zi] = 1;
           }
         }
@@ -720,7 +720,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
   in.push(boost::iostreams::zlib_decompressor());
   in.push(is);
 
-  // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << std::endl;
+  // std::cout << "Nums " << getXNumCells() << " " << getYNumCells() << " " << getZNumCells() << '\n';
 
   EigenSTL::vector_Vector3i obs_points;
   for (unsigned int x = 0; x < static_cast<unsigned int>(getXNumCells()); x++)
@@ -741,7 +741,7 @@ bool PropagationDistanceField::readFromStream(std::istream& is)
         {
           if (inbit[zi] == 1)
           {
-            // std::cout << "Adding obs cell " << x << " " << y << " " << z+zi << std::endl;
+            // std::cout << "Adding obs cell " << x << " " << y << " " << z+zi << '\n';
             obs_points.push_back(Eigen::Vector3i(x, y, z + zi));
           }
         }

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -562,8 +562,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
 
           EXPECT_GE(gradient_df.getCell(ncell_pos.x(), ncell_pos.y(), ncell_pos.z()).distance_square_, 1)
               << "dist=" << dist << " xyz=" << x << " " << y << " " << z << " grad=" << grad.x() << " " << grad.y()
-              << " " << grad.z() << " ncell=" << ncell_pos.x() << " " << ncell_pos.y() << " " << ncell_pos.z()
-              << '\n';
+              << " " << grad.z() << " ncell=" << ncell_pos.x() << " " << ncell_pos.y() << " " << ncell_pos.z() << '\n';
 
           double grad_size_sq = grad.squaredNorm();
           if (grad_size_sq < std::numeric_limits<double>::epsilon())

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -78,9 +78,9 @@ void print(PropagationDistanceField& pdf, int numX, int numY, int numZ)
       {
         std::cout << pdf.getCell(x, y, z).distance_square_ << " ";
       }
-      std::cout << std::endl;
+      std::cout << '\n';
     }
-    std::cout << std::endl;
+    std::cout << '\n';
   }
   for (int z = 0; z < numZ; z++)
   {
@@ -107,9 +107,9 @@ void printNeg(PropagationDistanceField& pdf, int numX, int numY, int numZ)
       {
         std::cout << pdf.getCell(x, y, z).negative_distance_square_ << " ";
       }
-      std::cout << std::endl;
+      std::cout << '\n';
     }
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 }
 
@@ -135,10 +135,10 @@ void printPointCoords(const Eigen::Vector3i& p)
 
 void printBoth(PropagationDistanceField& pdf, int numX, int numY, int numZ)
 {
-  std::cout << "Positive distance square ... negative distance square" << std::endl;
+  std::cout << "Positive distance square ... negative distance square" << '\n';
   for (int z = 0; z < numZ; z++)
   {
-    std::cout << "Z=" << z << std::endl;
+    std::cout << "Z=" << z << '\n';
     for (int y = 0; y < numY; y++)
     {
       for (int x = 0; x < numX; x++)
@@ -160,9 +160,9 @@ void printBoth(PropagationDistanceField& pdf, int numX, int numY, int numZ)
       {
         printPointCoords(pdf.getCell(x, y, z).closest_negative_point_);
       }
-      std::cout << std::endl;
+      std::cout << '\n';
     }
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 }
 
@@ -237,13 +237,13 @@ bool checkOctomapVersusDistanceField(const PropagationDistanceField& df, const o
             if (!result)
             {
               std::cout << "No point at potential boundary query " << query.x() << " " << query.y() << " " << query.z()
-                        << std::endl;
+                        << '\n';
               return false;
             }
           }
           if (!octree.isNodeOccupied(result))
           {
-            std::cout << "Disagreement at " << qx << " " << qy << " " << qz << std::endl;
+            std::cout << "Disagreement at " << qx << " " << qy << " " << qz << '\n';
             return false;
           }
         }
@@ -279,7 +279,7 @@ unsigned int countLeafNodes(const octomap::OcTree& octree)
   {
     if (octree.isNodeOccupied(*it))
     {
-      std::cout << "Leaf node " << it.getX() << " " << it.getY() << " " << it.getZ() << std::endl;
+      std::cout << "Leaf node " << it.getX() << " " << it.getY() << " " << it.getZ() << '\n';
       count++;
     }
   }
@@ -363,7 +363,7 @@ TEST(TestPropagationDistanceField, TestAddRemovePoints)
   EigenSTL::vector_Vector3d old_points;
   old_points.push_back(POINT1);
   df.updatePointsInField(old_points, points);
-  // std::cout << "One removal, one addition" << std::endl;
+  // std::cout << "One removal, one addition" << '\n';
   // print(df, numX, numY, numZ);
   // printNeg(df, numX, numY, numZ);
   check_distance_field(df, points, num_x, num_y, num_z, false);
@@ -408,21 +408,21 @@ TEST(TestPropagationDistanceField, TestAddRemovePoints)
           if (first)
           {
             first = false;
-            std::cout << "Dist " << dist << std::endl;
-            std::cout << "Cell " << x << " " << y << " " << z << " " << wx << " " << wy << " " << wz << std::endl;
-            std::cout << "Scale " << xscale << " " << yscale << " " << zscale << std::endl;
+            std::cout << "Dist " << dist << '\n';
+            std::cout << "Cell " << x << " " << y << " " << z << " " << wx << " " << wy << " " << wz << '\n';
+            std::cout << "Scale " << xscale << " " << yscale << " " << zscale << '\n';
             std::cout << "Grad " << grad.x() << " " << grad.y() << " " << grad.z() << " comp " << comp_x << " "
-                      << comp_y << " " << comp_z << std::endl;
+                      << comp_y << " " << comp_z << '\n';
           }
           ASSERT_NEAR(comp_x, POINT1.x(), RESOLUTION)
               << dist << x << " " << y << " " << z << " " << grad.x() << " " << grad.y() << " " << grad.z() << " "
-              << xscale << " " << yscale << " " << zscale << std::endl;
+              << xscale << " " << yscale << " " << zscale << '\n';
           ASSERT_NEAR(comp_y, POINT1.y(), RESOLUTION)
               << x << " " << y << " " << z << " " << grad.x() << " " << grad.y() << " " << grad.z() << " " << xscale
-              << " " << yscale << " " << zscale << std::endl;
+              << " " << yscale << " " << zscale << '\n';
           ASSERT_NEAR(comp_z, POINT1.z(), RESOLUTION)
               << x << " " << y << " " << z << " " << grad.x() << " " << grad.y() << " " << grad.z() << " " << xscale
-              << " " << yscale << " " << zscale << std::endl;
+              << " " << yscale << " " << zscale << '\n';
         }
       }
     }
@@ -481,9 +481,9 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
   EigenSTL::vector_Vector3d rem_points;
   rem_points.push_back(center_point);
   df.removePointsFromField(rem_points);
-  // std::cout << "Pos "<< std::endl;
+  // std::cout << "Pos "<< '\n';
   // print(df, numX, numY, numZ);
-  // std::cout << "Neg "<< std::endl;
+  // std::cout << "Neg "<< '\n';
   // printNeg(df, numX, numY, numZ);
 
   // testing equality with initial add of points without the center point
@@ -535,13 +535,13 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
           {
             EXPECT_GE(ncell_dist, gradient_df.getUninitializedDistance())
                 << "dist=" << dist << " xyz=" << x << " " << y << " " << z << " ncell=" << ncell_pos.x() << " "
-                << ncell_pos.y() << " " << ncell_pos.z() << std::endl;
+                << ncell_pos.y() << " " << ncell_pos.z() << '\n';
           }
           else if (ncell_dist < 0)
           {
             EXPECT_LE(ncell_dist, -gradient_df.getUninitializedDistance())
                 << "dist=" << dist << " xyz=" << x << " " << y << " " << z << " ncell=" << ncell_pos.x() << " "
-                << ncell_pos.y() << " " << ncell_pos.z() << std::endl;
+                << ncell_pos.y() << " " << ncell_pos.z() << '\n';
           }
         }
 
@@ -563,7 +563,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
           EXPECT_GE(gradient_df.getCell(ncell_pos.x(), ncell_pos.y(), ncell_pos.z()).distance_square_, 1)
               << "dist=" << dist << " xyz=" << x << " " << y << " " << z << " grad=" << grad.x() << " " << grad.y()
               << " " << grad.z() << " ncell=" << ncell_pos.x() << " " << ncell_pos.y() << " " << ncell_pos.z()
-              << std::endl;
+              << '\n';
 
           double grad_size_sq = grad.squaredNorm();
           if (grad_size_sq < std::numeric_limits<double>::epsilon())
@@ -593,7 +593,7 @@ TEST(TestSignedPropagationDistanceField, TestSignedAddRemovePoints)
           EXPECT_GE(cell->distance_square_, 1)
               << dist << " " << x << " " << y << " " << z << " " << grad.x() << " " << grad.y() << " " << grad.z()
               << " " << xscale << " " << yscale << " " << zscale << " cell " << comp_x << " " << comp_y << " " << comp_z
-              << std::endl;
+              << '\n';
         }
       }
     }
@@ -622,9 +622,9 @@ TEST(TestSignedPropagationDistanceField, TestShape)
   delete body;
   check_distance_field(df, point_vec, num_x, num_y, num_z, true);
 
-  // std::cout << "Shape pos "<< std::endl;
+  // std::cout << "Shape pos "<< '\n';
   // print(df, numX, numY, numZ);
-  // std::cout << "Shape neg "<< std::endl;
+  // std::cout << "Shape neg "<< '\n';
   // printNeg(df, numX, numY, numZ);
 
   df.addShapeToField(&sphere, np);
@@ -664,7 +664,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
 {
   std::cout << "Creating distance field with "
             << (PERF_WIDTH / PERF_RESOLUTION) * (PERF_HEIGHT / PERF_RESOLUTION) * (PERF_DEPTH / PERF_RESOLUTION)
-            << " entries" << std::endl;
+            << " entries" << '\n';
 
   auto dt = std::chrono::system_clock::now();
   PropagationDistanceField df(PERF_WIDTH, PERF_HEIGHT, PERF_DEPTH, PERF_RESOLUTION, PERF_ORIGIN_X, PERF_ORIGIN_Y,
@@ -672,7 +672,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
   std::cout
       << "Creating unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   PropagationDistanceField sdf(PERF_WIDTH, PERF_HEIGHT, PERF_DEPTH, PERF_RESOLUTION, PERF_ORIGIN_X, PERF_ORIGIN_Y,
@@ -681,7 +681,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
   std::cout
       << "Creating signed took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   shapes::Box big_table(2.0, 2.0, .5);
 
@@ -692,7 +692,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
 
   unsigned int big_num_points = ceil(2.0 / PERF_RESOLUTION) * ceil(2.0 / PERF_RESOLUTION) * ceil(.5 / PERF_RESOLUTION);
 
-  std::cout << "Adding " << big_num_points << " points" << std::endl;
+  std::cout << "Adding " << big_num_points << " points" << '\n';
 
   dt = std::chrono::system_clock::now();
   df.addShapeToField(&big_table, p);
@@ -704,14 +704,14 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
       << (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() /
           1000.0) /
              (big_num_points * 1.0)
-      << std::endl;
+      << '\n';
 
   dt = std::chrono::system_clock::now();
   df.addShapeToField(&big_table, p);
   std::cout
       << "Re-adding to unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   sdf.addShapeToField(&big_table, p);
@@ -723,35 +723,35 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
       << (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() /
           1000.0) /
              (big_num_points * 1.0)
-      << std::endl;
+      << '\n';
 
   dt = std::chrono::system_clock::now();
   df.moveShapeInField(&big_table, p, np);
   std::cout
       << "Moving in unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   sdf.moveShapeInField(&big_table, p, np);
   std::cout
       << "Moving in signed took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   df.removeShapeFromField(&big_table, np);
   std::cout
       << "Removing from unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   sdf.removeShapeFromField(&big_table, np);
   std::cout
       << "Removing from signed took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   df.reset();
@@ -760,7 +760,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
 
   unsigned int small_num_points = (13) * (13) * (3);
 
-  std::cout << "Adding " << small_num_points << " points" << std::endl;
+  std::cout << "Adding " << small_num_points << " points" << '\n';
 
   dt = std::chrono::system_clock::now();
   df.addShapeToField(&small_table, p);
@@ -768,7 +768,7 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
       << "Adding to unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
       << " secs"
-      << " avg " << (std::chrono::system_clock::now() - dt).count() / (small_num_points * 1.0) << std::endl;
+      << " avg " << (std::chrono::system_clock::now() - dt).count() / (small_num_points * 1.0) << '\n';
 
   dt = std::chrono::system_clock::now();
   sdf.addShapeToField(&small_table, p);
@@ -776,21 +776,21 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
       << "Adding to signed took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
       << " secs"
-      << " avg " << (std::chrono::system_clock::now() - dt).count() / (small_num_points * 1.0) << std::endl;
+      << " avg " << (std::chrono::system_clock::now() - dt).count() / (small_num_points * 1.0) << '\n';
 
   dt = std::chrono::system_clock::now();
   df.moveShapeInField(&small_table, p, np);
   std::cout
       << "Moving in unsigned took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   dt = std::chrono::system_clock::now();
   sdf.moveShapeInField(&small_table, p, np);
   std::cout
       << "Moving in signed took "
       << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - dt).count() / 1000.0
-      << " secs" << std::endl;
+      << " secs" << '\n';
 
   // uniformly spaced points - a worst case scenario
   PropagationDistanceField worstdfu(PERF_WIDTH, PERF_HEIGHT, PERF_DEPTH, PERF_RESOLUTION, PERF_ORIGIN_X, PERF_ORIGIN_Y,
@@ -866,7 +866,7 @@ TEST(TestSignedPropagationDistanceField, TestOcTree)
     }
   }
 
-  std::cout << "OcTree nodes " << count << std::endl;
+  std::cout << "OcTree nodes " << count << '\n';
   df.addOcTreeToField(&tree);
 
   EXPECT_TRUE(checkOctomapVersusDistanceField(df, tree));
@@ -906,7 +906,7 @@ TEST(TestSignedPropagationDistanceField, TestOcTree)
 
   df_highres.addOcTreeToField(&tree_lowres);
   EXPECT_EQ(countOccupiedCells(df_highres), 3u * (4u * 4u * 4u));
-  std::cout << "Occupied cells " << countOccupiedCells(df_highres) << std::endl;
+  std::cout << "Occupied cells " << countOccupiedCells(df_highres) << '\n';
 
   // testing adding shape that happens to be octree
   std::shared_ptr<octomap::OcTree> tree_shape(new octomap::OcTree(.05));
@@ -974,7 +974,7 @@ TEST(TestSignedPropagationDistanceField, TestReadWrite)
   std::ifstream i2("test_big.df", std::ios::in);
   auto wt = std::chrono::system_clock::now();
   PropagationDistanceField df3(i2, PERF_MAX_DIST + .02, false);
-  std::cout << "Reconstruction for big file took " << (std::chrono::system_clock::now() - wt).count() << std::endl;
+  std::cout << "Reconstruction for big file took " << (std::chrono::system_clock::now() - wt).count() << '\n';
   EXPECT_FALSE(areDistanceFieldsDistancesEqual(df, df3));
 }
 

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -324,17 +324,17 @@ void JointConstraint::print(std::ostream& out) const
 {
   if (joint_model_)
   {
-    out << "Joint constraint for joint " << joint_variable_name_ << ": " << std::endl;
+    out << "Joint constraint for joint " << joint_variable_name_ << ": \n";
     out << "  value = ";
     out << joint_position_ << "; ";
     out << "  tolerance below = ";
     out << joint_tolerance_below_ << "; ";
     out << "  tolerance above = ";
     out << joint_tolerance_above_ << "; ";
-    out << std::endl;
+    out << '\n';
   }
   else
-    out << "No constraint" << std::endl;
+    out << "No constraint" << '\n';
 }
 
 bool PositionConstraint::configure(const moveit_msgs::msg::PositionConstraint& pc, const moveit::core::Transforms& tf)
@@ -536,9 +536,9 @@ ConstraintEvaluationResult PositionConstraint::decide(const moveit::core::RobotS
 void PositionConstraint::print(std::ostream& out) const
 {
   if (enabled())
-    out << "Position constraint on link '" << link_model_->getName() << "'" << std::endl;
+    out << "Position constraint on link '" << link_model_->getName() << "'" << '\n';
   else
-    out << "No constraint" << std::endl;
+    out << "No constraint" << '\n';
 }
 
 void PositionConstraint::clear()
@@ -749,12 +749,12 @@ void OrientationConstraint::print(std::ostream& out) const
 {
   if (link_model_)
   {
-    out << "Orientation constraint on link '" << link_model_->getName() << "'" << std::endl;
+    out << "Orientation constraint on link '" << link_model_->getName() << "'" << '\n';
     Eigen::Quaterniond q_des(desired_rotation_matrix_);
-    out << "Desired orientation:" << q_des.x() << "," << q_des.y() << "," << q_des.z() << "," << q_des.w() << std::endl;
+    out << "Desired orientation:" << q_des.x() << "," << q_des.y() << "," << q_des.z() << "," << q_des.w() << '\n';
   }
   else
-    out << "No constraint" << std::endl;
+    out << "No constraint" << '\n';
 }
 
 VisibilityConstraint::VisibilityConstraint(const moveit::core::RobotModelConstPtr& model)
@@ -1168,11 +1168,11 @@ void VisibilityConstraint::print(std::ostream& out) const
   if (enabled())
   {
     out << "Visibility constraint for sensor in frame '" << sensor_frame_id_ << "' using target in frame '"
-        << target_frame_id_ << "'" << std::endl;
-    out << "Target radius: " << target_radius_ << ", using " << cone_sides_ << " sides." << std::endl;
+        << target_frame_id_ << "'" << '\n';
+    out << "Target radius: " << target_radius_ << ", using " << cone_sides_ << " sides." << '\n';
   }
   else
-    out << "No constraint" << std::endl;
+    out << "No constraint" << '\n';
 }
 
 void KinematicConstraintSet::clear()
@@ -1288,7 +1288,7 @@ ConstraintEvaluationResult KinematicConstraintSet::decide(const moveit::core::Ro
 
 void KinematicConstraintSet::print(std::ostream& out) const
 {
-  out << kinematic_constraints_.size() << " kinematic constraints" << std::endl;
+  out << kinematic_constraints_.size() << " kinematic constraints" << '\n';
   for (const KinematicConstraintPtr& kinematic_constraint : kinematic_constraints_)
     kinematic_constraint->print(out);
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -878,7 +878,7 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
         out << obj->subframe_poses_.size() << '\n';  // Number of subframes
         for (auto& pose_pair : obj->subframe_poses_)
         {
-          out << pose_pair.first << '\n';     // Subframe name
+          out << pose_pair.first << '\n';          // Subframe name
           writePoseToText(out, pose_pair.second);  // Subframe pose
         }
       }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -846,7 +846,7 @@ void PlanningScene::getPlanningSceneMsg(moveit_msgs::msg::PlanningScene& scene_m
 
 void PlanningScene::saveGeometryToStream(std::ostream& out) const
 {
-  out << name_ << std::endl;
+  out << name_ << '\n';
   const std::vector<std::string>& ids = world_->getObjectIds();
   for (const std::string& id : ids)
     if (id != OCTOMAP_NS)
@@ -854,12 +854,12 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
       collision_detection::CollisionEnv::ObjectConstPtr obj = world_->getObject(id);
       if (obj)
       {
-        out << "* " << id << std::endl;  // New object start
+        out << "* " << id << '\n';  // New object start
         // Write object pose
         writePoseToText(out, obj->pose_);
 
         // Write shapes and shape poses
-        out << obj->shapes_.size() << std::endl;  // Number of shapes
+        out << obj->shapes_.size() << '\n';  // Number of shapes
         for (std::size_t j = 0; j < obj->shapes_.size(); ++j)
         {
           shapes::saveAsText(obj->shapes_[j].get(), out);
@@ -868,22 +868,22 @@ void PlanningScene::saveGeometryToStream(std::ostream& out) const
           if (hasObjectColor(id))
           {
             const std_msgs::msg::ColorRGBA& c = getObjectColor(id);
-            out << c.r << " " << c.g << " " << c.b << " " << c.a << std::endl;
+            out << c.r << " " << c.g << " " << c.b << " " << c.a << '\n';
           }
           else
-            out << "0 0 0 0" << std::endl;
+            out << "0 0 0 0" << '\n';
         }
 
         // Write subframes
-        out << obj->subframe_poses_.size() << std::endl;  // Number of subframes
+        out << obj->subframe_poses_.size() << '\n';  // Number of subframes
         for (auto& pose_pair : obj->subframe_poses_)
         {
-          out << pose_pair.first << std::endl;     // Subframe name
+          out << pose_pair.first << '\n';     // Subframe name
           writePoseToText(out, pose_pair.second);  // Subframe pose
         }
       }
     }
-  out << "." << std::endl;
+  out << "." << '\n';
 }
 
 bool PlanningScene::loadGeometryFromStream(std::istream& in)
@@ -1015,9 +1015,9 @@ bool PlanningScene::readPoseFromText(std::istream& in, Eigen::Isometry3d& pose) 
 
 void PlanningScene::writePoseToText(std::ostream& out, const Eigen::Isometry3d& pose) const
 {
-  out << pose.translation().x() << " " << pose.translation().y() << " " << pose.translation().z() << std::endl;
+  out << pose.translation().x() << " " << pose.translation().y() << " " << pose.translation().z() << '\n';
   Eigen::Quaterniond r(pose.linear());
-  out << r.x() << " " << r.y() << " " << r.z() << " " << r.w() << std::endl;
+  out << r.x() << " " << r.y() << " " << r.z() << " " << r.w() << '\n';
 }
 
 void PlanningScene::setCurrentState(const moveit_msgs::msg::RobotState& state)

--- a/moveit_core/profiler/src/profiler.cpp
+++ b/moveit_core/profiler/src/profiler.cpp
@@ -130,8 +130,8 @@ void Profiler::status(std::ostream& out, bool merge)
   lock_.lock();
   printOnDestroy_ = false;
 
-  out << std::endl;
-  out << " *** Profiling statistics. Total counted time : " << to_seconds(tinfo_.total) << " seconds" << std::endl;
+  out << '\n';
+  out << " *** Profiling statistics. Total counted time : " << to_seconds(tinfo_.total) << " seconds\n";
 
   if (merge)
   {
@@ -162,7 +162,7 @@ void Profiler::status(std::ostream& out, bool merge)
   else
     for (std::map<boost::thread::id, PerThread>::const_iterator it = data_.begin(); it != data_.end(); ++it)
     {
-      out << "Thread " << it->first << ":" << std::endl;
+      out << "Thread " << it->first << ":\n";
       printThreadInfo(out, it->second);
     }
   lock_.unlock();
@@ -171,7 +171,7 @@ void Profiler::status(std::ostream& out, bool merge)
 void Profiler::console()
 {
   std::stringstream ss;
-  ss << std::endl;
+  ss << '\n';
   status(ss, true);
   RCLCPP_INFO(LOGGER, "%s", ss.str().c_str());
 }
@@ -221,9 +221,9 @@ void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)
   }
   std::sort(events.begin(), events.end(), SortIntByValue());
   if (!events.empty())
-    out << "Events:" << std::endl;
+    out << "Events:\n";
   for (const DataIntVal& event : events)
-    out << event.name_ << ": " << event.value_ << std::endl;
+    out << event.name_ << ": " << event.value_ << '\n';
 
   std::vector<DataDoubleVal> avg;
   for (const std::pair<const std::string, AvgInfo>& ia : data.avg)
@@ -233,13 +233,12 @@ void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)
   }
   std::sort(avg.begin(), avg.end(), SortDoubleByValue());
   if (!avg.empty())
-    out << "Averages:" << std::endl;
+    out << "Averages:\n";
   for (const DataDoubleVal& average : avg)
   {
     const AvgInfo& a = data.avg.find(average.name_)->second;
     out << average.name_ << ": " << average.value_ << " (stddev = "
-        << sqrt(fabs(a.totalSqr - (double)a.parts * average.value_ * average.value_) / ((double)a.parts - 1.)) << ")"
-        << std::endl;
+        << sqrt(fabs(a.totalSqr - (double)a.parts * average.value_ * average.value_) / ((double)a.parts - 1.)) << ")\n";
   }
 
   std::vector<DataDoubleVal> time;
@@ -252,7 +251,7 @@ void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)
 
   std::sort(time.begin(), time.end(), SortDoubleByValue());
   if (!time.empty())
-    out << "Blocks of time:" << std::endl;
+    out << "Blocks of time:\n";
 
   double unaccounted = total;
   for (DataDoubleVal& time_block : time)
@@ -270,7 +269,7 @@ void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)
       if (pavg < 1.0)
         out << " (" << 1.0 / pavg << " /s)";
     }
-    out << std::endl;
+    out << '\n';
     unaccounted -= time_block.value_;
   }
   // if we do not appear to have counted time multiple times, print the unaccounted time too
@@ -279,10 +278,10 @@ void Profiler::printThreadInfo(std::ostream& out, const PerThread& data)
     out << "Unaccounted time : " << unaccounted;
     if (total > 0.0)
       out << " (" << (100.0 * unaccounted / total) << " %)";
-    out << std::endl;
+    out << '\n';
   }
 
-  out << std::endl;
+  out << '\n';
 }
 
 }  // end of namespace tools

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -668,11 +668,11 @@ bool JointModelGroup::canSetStateFromIK(const std::string& tip) const
 
 void JointModelGroup::printGroupInfo(std::ostream& out) const
 {
-  out << "Group '" << name_ << "' using " << variable_count_ << " variables" << std::endl;
-  out << "  * Joints:" << std::endl;
+  out << "Group '" << name_ << "' using " << variable_count_ << " variables\n";
+  out << "  * Joints:\n";
   for (const JointModel* joint_model : joint_model_vector_)
-    out << "    '" << joint_model->getName() << "' (" << joint_model->getTypeName() << ")" << std::endl;
-  out << "  * Variables:" << std::endl;
+    out << "    '" << joint_model->getName() << "' (" << joint_model->getTypeName() << ")\n";
+  out << "  * Variables:\n";
   for (const std::string& variable_name : variable_names_)
   {
     int local_idx = joint_variables_index_map_.find(variable_name)->second;
@@ -682,10 +682,10 @@ void JointModelGroup::printGroupInfo(std::ostream& out) const
         << local_idx << " in group state";
     if (jm->getMimic())
       out << ", mimic '" << jm->getMimic()->getName() << "'";
-    out << std::endl;
-    out << "        " << parent_model_->getVariableBounds(variable_name) << std::endl;
+    out << '\n';
+    out << "        " << parent_model_->getVariableBounds(variable_name) << '\n';
   }
-  out << "  * Variables Index List:" << std::endl;
+  out << "  * Variables Index List:\n";
   out << "    ";
   for (int variable_index : variable_index_list_)
     out << variable_index << " ";
@@ -693,35 +693,35 @@ void JointModelGroup::printGroupInfo(std::ostream& out) const
     out << "(contiguous)";
   else
     out << "(non-contiguous)";
-  out << std::endl;
+  out << '\n';
   if (group_kinematics_.first)
   {
-    out << "  * Kinematics solver bijection:" << std::endl;
+    out << "  * Kinematics solver bijection:\n";
     out << "    ";
     for (unsigned int index : group_kinematics_.first.bijection_)
       out << index << " ";
-    out << std::endl;
+    out << '\n';
   }
   if (!group_kinematics_.second.empty())
   {
-    out << "  * Compound kinematics solver:" << std::endl;
+    out << "  * Compound kinematics solver:\n";
     for (const std::pair<const JointModelGroup* const, KinematicsSolver>& it : group_kinematics_.second)
     {
       out << "    " << it.first->getName() << ":";
       for (unsigned int index : it.second.bijection_)
         out << " " << index;
-      out << std::endl;
+      out << '\n';
     }
   }
 
   if (!group_mimic_update_.empty())
   {
-    out << "  * Local Mimic Updates:" << std::endl;
+    out << "  * Local Mimic Updates:\n";
     for (const GroupMimicUpdate& mimic_update : group_mimic_update_)
       out << "    [" << mimic_update.dest << "] = " << mimic_update.factor << " * [" << mimic_update.src << "] + "
-          << mimic_update.offset << std::endl;
+          << mimic_update.offset << '\n';
   }
-  out << std::endl;
+  out << '\n';
 }
 
 bool JointModelGroup::isValidVelocityMove(const std::vector<double>& from_joint_pose,

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1486,21 +1486,19 @@ void RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAlloc
 
 void RobotModel::printModelInfo(std::ostream& out) const
 {
-  out << "Model " << model_name_ << " in frame " << model_frame_ << ", using " << getVariableCount() << " variables"
-      << std::endl;
+  out << "Model " << model_name_ << " in frame " << model_frame_ << ", using " << getVariableCount() << " variables\n";
 
   std::ios_base::fmtflags old_flags = out.flags();
   out.setf(std::ios::fixed, std::ios::floatfield);
   std::streamsize old_prec = out.precision();
   out.precision(5);
-  out << "Joints: " << std::endl;
+  out << "Joints: \n";
   for (JointModel* joint_model : joint_model_vector_)
   {
-    out << " '" << joint_model->getName() << "' (" << joint_model->getTypeName() << ")" << std::endl;
-    out << "  * Joint Index: " << joint_model->getJointIndex() << std::endl;
+    out << " '" << joint_model->getName() << "' (" << joint_model->getTypeName() << ")\n";
+    out << "  * Joint Index: " << joint_model->getJointIndex() << '\n';
     const std::vector<std::string>& vn = joint_model->getVariableNames();
-    out << "  * " << vn.size() << (vn.size() > 1 ? " variables:" : (vn.empty() ? " variables" : " variable:"))
-        << std::endl;
+    out << "  * " << vn.size() << (vn.size() > 1 ? " variables:" : (vn.empty() ? " variables" : " variable:\n"));
     int idx = joint_model->getFirstVariableIndex();
     for (const std::string& it : vn)
     {
@@ -1509,26 +1507,26 @@ void RobotModel::printModelInfo(std::ostream& out) const
         out << ", mimic '" << joint_model->getMimic()->getName() << "'";
       if (joint_model->isPassive())
         out << ", passive";
-      out << std::endl;
-      out << "        " << joint_model->getVariableBounds(it) << std::endl;
+      out << '\n';
+      out << "        " << joint_model->getVariableBounds(it) << '\n';
     }
   }
-  out << std::endl;
+  out << '\n';
   out.precision(old_prec);
   out.flags(old_flags);
-  out << "Links: " << std::endl;
+  out << "Links: \n";
   for (LinkModel* link_model : link_model_vector_)
   {
-    out << " '" << link_model->getName() << "' with " << link_model->getShapes().size() << " geoms" << std::endl;
+    out << " '" << link_model->getName() << "' with " << link_model->getShapes().size() << " geoms\n";
     if (link_model->parentJointIsFixed())
       out << "   * "
-          << "parent joint is fixed" << std::endl;
+          << "parent joint is fixed" << '\n';
     if (link_model->jointOriginTransformIsIdentity())
       out << "   * "
-          << "joint origin transform is identity" << std::endl;
+          << "joint origin transform is identity\n";
   }
 
-  out << "Available groups: " << std::endl;
+  out << "Available groups: \n";
   for (JointModelGroup* joint_model_group : joint_model_groups_)
     joint_model_group->printGroupInfo(out);
 }

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -496,7 +496,7 @@ void robotStateToStream(const RobotState& state, std::ostream& out, bool include
       if (i < state.getVariableCount() - 1)
         out << separator;
     }
-    out << std::endl;
+    out << '\n';
   }
 
   // Output values of joints
@@ -508,7 +508,7 @@ void robotStateToStream(const RobotState& state, std::ostream& out, bool include
     if (i < state.getVariableCount() - 1)
       out << separator;
   }
-  out << std::endl;
+  out << '\n';
 }
 
 void robotStateToStream(const RobotState& state, std::ostream& out,
@@ -544,8 +544,8 @@ void robotStateToStream(const RobotState& state, std::ostream& out,
 
   // Push all headers and joints to our output stream
   if (include_header)
-    out << headers.str() << std::endl;
-  out << joints.str() << std::endl;
+    out << headers.str() << '\n';
+  out << joints.str() << '\n';
 }
 
 void streamToRobotState(RobotState& state, const std::string& line, const std::string& separator)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2058,7 +2058,7 @@ void RobotState::printStatePositions(std::ostream& out) const
 {
   const std::vector<std::string>& nm = robot_model_->getVariableNames();
   for (std::size_t i = 0; i < nm.size(); ++i)
-    out << nm[i] << "=" << position_[i] << std::endl;
+    out << nm[i] << "=" << position_[i] << '\n';
 }
 
 void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointModelGroup* jmg, std::ostream& out) const
@@ -2106,7 +2106,7 @@ void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointMod
 
     // show max position
     out << " \t" << std::fixed << std::setprecision(5) << bound.max_position_ << "  \t" << joint->getName()
-        << " current: " << std::fixed << std::setprecision(5) << current_value << std::endl;
+        << " current: " << std::fixed << std::setprecision(5) << current_value << '\n';
 
     if (out_of_bounds)
       out << MOVEIT_CONSOLE_COLOR_RESET;
@@ -2115,20 +2115,20 @@ void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointMod
 
 void RobotState::printDirtyInfo(std::ostream& out) const
 {
-  out << "  * Dirty Joint Transforms: " << std::endl;
+  out << "  * Dirty Joint Transforms: \n";
   const std::vector<const JointModel*>& jm = robot_model_->getJointModels();
   for (const JointModel* joint : jm)
     if (joint->getVariableCount() > 0 && dirtyJointTransform(joint))
-      out << "    " << joint->getName() << std::endl;
+      out << "    " << joint->getName() << '\n';
   out << "  * Dirty Link Transforms: " << (dirty_link_transforms_ ? dirty_link_transforms_->getName() : "NULL")
-      << std::endl;
+      << '\n';
   out << "  * Dirty Collision Body Transforms: "
-      << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL") << std::endl;
+      << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL\n");
 }
 
 void RobotState::printStateInfo(std::ostream& out) const
 {
-  out << "Robot State @" << this << std::endl;
+  out << "Robot State @" << this << '\n';
 
   std::size_t n = robot_model_->getVariableCount();
   if (position_)
@@ -2136,35 +2136,34 @@ void RobotState::printStateInfo(std::ostream& out) const
     out << "  * Position: ";
     for (std::size_t i = 0; i < n; ++i)
       out << position_[i] << " ";
-    out << std::endl;
+    out << '\n';
   }
   else
-    out << "  * Position: NULL" << std::endl;
+    out << "  * Position: NULL\n";
 
   if (velocity_)
   {
     out << "  * Velocity: ";
     for (std::size_t i = 0; i < n; ++i)
       out << velocity_[i] << " ";
-    out << std::endl;
+    out << '\n';
   }
   else
-    out << "  * Velocity: NULL" << std::endl;
+    out << "  * Velocity: NULL\n";
 
   if (acceleration_)
   {
     out << "  * Acceleration: ";
     for (std::size_t i = 0; i < n; ++i)
       out << acceleration_[i] << " ";
-    out << std::endl;
+    out << '\n';
   }
   else
-    out << "  * Acceleration: NULL" << std::endl;
+    out << "  * Acceleration: NULL\n";
 
-  out << "  * Dirty Link Transforms: " << (dirty_link_transforms_ ? dirty_link_transforms_->getName() : "NULL")
-      << std::endl;
+  out << "  * Dirty Link Transforms: " << (dirty_link_transforms_ ? dirty_link_transforms_->getName() : "NULL\n");
   out << "  * Dirty Collision Body Transforms: "
-      << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL") << std::endl;
+      << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL\n");
 
   printTransforms(out);
 }
@@ -2175,18 +2174,18 @@ void RobotState::printTransform(const Eigen::Isometry3d& transform, std::ostream
   Eigen::Quaterniond q(transform.linear());
   out << "T.xyz = [" << transform.translation().x() << ", " << transform.translation().y() << ", "
       << transform.translation().z() << "], Q.xyzw = [" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()
-      << "]" << std::endl;
+      << "]\n";
 }
 
 void RobotState::printTransforms(std::ostream& out) const
 {
   if (!variable_joint_transforms_)
   {
-    out << "No transforms computed" << std::endl;
+    out << "No transforms computed\n";
     return;
   }
 
-  out << "Joint transforms:" << std::endl;
+  out << "Joint transforms:\n";
   const std::vector<const JointModel*>& jm = robot_model_->getJointModels();
   for (const JointModel* joint : jm)
   {
@@ -2198,7 +2197,7 @@ void RobotState::printTransforms(std::ostream& out) const
     printTransform(variable_joint_transforms_[idx], out);
   }
 
-  out << "Link poses:" << std::endl;
+  out << "Link poses:\n";
   const std::vector<const LinkModel*>& link_model = robot_model_->getLinkModels();
   for (const LinkModel* link : link_model)
   {
@@ -2210,7 +2209,7 @@ void RobotState::printTransforms(std::ostream& out) const
 std::string RobotState::getStateTreeString(const std::string& prefix) const
 {
   std::stringstream ss;
-  ss << "ROBOT: " << robot_model_->getName() << std::endl;
+  ss << "ROBOT: " << robot_model_->getName() << '\n';
   getStateTreeJointString(ss, robot_model_->getRootJoint(), "   ", true);
   return ss.str();
 }
@@ -2227,7 +2226,7 @@ void getPoseString(std::ostream& ss, const Eigen::Isometry3d& pose, const std::s
     {
       ss << std::setw(8) << pose(y, x) << " ";
     }
-    ss << std::endl;
+    ss << '\n';
   }
 }
 }  // namespace
@@ -2237,19 +2236,19 @@ void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm,
 {
   std::string pfx = pfx0 + "+--";
 
-  ss << pfx << "Joint: " << jm->getName() << std::endl;
+  ss << pfx << "Joint: " << jm->getName() << '\n';
 
   pfx = pfx0 + (last ? "   " : "|  ");
 
   for (std::size_t i = 0; i < jm->getVariableCount(); ++i)
   {
     ss.precision(3);
-    ss << pfx << jm->getVariableNames()[i] << std::setw(12) << position_[jm->getFirstVariableIndex() + i] << std::endl;
+    ss << pfx << jm->getVariableNames()[i] << std::setw(12) << position_[jm->getFirstVariableIndex() + i] << '\n';
   }
 
   const LinkModel* link_model = jm->getChildLinkModel();
 
-  ss << pfx << "Link: " << link_model->getName() << std::endl;
+  ss << pfx << "Link: " << link_model->getName() << '\n';
   getPoseString(ss, link_model->getJointOriginTransform(), pfx + "joint_origin:");
   if (variable_joint_transforms_)
   {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2120,8 +2120,7 @@ void RobotState::printDirtyInfo(std::ostream& out) const
   for (const JointModel* joint : jm)
     if (joint->getVariableCount() > 0 && dirtyJointTransform(joint))
       out << "    " << joint->getName() << '\n';
-  out << "  * Dirty Link Transforms: " << (dirty_link_transforms_ ? dirty_link_transforms_->getName() : "NULL")
-      << '\n';
+  out << "  * Dirty Link Transforms: " << (dirty_link_transforms_ ? dirty_link_transforms_->getName() : "NULL") << '\n';
   out << "  * Dirty Collision Body Transforms: "
       << (dirty_collision_body_transforms_ ? dirty_collision_body_transforms_->getName() : "NULL\n");
 }

--- a/moveit_core/robot_state/test/robot_state_benchmark.cpp
+++ b/moveit_core/robot_state/test/robot_state_benchmark.cpp
@@ -65,7 +65,7 @@ public:
         *gold_standard_ = elapsed.count();
       std::cerr << 100 * elapsed.count() / *gold_standard_ << "%";
     }
-    std::cerr << std::endl;
+    std::cerr << '\n';
   }
 };
 

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -556,21 +556,21 @@ TEST_F(OneRobot, testPrintCurrentPositionWithJointLimits)
 
   state.setToDefaultValues();
 
-  std::cout << "\nVisual inspection should show NO joints out of bounds:" << std::endl;
+  std::cout << "\nVisual inspection should show NO joints out of bounds:\n";
   state.printStatePositionsWithJointLimits(joint_model_group);
 
-  std::cout << "\nVisual inspection should show ONE joint out of bounds:" << std::endl;
+  std::cout << "\nVisual inspection should show ONE joint out of bounds:\n";
   std::vector<double> single_joint(1);
   single_joint[0] = -1.0;
   state.setJointPositions("joint_c", single_joint);
   state.printStatePositionsWithJointLimits(joint_model_group);
 
-  std::cout << "\nVisual inspection should show TWO joint out of bounds:" << std::endl;
+  std::cout << "\nVisual inspection should show TWO joint out of bounds:\n";
   single_joint[0] = 1.0;
   state.setJointPositions("joint_f", single_joint);
   state.printStatePositionsWithJointLimits(joint_model_group);
 
-  std::cout << "\nVisual inspection should show ONE joint out of bounds:" << std::endl;
+  std::cout << "\nVisual inspection should show ONE joint out of bounds:\n";
   single_joint[0] = 0.19;
   state.setJointPositions("joint_f", single_joint);
   state.printStatePositionsWithJointLimits(joint_model_group);
@@ -676,7 +676,7 @@ TEST_F(OneRobot, testInterpolation)
   }
   catch (std::exception& e)
   {
-    std::cout << "Caught expected exception: " << e.what() << std::endl;
+    std::cout << "Caught expected exception: " << e.what() << '\n';
     nan_exception = true;
   }
   EXPECT_TRUE(nan_exception) << "NaN interpolation parameter did not create expected exception.";

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -142,13 +142,13 @@ TEST_F(TestAABB, TestPR2)
   EXPECT_NEAR(aabb.sizes()[2], 0.2901, 1e-4);
 
 #if VISUALIZE_PR2_RVIZ
-  std::cout << "Overall bounding box of PR2:" << std::endl;
+  std::cout << "Overall bounding box of PR2:" << '\n';
   std::string dims[] = { "x", "y", "z" };
   for (std::size_t i = 0; i < 3; ++i)
   {
     double dim = pr2_aabb[2 * i + 1] - pr2_aabb[2 * i];
     double center = dim / 2;
-    std::cout << dims[i] << ": size=" << dim << ", offset=" << (pr2_aabb[2 * i + 1] - center) << std::endl;
+    std::cout << dims[i] << ": size=" << dim << ", offset=" << (pr2_aabb[2 * i + 1] - center) << '\n';
   }
 
   // Initialize a ROS publisher

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -127,7 +127,7 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
   EXPECT_TRUE(time_parameterization.computeTimeStamps(TRAJECTORY));
 
   std::cout << "IterativeParabolicTimeParameterization  took " << (std::chrono::system_clock::now() - wt).count()
-            << std::endl;
+            << '\n';
   printTrajectory(TRAJECTORY);
   ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 3.0);
 }
@@ -139,7 +139,7 @@ TEST(TestTimeParameterization, TestIterativeSpline)
 
   auto wt = std::chrono::system_clock::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(TRAJECTORY));
-  std::cout << "IterativeSplineParameterization took " << (std::chrono::system_clock::now() - wt).count() << std::endl;
+  std::cout << "IterativeSplineParameterization took " << (std::chrono::system_clock::now() - wt).count() << '\n';
   printTrajectory(TRAJECTORY);
   ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 5.0);
 }
@@ -152,7 +152,7 @@ TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
   auto wt = std::chrono::system_clock::now();
   EXPECT_TRUE(time_parameterization.computeTimeStamps(TRAJECTORY));
   std::cout << "IterativeSplineParameterization with added points took "
-            << (std::chrono::system_clock::now() - wt).count() << std::endl;
+            << (std::chrono::system_clock::now() - wt).count() << '\n';
   printTrajectory(TRAJECTORY);
   ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 5.0);
 }

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/src/kinematics_cache.cpp
@@ -335,24 +335,24 @@ bool KinematicsCache::writeToFile(const std::string& filename)
   if (file.good())
   {
     std::string group_name = kinematics_solver_->getGroupName();
-    file << group_name << std::endl;
+    file << group_name << '\n';
 
-    file << options_.origin.x << " " << options_.origin.y << " " << options_.origin.z << std::endl;
+    file << options_.origin.x << " " << options_.origin.y << " " << options_.origin.z << '\n';
     file << options_.workspace_size[0] << " " << options_.workspace_size[1] << " " << options_.workspace_size[2]
-         << std::endl;
-    file << options_.resolution[0] << " " << options_.resolution[1] << " " << options_.resolution[2] << std::endl;
-    file << options_.max_solutions_per_grid_location << std::endl;
-    file << min_squared_distance_ << std::endl;
-    file << max_squared_distance_ << std::endl;
-    file << kinematics_cache_vector_.size() << std::endl;
+         << '\n';
+    file << options_.resolution[0] << " " << options_.resolution[1] << " " << options_.resolution[2] << '\n';
+    file << options_.max_solutions_per_grid_location << '\n';
+    file << min_squared_distance_ << '\n';
+    file << max_squared_distance_ << '\n';
+    file << kinematics_cache_vector_.size() << '\n';
     std::copy(kinematics_cache_vector_.begin(), kinematics_cache_vector_.end(),
               std::ostream_iterator<double>(file, " "));
-    file << std::endl;
+    file << '\n';
 
-    file << num_solutions_vector_.size() << std::endl;
+    file << num_solutions_vector_.size() << '\n';
     std::copy(num_solutions_vector_.begin(), num_solutions_vector_.end(),
               std::ostream_iterator<unsigned int>(file, " "));
-    file << std::endl;
+    file << '\n';
   }
 
   file.close();

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
@@ -344,24 +344,24 @@ bool KinematicsCache::writeToFile(const std::string& filename)
   if (file.good())
   {
     std::string group_name = kinematics_solver_->getGroupName();
-    file << group_name << std::endl;
+    file << group_name << '\n';
 
-    file << options_.origin.x << " " << options_.origin.y << " " << options_.origin.z << std::endl;
+    file << options_.origin.x << " " << options_.origin.y << " " << options_.origin.z << '\n';
     file << options_.workspace_size[0] << " " << options_.workspace_size[1] << " " << options_.workspace_size[2]
-         << std::endl;
-    file << options_.resolution[0] << " " << options_.resolution[1] << " " << options_.resolution[2] << std::endl;
-    file << options_.max_solutions_per_grid_location << std::endl;
-    file << min_squared_distance_ << std::endl;
-    file << max_squared_distance_ << std::endl;
-    file << kinematics_cache_vector_.size() << std::endl;
+         << '\n';
+    file << options_.resolution[0] << " " << options_.resolution[1] << " " << options_.resolution[2] << '\n';
+    file << options_.max_solutions_per_grid_location << '\n';
+    file << min_squared_distance_ << '\n';
+    file << max_squared_distance_ << '\n';
+    file << kinematics_cache_vector_.size() << '\n';
     std::copy(kinematics_cache_vector_.begin(), kinematics_cache_vector_.end(),
               std::ostream_iterator<double>(file, " "));
-    file << std::endl;
+    file << '\n';
 
-    file << num_solutions_vector_.size() << std::endl;
+    file << num_solutions_vector_.size() << '\n';
     std::copy(num_solutions_vector_.begin(), num_solutions_vector_.end(),
               std::ostream_iterator<unsigned int>(file, " "));
-    file << std::endl;
+    file << '\n';
   }
 
   file.close();

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -264,7 +264,7 @@ public:
         for (typename std::unordered_set<const _T*>::const_iterator it = gnat.removed_.begin();
              it != gnat.removed_.end(); it++)
           out << **it << '\t';
-        out << std::endl;
+        out << '\n';
       }
     }
     return out;
@@ -291,7 +291,7 @@ public:
         std::cout << "***** FAIL!! ******\n" << *this << '\n';
         for (unsigned int j = 0; j < lst.size(); ++j)
           std::cout << lst[j] << '\t';
-        std::cout << std::endl;
+        std::cout << '\n';
       }
       assert(i != lst.size());
     }
@@ -300,7 +300,7 @@ public:
     // get elements in the tree with elements marked for removal purged from the list
     list(lst);
     if (lst.size() != size_)
-      std::cout << "#########################################\n" << *this << std::endl;
+      std::cout << "#########################################\n" << *this << '\n';
     assert(lst.size() == size_);
   }
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -71,10 +71,10 @@ bool SrvKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
 
   if (debug)
   {
-    std::cout << std::endl << "Joint Model Variable Names: ------------------------------------------- " << std::endl;
+    std::cout << "Joint Model Variable Names: ------------------------------------------- \n ";
     const std::vector<std::string> jm_names = joint_model_group_->getVariableNames();
     std::copy(jm_names.begin(), jm_names.end(), std::ostream_iterator<std::string>(std::cout, "\n"));
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 
   // Get the dimension of the planning group

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -470,8 +470,8 @@ TEST_F(KinematicsTest, unitIK)
       ASSERT_EQ(truth.size(), sol.size()) << "Invalid size of ground truth joints vector";
       Eigen::Map<Eigen::ArrayXd> solution(sol.data(), sol.size());
       Eigen::Map<Eigen::ArrayXd> ground_truth(truth.data(), truth.size());
-      EXPECT_TRUE(solution.isApprox(ground_truth, 10 * tolerance_)) << solution.transpose() << std::endl
-                                                                    << ground_truth.transpose() << std::endl;
+      EXPECT_TRUE(solution.isApprox(ground_truth, 10 * tolerance_)) << solution.transpose() << '\n'
+                                                                    << ground_truth.transpose() << '\n';
     }
   };
 
@@ -631,7 +631,7 @@ TEST_F(KinematicsTest, getIK)
 
     Eigen::Map<Eigen::ArrayXd> sol(solution.data(), solution.size());
     Eigen::Map<Eigen::ArrayXd> truth(fk_values.data(), fk_values.size());
-    EXPECT_TRUE(sol.isApprox(truth, tolerance_)) << sol.transpose() << std::endl << truth.transpose() << std::endl;
+    EXPECT_TRUE(sol.isApprox(truth, tolerance_)) << sol.transpose() << '\n' << truth.transpose() << '\n';
   }
 }
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -715,7 +715,7 @@ void ChompOptimizer::debugCost()
   double cost = 0.0;
   for (int i = 0; i < num_joints_; i++)
     cost += joint_costs_[i].getCost(group_trajectory_.getJointTrajectory(i));
-  std::cout << "Cost = " << cost << std::endl;
+  std::cout << "Cost = " << cost << '\n';
 }
 
 double ChompOptimizer::getTrajectoryCost()

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -378,14 +378,14 @@ void ompl_interface::ConstraintsLibrary::saveConstraintApproximations(const std:
     for (std::map<std::string, ConstraintApproximationPtr>::const_iterator it = constraint_approximations_.begin();
          it != constraint_approximations_.end(); ++it)
     {
-      fout << it->second->getGroup() << std::endl;
-      fout << it->second->getStateSpaceParameterization() << std::endl;
-      fout << it->second->hasExplicitMotions() << std::endl;
-      fout << it->second->getMilestoneCount() << std::endl;
+      fout << it->second->getGroup() << '\n';
+      fout << it->second->getStateSpaceParameterization() << '\n';
+      fout << it->second->hasExplicitMotions() << '\n';
+      fout << it->second->getMilestoneCount() << '\n';
       std::string serialization;
       msgToHex(it->second->getConstraintsMsg(), serialization);
-      fout << serialization << std::endl;
-      fout << it->second->getFilename() << std::endl;
+      fout << serialization << '\n';
+      fout << it->second->getFilename() << '\n';
       if (it->second->getStateStorage())
         it->second->getStateStorage()->store((path + "/" + it->second->getFilename()).c_str());
     }
@@ -404,13 +404,13 @@ void ompl_interface::ConstraintsLibrary::printConstraintApproximations(std::ostr
   for (const std::pair<const std::string, ConstraintApproximationPtr>& constraint_approximation :
        constraint_approximations_)
   {
-    out << constraint_approximation.second->getGroup() << std::endl;
-    out << constraint_approximation.second->getStateSpaceParameterization() << std::endl;
-    out << constraint_approximation.second->hasExplicitMotions() << std::endl;
-    out << constraint_approximation.second->getMilestoneCount() << std::endl;
-    out << constraint_approximation.second->getFilename() << std::endl;
+    out << constraint_approximation.second->getGroup() << '\n';
+    out << constraint_approximation.second->getStateSpaceParameterization() << '\n';
+    out << constraint_approximation.second->hasExplicitMotions() << '\n';
+    out << constraint_approximation.second->getMilestoneCount() << '\n';
+    out << constraint_approximation.second->getFilename() << '\n';
     // TODO(henningkayser): format print constraint message
-    // out << constraint_approximation.second->getConstraintsMsg() << std::endl;
+    // out << constraint_approximation.second->getConstraintsMsg() << '\n';
   }
 }
 

--- a/moveit_planners/ompl/ompl_interface/src/detail/goal_union.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/goal_union.cpp
@@ -132,8 +132,8 @@ double ompl_interface::GoalSampleableRegionMux::distanceGoal(const ompl::base::S
 
 void ompl_interface::GoalSampleableRegionMux::print(std::ostream& out) const
 {
-  out << "MultiGoal [" << std::endl;
+  out << "MultiGoal [\n";
   for (const ompl::base::GoalPtr& goal : goals_)
     goal->print(out);
-  out << "]" << std::endl;
+  out << "]\n";
 }

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/model_based_state_space.cpp
@@ -289,7 +289,7 @@ ompl::base::StateSamplerPtr ompl_interface::ModelBasedStateSpace::allocDefaultSt
 
 void ompl_interface::ModelBasedStateSpace::printSettings(std::ostream& out) const
 {
-  out << "ModelBasedStateSpace '" << getName() << "' at " << this << std::endl;
+  out << "ModelBasedStateSpace '" << getName() << "' at " << this << '\n';
 }
 
 void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* state, std::ostream& out) const
@@ -301,21 +301,21 @@ void ompl_interface::ModelBasedStateSpace::printState(const ompl::base::State* s
     const int vc = j->getVariableCount();
     for (int i = 0; i < vc; ++i)
       out << state->as<StateType>()->values[idx + i] << " ";
-    out << std::endl;
+    out << '\n';
   }
 
   if (state->as<StateType>()->isStartState())
-    out << "* start state" << std::endl;
+    out << "* start state \n";
   if (state->as<StateType>()->isGoalState())
-    out << "* goal state" << std::endl;
+    out << "* goal state \n";
   if (state->as<StateType>()->isValidityKnown())
   {
     if (state->as<StateType>()->isMarkedValid())
-      out << "* valid state" << std::endl;
+      out << "* valid state \n";
     else
-      out << "* invalid state" << std::endl;
+      out << "* invalid state \n";
   }
-  out << "Tag: " << state->as<StateType>()->tag << std::endl;
+  out << "Tag: " << state->as<StateType>()->tag << '\n';
 }
 
 void ompl_interface::ModelBasedStateSpace::copyToRobotState(moveit::core::RobotState& rstate,

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -227,7 +227,7 @@ bool ompl_interface::PoseModelStateSpace::PoseComponent::computeStateIK(StateTyp
   std::cout << "seed: ";
   for (std::size_t i = 0 ; i < seed_values.size() ; ++i)
     std::cout << seed_values[i] << " ";
-  std::cout << std::endl;
+  std::cout << '\n';
   */
 
   // construct the pose

--- a/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
+++ b/moveit_planners/ompl/ompl_interface/test/load_test_robot.h
@@ -112,7 +112,7 @@ protected:
     ee_link_name_ = joint_model_group_->getLinkModelNames().back();
     base_link_name_ = robot_model_->getRootLinkName();
 
-    std::cout << "Loading robot: " << robot_name << " for planning group: " << group_name << std::endl;
+    std::cout << "Loading robot: " << robot_name << " for planning group: " << group_name << '\n';
   }
 
   Eigen::VectorXd getRandomState() const

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -144,12 +144,12 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
         robot_state.getRobotModel()->getJointModelGroup(joint_model_state_space.getJointModelGroupName()));
     std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
                   robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
-              << std::endl;
+              << '\n';
     EXPECT_TRUE(robot_state.distance(robot_state2) > EPSILON);
     joint_model_state_space.copyToRobotState(robot_state, state);
     std::cout << (robot_state.getGlobalLinkTransform("r_wrist_roll_link").translation() -
                   robot_state2.getGlobalLinkTransform("r_wrist_roll_link").translation())
-              << std::endl;
+              << '\n';
     EXPECT_TRUE(robot_state.distance(robot_state2) < EPSILON);
   }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
@@ -396,25 +396,25 @@ void VelocityProfileATrap::Write(std::ostream& os) const
 
 std::ostream& operator<<(std::ostream& os, const VelocityProfileATrap& p)
 {
-  os << "Asymmetric Trapezoid " << std::endl
-     << "maximal velocity: " << p.max_vel_ << std::endl
-     << "maximal acceleration: " << p.max_acc_ << std::endl
-     << "maximal deceleration: " << p.max_dec_ << std::endl
-     << "start position: " << p.start_pos_ << std::endl
-     << "end position: " << p.end_pos_ << std::endl
-     << "start velocity: " << p.start_vel_ << std::endl
-     << "a1: " << p.a1_ << std::endl
-     << "a2: " << p.a2_ << std::endl
-     << "a3: " << p.a3_ << std::endl
-     << "b1: " << p.b1_ << std::endl
-     << "b2: " << p.b2_ << std::endl
-     << "b3: " << p.b3_ << std::endl
-     << "c1: " << p.c1_ << std::endl
-     << "c2: " << p.c2_ << std::endl
-     << "c3: " << p.c3_ << std::endl
-     << "firstPhaseDuration " << p.firstPhaseDuration() << std::endl
-     << "secondPhaseDuration " << p.secondPhaseDuration() << std::endl
-     << "thirdPhaseDuration " << p.thirdPhaseDuration() << std::endl;
+  os << "Asymmetric Trapezoid " << '\n'
+     << "maximal velocity: " << p.max_vel_ << '\n'
+     << "maximal acceleration: " << p.max_acc_ << '\n'
+     << "maximal deceleration: " << p.max_dec_ << '\n'
+     << "start position: " << p.start_pos_ << '\n'
+     << "end position: " << p.end_pos_ << '\n'
+     << "start velocity: " << p.start_vel_ << '\n'
+     << "a1: " << p.a1_ << '\n'
+     << "a2: " << p.a2_ << '\n'
+     << "a3: " << p.a3_ << '\n'
+     << "b1: " << p.b1_ << '\n'
+     << "b2: " << p.b2_ << '\n'
+     << "b3: " << p.b3_ << '\n'
+     << "c1: " << p.c1_ << '\n'
+     << "c2: " << p.c2_ << '\n'
+     << "c3: " << p.c3_ << '\n'
+     << "firstPhaseDuration " << p.firstPhaseDuration() << '\n'
+     << "secondPhaseDuration " << p.secondPhaseDuration() << '\n'
+     << "thirdPhaseDuration " << p.thirdPhaseDuration() << '\n';
   return os;
 }
 // LCOV_EXCL_STOP

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_planning.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_planning.cpp
@@ -248,9 +248,9 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
 {
   planning_interface::MotionPlanRequest req{ test_data_->getLinJoint("lin2").toRequest() };
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 1 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 1 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
@@ -263,17 +263,17 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
 
   ASSERT_EQ(moveit_msgs::msg::MoveItErrorCodes::SUCCESS, response.error_code.val) << "Planning failed!";
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 2 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 2 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 3 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 3 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   ASSERT_TRUE(testutils::checkCartesianLinearity(robot_model_, response.trajectory.joint_trajectory, req,
                                                  pose_norm_tolerance_, orientation_norm_tolerance_))
@@ -300,9 +300,9 @@ TEST_F(IntegrationTestCommandPlanning, LinJointCart)
   ros::NodeHandle node_handle("~");
   planning_interface::MotionPlanRequest req{ test_data_->getLinJointCart("lin2").toRequest() };
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 1 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 1 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
@@ -314,17 +314,17 @@ TEST_F(IntegrationTestCommandPlanning, LinJointCart)
 
   ASSERT_EQ(moveit_msgs::msg::MoveItErrorCodes::SUCCESS, response.error_code.val) << "Planning failed!";
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 2 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 2 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 
-  std::cout << "++++++++++" << std::endl;
-  std::cout << "+ Step 3 +" << std::endl;
-  std::cout << "++++++++++" << std::endl;
+  std::cout << "++++++++++" << '\n';
+  std::cout << "+ Step 3 +" << '\n';
+  std::cout << "++++++++++" << '\n';
 
   ASSERT_TRUE(testutils::checkCartesianLinearity(robot_model_, response.trajectory.joint_trajectory, req,
                                                  pose_norm_tolerance_, orientation_norm_tolerance_))

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -371,8 +371,7 @@ bool testutils::isVelocityBounded(const trajectory_msgs::msg::JointTrajectory& t
                   << " Joint Name: " << trajectory.joint_names.at(i) << "; Position: " << point.positions.at(i)
                   << "; Velocity: " << point.velocities.at(i) << "; Acceleration: " << point.accelerations.at(i)
                   << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
-                  << "; Velocity Limit: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_velocity
-                  << '\n';
+                  << "; Velocity Limit: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_velocity << '\n';
 
         return false;
       }
@@ -456,8 +455,7 @@ bool testutils::isPositionBounded(const trajectory_msgs::msg::JointTrajectory& t
                   << "; Velocity: " << point.velocities.at(i) << "; Acceleration: " << point.accelerations.at(i)
                   << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
                   << "; Max Position: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_position
-                  << "; Min Position: " << joint_limits.getLimit(trajectory.joint_names.at(i)).min_position
-                  << '\n';
+                  << "; Min Position: " << joint_limits.getLimit(trajectory.joint_names.at(i)).min_position << '\n';
 
         return false;
       }

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -135,7 +135,7 @@ bool testutils::isGoalReached(const trajectory_msgs::msg::JointTrajectory& traje
     {
       std::cerr << "[ Fail     ] goal has non zero velocity."
                 << " Joint Name: " << trajectory.joint_names.at(i) << "; Velocity: " << last_point.velocities.at(i)
-                << std::endl;
+                << '\n';
       return false;
     }
 
@@ -148,7 +148,7 @@ bool testutils::isGoalReached(const trajectory_msgs::msg::JointTrajectory& traje
           std::cerr << "[ Fail     ] goal position not reached."
                     << " Joint Name: " << trajectory.joint_names.at(i)
                     << "; Actual Position: " << last_point.positions.at(i)
-                    << "; Expected Position: " << joint_goal.position << std::endl;
+                    << "; Expected Position: " << joint_goal.position << '\n';
           return false;
         }
       }
@@ -188,7 +188,7 @@ bool testutils::isGoalReached(const moveit::core::RobotModelConstPtr& robot_mode
 
   if (!computeLinkFK(robot_model, link_name, joint_state, goal_pose_actual))
   {
-    std::cerr << "[ Fail     ] forward kinematics computation failed for link: " << link_name << std::endl;
+    std::cerr << "[ Fail     ] forward kinematics computation failed for link: " << link_name << '\n';
   }
 
   auto actual_rotation{ goal_pose_actual.rotation() };
@@ -198,9 +198,9 @@ bool testutils::isGoalReached(const moveit::core::RobotModelConstPtr& robot_mode
   {
     std::cout << "\nOrientation difference = " << rot_diff.norm() << " (eps=" << orientation_tolerance << ")"
               << "\n### Expected goal orientation: ### \n"
-              << expected_rotation << std::endl
+              << expected_rotation << '\n'
               << "### Actual goal orientation ### \n"
-              << actual_rotation << std::endl;
+              << actual_rotation << '\n';
     return false;
   }
 
@@ -211,9 +211,9 @@ bool testutils::isGoalReached(const moveit::core::RobotModelConstPtr& robot_mode
   {
     std::cout << "\nPosition difference = " << pos_diff.norm() << " (eps=" << pos_tolerance << ")"
               << "\n### Expected goal position: ### \n"
-              << expected_position << std::endl
+              << expected_position << '\n'
               << "### Actual goal position ### \n"
-              << actual_position << std::endl;
+              << actual_position << '\n';
     return false;
   }
 
@@ -282,9 +282,9 @@ bool testutils::checkCartesianLinearity(const moveit::core::RobotModelConstPtr& 
                  .norm()) > fabs(translation_norm_tolerance))
     {
       std::cout << "Translational linearity is violated. \n"
-                << "goal tanslation: " << goal_pose_expect.translation() << std::endl
-                << "start translation: " << start_pose.translation() << std::endl
-                << "acutual translation " << way_point_pose.translation() << std::endl;
+                << "goal tanslation: " << goal_pose_expect.translation() << '\n'
+                << "start translation: " << start_pose.translation() << '\n'
+                << "acutual translation " << way_point_pose.translation() << '\n';
       return false;
     }
 
@@ -314,11 +314,11 @@ bool testutils::checkSLERP(const Eigen::Isometry3d& start_pose, const Eigen::Iso
         (fabs(start_wp_aa.angle()) < fabs(rot_angle_tolerance))))
   {
     std::cout << "Rotational linearity is violated. \n"
-              << std::endl
-              << "start goal angle: " << start_goal_aa.angle() << "; axis: " << std::endl
-              << start_goal_aa.axis() << std::endl
-              << "start waypoint angle: " << start_wp_aa.angle() << "; axis: " << std::endl
-              << start_wp_aa.axis() << std::endl;
+              << '\n'
+              << "start goal angle: " << start_goal_aa.angle() << "; axis: " << '\n'
+              << start_goal_aa.axis() << '\n'
+              << "start waypoint angle: " << start_wp_aa.angle() << "; axis: " << '\n'
+              << start_wp_aa.axis() << '\n';
 
     return false;
   }
@@ -372,7 +372,7 @@ bool testutils::isVelocityBounded(const trajectory_msgs::msg::JointTrajectory& t
                   << "; Velocity: " << point.velocities.at(i) << "; Acceleration: " << point.accelerations.at(i)
                   << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
                   << "; Velocity Limit: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_velocity
-                  << std::endl;
+                  << '\n';
 
         return false;
       }
@@ -416,7 +416,7 @@ bool testutils::isAccelerationBounded(const trajectory_msgs::msg::JointTrajector
                     << "; Acceleration: " << point.accelerations.at(i)
                     << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
                     << ". Deceleration Limit: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_deceleration
-                    << std::endl;
+                    << '\n';
           return false;
         }
       }
@@ -430,7 +430,7 @@ bool testutils::isAccelerationBounded(const trajectory_msgs::msg::JointTrajector
                     << "; Acceleration: " << point.accelerations.at(i)
                     << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
                     << ". Acceleration Limit: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_acceleration
-                    << std::endl;
+                    << '\n';
 
           return false;
         }
@@ -457,7 +457,7 @@ bool testutils::isPositionBounded(const trajectory_msgs::msg::JointTrajectory& t
                   << "; Time from start: " << rclcpp::Duration(point.time_from_start).seconds()
                   << "; Max Position: " << joint_limits.getLimit(trajectory.joint_names.at(i)).max_position
                   << "; Min Position: " << joint_limits.getLimit(trajectory.joint_names.at(i)).min_position
-                  << std::endl;
+                  << '\n';
 
         return false;
       }
@@ -472,22 +472,22 @@ bool testutils::checkJointTrajectory(const trajectory_msgs::msg::JointTrajectory
 {
   if (!testutils::isTrajectoryConsistent(trajectory))
   {
-    std::cout << "Joint trajectory is not consistent." << std::endl;
+    std::cout << "Joint trajectory is not consistent." << '\n';
     return false;
   }
   if (!testutils::isPositionBounded(trajectory, joint_limits))
   {
-    std::cout << "Joint poisiton violated the limits." << std::endl;
+    std::cout << "Joint poisiton violated the limits." << '\n';
     return false;
   }
   if (!testutils::isVelocityBounded(trajectory, joint_limits))
   {
-    std::cout << "Joint velocity violated the limits." << std::endl;
+    std::cout << "Joint velocity violated the limits." << '\n';
     return false;
   }
   if (!testutils::isAccelerationBounded(trajectory, joint_limits))
   {
-    std::cout << "Joint acceleration violated the limits." << std::endl;
+    std::cout << "Joint acceleration violated the limits." << '\n';
     return false;
   }
 
@@ -581,7 +581,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.first_trajectory->getWayPoint(i).getVariablePosition(joint_name) !=
           req.first_trajectory->getWayPoint(i).getVariablePosition(joint_name))
       {
-        std::cout << i << "th position of the first trajectory is not same." << std::endl;
+        std::cout << i << "th position of the first trajectory is not same." << '\n';
         return false;
       }
 
@@ -589,7 +589,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.first_trajectory->getWayPoint(i).getVariableVelocity(joint_name) !=
           req.first_trajectory->getWayPoint(i).getVariableVelocity(joint_name))
       {
-        std::cout << i << "th velocity of the first trajectory is not same." << std::endl;
+        std::cout << i << "th velocity of the first trajectory is not same." << '\n';
         return false;
       }
 
@@ -597,7 +597,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.first_trajectory->getWayPoint(i).getVariableAcceleration(joint_name) !=
           req.first_trajectory->getWayPoint(i).getVariableAcceleration(joint_name))
       {
-        std::cout << i << "th acceleration of the first trajectory is not same." << std::endl;
+        std::cout << i << "th acceleration of the first trajectory is not same." << '\n';
         return false;
       }
     }
@@ -605,7 +605,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
     // check time from start
     if (res.first_trajectory->getWayPointDurationFromStart(i) != req.first_trajectory->getWayPointDurationFromStart(i))
     {
-      std::cout << i << "th time_from_start of the first trajectory is not same." << std::endl;
+      std::cout << i << "th time_from_start of the first trajectory is not same." << '\n';
       return false;
     }
   }
@@ -622,7 +622,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.second_trajectory->getWayPoint(size_second - i - 1).getVariablePosition(joint_name) !=
           req.second_trajectory->getWayPoint(size_second_original - i - 1).getVariablePosition(joint_name))
       {
-        std::cout << i - 1 << "th position of the second trajectory is not same." << std::endl;
+        std::cout << i - 1 << "th position of the second trajectory is not same." << '\n';
         return false;
       }
 
@@ -630,7 +630,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.second_trajectory->getWayPoint(size_second - i - 1).getVariableVelocity(joint_name) !=
           req.second_trajectory->getWayPoint(size_second_original - i - 1).getVariableVelocity(joint_name))
       {
-        std::cout << i - 1 << "th position of the second trajectory is not same." << std::endl;
+        std::cout << i - 1 << "th position of the second trajectory is not same." << '\n';
         return false;
       }
 
@@ -638,7 +638,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
       if (res.second_trajectory->getWayPoint(size_second - i - 1).getVariableAcceleration(joint_name) !=
           req.second_trajectory->getWayPoint(size_second_original - i - 1).getVariableAcceleration(joint_name))
       {
-        std::cout << i - 1 << "th position of the second trajectory is not same." << std::endl;
+        std::cout << i - 1 << "th position of the second trajectory is not same." << '\n';
         return false;
       }
     }
@@ -655,7 +655,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
                   << res.second_trajectory->getWayPointDurationFromStart(size_second - i - 1) << ", "
                   << res.second_trajectory->getWayPointDurationFromStart(size_second - i - 2) << ", "
                   << req.second_trajectory->getWayPointDurationFromStart(size_second_original - i - 1) << ", "
-                  << req.second_trajectory->getWayPointDurationFromStart(size_second_original - i - 2) << std::endl;
+                  << req.second_trajectory->getWayPointDurationFromStart(size_second_original - i - 2) << '\n';
         return false;
       }
     }
@@ -669,7 +669,7 @@ bool testutils::checkOriginalTrajectoryAfterBlending(const pilz_industrial_motio
                   << res.second_trajectory->getWayPointDurationFromStart(size_second - i - 1) << ", "
                   << req.second_trajectory->getWayPointDurationFromStart(size_second_original - i - 1) -
                          req.second_trajectory->getWayPointDurationFromStart(size_second_original - i - 2)
-                  << std::endl;
+                  << '\n';
         return false;
       }
     }
@@ -699,7 +699,7 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
   {
     std::cout << "Different sizes of the position/velocity/acceleration "
                  "between first trajectory and blend trajectory."
-              << std::endl;
+              << '\n';
     return false;
   }
 
@@ -712,10 +712,10 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
     {
       std::cout << "Velocity computed from positions are different from the "
                    "value in trajectory."
-                << std::endl
+                << '\n'
                 << "position: " << blend_start.positions.at(i) << "; " << first_end.positions.at(i)
                 << "computed: " << blend_start_velo << "; "
-                << "in trajectory: " << blend_start.velocities.at(i) << std::endl;
+                << "in trajectory: " << blend_start.velocities.at(i) << '\n';
       return false;
     }
 
@@ -725,9 +725,9 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
     {
       std::cout << "Acceleration computed from positions/velocities are "
                    "different from the value in trajectory."
-                << std::endl
+                << '\n'
                 << "computed: " << blend_start_acc << "; "
-                << "in trajectory: " << blend_start.accelerations.at(i) << std::endl;
+                << "in trajectory: " << blend_start.accelerations.at(i) << '\n';
       return false;
     }
   }
@@ -744,10 +744,10 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
   {
     std::cout << "Different sizes of the position/velocity/acceleration "
                  "between first trajectory and blend trajectory."
-              << std::endl
-              << blend_end.positions.size() << ", " << second_start.positions.size() << std::endl
-              << blend_end.velocities.size() << ", " << second_start.positions.size() << std::endl
-              << blend_end.accelerations.size() << ", " << second_start.accelerations.size() << std::endl;
+              << '\n'
+              << blend_end.positions.size() << ", " << second_start.positions.size() << '\n'
+              << blend_end.velocities.size() << ", " << second_start.positions.size() << '\n'
+              << blend_end.accelerations.size() << ", " << second_start.accelerations.size() << '\n';
     return false;
   }
 
@@ -760,9 +760,9 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
     {
       std::cout << "Velocity computed from positions are different from the "
                    "value in trajectory."
-                << std::endl
+                << '\n'
                 << "computed: " << second_start_velo << "; "
-                << "in trajectory: " << second_start.velocities.at(i) << std::endl;
+                << "in trajectory: " << second_start.velocities.at(i) << '\n';
       return false;
     }
 
@@ -772,9 +772,9 @@ bool testutils::checkBlendingJointSpaceContinuity(const pilz_industrial_motion_p
     {
       std::cout << "Acceleration computed from positions/velocities are "
                    "different from the value in trajectory."
-                << std::endl
+                << '\n'
                 << "computed: " << second_start_acc << "; "
-                << "in trajectory: " << second_start.accelerations.at(i) << std::endl;
+                << "in trajectory: " << second_start.accelerations.at(i) << '\n';
       return false;
     }
   }
@@ -792,7 +792,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
   {
     std::cout << "Cannot perform check of cartesian space continuity with "
                  "sampling time 0.0"
-              << std::endl;
+              << '\n';
     return false;
   }
 
@@ -828,28 +828,28 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
   // second point of second trajectory
   pose_second_start_1 = res.second_trajectory->getWayPointPtr(1)->getFrameTransform(req.link_name);
 
-  //  std::cout << "### sample duration: " << duration << " ###" << std::endl;
-  //  std::cout << "### end pose of first trajectory ###" << std::endl;
-  //  std::cout << pose_first_end.matrix() << std::endl;
-  //  std::cout << "### start pose of blend trajectory ###" << std::endl;
-  //  std::cout << pose_blend_start.matrix() << std::endl;
-  //  std::cout << "### end pose of blend trajectory ###" << std::endl;
-  //  std::cout << pose_blend_end.matrix() << std::endl;
-  //  std::cout << "### start pose of second trajectory ###" << std::endl;
-  //  std::cout << pose_second_start.matrix() << std::endl;
+  //  std::cout << "### sample duration: " << duration << " ###" << '\n';
+  //  std::cout << "### end pose of first trajectory ###" << '\n';
+  //  std::cout << pose_first_end.matrix() << '\n';
+  //  std::cout << "### start pose of blend trajectory ###" << '\n';
+  //  std::cout << pose_blend_start.matrix() << '\n';
+  //  std::cout << "### end pose of blend trajectory ###" << '\n';
+  //  std::cout << pose_blend_end.matrix() << '\n';
+  //  std::cout << "### start pose of second trajectory ###" << '\n';
+  //  std::cout << pose_second_start.matrix() << '\n';
 
-  //  std::cout << "### v_1 ###" << std::endl;
-  //  std::cout << v_1 << std::endl;
-  //  std::cout << "### w_1 ###" << std::endl;
-  //  std::cout << w_1 << std::endl;
-  //  std::cout << "### v_2 ###" << std::endl;
-  //  std::cout << v_2 << std::endl;
-  //  std::cout << "### w_2 ###" << std::endl;
-  //  std::cout << w_2 << std::endl;
-  //  std::cout << "### v_3 ###" << std::endl;
-  //  std::cout << v_3 << std::endl;
-  //  std::cout << "### w_3 ###" << std::endl;
-  //  std::cout << w_3 << std::endl;
+  //  std::cout << "### v_1 ###" << '\n';
+  //  std::cout << v_1 << '\n';
+  //  std::cout << "### w_1 ###" << '\n';
+  //  std::cout << w_1 << '\n';
+  //  std::cout << "### v_2 ###" << '\n';
+  //  std::cout << v_2 << '\n';
+  //  std::cout << "### w_2 ###" << '\n';
+  //  std::cout << w_2 << '\n';
+  //  std::cout << "### v_3 ###" << '\n';
+  //  std::cout << v_3 << '\n';
+  //  std::cout << "### w_3 ###" << '\n';
+  //  std::cout << w_3 << '\n';
 
   // check the connection points between first trajectory and blend trajectory
   Eigen::Vector3d v_1, w_1, v_2, w_2, v_3, w_3;
@@ -863,7 +863,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Translational velocity between first trajectory and blend "
                  "trajectory exceeds the limit."
               << "Actual velocity (norm): " << v_2.norm() << "; "
-              << "Limits: " << max_trans_velo << std::endl;
+              << "Limits: " << max_trans_velo << '\n';
   }
   // rotational velocity
   if (w_2.norm() > max_rot_velo)
@@ -871,7 +871,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Rotational velocity between first trajectory and blend "
                  "trajectory exceeds the limit."
               << "Actual velocity (norm): " << w_2.norm() << "; "
-              << "Limits: " << max_rot_velo << std::endl;
+              << "Limits: " << max_rot_velo << '\n';
   }
   // translational acceleration
   Eigen::Vector3d a_1 = (v_2 - v_1) / duration;
@@ -881,7 +881,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Translational acceleration between first trajectory and "
                  "blend trajectory exceeds the limit."
               << "Actual acceleration (norm): " << a_1.norm() << ", " << a_1.norm() << "; "
-              << "Limits: " << max_trans_acc << std::endl;
+              << "Limits: " << max_trans_acc << '\n';
   }
 
   // rotational acceleration
@@ -892,7 +892,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Rotational acceleration between first trajectory and blend "
                  "trajectory exceeds the limit."
               << "Actual acceleration (norm): " << a_1.norm() << ", " << a_1.norm() << "; "
-              << "Limits: " << max_rot_acc << std::endl;
+              << "Limits: " << max_rot_acc << '\n';
   }
 
   computeCartVelocity(pose_blend_end_1, pose_blend_end, duration, v_1, w_1);
@@ -904,14 +904,14 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Translational velocity between blend trajectory and second "
                  "trajectory exceeds the limit."
               << "Actual velocity (norm): " << v_2.norm() << "; "
-              << "Limits: " << max_trans_velo << std::endl;
+              << "Limits: " << max_trans_velo << '\n';
   }
   if (w_2.norm() > max_rot_velo)
   {
     std::cout << "Rotational velocity between blend trajectory and second "
                  "trajectory exceeds the limit."
               << "Actual velocity (norm): " << w_2.norm() << "; "
-              << "Limits: " << max_rot_velo << std::endl;
+              << "Limits: " << max_rot_velo << '\n';
   }
   a_1 = (v_2 - v_1) / duration;
   a_2 = (v_3 - v_2) / duration;
@@ -920,7 +920,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Translational acceleration between blend trajectory and "
                  "second trajectory exceeds the limit."
               << "Actual acceleration (norm): " << a_1.norm() << ", " << a_1.norm() << "; "
-              << "Limits: " << max_trans_acc << std::endl;
+              << "Limits: " << max_trans_acc << '\n';
   }
   // check rotational acceleration
   a_1 = (w_2 - w_1) / duration;
@@ -930,7 +930,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
     std::cout << "Rotational acceleration between blend trajectory and second "
                  "trajectory exceeds the limit."
               << "Actual acceleration (norm): " << a_1.norm() << ", " << a_1.norm() << "; "
-              << "Limits: " << max_rot_acc << std::endl;
+              << "Limits: " << max_rot_acc << '\n';
   }
 
   return true;
@@ -946,7 +946,7 @@ bool testutils::checkThatPointsInRadius(const std::string& link_name, const doub
     if ((curr_pos.translation() - circ_pose.translation()).norm() > r)
     {
       std::cout << "Point " << i << " does not lie within blending radius (dist: "
-                << ((curr_pos.translation() - circ_pose.translation()).norm() - r) << ")." << std::endl;
+                << ((curr_pos.translation() - circ_pose.translation()).norm() - r) << ")." << '\n';
       result = false;
     }
   }
@@ -1088,7 +1088,7 @@ bool testutils::generateTrajFromBlendTestData(
   // trajectory generation
   if (!tg->generate(scene, req_1, res_1, sampling_time_1))
   {
-    std::cout << "Failed to generate first trajectory." << std::endl;
+    std::cout << "Failed to generate first trajectory." << '\n';
     return false;
   }
 
@@ -1108,7 +1108,7 @@ bool testutils::generateTrajFromBlendTestData(
   // trajectory generation
   if (!tg->generate(scene, req_2, res_2, sampling_time_2))
   {
-    std::cout << "Failed to generate second trajectory." << std::endl;
+    std::cout << "Failed to generate second trajectory." << '\n';
     return false;
   }
 
@@ -1338,27 +1338,27 @@ void testutils::checkRobotModel(const moveit::core::RobotModelConstPtr& robot_mo
   std::stringstream debug_stream;
   for (auto it = accelerations.begin(); it != it_last_acc + 1; it++)
   {
-    debug_stream << *it << "(Acc)" << std::endl;
+    debug_stream << *it << "(Acc)" << '\n';
   }
 
   for (auto it = it_last_acc + 1; it != it_last_intermediate + 1; it++)
   {
-    debug_stream << *it << "(Inter1)" << std::endl;
+    debug_stream << *it << "(Inter1)" << '\n';
   }
 
   for (auto it = it_first_const; it != it_last_const + 1; it++)
   {
-    debug_stream << *it << "(Const)" << std::endl;
+    debug_stream << *it << "(Const)" << '\n';
   }
 
   for (auto it = it_last_const + 1; it != it_first_dec; it++)
   {
-    debug_stream << *it << "(Inter2)" << std::endl;
+    debug_stream << *it << "(Inter2)" << '\n';
   }
 
   for (auto it = it_first_dec; it != accelerations.end(); it++)
   {
-    debug_stream << *it << "(Dec)" << std::endl;
+    debug_stream << *it << "(Dec)" << '\n';
   }
 
   RCLCPP_DEBUG_STREAM(LOGGER, debug_stream.str());

--- a/moveit_planners/sbpl/core/sbpl_interface/src/bfs3d/Search.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/bfs3d/Search.cpp
@@ -80,7 +80,7 @@ void BFS_3D::search(int width, int planeSize, int volatile* distance_grid, int* 
     EXPAND_NEIGHBOR(width + 1 - planeSize);
     EXPAND_NEIGHBOR(width - 1 - planeSize);
   }
-  // std::cerr << "Search thread done" << std::endl;
+  // std::cerr << "Search thread done" << '\n';
   running = false;
 }
 }  // namespace sbpl_interface

--- a/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
@@ -92,7 +92,7 @@ bool EnvironmentChain3D::InitializeEnv(const char* sEnvFile)
 
 int EnvironmentChain3D::GetFromToHeuristic(int FromStateID, int ToStateID)
 {
-  // std::cerr << "Getting heuristic" << std::endl;
+  // std::cerr << "Getting heuristic" << '\n';
   return getEndEffectorHeuristic(FromStateID, ToStateID);
 }
 
@@ -101,7 +101,7 @@ int EnvironmentChain3D::GetGoalHeuristic(int stateID)
   if (planning_data_.state_ID_to_coord_table_.size() < DEBUG_OVER)
   {
     std::cerr << "Getting heur distance from " << stateID << " to " << planning_data_.goal_hash_entry_->stateID << " "
-              << GetFromToHeuristic(stateID, planning_data_.goal_hash_entry_->stateID) << std::endl;
+              << GetFromToHeuristic(stateID, planning_data_.goal_hash_entry_->stateID) << '\n';
   }
   return GetFromToHeuristic(stateID, planning_data_.goal_hash_entry_->stateID);
 }
@@ -145,7 +145,7 @@ void EnvironmentChain3D::PrintEnv_Config(FILE* fOut)
 void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_idv, std::vector<int>* cost_v)
 {
   boost::this_thread::interruption_point();
-  // std::cerr << "Calling get succ state " << source_state_ID << std::endl;
+  // std::cerr << "Calling get succ state " << source_state_ID << '\n';
 
   ros::WallTime expansion_start_time = ros::WallTime::now();
 
@@ -155,20 +155,20 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
   // From environment_robarm3d.cpp -- //goal state should be absorbing
   if (source_state_ID == planning_data_.goal_hash_entry_->stateID)
   {
-    std::cerr << "Think we have goal" << std::endl;
+    std::cerr << "Think we have goal" << '\n';
     return;
   }
 
   if (source_state_ID > (int)planning_data_.state_ID_to_coord_table_.size() - 1)
   {
     ROS_WARN_STREAM("source id too large");
-    std::cerr << "Source id too large" << std::endl;
+    std::cerr << "Source id too large" << '\n';
     return;
   }
 
   if (planning_data_.state_ID_to_coord_table_.size() < DEBUG_OVER)
   {
-    std::cerr << "Expanding " << source_state_ID << std::endl;
+    std::cerr << "Expanding " << source_state_ID << '\n';
   }
 
   EnvChain3DHashEntry* hash_entry = planning_data_.state_ID_to_coord_table_[source_state_ID];
@@ -180,7 +180,7 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
   std::vector<double> succ_joint_angles;
 
   // for(unsigned int i = 0; i < source_joint_angles.size(); i++) {
-  //   std::cerr << "Source " << i << " " << source_joint_angles[i] << std::endl;
+  //   std::cerr << "Source " << i << " " << source_joint_angles[i] << '\n';
   // }
 
   planning_statistics_.total_expansions_++;
@@ -204,17 +204,17 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     // double dist = 0.0;
     // for(unsigned int j = 0; j < planning_data_.goal_hash_entry_->angles.size(); j++) {
     //   dist += fabs(planning_data_.goal_hash_entry_->angles[j]-succ_joint_angles[j]);
-    //   //std::cerr << "Succ " << i << " " << j << " " << succ_joint_angles[j] << std::endl;
+    //   //std::cerr << "Succ " << i << " " << j << " " << succ_joint_angles[j] << '\n';
     // }
     // if(dist < closest_to_goal_) {
-    //   //std::cerr << "Got dist " << dist << std::endl;
+    //   //std::cerr << "Got dist " << dist << '\n';
     //   closest_to_goal_ = dist;
     // }
 
     // int max_dist = getJointDistanceIntegerMax(succ_joint_angles,
     //                                           planning_data_.goal_hash_entry_->angles);
     // if(max_dist*1.0 < closest_to_goal_) {
-    //   std::cerr << "Max integer distance is " << max_dist << std::endl;
+    //   std::cerr << "Max integer distance is " << max_dist << '\n';
     //   closest_to_goal_ = max_dist*1.0;
     //   // for(unsigned int j = 0; j < joint_motion_wrappers_.size(); j++) {
     //   //   if(joint_motion_wrappers_[j]->canGetCloser(succ_joint_angles[j],
@@ -237,8 +237,8 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     }
 
     // if(!joint_state_group_->satisfiesBounds()) {
-    //   std::cerr << "ERROR - successor doesn't satisfy bounds" << std::endl;
-    //   //std::cerr << "Successor doesn't satisfy bounds" << std::endl;
+    //   std::cerr << "ERROR - successor doesn't satisfy bounds" << '\n';
+    //   //std::cerr << "Successor doesn't satisfy bounds" << '\n';
     //   continue;
     // }
     ros::WallTime before_coll = ros::WallTime::now();
@@ -254,14 +254,14 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
       planning_scene_->checkCollision(req, res, state_);
     }
     planning_statistics_.coll_checks_++;
-    // std::cerr << "Elapsed " << t.elapsed() << std::endl;
+    // std::cerr << "Elapsed " << t.elapsed() << '\n';
     ros::WallDuration dur(ros::WallTime::now() - before_coll);
-    // std::cerr << dur.toSec() << std::endl;
+    // std::cerr << dur.toSec() << '\n';
     // ROS_DEBUG_STREAM("Time " << ros::WallTime::now()-before_coll);
     planning_statistics_.total_coll_check_time_ += dur;
     if (res.collision)
     {
-      // std::cerr << "Successor in collision" << std::endl;
+      // std::cerr << "Successor in collision" << '\n';
       continue;
     }
 
@@ -272,7 +272,7 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     {
       if (!getGridXYZInt(pose, xyz))
       {
-        std::cerr << "Can't get successor x y z" << std::endl;
+        std::cerr << "Can't get successor x y z" << '\n';
         continue;
       }
     }
@@ -304,7 +304,7 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     if ((planning_parameters_.use_bfs_ && dist == 0) || (!planning_parameters_.use_bfs_ && dist == 1))
     {
       // std::cerr << "Joint distance for goal move " <<
-      // getJointDistanceDoubleSum(planning_data_.goal_hash_entry_->angles, succ_joint_angles) << std::endl;
+      // getJointDistanceDoubleSum(planning_data_.goal_hash_entry_->angles, succ_joint_angles) << '\n';
       std::vector<std::vector<double> > interpolated_values;
       if (interpolateAndCollisionCheck(source_joint_angles, planning_data_.goal_hash_entry_->angles,
                                        interpolated_values))
@@ -327,7 +327,7 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
       {
         if (!interpolateAndCollisionCheck(source_joint_angles, succ_joint_angles, interpolated_values))
         {
-          // std::cerr << "Interpolation failed" << std::endl;
+          // std::cerr << "Interpolation failed" << '\n';
           continue;
         }
       }
@@ -338,14 +338,14 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     //   std::cerr << "State " << source_state_ID << " sum dist " <<
     //   getJointDistanceSum(planning_data_.goal_hash_entry_->angles, succ_joint_angles) << " max "
     //             << " " << getJointDistanceMax(planning_data_.goal_hash_entry_->angles, succ_joint_angles) <<
-    //             std::endl;
+    //             '\n';
     //   for(unsigned int i = 0; i < planning_data_.goal_hash_entry_->angles.size(); i++) {
     //     std::cerr << "Joint " << i << " " << planning_data_.goal_hash_entry_->angles[i] << " " <<
-    //     succ_joint_angles[i] << std::endl;
+    //     succ_joint_angles[i] << '\n';
     //   }
     //   closest_to_goal_ = max_dist;
     // }
-    // std::cerr << "Dist " << dist << " source state id " << source_state_ID << std::endl;
+    // std::cerr << "Dist " << dist << " source state id " << source_state_ID << '\n';
     // if(max_dist <= LONG_RANGE_JOINT_DIFF/2.0+.001) {
     //   succ_hash_entry = planning_data_.goal_hash_entry_;
     // } else {
@@ -354,7 +354,7 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
 
     // kinematic_constraints::ConstraintEvaluationResult con_res = goal_constraint_set_.decide(state_);
     // if(con_res.satisfied) {
-    //   std::cerr << "Constraints satisfied, dist is " << dist << std::endl;
+    //   std::cerr << "Constraints satisfied, dist is " << dist << '\n';
     //   succ_hash_entry = planning_data_.goal_hash_entry_;
     // } else {
     //   succ_hash_entry = planning_data_.getHashEntry(succ_coord, i);
@@ -367,25 +367,25 @@ void EnvironmentChain3D::GetSuccs(int source_state_ID, std::vector<int>* succ_id
     {
       if (planning_data_.state_ID_to_coord_table_.size() < DEBUG_OVER)
       {
-        std::cerr << "Already have hash entry " << succ_hash_entry->stateID << std::endl;
+        std::cerr << "Already have hash entry " << succ_hash_entry->stateID << '\n';
       }
     }
 
     if (planning_parameters_.interpolation_distance_ < planning_parameters_.joint_motion_primitive_distance_ &&
         !succ_is_goal_state)
     {
-      // std::cerr << "Adding segment from " << source_state_ID << " to " << succ_hash_entry->stateID << std::endl;
+      // std::cerr << "Adding segment from " << source_state_ID << " to " << succ_hash_entry->stateID << '\n';
       generated_interpolations_map_[source_state_ID][succ_hash_entry->stateID] = interpolated_values;
     }
 
-    // std::cerr << "Adding hash entry" << std::endl;
+    // std::cerr << "Adding hash entry" << '\n';
     if (planning_data_.state_ID_to_coord_table_.size() < DEBUG_OVER)
     {
-      std::cerr << std::endl;
-      std::cerr << "Adding " << succ_hash_entry->stateID << std::endl;
+      std::cerr << '\n';
+      std::cerr << "Adding " << succ_hash_entry->stateID << '\n';
       for (unsigned int j = 0; j < planning_data_.goal_hash_entry_->angles.size(); j++)
       {
-        std::cerr << "Succ " << j << " " << succ_joint_angles[j] << std::endl;
+        std::cerr << "Succ " << j << " " << succ_joint_angles[j] << '\n';
       }
     }
     succ_idv->push_back(succ_hash_entry->stateID);
@@ -427,7 +427,7 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
                                             moveit_msgs::srv::GetMotionPlan::Response& mres,
                                             const PlanningParameters& params)
 {
-  std::cerr << "really here " << std::endl;
+  std::cerr << "really here " << '\n';
   planning_scene_ = planning_scene;
 
   planning_group_ = mreq.motion_plan_request.group_name;
@@ -510,14 +510,14 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
         world_distance_field->getZNumCells() != gsr_->dfce_->distance_field_->getZNumCells())
     {
       ROS_WARN_STREAM("Size mismatch between world and self distance fields");
-      std::cerr << "Size mismatch between world and self distance fields" << std::endl;
+      std::cerr << "Size mismatch between world and self distance fields" << '\n';
       mres.error_code.val = moveit_msgs::msg::MoveItErrorCodes::COLLISION_CHECKING_UNAVAILABLE;
       return false;
     }
     // std::cerr << "BFS dimensions are "
     //           << world_distance_field->getXNumCells() << " "
     //           << world_distance_field->getYNumCells() << " "
-    //           << world_distance_field->getZNumCells() << std::endl;
+    //           << world_distance_field->getZNumCells() << '\n';
     unsigned int wall_count = 0;
     for (int i = 0; i < gsr_->dfce_->distance_field_->getXNumCells() - 2; i++)
     {
@@ -538,7 +538,7 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
   }
   // std::cerr << "Wall cells are " << wall_count << " of " <<
   //   world_distance_field->getXNumCells()*world_distance_field->getYNumCells()*world_distance_field->getZNumCells() <<
-  //   std::endl;
+  //   '\n';
 
   // setting start position
   std::vector<double> start_joint_values;
@@ -552,7 +552,7 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
   {
     if (!getGridXYZInt(start_pose, start_xyz))
     {
-      std::cerr << "Bad start pose" << std::endl;
+      std::cerr << "Bad start pose" << '\n';
       mres.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE;
       return false;
     }
@@ -601,7 +601,7 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
   {
     if (!getGridXYZInt(goal_pose_, goal_xyz))
     {
-      std::cerr << "Bad goal pose" << std::endl;
+      std::cerr << "Bad goal pose" << '\n';
       mres.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS;
       return false;
     }
@@ -621,12 +621,12 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
   {
     ROS_DEBUG_STREAM("Goal " << goal_dofs[i] << " pos " << goal_joint_values[i]);
   }
-  // std::cerr << "Running bfs with goal " << goal_xyz[0] << " " <<  goal_xyz[1] << " " << goal_xyz[2] << std::endl;
+  // std::cerr << "Running bfs with goal " << goal_xyz[0] << " " <<  goal_xyz[1] << " " << goal_xyz[2] << '\n';
   if (planning_parameters_.use_bfs_)
   {
     bfs_->run(goal_xyz[0], goal_xyz[1], goal_xyz[2]);
     // std::cerr << "Got start " << start_xyz[0] << " " <<  start_xyz[1] << " " << start_xyz[2] << " cost "
-    //           << getBFSCostToGoal(start_xyz[0], start_xyz[1], start_xyz[2]) << std::endl;
+    //           << getBFSCostToGoal(start_xyz[0], start_xyz[1], start_xyz[2]) << '\n';
   }
   goal_constraint_set_.clear();
   goal_constraint_set_.add(mreq.motion_plan_request.goal_constraints[0]);
@@ -691,14 +691,14 @@ void EnvironmentChain3D::determineMaximumEndEffectorTravel()
     double motion_y = motion_pose.translation().y();
     double motion_z = motion_pose.translation().z();
     double dist = getEuclideanDistance(default_x, default_y, default_z, motion_x, motion_y, motion_z);
-    // std::cerr << "Motion " << i << " dist " << dist << std::endl;
+    // std::cerr << "Motion " << i << " dist " << dist << '\n';
     if (dist > max_dist)
     {
       max_dist = dist;
     }
   }
   maximum_distance_for_motion_ = ceil(max_dist / angle_discretization_);
-  // std::cerr << "Maximum distance is " << maximum_distance_for_motion_ << std::endl;
+  // std::cerr << "Maximum distance is " << maximum_distance_for_motion_ << '\n';
 }
 
 int EnvironmentChain3D::calculateCost(EnvChain3DHashEntry* HashEntry1, EnvChain3DHashEntry* HashEntry2)
@@ -756,10 +756,10 @@ int EnvironmentChain3D::calculateCost(EnvChain3DHashEntry* HashEntry1, EnvChain3
 
 int EnvironmentChain3D::getBFSCostToGoal(int x, int y, int z) const
 {
-  // std::cerr << "Getting cost for " << x << " " << y << " " << z << std::endl;
+  // std::cerr << "Getting cost for " << x << " " << y << " " << z << '\n';
   // TODO - deal with cost_per_cell
   int cost = (floor(bfs_->getDistance(x, y, z) / (maximum_distance_for_motion_))) * JOINT_DIST_MULT;
-  // std::cerr << "Cost is " << cost << std::endl;
+  // std::cerr << "Cost is " << cost << '\n';
   return cost;
   //* .05;//prms_.cost_per_cell_;
 }
@@ -769,7 +769,7 @@ int EnvironmentChain3D::getJointDistanceIntegerSum(const std::vector<double>& an
 {
   if (angles1.size() != angles2.size())
   {
-    std::cerr << "Angles aren't the same size!!!" << std::endl;
+    std::cerr << "Angles aren't the same size!!!" << '\n';
     return INT_MAX;
   }
   int dist = 0;
@@ -785,7 +785,7 @@ int EnvironmentChain3D::getJointDistanceIntegerMax(const std::vector<double>& an
 {
   if (angles1.size() != angles2.size())
   {
-    std::cerr << "Angles aren't the same size!!!" << std::endl;
+    std::cerr << "Angles aren't the same size!!!" << '\n';
     return INT_MAX;
   }
   int max_dist = 0;
@@ -812,7 +812,7 @@ double EnvironmentChain3D::getJointDistanceDoubleSum(const std::vector<double>& 
   {
     double jdist = joint_motion_wrappers_[i]->getDoubleDistance(angles1[i], angles2[i]);
     // std::cerr << "Joint " << i << " angle1 " << angles1[i] << " " << angles2[i] << " distance " << jdist <<
-    // std::endl;
+    // '\n';
     dist += jdist;
   }
   return dist;
@@ -854,7 +854,7 @@ int EnvironmentChain3D::getEndEffectorHeuristic(int from_stateID, int to_stateID
   EnvChain3DHashEntry* to_hash_entry = planning_data_.state_ID_to_coord_table_[to_stateID];
   // if(planning_data_.state_ID_to_coord_table_.size() < PRINT_HEURISTIC_UNDER) {
   // std::cerr << " Dist " << dist << " heur " << getBFSCostToGoal(from_hash_entry->xyz[0], from_hash_entry->xyz[1],
-  // from_hash_entry->xyz[2]) << std::endl;
+  // from_hash_entry->xyz[2]) << '\n';
   if (planning_parameters_.use_bfs_)
   {
     return getBFSCostToGoal(from_hash_entry->xyz[0], from_hash_entry->xyz[1], from_hash_entry->xyz[2]);
@@ -873,7 +873,7 @@ int EnvironmentChain3D::getEndEffectorHeuristic(int from_stateID, int to_stateID
   //                                               from_hash_entry->xyz[1],
   //                                               from_hash_entry->xyz[2],
   //                                               x,y,z)) {
-  //   std::cerr << "problem" << std::endl;
+  //   std::cerr << "problem" << '\n';
   //   return 1000000;
   // }
   // return getEuclideanDistance(x, y, z, goal_pose_.translation().x(), goal_pose_.translation().y(),
@@ -919,7 +919,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
       if (it2 == it->second.end())
       {
         std::cerr << "No interpolated segment connecting state id " << (*state_ids.end() - 2) << " and goal "
-                  << state_ids.back() << std::endl;
+                  << state_ids.back() << '\n';
       }
       else
       {
@@ -929,7 +929,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
     else
     {
       std::cerr << "No interpolated segment connecting state id " << (*state_ids.end() - 2) << " and goal "
-                << state_ids.back() << std::endl;
+                << state_ids.back() << '\n';
     }
     traj.points.resize(end_points.size() + angle_vector.size());
     for (unsigned int i = 0; i < angle_vector.size() - 1; i++)
@@ -945,11 +945,11 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
     {
       ROS_DEBUG_STREAM("Last " << i << " " << traj.points.back().positions[i]);
     }
-    std::cerr << "Original path " << angle_vector.size() << " end path " << end_points.size() << std::endl;
+    std::cerr << "Original path " << angle_vector.size() << " end path " << end_points.size() << '\n';
   }
   else
   {
-    std::cerr << "Num states " << state_ids.size() << std::endl;
+    std::cerr << "Num states " << state_ids.size() << '\n';
     for (unsigned int i = 0; i < state_ids.size() - 1; i++)
     {
       trajectory_msgs::JointTrajectoryPoint statep;
@@ -959,7 +959,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
       // std::cerr << "State " << i << " id " << state_ids[i] << " dist "
       //           <<  getJointDistanceIntegerMax(traj.points.back().positions,
       //                                          statep.positions,
-      //                                          INTERPOLATION_DISTANCE) << std::endl;
+      //                                          INTERPOLATION_DISTANCE) << '\n';
       //}
       traj.points.push_back(statep);
       std::map<int, std::map<int, std::vector<std::vector<double> > > >::const_iterator it =
@@ -970,7 +970,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
         if (it2 == it->second.end())
         {
           std::cerr << "No interpolated segment connecting state id " << state_ids[i] << " and state "
-                    << state_ids[i + 1] << std::endl;
+                    << state_ids[i + 1] << '\n';
           continue;
         }
         else
@@ -981,7 +981,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
             p.positions = it2->second[j];
             // std::cerr << "Interp " << getJointDistanceIntegerMax(traj.points.back().positions,
             //                                                      p.positions,
-            //                                                      INTERPOLATION_DISTANCE) << std::endl;
+            //                                                      INTERPOLATION_DISTANCE) << '\n';
             traj.points.push_back(p);
           }
         }
@@ -989,7 +989,7 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
       else
       {
         std::cerr << "No interpolated segment connecting state id " << state_ids[i] << " and state " << state_ids[i + 1]
-                  << std::endl;
+                  << '\n';
         continue;
       }
     }
@@ -998,11 +998,11 @@ bool EnvironmentChain3D::populateTrajectoryFromStateIDSequence(const std::vector
     statep.positions = angle_vector.back();
     // std::cerr << "Last " << getJointDistanceIntegerMax(traj.points.back().positions,
     //                                                    statep.positions,
-    //                                                    INTERPOLATION_DISTANCE) << std::endl;
+    //                                                    INTERPOLATION_DISTANCE) << '\n';
 
     traj.points.push_back(statep);
   }
-  std::cerr << "Resulting path is " << traj.points.size() << std::endl;
+  std::cerr << "Resulting path is " << traj.points.size() << '\n';
   return true;
 }
 
@@ -1080,14 +1080,14 @@ bool EnvironmentChain3D::interpolateAndCollisionCheck(const std::vector<double> 
   int maximum_moves = getJointDistanceIntegerMax(angles1, angles2, planning_parameters_.interpolation_distance_);
   if (print_first)
   {
-    std::cerr << "Maximum moves " << maximum_moves << std::endl;
+    std::cerr << "Maximum moves " << maximum_moves << '\n';
     for (unsigned int i = 0; i < angles1.size(); i++)
     {
-      std::cerr << "Start " << i << " " << angles1[i] << std::endl;
+      std::cerr << "Start " << i << " " << angles1[i] << '\n';
     }
     for (unsigned int i = 0; i < angles2.size(); i++)
     {
-      std::cerr << "End " << i << " " << angles2[i] << std::endl;
+      std::cerr << "End " << i << " " << angles2[i] << '\n';
     }
   }
   for (int i = 1; i < maximum_moves; i++)
@@ -1118,7 +1118,7 @@ bool EnvironmentChain3D::interpolateAndCollisionCheck(const std::vector<double> 
     {
       for (unsigned int j = 0; j < state_values.back().size(); j++)
       {
-        std::cerr << "Interp " << i << " " << j << " " << state_values.back()[j] << std::endl;
+        std::cerr << "Interp " << i << " " << j << " " << state_values.back()[j] << '\n';
       }
     }
   }
@@ -1145,10 +1145,10 @@ void EnvironmentChain3D::attemptShortcut(const trajectory_msgs::JointTrajectory&
   if (planning_parameters_.attempt_full_shortcut_)
   {
     std::vector<std::vector<double> > full_shortcut;
-    // std::cerr << "Checking" << std::endl;
+    // std::cerr << "Checking" << '\n';
     if (interpolateAndCollisionCheck(traj_in.points.front().positions, traj_in.points.back().positions, full_shortcut))
     {
-      std::cerr << "Full shortcut has " << full_shortcut.size() << " points " << std::endl;
+      std::cerr << "Full shortcut has " << full_shortcut.size() << " points " << '\n';
       for (unsigned int i = 0; i < full_shortcut.size(); i++)
       {
         trajectory_msgs::JointTrajectoryPoint jtp;
@@ -1156,14 +1156,14 @@ void EnvironmentChain3D::attemptShortcut(const trajectory_msgs::JointTrajectory&
         traj_out.points.push_back(jtp);
       }
       traj_out.points.push_back(traj_in.points.back());
-      std::cerr << "Full shortcut worked" << std::endl;
+      std::cerr << "Full shortcut worked" << '\n';
       return;
     }
   }
 
   while (1)
   {
-    // std::cerr << "Checking from " << last_point_ind << " to " << current_point_ind << std::endl;
+    // std::cerr << "Checking from " << last_point_ind << " to " << current_point_ind << '\n';
     const trajectory_msgs::JointTrajectoryPoint& start_point = traj_in.points[last_point_ind];
     const trajectory_msgs::JointTrajectoryPoint& end_point = traj_in.points[current_point_ind];
     std::vector<std::vector<double> > segment_values;
@@ -1174,7 +1174,7 @@ void EnvironmentChain3D::attemptShortcut(const trajectory_msgs::JointTrajectory&
       last_good_end_ind = current_point_ind;
       last_good_segment_values = segment_values;
       current_point_ind++;
-      // std::cerr << "Interpolation ok" << std::endl;
+      // std::cerr << "Interpolation ok" << '\n';
     }
     else
     {
@@ -1196,7 +1196,7 @@ void EnvironmentChain3D::attemptShortcut(const trajectory_msgs::JointTrajectory&
       last_point_ind = last_good_end_ind;
       current_point_ind = last_good_end_ind + 1;
       last_good_segment_values.clear();
-      // std::cerr << "Interpolation not ok" << std::endl;
+      // std::cerr << "Interpolation not ok" << '\n';
     }
     if (current_point_ind >= traj_in.points.size())
     {

--- a/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_interface.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_interface.cpp
@@ -52,11 +52,11 @@ bool SBPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   boost::shared_ptr<EnvironmentChain3D> env_chain(new EnvironmentChain3D(planning_scene));
   if (!env_chain->setupForMotionPlan(planning_scene, req, res, params))
   {
-    // std::cerr << "Env chain setup failing" << std::endl;
+    // std::cerr << "Env chain setup failing" << '\n';
     return false;
   }
   // std::cerr << "Creation with params " << params.use_bfs_ << " took " << (ros::WallTime::now()-wt).toSec() <<
-  // std::endl;
+  // '\n';
   boost::this_thread::interruption_point();
 
   // DummyEnvironment* dummy_env = new DummyEnvironment();
@@ -66,7 +66,7 @@ bool SBPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   planner->force_planning_from_scratch();
   planner->set_start(env_chain->getPlanningData().start_hash_entry_->stateID);
   planner->set_goal(env_chain->getPlanningData().goal_hash_entry_->stateID);
-  // std::cerr << "Creation took " << (ros::WallTime::now()-wt) << std::endl;
+  // std::cerr << "Creation took " << (ros::WallTime::now()-wt) << '\n';
   std::vector<int> solution_state_ids;
   int solution_cost;
   wt = ros::WallTime::now();
@@ -74,19 +74,19 @@ bool SBPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   bool b_ret = planner->replan(10.0, &solution_state_ids, &solution_cost);
   // CALLGRIND_STOP_INSTRUMENTATION;
   double el = (ros::WallTime::now() - wt).toSec();
-  std::cerr << "B ret is " << b_ret << " planning time " << el << std::endl;
+  std::cerr << "B ret is " << b_ret << " planning time " << el << '\n';
   std::cerr << "Expansions " << env_chain->getPlanningStatistics().total_expansions_ << " average time "
             << (env_chain->getPlanningStatistics().total_expansion_time_.toSec() /
                 (env_chain->getPlanningStatistics().total_expansions_ * 1.0))
             << " hz "
             << 1.0 / (env_chain->getPlanningStatistics().total_expansion_time_.toSec() /
                       (env_chain->getPlanningStatistics().total_expansions_ * 1.0))
-            << std::endl;
+            << '\n';
   std::cerr << "Total coll checks " << env_chain->getPlanningStatistics().coll_checks_ << " hz "
             << 1.0 / (env_chain->getPlanningStatistics().total_coll_check_time_.toSec() /
                       (env_chain->getPlanningStatistics().coll_checks_ * 1.0))
-            << std::endl;
-  std::cerr << "Path length is " << solution_state_ids.size() << std::endl;
+            << '\n';
+  std::cerr << "Path length is " << solution_state_ids.size() << '\n';
   if (!b_ret)
   {
     res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
@@ -94,22 +94,22 @@ bool SBPLInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   }
   if (solution_state_ids.size() == 0)
   {
-    std::cerr << "Success but no path" << std::endl;
+    std::cerr << "Success but no path" << '\n';
     res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
   if (!env_chain->populateTrajectoryFromStateIDSequence(solution_state_ids, res.trajectory.joint_trajectory))
   {
-    std::cerr << "Success but path bad" << std::endl;
+    std::cerr << "Success but path bad" << '\n';
     res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
   ros::WallTime pre_short = ros::WallTime::now();
-  // std::cerr << "Num traj points before " << res.trajectory.joint_trajectory.points.size() << std::endl;
+  // std::cerr << "Num traj points before " << res.trajectory.joint_trajectory.points.size() << '\n';
   trajectory_msgs::JointTrajectory traj = res.trajectory.joint_trajectory;
   env_chain->attemptShortcut(traj, res.trajectory.joint_trajectory);
-  // std::cerr << "Num traj points after " << res.trajectory.joint_trajectory.points.size() << std::endl;
-  // std::cerr << "Time " << (ros::WallTime::now()-pre_short).toSec() << std::endl;
+  // std::cerr << "Num traj points after " << res.trajectory.joint_trajectory.points.size() << '\n';
+  // std::cerr << "Time " << (ros::WallTime::now()-pre_short).toSec() << '\n';
   // env_chain->getPlaneBFSMarker(mark, env_chain->getGoalPose().translation().z());
   res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   PlanningStatistics stats = env_chain->getPlanningStatistics();

--- a/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/sbpl_meta_interface.cpp
@@ -67,10 +67,10 @@ bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& plann
 
   if (first_done_)
   {
-    std::cerr << "FIRST DONE" << std::endl;
+    std::cerr << "FIRST DONE" << '\n';
     if (first_ok_)
     {
-      std::cerr << "First ok, interrupting second" << std::endl;
+      std::cerr << "First ok, interrupting second" << '\n';
       if (!second_done_)
       {
         thread2.interrupt();
@@ -87,10 +87,10 @@ bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& plann
   }
   if (second_done_)
   {
-    std::cerr << "Second done" << std::endl;
+    std::cerr << "Second done" << '\n';
     if (second_ok_)
     {
-      std::cerr << "Second ok, interrupting first" << std::endl;
+      std::cerr << "Second ok, interrupting first" << '\n';
       if (!first_done_)
       {
         thread1.interrupt();
@@ -108,14 +108,14 @@ bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& plann
 
   if (!first_ok_ && !second_ok_)
   {
-    std::cerr << "Both planners failed" << std::endl;
+    std::cerr << "Both planners failed" << '\n';
     res = res1;
     return false;
   }
   if (!first_ok_ && second_ok_)
   {
     std::cerr << "Sbpl interface no bfs reports time "
-              << sbpl_interface_second_->getLastPlanningStatistics().total_planning_time_ << std::endl;
+              << sbpl_interface_second_->getLastPlanningStatistics().total_planning_time_ << '\n';
     last_planning_statistics_ = sbpl_interface_second_->getLastPlanningStatistics();
     res = res2;
     return true;
@@ -123,15 +123,15 @@ bool SBPLMetaInterface::solve(const planning_scene::PlanningSceneConstPtr& plann
   else if (first_ok_ && !second_ok_)
   {
     std::cerr << "Sbpl interface bfs reports time "
-              << sbpl_interface_first_->getLastPlanningStatistics().total_planning_time_ << std::endl;
+              << sbpl_interface_first_->getLastPlanningStatistics().total_planning_time_ << '\n';
     last_planning_statistics_ = sbpl_interface_first_->getLastPlanningStatistics();
     res = res1;
     return true;
   }
   std::cerr << "Sbpl interface bfs reports time "
-            << sbpl_interface_first_->getLastPlanningStatistics().total_planning_time_ << std::endl;
+            << sbpl_interface_first_->getLastPlanningStatistics().total_planning_time_ << '\n';
   std::cerr << "Sbpl interface no bfs reports time "
-            << sbpl_interface_second_->getLastPlanningStatistics().total_planning_time_ << std::endl;
+            << sbpl_interface_second_->getLastPlanningStatistics().total_planning_time_ << '\n';
   if (sbpl_interface_first_->getLastPlanningStatistics().total_planning_time_ <
       sbpl_interface_second_->getLastPlanningStatistics().total_planning_time_)
   {
@@ -154,13 +154,13 @@ void SBPLMetaInterface::runSolver(bool use_first, const planning_scene::Planning
   {
     if (use_first)
     {
-      std::cerr << "Running first planner" << std::endl;
+      std::cerr << "Running first planner" << '\n';
       first_ok_ = sbpl_interface_first_->solve(planning_scene, req, res, params);
       first_done_ = true;
     }
     else
     {
-      std::cerr << "Running second planner" << std::endl;
+      std::cerr << "Running second planner" << '\n';
       second_ok_ = sbpl_interface_second_->solve(planning_scene, req, res, params);
       second_done_ = true;
     }

--- a/moveit_planners/trajopt/test/trajectory_test.cpp
+++ b/moveit_planners/trajopt/test/trajectory_test.cpp
@@ -169,7 +169,7 @@ TEST_F(TrajectoryTest, goalTolerance)
     for (std::size_t i = 0; i < classes.size(); ++i)
       ss << classes[i] << " ";
     ROS_ERROR_STREAM_NAMED(NODE_NAME, "Exception while loading planner '" << planner_plugin_name << "': " << ex.what()
-                                                                          << std::endl
+                                                                          << '\n'
                                                                           << "Available plugins: " << ss.str());
   }
 
@@ -192,7 +192,7 @@ TEST_F(TrajectoryTest, goalTolerance)
   {
     double goal_error =
         abs(joints_values_last_step[joint_index] - req.goal_constraints[0].joint_constraints[joint_index].position);
-    std::cerr << "goal_error: " << goal_error << std::endl;
+    std::cerr << "goal_error: " << goal_error << '\n';
     EXPECT_LT(goal_error, GOAL_TOLERANCE);
   }
 }

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -769,25 +769,25 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
 void moveit_benchmarks::BenchmarkExecution::printOptions(std::ostream& out)
 {
   out << "Benchmark for scene '" << options_.scene << "' to be saved at location '" << options_.output << "'"
-      << std::endl;
+      << '\n';
   if (!options_.query_regex.empty())
     out << "Planning requests associated to the scene that match '" << options_.query_regex << "' will be evaluated"
-        << std::endl;
+        << '\n';
   if (!options_.goal_regex.empty())
     out << "Planning requests constructed from goal constraints that match '" << options_.goal_regex
-        << "' will be evaluated" << std::endl;
+        << "' will be evaluated" << '\n';
   if (!options_.trajectory_regex.empty())
     out << "Planning requests constructed from trajectory constraints that match '" << options_.trajectory_regex
-        << "' will be evaluated" << std::endl;
-  out << "Plugins:" << std::endl;
+        << "' will be evaluated" << '\n';
+  out << "Plugins:" << '\n';
   for (std::size_t i = 0; i < options_.plugins.size(); ++i)
   {
     out << "   * name: " << options_.plugins[i].name << " (to be run " << options_.plugins[i].runs
-        << " times for each planner)" << std::endl;
+        << " times for each planner)" << '\n';
     out << "   * planners:";
     for (std::size_t j = 0; j < options_.plugins[i].planners.size(); ++j)
       out << ' ' << options_.plugins[i].planners[j];
-    out << std::endl;
+    out << '\n';
   }
 }
 
@@ -1024,10 +1024,10 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
     if (planner_ids_to_benchmark_per_planner_interface[i].empty())
       continue;
     sst << "  * " << planner_interfaces_to_benchmark[i]->getDescription() << " - Will execute interface "
-        << runs_per_planner_interface[i] << " times:" << std::endl;
+        << runs_per_planner_interface[i] << " times:" << '\n';
     for (std::size_t k = 0; k < planner_ids_to_benchmark_per_planner_interface[i].size(); ++k)
-      sst << "    - " << planner_ids_to_benchmark_per_planner_interface[i][k] << std::endl;
-    sst << std::endl;
+      sst << "    - " << planner_ids_to_benchmark_per_planner_interface[i][k] << '\n';
+    sst << '\n';
   }
   ROS_INFO("Benchmarking Planning Interfaces:\n%s", sst.str().c_str());
 
@@ -1145,14 +1145,14 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
                               boost::posix_time::to_iso_extended_string(startTime.toBoost()) + ".log") :
                              req.filename;
   std::ofstream out(filename.c_str());
-  out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << std::endl;
-  out << "Running on " << (host.empty() ? "UNKNOWN" : host) << std::endl;
-  out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << std::endl;
-  out << "Goal name " << (req.goal_name.empty() ? "UNKNOWN" : req.goal_name) << std::endl;
-  // out << "<<<|" << std::endl << "ROS" << std::endl << req.motion_plan_request << std::endl << "|>>>" << std::endl;
-  out << req.motion_plan_request.allowed_planning_time << " seconds per run" << std::endl;
-  out << duration << " seconds spent to collect the data" << std::endl;
-  out << total_n_planners << " planners" << std::endl;
+  out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << '\n';
+  out << "Running on " << (host.empty() ? "UNKNOWN" : host) << '\n';
+  out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << '\n';
+  out << "Goal name " << (req.goal_name.empty() ? "UNKNOWN" : req.goal_name) << '\n';
+  // out << "<<<|" << '\n' << "ROS" << '\n' << req.motion_plan_request << '\n' << "|>>>" << '\n';
+  out << req.motion_plan_request.allowed_planning_time << " seconds per run" << '\n';
+  out << duration << " seconds spent to collect the data" << '\n';
+  out << total_n_planners << " planners" << '\n';
 
   // tracks iteration location in data[] vector
   std::size_t run_id = 0;
@@ -1166,11 +1166,11 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
       // Output name of planning algorithm
       out << planner_interfaces_to_benchmark[q]->getDescription() + "_" +
                  planner_ids_to_benchmark_per_planner_interface[q][p]
-          << std::endl;
+          << '\n';
 
       // in general, we could have properties specific for a planner;
       // right now, we do not include such properties
-      out << "0 common properties" << std::endl;
+      out << "0 common properties" << '\n';
 
       // construct the list of all possible properties for all runs
       std::set<std::string> properties_set;
@@ -1186,12 +1186,12 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
       std::vector<std::string> properties;
       for (std::set<std::string>::iterator it = properties_set.begin(); it != properties_set.end(); ++it)
         properties.push_back(*it);
-      out << properties.size() << " properties for each run" << std::endl;
+      out << properties.size() << " properties for each run" << '\n';
 
       // output the vector of properties to the log file
       for (unsigned int j = 0; j < properties.size(); ++j)
-        out << properties[j] << std::endl;
-      out << data[run_id].size() << " runs" << std::endl;
+        out << properties[j] << '\n';
+      out << data[run_id].size() << " runs" << '\n';
 
       // output all the data to the log file
       for (std::size_t j = 0; j < data[run_id].size(); ++j)
@@ -1206,9 +1206,9 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
         }
 
         // end the line
-        out << std::endl;
+        out << '\n';
       }
-      out << '.' << std::endl;
+      out << '.' << '\n';
 
       ++run_id;
     }
@@ -1305,16 +1305,16 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
                                 boost::posix_time::to_iso_extended_string(startTime.toBoost()) + ".log") :
                                req.filename;
     std::ofstream out(filename.c_str());
-    out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << std::endl;
-    out << "Running on " << (host.empty() ? "UNKNOWN" : host) << std::endl;
-    out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << std::endl;
-    out << "<<<|" << std::endl << "ROS" << std::endl << req.motion_plan_request << std::endl << "|>>>" << std::endl;
-    out << req.motion_plan_request.allowed_planning_time << " seconds per run" << std::endl;
-    out << duration << " seconds spent to collect the data" << std::endl;
-    out << "reachable BOOLEAN" << std::endl;
-    out << "collision_free BOOLEAN" << std::endl;
-    out << "total_time REAL" << std::endl;
-    out << reachable << "; " << success << "; " << duration << std::endl;
+    out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << '\n';
+    out << "Running on " << (host.empty() ? "UNKNOWN" : host) << '\n';
+    out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << '\n';
+    out << "<<<|" << '\n' << "ROS" << '\n' << req.motion_plan_request << '\n' << "|>>>" << '\n';
+    out << req.motion_plan_request.allowed_planning_time << " seconds per run" << '\n';
+    out << duration << " seconds spent to collect the data" << '\n';
+    out << "reachable BOOLEAN" << '\n';
+    out << "collision_free BOOLEAN" << '\n';
+    out << "total_time REAL" << '\n';
+    out << reachable << "; " << success << "; " << duration << '\n';
     out.close();
     ROS_INFO("Results saved to '%s'", filename.c_str());
   }
@@ -1330,14 +1330,14 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
                                 boost::posix_time::to_iso_extended_string(startTime.toBoost()) + ".log") :
                                req.filename;
     std::ofstream out(filename.c_str());
-    out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << std::endl;
-    out << "Running on " << (host.empty() ? "UNKNOWN" : host) << std::endl;
-    out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << std::endl;
-    out << "<<<|" << std::endl << "ROS" << std::endl << req.motion_plan_request << std::endl << "|>>>" << std::endl;
-    out << req.motion_plan_request.allowed_planning_time << " seconds per run" << std::endl;
-    out << "reachable BOOLEAN" << std::endl;
-    out << "collision_free BOOLEAN" << std::endl;
-    out << "total_time REAL" << std::endl;
+    out << "Experiment " << (planning_scene_->getName().empty() ? "NO_NAME" : planning_scene_->getName()) << '\n';
+    out << "Running on " << (host.empty() ? "UNKNOWN" : host) << '\n';
+    out << "Starting at " << boost::posix_time::to_iso_extended_string(startTime.toBoost()) << '\n';
+    out << "<<<|" << '\n' << "ROS" << '\n' << req.motion_plan_request << '\n' << "|>>>" << '\n';
+    out << req.motion_plan_request.allowed_planning_time << " seconds per run" << '\n';
+    out << "reachable BOOLEAN" << '\n';
+    out << "collision_free BOOLEAN" << '\n';
+    out << "total_time REAL" << '\n';
 
     for (std::size_t tc = 0; tc < req.motion_plan_request.trajectory_constraints.constraints.size(); ++tc)
     {
@@ -1390,7 +1390,7 @@ void moveit_benchmarks::BenchmarkExecution::runGoalExistenceBenchmark(BenchmarkR
         ROS_INFO("  Not reachable");
       }
 
-      out << reachable << "; " << success << "; " << duration << std::endl;
+      out << reachable << "; " << success << "; " << duration << '\n';
     }
     out.close();
     ROS_INFO("Results saved to '%s'", filename.c_str());
@@ -1464,7 +1464,7 @@ std::size_t moveit_benchmarks::BenchmarkExecution::generateParamCombinations()
     // Debug map
     for(std::map<std::string,double>::const_iterator it = param_combinations_[i].begin(); it !=
   param_combinations_[i].end(); ++it)
-      std::cout << "  - " << it->first << " => " << it->second << std::endl;
+      std::cout << "  - " << it->first << " => " << it->second << '\n';
   }
   */
 
@@ -1505,10 +1505,10 @@ void moveit_benchmarks::BenchmarkExecution::printConfigurationSettings(
   // Debug map
   for (planning_interface::PlannerConfigurationMap::const_iterator it = settings.begin(); it != settings.end(); ++it)
   {
-    out << "  - " << it->first << " => " << it->second.name << "/" << it->second.group << std::endl;
+    out << "  - " << it->first << " => " << it->second.name << "/" << it->second.group << '\n';
     // Debug map
     for (std::map<std::string, std::string>::const_iterator config_it = it->second.config.begin();
          config_it != it->second.config.end(); ++config_it)
-      out << "      - " << config_it->first << " => " << config_it->second << std::endl;
+      out << "      - " << config_it->first << " => " << config_it->second << '\n';
   }
 }

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -768,8 +768,7 @@ bool moveit_benchmarks::BenchmarkExecution::readOptions(const std::string& filen
 
 void moveit_benchmarks::BenchmarkExecution::printOptions(std::ostream& out)
 {
-  out << "Benchmark for scene '" << options_.scene << "' to be saved at location '" << options_.output << "'"
-      << '\n';
+  out << "Benchmark for scene '" << options_.scene << "' to be saved at location '" << options_.output << "'" << '\n';
   if (!options_.query_regex.empty())
     out << "Planning requests associated to the scene that match '" << options_.query_regex << "' will be evaluated"
         << '\n';

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -578,9 +578,9 @@ bool BenchmarkExecutor::plannerConfigurationsExist(
       {
         RCLCPP_ERROR(LOGGER, "Planner '%s' does NOT exist for group '%s' in pipeline '%s'", entry.second[i].c_str(),
                      group_name.c_str(), entry.first.c_str());
-        std::cout << "There are " << config_map.size() << " planner entries: " << std::endl;
+        std::cout << "There are " << config_map.size() << " planner entries: " << '\n';
         for (const auto& config_map_entry : config_map)
-          std::cout << config_map_entry.second.name << std::endl;
+          std::cout << config_map_entry.second.name << '\n';
         return false;
       }
     }
@@ -1111,42 +1111,42 @@ void BenchmarkExecutor::writeOutput(const BenchmarkRequest& brequest, const std:
     return;
   }
 
-  out << "MoveIt version " << MOVEIT_VERSION << std::endl;
-  out << "Experiment " << brequest.name << std::endl;
-  out << "Running on " << hostname << std::endl;
-  out << "Starting at " << start_time << std::endl;
+  out << "MoveIt version " << MOVEIT_VERSION << '\n';
+  out << "Experiment " << brequest.name << '\n';
+  out << "Running on " << hostname << '\n';
+  out << "Starting at " << start_time << '\n';
 
   // Experiment setup
   moveit_msgs::msg::PlanningScene scene_msg;
   planning_scene_->getPlanningSceneMsg(scene_msg);
-  out << "<<<|" << std::endl;
+  out << "<<<|" << '\n';
   // TODO(YuYan): implement stream print for the message formats
-  // out << "Motion plan request:" << std::endl << brequest.request << std::endl;
-  // out << "Planning scene: " << std::endl << scene_msg << std::endl << "|>>>" << std::endl;
-  out << "Motion plan request:" << std::endl
-      << "  planner_id: " << brequest.request.planner_id << std::endl
-      << "  group_name: " << brequest.request.group_name << std::endl
-      << "  num_planning_attempts: " << brequest.request.num_planning_attempts << std::endl
-      << "  allowed_planning_time: " << brequest.request.allowed_planning_time << std::endl;
-  out << "Planning scene:" << std::endl
-      << "  scene_name: " << scene_msg.name << std::endl
-      << "  robot_model_name: " << scene_msg.robot_model_name << std::endl
-      << "|>>>" << std::endl;
+  // out << "Motion plan request:" << '\n' << brequest.request << '\n';
+  // out << "Planning scene: " << '\n' << scene_msg << '\n' << "|>>>" << '\n';
+  out << "Motion plan request:" << '\n'
+      << "  planner_id: " << brequest.request.planner_id << '\n'
+      << "  group_name: " << brequest.request.group_name << '\n'
+      << "  num_planning_attempts: " << brequest.request.num_planning_attempts << '\n'
+      << "  allowed_planning_time: " << brequest.request.allowed_planning_time << '\n';
+  out << "Planning scene:" << '\n'
+      << "  scene_name: " << scene_msg.name << '\n'
+      << "  robot_model_name: " << scene_msg.robot_model_name << '\n'
+      << "|>>>" << '\n';
 
   // Not writing optional cpu information
 
   // The real random seed is unknown.  Writing a fake value
-  out << "0 is the random seed" << std::endl;
-  out << brequest.request.allowed_planning_time << " seconds per run" << std::endl;
+  out << "0 is the random seed" << '\n';
+  out << brequest.request.allowed_planning_time << " seconds per run" << '\n';
   // There is no memory cap
-  out << "-1 MB per run" << std::endl;
-  out << options_.getNumRuns() << " runs per planner" << std::endl;
-  out << benchmark_duration << " seconds spent to collect the data" << std::endl;
+  out << "-1 MB per run" << '\n';
+  out << options_.getNumRuns() << " runs per planner" << '\n';
+  out << benchmark_duration << " seconds spent to collect the data" << '\n';
 
   // No enum types
-  out << "0 enum types" << std::endl;
+  out << "0 enum types" << '\n';
 
-  out << num_planners << " planners" << std::endl;
+  out << num_planners << " planners" << '\n';
 
   size_t run_id = 0;
   for (const std::pair<const std::string, std::vector<std::string>>& pipeline : pipelines)
@@ -1154,11 +1154,11 @@ void BenchmarkExecutor::writeOutput(const BenchmarkRequest& brequest, const std:
     for (std::size_t i = 0; i < pipeline.second.size(); ++i, ++run_id)
     {
       // Write the name of the planner and the used pipeline
-      out << pipeline.second[i] << " (" << pipeline.first << ")" << std::endl;
+      out << pipeline.second[i] << " (" << pipeline.first << ")" << '\n';
 
       // in general, we could have properties specific for a planner;
       // right now, we do not include such properties
-      out << "0 common properties" << std::endl;
+      out << "0 common properties" << '\n';
 
       // Create a list of the benchmark properties for this planner
       std::set<std::string> properties_set;
@@ -1168,12 +1168,12 @@ void BenchmarkExecutor::writeOutput(const BenchmarkRequest& brequest, const std:
           properties_set.insert(pit->first);
 
       // Writing property list
-      out << properties_set.size() << " properties for each run" << std::endl;
+      out << properties_set.size() << " properties for each run" << '\n';
       for (const std::string& property : properties_set)
-        out << property << std::endl;
+        out << property << '\n';
 
       // Number of runs
-      out << benchmark_data_[run_id].size() << " runs" << std::endl;
+      out << benchmark_data_[run_id].size() << " runs" << '\n';
 
       // And the benchmark properties
       for (PlannerRunData& planner_run_data : benchmark_data_[run_id])  // each run of this planner
@@ -1187,9 +1187,9 @@ void BenchmarkExecutor::writeOutput(const BenchmarkRequest& brequest, const std:
             out << runit->second;
           out << "; ";
         }
-        out << std::endl;  // end of the run
+        out << '\n';  // end of the run
       }
-      out << "." << std::endl;  // end the planner
+      out << "." << '\n';  // end the planner
     }
   }
 

--- a/moveit_ros/move_group/src/list_capabilities.cpp
+++ b/moveit_ros/move_group/src/list_capabilities.cpp
@@ -45,11 +45,11 @@ int main(int /*argc*/, char** /*argv*/)
     pluginlib::ClassLoader<move_group::MoveGroupCapability> capability_plugin_loader("moveit_ros_move_group",
                                                                                      "move_group::MoveGroupCapability");
     std::cout << "Available capabilities:\n"
-              << boost::algorithm::join(capability_plugin_loader.getDeclaredClasses(), "\n") << std::endl;
+              << boost::algorithm::join(capability_plugin_loader.getDeclaredClasses(), "\n") << '\n';
   }
   catch (pluginlib::PluginlibException& ex)
   {
-    std::cerr << "Exception while creating plugin loader for move_group capabilities: " << ex.what() << std::endl;
+    std::cerr << "Exception while creating plugin loader for move_group capabilities: " << ex.what() << '\n';
   }
 
   return 0;

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -187,13 +187,13 @@ private:
     }
 
     std::stringstream ss;
-    ss << std::endl;
-    ss << std::endl;
-    ss << "********************************************************" << std::endl;
-    ss << "* MoveGroup using: " << std::endl;
+    ss << '\n';
+    ss << '\n';
+    ss << "********************************************************" << '\n';
+    ss << "* MoveGroup using: " << '\n';
     for (const MoveGroupCapabilityPtr& cap : capabilities_)
-      ss << "*     - " << cap->getName() << std::endl;
-    ss << "********************************************************" << std::endl;
+      ss << "*     - " << cap->getName() << '\n';
+    ss << "********************************************************" << '\n';
     RCLCPP_INFO(LOGGER, "%s", ss.str().c_str());
   }
 

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp
@@ -131,7 +131,7 @@ OccupancyMapUpdaterPtr OccupancyMapMonitorMiddlewareHandle::loadOccupancyMapUpda
   catch (pluginlib::PluginlibException& exception)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Exception while loading octomap updater '" << sensor_plugin
-                                                                            << "': " << exception.what() << std::endl);
+                                                                            << "': " << exception.what() << '\n');
   }
   return nullptr;
 }

--- a/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/display_random_state.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
     else if (invalid)
       std::cout << "invalid ";
     std::cout << "states will be randomly generated at an interval of one second and published as a planning scene."
-              << std::endl;
+              << '\n';
     std::size_t n;
     std::cin >> n;
 
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
         } while (!found && attempts < 100);
         if (!found)
         {
-          std::cout << "Unable to find valid state" << std::endl;
+          std::cout << "Unable to find valid state" << '\n';
           continue;
         }
       }
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
         } while (!found && attempts < 100);
         if (!found)
         {
-          std::cout << "Unable to find invalid state" << std::endl;
+          std::cout << "Unable to find invalid state" << '\n';
           continue;
         }
       }
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
       moveit_msgs::msg::PlanningScene psmsg;
       psm.getPlanningScene()->getPlanningSceneMsg(psmsg);
       pub_scene->publish(psmsg);
-      std::cout << psm.getPlanningScene()->getCurrentState() << std::endl;
+      std::cout << psm.getPlanningScene()->getCurrentState() << '\n';
 
       rclcpp::sleep_for(1s);
     }

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help"))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 0;
   }
 
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
     {
       psm.startWorldGeometryMonitor();
       psm.startSceneMonitor();
-      std::cout << "Listening to planning scene updates. Press Enter to continue ..." << std::endl;
+      std::cout << "Listening to planning scene updates. Press Enter to continue ..." << '\n';
       std::cin.get();
     }
     else

--- a/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
@@ -57,8 +57,7 @@ int main(int argc, char** argv)
     psm.startSceneMonitor();
     psm.startStateMonitor();
     auto pub_markers = node->create_publisher<visualization_msgs::msg::MarkerArray>("visualization_marker_array", 10);
-    std::cout << "\nListening for planning scene...\nType the number of spheres to generate and press Enter: "
-              << '\n';
+    std::cout << "\nListening for planning scene...\nType the number of spheres to generate and press Enter: " << '\n';
     int num_spheres;
     std::cin >> num_spheres;
 

--- a/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/visualize_robot_collision_volume.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     psm.startStateMonitor();
     auto pub_markers = node->create_publisher<visualization_msgs::msg::MarkerArray>("visualization_marker_array", 10);
     std::cout << "\nListening for planning scene...\nType the number of spheres to generate and press Enter: "
-              << std::endl;
+              << '\n';
     int num_spheres;
     std::cin >> num_spheres;
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/list.cpp
@@ -53,14 +53,14 @@ int main(int argc, char** argv)
   }
   catch (pluginlib::PluginlibException& ex)
   {
-    std::cout << "Exception while creating class loader " << ex.what() << std::endl;
+    std::cout << "Exception while creating class loader " << ex.what() << '\n';
   }
 
   const std::vector<std::string>& classes = loader->getDeclaredClasses();
-  std::cout << "Available planning request adapter plugins:" << std::endl;
+  std::cout << "Available planning request adapter plugins:" << '\n';
   for (const std::string& adapter_plugin_name : classes)
   {
-    std::cout << " \t " << adapter_plugin_name << std::endl;
+    std::cout << " \t " << adapter_plugin_name << '\n';
     planning_request_adapter::PlanningRequestAdapterConstPtr ad;
     try
     {
@@ -69,11 +69,11 @@ int main(int argc, char** argv)
     catch (pluginlib::PluginlibException& ex)
     {
       std::cout << " \t\t  Exception while planning adapter plugin '" << adapter_plugin_name << "': " << ex.what()
-                << std::endl;
+                << '\n';
     }
     if (ad)
-      std::cout << " \t\t  " << ad->getDescription() << std::endl;
-    std::cout << std::endl << std::endl;
+      std::cout << " \t\t  " << ad->getDescription() << '\n';
+    std::cout << '\n' << '\n';
   }
   rclcpp::shutdown();
   return 0;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -315,10 +315,10 @@ bool TrajectoryExecutionManager::push(const moveit_msgs::msg::RobotTrajectory& t
       ss << "Pushed trajectory for execution using controllers [ ";
       for (const std::string& controller : context->controllers_)
         ss << controller << " ";
-      ss << "]:" << std::endl;
+      ss << "]:" << '\n';
       // TODO: Provide message serialization
       // for (const moveit_msgs::msg::RobotTrajectory& trajectory_part : context->trajectory_parts_)
-      // ss << trajectory_part << std::endl;
+      // ss << trajectory_part << '\n';
       RCLCPP_INFO_STREAM(LOGGER, ss.str());
     }
     trajectories_.push_back(context);
@@ -1170,7 +1170,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
     std::set<std::string>::const_iterator ji;
     for (ji = mi->second.joints_.begin(); ji != mi->second.joints_.end(); ji++)
     {
-      ss2 << "  " << *ji << std::endl;
+      ss2 << "  " << *ji << '\n';
     }
   }
   RCLCPP_ERROR(LOGGER, "Known controllers and their joints:\n%s", ss2.str().c_str());

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_moveit_controller_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_moveit_controller_manager.h
@@ -152,12 +152,12 @@ public:
     for (const std::string& controller : deactivate)
     {
       controllers_[controller] &= ~ACTIVE;
-      std::cout << "Deactivated controller " << controller << std::endl;
+      std::cout << "Deactivated controller " << controller << '\n';
     }
     for (const std::string& controller : activate)
     {
       controllers_[controller] |= ACTIVE;
-      std::cout << "Activated controller " << controller << std::endl;
+      std::cout << "Activated controller " << controller << '\n';
     }
     return true;
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -449,7 +449,7 @@ void MotionPlanningDisplay::displayTable(const std::map<std::string, double>& va
   // the line we want to render
   std::stringstream ss;
   for (const std::pair<const std::string, double>& value : values)
-    ss << boost::format("%-10s %-4.2f") % value.first % value.second << std::endl;
+    ss << boost::format("%-10s %-4.2f") % value.first % value.second << '\n';
 
   if (ss.str().empty())
   {

--- a/moveit_ros/warehouse/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/warehouse/src/broadcast.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help") || (!vm.count("scene") && !vm.count("constraint") && !vm.count("state")))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
   try
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
   }
   catch (...)
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 2;
   }
   // Set up db

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -229,7 +229,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help") || argc == 1)  // show help if no parameters passed
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
   // Set up db

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help"))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
   // Set up db

--- a/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help"))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
   // Set up db
@@ -143,33 +143,33 @@ int main(int argc, char** argv)
       if (!(robot_state_names.empty() && constraint_names.empty()))
       {
         std::ofstream qfout((scene_name + ".queries").c_str());
-        qfout << scene_name << std::endl;
+        qfout << scene_name << '\n';
         if (!robot_state_names.empty())
         {
-          qfout << "start" << std::endl;
-          qfout << robot_state_names.size() << std::endl;
+          qfout << "start" << '\n';
+          qfout << robot_state_names.size() << '\n';
           for (const std::string& robot_state_name : robot_state_names)
           {
             RCLCPP_INFO(LOGGER, "Saving start state %s for scene %s", robot_state_name.c_str(), scene_name.c_str());
-            qfout << robot_state_name << std::endl;
+            qfout << robot_state_name << '\n';
             moveit_warehouse::RobotStateWithMetadata robot_state;
             rss.getRobotState(robot_state, robot_state_name);
             moveit::core::RobotState ks(km);
             moveit::core::robotStateMsgToRobotState(*robot_state, ks, false);
             ks.printStateInfo(qfout);
-            qfout << "." << std::endl;
+            qfout << "." << '\n';
           }
         }
 
         if (!constraint_names.empty())
         {
-          qfout << "goal" << std::endl;
-          qfout << constraint_names.size() << std::endl;
+          qfout << "goal" << '\n';
+          qfout << constraint_names.size() << '\n';
           for (const std::string& constraint_name : constraint_names)
           {
             RCLCPP_INFO(LOGGER, "Saving goal %s for scene %s", constraint_name.c_str(), scene_name.c_str());
-            qfout << "link_constraint" << std::endl;
-            qfout << constraint_name << std::endl;
+            qfout << "link_constraint" << '\n';
+            qfout << constraint_name << '\n';
             moveit_warehouse::ConstraintsWithMetadata constraints;
             cs.getConstraints(constraints, constraint_name);
 
@@ -179,13 +179,13 @@ int main(int argc, char** argv)
             {
               std::string link_name = iter.first;
               LinkConstraintPair lcp = iter.second;
-              qfout << link_name << std::endl;
-              qfout << "xyz " << lcp.first.x << " " << lcp.first.y << " " << lcp.first.z << std::endl;
+              qfout << link_name << '\n';
+              qfout << "xyz " << lcp.first.x << " " << lcp.first.y << " " << lcp.first.z << '\n';
               Eigen::Quaterniond orientation(lcp.second.w, lcp.second.x, lcp.second.y, lcp.second.z);
               Eigen::Vector3d rpy = orientation.matrix().eulerAngles(0, 1, 2);
-              qfout << "rpy " << rpy[0] << " " << rpy[1] << " " << rpy[2] << std::endl;
+              qfout << "rpy " << rpy[0] << " " << rpy[1] << " " << rpy[2] << '\n';
             }
-            qfout << "." << std::endl;
+            qfout << "." << '\n';
           }
         }
         qfout.close();

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
 
   if (vm.count("help"))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
   // Set up db

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
 
   if (vm.count("help"))
   {
-    std::cout << desc << std::endl;
+    std::cout << desc << '\n';
     return 1;
   }
 

--- a/moveit_setup_assistant/src/setup_assistant_main.cpp
+++ b/moveit_setup_assistant/src/setup_assistant_main.cpp
@@ -49,7 +49,7 @@ static void siginthandler(int /*param*/)
 
 void usage(boost::program_options::options_description& desc, int exit_code)
 {
-  std::cout << desc << std::endl;
+  std::cout << desc << '\n';
   exit(exit_code);
 }
 
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
   }
   catch (const std::exception& e)
   {
-    std::cerr << e.what() << std::endl;
+    std::cerr << e.what() << '\n';
     usage(desc, 1);
   }
   // Start ROS Node

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -274,7 +274,7 @@ bool MoveItConfigData::outputOMPLPlanningYAML(const std::string& file_path)
     return false;
   }
 
-  output_stream << emitter.c_str() << std::endl;
+  output_stream << emitter.c_str() << '\n';
   output_stream.close();
 
   return true;  // file created successfully

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1117,7 +1117,7 @@ void ConfigurationFilesWidget::loadTemplateStrings()
   {
     const srdf::Model::VirtualJoint& vj = config_data_->srdf_->virtual_joints_[i];
     vjb << "  <node pkg=\"tf2_ros\" type=\"static_transform_publisher\" name=\"virtual_joint_broadcaster_" << i
-        << "\" args=\"0 0 0 0 0 0 " << vj.parent_frame_ << " " << vj.child_link_ << "\" />" << std::endl;
+        << "\" args=\"0 0 0 0 0 0 " << vj.parent_frame_ << " " << vj.child_link_ << "\" />" << '\n';
   }
   addTemplateString("[VIRTUAL_JOINT_BROADCASTER]", vjb.str());
 


### PR DESCRIPTION
As described in PR #875, as a solution to the good first issue, this PR removes `std::endl` in all the code files in `moveit2` repo and replaces them with `'\n'`. As mentioned [here](https://github.com/cpp-best-practices/cppbestpractices/blob/master/08-Considering_Performance.md#get-rid-of-stdendl), removing `std::endl` is considered to be a better code practice as it improves performance. More information of when to use `std::endl` and when not to use, can be found [here](https://accu.org/journals/overload/27/149/sharpe_2619/)
