### PR TITLE
Depend on released versions of ros2_control

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -20,11 +20,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/warehouse_ros_mongo
     version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control
-    version: 1.1.0
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: 1.1.0


### PR DESCRIPTION
### Description

ros2_control and ros2_controllers should be released and synced for rolling and galactic.  We should be able to stop building them from source in our CI system.

@vatanaksoytezer this should fix the latest rolling issue that ros2_control has blocking our CI.  As they've released into rolling I don't forsee us adding it back into the repos file after this unless we work on a feature with them we depend on.