### PR TITLE
[foxy] Link boost serializaiton

### DIFF
--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -42,6 +42,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   OMPL
   Boost
 )
+target_link_libraries(${MOVEIT_LIB_NAME} Boost::serialization)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 


### PR DESCRIPTION
Closes #923. Somehow CI wasn't able to catch this (I'm assuming it was caching that part), but docker action caught this as well (https://github.com/ros-planning/moveit2/runs/4523535433?check_suite_focus=true). This PR just adds a one linn to properly link boost_serialization library in `ompl_interface`. Tested by building the docker locally. I am not sure why we haven't seen this in main though.