### PR TITLE
Add codespell to precommit, fix A LOT of spelling mistakes

### DIFF
--- a/.codespell_words
+++ b/.codespell_words
@@ -1,0 +1,15 @@
+ang
+ans
+atleast
+ba
+dof
+dur
+iff
+keyserver
+nto
+ot
+parameterizes
+planed
+tork
+uint
+whis

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
-      - name: Login to Github Containter Registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
-      - name: Login to Github Containter Registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
-      - name: Login to Github Containter Registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to Github Containter Registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,9 @@ repos:
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+      - id: codespell
+        args: ['--write-changes', '--ignore-words=.codespell_words']
+        exclude: CHANGELOG.rst

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -37,7 +37,7 @@ API changes in MoveIt releases
 
 - Migration to ``tf2`` API.
 - Replaced Eigen::Affine3d with Eigen::Isometry3d, which is computationally more efficient.
-  Simply find-replace occurences of Affine3d:
+  Simply find-replace occurrences of Affine3d:
   ``find . -iname "*.[hc]*" -print0 | xargs -0 sed -i 's#Affine3#Isometry3#g'``
 - The move_group capability ``ExecuteTrajectoryServiceCapability`` has been removed in favor of the improved ``ExecuteTrajectoryActionCapability`` capability. Since Indigo, both capabilities were supported. If you still load default capabilities in your ``config/launch/move_group.launch``, you can just remove them from the capabilities parameter. The correct default capabilities will be loaded automatically.
 - Deprecated method ``CurrentStateMonitor::waitForCurrentState(double wait_time)`` was finally removed.

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -474,7 +474,7 @@ class MoveGroupCommander(object):
         return self._g.get_known_constraints()
 
     def get_path_constraints(self):
-        """ Get the acutal path constraints in form of a moveit_msgs.msgs.Constraints """
+        """ Get the actual path constraints in form of a moveit_msgs.msgs.Constraints """
         c = Constraints()
         c_str = self._g.get_path_constraints()
         conversions.msg_from_string(c, c_str)
@@ -687,7 +687,7 @@ class MoveGroupCommander(object):
             return self._g.async_execute(conversions.msg_to_string(plan_msg))
 
     def attach_object(self, object_name, link_name="", touch_links=[]):
-        """ Given the name of an object existing in the planning scene, attach it to a link. The link used is specified by the second argument. If left unspecified, the end-effector link is used, if one is known. If there is no end-effector link, the first link in the group is used. If no link is identified, failure is reported. True is returned if an attach request was succesfully sent to the move_group node. This does not verify that the attach request also was successfuly applied by move_group."""
+        """ Given the name of an object existing in the planning scene, attach it to a link. The link used is specified by the second argument. If left unspecified, the end-effector link is used, if one is known. If there is no end-effector link, the first link in the group is used. If no link is identified, failure is reported. True is returned if an attach request was successfully sent to the move_group node. This does not verify that the attach request also was successfully applied by move_group."""
         return self._g.attach_object(object_name, link_name, touch_links)
 
     def detach_object(self, name=""):

--- a/moveit_commander/src/moveit_commander/robot.py
+++ b/moveit_commander/src/moveit_commander/robot.py
@@ -168,7 +168,7 @@ class RobotCommander(object):
         """Get a MarkerArray of the markers that make up this robot
 
         Usage:
-            (): get's all markers for current state
+            (): gets all markers for current state
             state (RobotState): gets markers for a particular state
             values (dict): get markers with given values
             values, links (dict, list): get markers with given values and these links

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -97,8 +97,8 @@ struct Contact
 
   /** \brief The distance percentage between casted poses until collision.
    *
-   *  If the value is 0, then the collision occured in the start pose. If the value is 1, then the collision occured in
-   *  the end pose. */
+   *  If the value is 0, then the collision occurred in the start pose. If the value is 1, then the collision occurred
+   * in the end pose. */
   double percent_interpolation;
 
   /** \brief The two nearest points connecting the two bodies */
@@ -115,7 +115,7 @@ struct CostSource
   /// The maximum bound of the AABB defining the volume responsible for this partial cost
   boost::array<double, 3> aabb_max;
 
-  /// The partial cost (the probability of existance for the object there is a collision with)
+  /// The partial cost (the probability of existence for the object there is a collision with)
   double cost;
 
   /// Get the volume of the AABB around the cost source

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -178,7 +178,7 @@ TEST(World, AddRemoveShape)
     EXPECT_FALSE(world.hasObject("mix1"));
     EXPECT_TRUE(world.hasObject("ball2"));
 
-    // ask for nonexistant object
+    // ask for nonexistent object
     collision_detection::World::ObjectConstPtr obj3 = world.getObject("abc");
     EXPECT_FALSE(obj3);
   }

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_bvh_manager.h
@@ -78,7 +78,7 @@ public:
 
   /**@brief Set a single static collision object's tansform
    * @param name The name of the object
-   * @param pose The tranformation in world */
+   * @param pose The transformation in world */
   void setCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d& pose);
 
   /**@brief Set which collision objects are active
@@ -139,7 +139,7 @@ protected:
   /** @brief The contact distance threshold */
   double contact_distance_;
 
-  /** @brief The bullet collision dispatcher used for getting object to object collison algorithm */
+  /** @brief The bullet collision dispatcher used for getting object to object collision algorithm */
   std::unique_ptr<btCollisionDispatcher> dispatcher_;
 
   /** @brief The bullet collision dispatcher configuration information */

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h
@@ -62,8 +62,8 @@ public:
    * This should only be used for moving objects.
    *
    * @param name The name of the object
-   * @param pose1 The start tranformation in world
-   * @param pose2 The end tranformation in world */
+   * @param pose1 The start transformation in world
+   * @param pose2 The end transformation in world */
   void setCastCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d& pose1,
                                         const Eigen::Isometry3d& pose2);
 

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h
@@ -41,7 +41,7 @@ namespace collision_detection_bullet
 {
 MOVEIT_CLASS_FORWARD(BulletDiscreteBVHManager);
 
-/** @brief A bounding volume hierarchy (BVH) implementaiton of a discrete bullet manager */
+/** @brief A bounding volume hierarchy (BVH) implementation of a discrete bullet manager */
 class BulletDiscreteBVHManager : public BulletBVHManager
 {
 public:

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -176,7 +176,7 @@ public:
     aabb_max += contact_threshold;
   }
 
-  /** @brief Clones the collision objects but not the collision shape wich is const.
+  /** @brief Clones the collision objects but not the collision shape which is const.
    *  @return Shared Pointer to the cloned collision object */
   std::shared_ptr<CollisionObjectWrapper> clone()
   {
@@ -220,7 +220,7 @@ protected:
 
   collision_detection::BodyType m_type_id;
 
-  /** @brief The shapes that define the collison object */
+  /** @brief The shapes that define the collision object */
   std::vector<shapes::ShapeConstPtr> m_shapes;
 
   /** @brief The poses of the shapes, must be same length as m_shapes */
@@ -235,7 +235,7 @@ protected:
 
 /** @brief Casted collision shape used for checking if an object is collision free between two discrete poses
  *
- *  The cast is not explicitely computed but implicitely represented through the single shape and the transformation
+ *  The cast is not explicitly computed but implicitly represented through the single shape and the transformation
  *  between the first and second pose. */
 struct CastHullShape : public btConvexShape
 {

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
@@ -68,7 +68,7 @@ collision_detection::Contact* processResult(ContactTestData& cdata, collision_de
  *                units towards the center along its normal).
  * @param (input) shrinkClamp If positive, "shrink" is clamped to not exceed "shrinkClamp * innerRadius", where
  *                "innerRadius" is the minimum distance of a face to the center of the convex hull.
- * @return The number of faces. If less than zero an error occured when trying to create the convex hull
+ * @return The number of faces. If less than zero an error occurred when trying to create the convex hull
  */
 int createConvexHull(AlignedVector<Eigen::Vector3d>& vertices, std::vector<int>& faces,
                      const AlignedVector<Eigen::Vector3d>& input, double shrink = -1, double shrinkClamp = -1);

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_cast_bvh_manager.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_cast_bvh_manager.cpp
@@ -78,7 +78,7 @@ void BulletCastBVHManager::setCastCollisionObjectsTransform(const std::string& n
     cow->setWorldTransform(tf1);
     link2cow_[name]->setWorldTransform(tf1);
 
-    // If collision object is disabled dont proceed
+    // If collision object is disabled don't proceed
     if (cow->m_enabled)
     {
       if (btBroadphaseProxy::isConvex(cow->getCollisionShape()->getShapeType()))

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/contact_checker_common.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/contact_checker_common.cpp
@@ -62,7 +62,7 @@ collision_detection::Contact* processResult(ContactTestData& cdata, collision_de
 
     std::vector<collision_detection::Contact> data;
 
-    // if we dont want contacts we are done here
+    // if we don't want contacts we are done here
     if (!cdata.req.contacts)
     {
       if (!cdata.req.distance)

--- a/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
+++ b/moveit_core/collision_detection_bullet/test/test_bullet_continuous_collision_checking.cpp
@@ -262,7 +262,7 @@ TEST_F(BulletCollisionDetectionTester, DISABLED_ContinuousCollisionSelf)
   ASSERT_FALSE(res.collision);
   res.clear();
 
-  RCLCPP_INFO(TEST_LOGGER, "Continous to continous collisions are not supported yet, therefore fail here.");
+  RCLCPP_INFO(TEST_LOGGER, "Continuous to continuous collisions are not supported yet, therefore fail here.");
   ASSERT_TRUE(res.collision);
   res.clear();
 }

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -130,7 +130,7 @@ protected:
    *   state and specifying a broadphase collision manager of FCL where the constructed object is registered to. */
   void allocSelfCollisionBroadPhase(const moveit::core::RobotState& state, FCLManager& manager) const;
 
-  /** \brief Converts all shapes which make up an atttached body into a vector of FCLGeometryConstPtr.
+  /** \brief Converts all shapes which make up an attached body into a vector of FCLGeometryConstPtr.
    *
    *   When they are converted, they can be added to the FCL representation of the robot for collision checking.
    *

--- a/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
@@ -262,7 +262,7 @@ TEST_F(CollisionDetectionEnvTest, DISABLED_ContinuousCollisionSelf)
   res.clear();
 
   // c_env_->checkSelfCollision(req, res, state1, state2, *acm_);
-  RCLCPP_INFO(LOGGER, "Continous to continous collisions are not supported yet, therefore fail here.");
+  RCLCPP_INFO(LOGGER, "Continuous to continuous collisions are not supported yet, therefore fail here.");
   ASSERT_TRUE(res.collision);
   res.clear();
 }

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -182,7 +182,7 @@ public:
    * calculation
    * @param tolerance
    * @param subtract_radii distance to the sphere centers will be computed by
-   * substracting the sphere radius from the nearest point
+   * subtracting the sphere radius from the nearest point
    * @param maximum_value
    * @param stop_at_first_collision when true the computation is terminated when
    * the first collision is found
@@ -197,7 +197,7 @@ protected:
 };
 
 // determines set of collision spheres given a posed body; this is BAD!
-// Allocation erorrs will happen; change this function so it does not return
+// Allocation errors will happen; change this function so it does not return
 // that vector by value
 std::vector<CollisionSphere> determineCollisionSpheres(const bodies::Body* body, Eigen::Isometry3d& relativeTransform);
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -147,7 +147,7 @@ public:
    * @param [in] reference_state Reference kinematic state that will be passed through to samplers
    * @param [in] max_attempts Max attempts, which will be passed through to samplers
    *
-   * @return True if all invidual samplers return true
+   * @return True if all individual samplers return true
    */
   bool sample(moveit::core::RobotState& state, const moveit::core::RobotState& reference_state,
               unsigned int max_attempts) override;

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -194,7 +194,7 @@ public:
   /** \brief Get the list of active controllers.
    *
    * If there is only one controller in the system, this will be active.  When multiple controllers exist,
-   * and they operate on overlaping sets of joints, not all controllers should be active at the same time. */
+   * and they operate on overlapping sets of joints, not all controllers should be active at the same time. */
   virtual void getActiveControllers(std::vector<std::string>& names) = 0;
 
   /** \brief Report the joints a controller operates on, given the controller name.

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -146,7 +146,7 @@ public:
    * position does not overlap with the new object position, then it
    * may be more efficient to call \ref removePointsFromField on the
    * old points and \ref addPointsToField on the new points.  If the
-   * object has moved only slighly, however, this function may offer a
+   * object has moved only slightly, however, this function may offer a
    * speed improvement.  All points in the old_points set should have
    * been previously added to the field in order for this function to
    * act as intended - points that are in both the old_points set and
@@ -473,7 +473,7 @@ public:
    * @param [in] height The height of the plane to show.  If the type
    * is XY, it's interpreted along the Z axis.  If the type is XZ,
    * it's interpreted along the Y axis.  If the type is YZ, it's
-   * interpeted along the X axis.
+   * interpreted along the X axis.
 
    * @param [in] origin The minimum point along each axis to display
    * @param [in] frame_id The frame to use as the header in the marker
@@ -583,7 +583,7 @@ public:
    * \brief Gets a distance value for an invalid cell.
    *
    *
-   * @return The distance associated with an unitialized cell
+   * @return The distance associated with an uninitialized cell
    */
   virtual double getUninitializedDistance() const = 0;
 

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -105,7 +105,7 @@ struct PropDistanceFieldVoxel
   int negative_update_direction_; /**< \brief Direction from which this voxel was updated  for negative distance
                                      propagation*/
 
-  static const int UNINITIALIZED = -1; /**< \brief Value that represents an unitialized voxel */
+  static const int UNINITIALIZED = -1; /**< \brief Value that represents an uninitialized voxel */
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
@@ -121,7 +121,7 @@ struct PropDistanceFieldVoxel
  * This class uses a \ref VoxelGrid to hold all data.  One important
  * decision that must be made on construction is whether or not to
  * create a signed version of the distance field.  If the distance
- * field is unsigned, it means that the minumum obstacle distance is
+ * field is unsigned, it means that the minimum obstacle distance is
  * 0, a value that will be assigned to all obstacle cells.  Gradient
  * queries for obstacle cells will not give useful information, as the
  * gradient at an obstacle cell will point to the cell itself.  If

--- a/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
@@ -72,7 +72,7 @@ public:
    * assume that the units are meters.  The size of the the volume is
    * given along each of the X, Y, and Z axes.  The volume begins at
    * the minimum point in each dimension, as specified by the origin
-   * parameters.  The data structure will remain unintialized until
+   * parameters.  The data structure will remain uninitialized until
    * the \ref VoxelGrid::reset function is called.
    *
    * @param [in] size_x Size of the X axis in meters
@@ -206,7 +206,7 @@ public:
   double getResolution(Dimension dim) const;
 
   /**
-   * \brief Gets the origin (miniumum point) of the indicated dimension
+   * \brief Gets the origin (minimum point) of the indicated dimension
    *
    * @param [in] dim The dimension for the query
    *
@@ -292,7 +292,7 @@ protected:
   double size_[3];         /**< \brief The size of each dimension in meters (in Dimension order) */
   double resolution_;      /**< \brief The resolution of each dimension in meters (in Dimension order) */
   double oo_resolution_;   /**< \brief 1.0/resolution_ */
-  double origin_[3];       /**< \brief The origin (minumum point) of each dimension in meters (in Dimension order) */
+  double origin_[3];       /**< \brief The origin (minimum point) of each dimension in meters (in Dimension order) */
   double origin_minus_[3]; /**< \brief origin - 0.5/resolution */
   int num_cells_[3];       /**< \brief The number of cells in each dimension (in Dimension order) */
   int num_cells_total_;    /**< \brief The total number of voxels in the grid */

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -267,7 +267,7 @@ void PropagationDistanceField::addNewObstacleVoxels(const EigenSTL::vector_Vecto
           // our closest non-obstacle cell has become an obstacle
           if (closest_point_voxel.negative_distance_square_ != 0)
           {
-            // find all neigbors inside pre-existing obstacles whose
+            // find all neighbors inside pre-existing obstacles whose
             // closest_negative_point_ is now an obstacle.  These must all be
             // set to max_distance_sq_ so they will be re-propogated with a new
             // closest_negative_point_ that is outside the obstacle.
@@ -282,7 +282,7 @@ void PropagationDistanceField::addNewObstacleVoxels(const EigenSTL::vector_Vecto
           }
           else
           {
-            // this cell still has a valid non-obstacle cell, so we need to propogate from it
+            // this cell still has a valid non-obstacle cell, so we need to propagate from it
             nvoxel.negative_update_direction_ = initial_update_direction;
             negative_bucket_queue_[0].push_back(nloc);
           }

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -185,7 +185,7 @@ MOVEIT_CLASS_FORWARD(JointConstraint);  // Defines JointConstraintPtr, ConstPtr,
  *
  * This class handles single DOF constraints expressed as a tolerance
  * above and below a target position.  Multi-DOF joints can be
- * accomodated by using local name formulations - i.e. for a planar
+ * accommodated by using local name formulations - i.e. for a planar
  * joint specifying a constraint in terms of "planar_joint_name"/x.
  *
  * Continuous revolute single DOF joints will be evaluated based on
@@ -729,7 +729,7 @@ MOVEIT_CLASS_FORWARD(VisibilityConstraint);  // Defines VisibilityConstraintPtr,
  * and the target along its Z axis to be pointing at each other.
  * Practically speaking, this ensures that the sensor has sufficient
  * visibility to the front of the target - if the target is pointing
- * the opposite direction, or is too steeply perpindicular to the
+ * the opposite direction, or is too steeply perpendicular to the
  * target, then the max_view_angle part of the constraint will be
  * violated.  The getMarkers function can again help explain this -
  * the view angle is the angular difference between the blue arrow
@@ -738,7 +738,7 @@ MOVEIT_CLASS_FORWARD(VisibilityConstraint);  // Defines VisibilityConstraintPtr,
 
  * \image html exact_opposites.png "Max view angle is evaluated at 0.0"
  * \image html fourty_five.png "Max view angle evaluates around pi/4"
- * \image html perpindicular.png "Max view angle evaluates at pi/2, the maximum"
+ * \image html perpendicular.png "Max view angle evaluates at pi/2, the maximum"
  * \image html other_side.png "Sensor pointed at wrong side of target, will violate constraint as long as max_view_angle
  > 0.0"
  *

--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -217,7 +217,7 @@ TEST_F(LoadPlanningModelsPr2, JointConstraintsCont)
   robot_state.setVariablePositions(jvals);
   EXPECT_TRUE(jc.decide(robot_state).satisfied);
 
-  // ouside the below tolerance
+  // outside the below tolerance
   jvals[jcm.joint_name] = -.03;
   robot_state.setVariablePositions(jvals);
   EXPECT_FALSE(jc.decide(robot_state).satisfied);
@@ -850,7 +850,7 @@ TEST_F(LoadPlanningModelsPr2, TestKinematicConstraintSet)
   jcv.back().joint_name = "no_joint";
   EXPECT_FALSE(kcs.add(jcv));
 
-  // but we can still evaluate it succesfully for the remaining constraint
+  // but we can still evaluate it successfully for the remaining constraint
   EXPECT_TRUE(kcs.decide(robot_state).satisfied);
 
   // violating the remaining good constraint changes this

--- a/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_orientation_constraints.cpp
@@ -456,7 +456,7 @@ TEST_F(FloatingJointRobot, OrientationConstraintsParameterization)
     EXPECT_TRUE(oc_rotvec.decide(robot_state).satisfied);
   }
 
-  // and now some simple test cases where whe change the nominal orientation of the constraints,
+  // and now some simple test cases where we change the nominal orientation of the constraints,
   // instead of changing the orientation of the robot
   robot_state.setToDefaultValues();
   robot_state.update();

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -51,7 +51,7 @@ ButterworthFilter::ButterworthFilter(double low_pass_filter_coeff)
   , scale_term_(1. / (1. + low_pass_filter_coeff))
   , feedback_term_(1. - low_pass_filter_coeff)
 {
-  // guarantee this doesn't change because the logic below depends on this length implicity
+  // guarantee this doesn't change because the logic below depends on this length implicitly
   static_assert(ButterworthFilter::FILTER_LENGTH == 2,
                 "online_signal_smoothing::ButterworthFilter::FILTER_LENGTH should be 2");
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -133,7 +133,7 @@ public:
    * has the diffs specified by \e msg applied. */
   PlanningScenePtr diff(const moveit_msgs::msg::PlanningScene& msg) const;
 
-  /** \brief Get the parent scene (whith respect to which the diffs are maintained). This may be empty */
+  /** \brief Get the parent scene (with respect to which the diffs are maintained). This may be empty */
   const PlanningSceneConstPtr& getParent() const
   {
     return parent_;

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -636,7 +636,7 @@ protected:
 
   /** \brief The group includes all the joint variables that make up the joints the group consists of.
       This map gives the position in the state vector of the group for each of these variables.
-      Additionaly, it includes the names of the joints and the index for the first variable of that joint. */
+      Additionally, it includes the names of the joints and the index for the first variable of that joint. */
   VariableIndexMap joint_variables_index_map_;
 
   /** \brief The bounds for all the active joint models */

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -545,7 +545,7 @@ protected:
 
   std::vector<const JointModel*> multi_dof_joints_;
 
-  /** \brief For every two joints, the index of the common root for thw joints is stored.
+  /** \brief For every two joints, the index of the common root for the joints is stored.
 
       for jointA, jointB
       the index of the common root is located in the array at location
@@ -565,7 +565,7 @@ protected:
 
   /** \brief The state includes all the joint variables that make up the joints the state consists of.
       This map gives the position in the state vector of the group for each of these variables.
-      Additionaly, it includes the names of the joints and the index for the first variable of that joint. */
+      Additionally, it includes the names of the joints and the index for the first variable of that joint. */
   VariableIndexMap joint_variables_index_map_;
 
   std::vector<int> active_joint_model_start_index_;

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -66,7 +66,7 @@ std::string JointModel::getTypeName() const
   switch (type_)
   {
     case UNKNOWN:
-      return "Unkown";
+      return "Unknown";
     case REVOLUTE:
       return "Revolute";
     case PRISMATIC:
@@ -78,7 +78,7 @@ std::string JointModel::getTypeName() const
     case FIXED:
       return "Fixed";
     default:
-      return "[Unkown]";
+      return "[Unknown]";
   }
 }
 

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -153,7 +153,7 @@ public:
 
      In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
      reached for the origin of a robot link (\e link). The waypoints are transforms given either in a global reference
-     frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move
+     frame or in the local reference frame of the link at the immediately preceding waypoint. The link needs to move
      in a straight line between two consecutive waypoints. All other comments apply. */
   static double
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,

--- a/moveit_core/robot_state/include/moveit/robot_state/conversions.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/conversions.h
@@ -113,7 +113,7 @@ bool jointTrajPointToRobotState(const trajectory_msgs::msg::JointTrajectory& tra
  * @param state - The input MoveIt robot state object
  * @param out - a file stream, or any other stream
  * @param include_header - flag to prefix the output with a line of joint names.
- * @param separator - allows to override the comma seperator with any symbol, such as a white space
+ * @param separator - allows to override the comma separator with any symbol, such as a white space
  */
 void robotStateToStream(const RobotState& state, std::ostream& out, bool include_header = true,
                         const std::string& separator = ",");
@@ -125,7 +125,7 @@ void robotStateToStream(const RobotState& state, std::ostream& out, bool include
  * @param out - a file stream, or any other stream
  * @param joint_group_ordering - output joints based on ordering of joint groups
  * @param include_header - flag to prefix the output with a line of joint names.
- * @param separator - allows to override the comma seperator with any symbol, such as a white space
+ * @param separator - allows to override the comma separator with any symbol, such as a white space
  */
 void robotStateToStream(const RobotState& state, std::ostream& out,
                         const std::vector<std::string>& joint_groups_ordering, bool include_header = true,
@@ -135,7 +135,7 @@ void robotStateToStream(const RobotState& state, std::ostream& out,
  * \brief Convert a string of joint values from a file (CSV) or input source into a RobotState
  * @param state - the output MoveIt robot state object
  * @param line - the input string of joint values
- * @param separator - allows to override the comma seperator with any symbol, such as a white space
+ * @param separator - allows to override the comma separator with any symbol, such as a white space
  * \return true on success
  */
 void streamToRobotState(RobotState& state, const std::string& line, const std::string& separator = ",");

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1120,7 +1120,7 @@ public:
 
      In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
      reached for the origin of a robot link (\e link). The waypoints are transforms given either in a global reference
-     frame or in the local reference frame of the link at the immediately preceeding waypoint. The link needs to move
+     frame or in the local reference frame of the link at the immediately preceding waypoint. The link needs to move
      in a straight line between two consecutive waypoints. All other comments apply.
 
      NOTE: As of ROS-Melodic these are deprecated and should not be used
@@ -1286,7 +1286,7 @@ public:
    */
 
   /** \brief Update the transforms for the collision bodies. This call is needed before calling collision checking.
-      If updating link transforms or joint transorms is needed, the corresponding updates are also triggered. */
+      If updating link transforms or joint transforms is needed, the corresponding updates are also triggered. */
   void updateCollisionBodyTransforms();
 
   /** \brief Update the reference frame transforms for links. This call is needed before using the transforms of links

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -290,7 +290,7 @@ public:
   RobotTrajectory& unwind();
   RobotTrajectory& unwind(const moveit::core::RobotState& state);
 
-  /** @brief Finds the waypoint indicies before and after a duration from start.
+  /** @brief Finds the waypoint indices before and after a duration from start.
    *  @param The duration from start.
    *  @param The waypoint index before the supplied duration.
    *  @param The waypoint index after (or equal to) the supplied duration.

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -455,7 +455,7 @@ void RobotTrajectory::findWayPointIndicesForDurationAfterStart(const double& dur
     return;
   }
 
-  // Find indicies
+  // Find indices
   std::size_t index = 0, num_points = waypoints_.size();
   double running_duration = 0.0;
   for (; index < num_points; ++index)

--- a/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
+++ b/moveit_core/sensor_manager/include/moveit/sensor_manager/sensor_manager.h
@@ -57,7 +57,7 @@ struct SensorInfo
 
   /* Define the frustum (or approximation of the frustum) */
 
-  /// The minumum distance along the Z axis at which observations start
+  /// The minimum distance along the Z axis at which observations start
   double min_dist;
 
   /// The maximum distance along the Z axis at which observations can be
@@ -99,7 +99,7 @@ public:
   /// it may or may not execute that trajectory.
   /// If it does not, it returns it as part of \e sensor_trajectory. This is the recommended behaviour, since the caller
   /// of this function can perform checks on the safety of the trajectory.
-  /// The function returns true on success (either completing execution succesfully or computing a trajecotory
+  /// The function returns true on success (either completing execution successfully or computing a trajecotory
   /// successufully)
   virtual bool pointSensorTo(const std::string& name, const geometry_msgs::msg::PointStamped& target,
                              moveit_msgs::msg::RobotTrajectory& sensor_trajectory) = 0;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -373,7 +373,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
 
   This matrix is tridiagonal, which can be solved solved in O(N) time
   using the tridiagonal algorithm.
-  There is a forward propogation pass followed by a backsubstitution pass.
+  There is a forward propagation pass followed by a backsubstitution pass.
 
   n is the number of points
   dt contains the time difference between each point (size=n-1)

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -342,7 +342,7 @@ void IterativeParabolicTimeParameterization::applyAccelerationConstraints(
     iteration++;
 
     // In this case we iterate through the joints on the outer loop.
-    // This is so that any time interval increases have a chance to get propogated through the trajectory
+    // This is so that any time interval increases have a chance to get propagated through the trajectory
     for (unsigned int j = 0; j < num_joints; ++j)
     {
       // Loop forwards, then backwards

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -151,7 +151,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
         for (size_t joint = 0; joint < num_dof; ++joint)
         {
           ruckig_input.target_velocity.at(joint) *= 0.9;
-          // Propogate the change in velocity to acceleration, too.
+          // Propagate the change in velocity to acceleration, too.
           // We don't change the position to ensure the exact target position is achieved.
           ruckig_input.target_acceleration.at(joint) =
               (ruckig_input.target_velocity.at(joint) - ruckig_output.new_velocity.at(joint)) / timestep;

--- a/moveit_core/utils/include/moveit/utils/lexical_casts.h
+++ b/moveit_core/utils/include/moveit/utils/lexical_casts.h
@@ -39,7 +39,7 @@
 /** \file lexical_casts.h
  *  \brief locale-agnostic conversion functions from floating point numbers to strings
  *
- *  Depending on the system locale, a different decimal seperator might be used
+ *  Depending on the system locale, a different decimal separator might be used
  *  for floating point numbers. This is often not wanted for internal (ie non-user
  *  facing) purposes. This module provides conversion functions that use std::locale::classic()
  *  (i.e. the default if no locale is set on the system).

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -100,7 +100,7 @@ public:
    *  @param solver An instance of a kinematics solver
    *  @param kinematic_model An instance of a kinematic model
    *  @param opt Parameters needed for defining the cache workspace
-   *  @return False if any error occured during initialization
+   *  @return False if any error occurred during initialization
    */
   bool initialize(kinematics::KinematicsBaseConstPtr& solver,
                   const planning_models::RobotModelConstPtr& kinematic_model, const KinematicsCache::Options& opt);

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/src/kinematics_cache.cpp
@@ -137,7 +137,7 @@ bool KinematicsCache::addToCache(const geometry_msgs::Pose& pose, const std::vec
   unsigned int start_index = getSolutionLocation(grid_index, num_solutions);
   for (unsigned int i = 0; i < joint_values.size(); ++i)
   {
-    //    ROS_INFO("Joint value[%d]: %f, localtion: %d",i,joint_values[i],start_index+i);
+    //    ROS_INFO("Joint value[%d]: %f, location: %d",i,joint_values[i],start_index+i);
     kinematics_cache_vector_[start_index + i] = joint_values[i];
   }
   if (num_solutions_vector_[grid_index] < max_solutions_per_grid_location_)

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -100,7 +100,7 @@ public:
    *  @param solver An instance of a kinematics solver
    *  @param kinematic_model An instance of a kinematic model
    *  @param opt Parameters needed for defining the cache workspace
-   *  @return False if any error occured during initialization
+   *  @return False if any error occurred during initialization
    */
   bool initialize(kinematics::KinematicsBaseConstPtr& solver, const moveit::core::RobotModelConstPtr& kinematic_model,
                   const KinematicsCache::Options& opt);

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/src/kinematics_cache.cpp
@@ -141,7 +141,7 @@ bool KinematicsCache::addToCache(const geometry_msgs::Pose& pose, const std::vec
   unsigned int start_index = getSolutionLocation(grid_index, num_solutions);
   for (unsigned int i = 0; i < joint_values.size(); ++i)
   {
-    //    ROS_INFO("Joint value[%d]: %f, localtion: %d",i,joint_values[i],start_index+i);
+    //    ROS_INFO("Joint value[%d]: %f, location: %d",i,joint_values[i],start_index+i);
     kinematics_cache_vector_[start_index + i] = joint_values[i];
   }
   if (num_solutions_vector_[grid_index] < max_solutions_per_grid_location_)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -376,7 +376,7 @@ private:
    * @brief  Transforms the input pose to the correct frame for the solver. This assumes that the group includes the
    * entire solver chain and that any joints outside of the solver chain within the group are are fixed.
    * @param  ik_pose             The pose to be transformed which should be in the correct frame for the group.
-   * @param  ik_pose_chain       The ik_pose to be populated with the apropriate pose for the solver
+   * @param  ik_pose_chain       The ik_pose to be populated with the appropriate pose for the solver
    */
   void transformToChainFrame(const geometry_msgs::msg::Pose& ik_pose, KDL::Frame& ik_pose_chain) const;
 };  // end class
@@ -964,7 +964,7 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose& ik
   vfree[0] = initial_guess;
 
   // -------------------------------------------------------------------------------------------------
-  // Handle consitency limits if needed
+  // Handle consistency limits if needed
   int num_positive_increments;
   int num_negative_increments;
   double search_discretization = redundant_joint_discretization_.at(free_params_[0]);

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -333,7 +333,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg:
   // Convert the robot state message to our robot_state representation
   if (!moveit::core::robotStateMsgToRobotState(response->solution, *robot_state_))
   {
-    RCLCPP_ERROR(LOGGER, "An error occured converting received robot state message into internal robot state.");
+    RCLCPP_ERROR(LOGGER, "An error occurred converting received robot state message into internal robot state.");
     error_code.val = error_code.FAILURE;
     return false;
   }

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -207,7 +207,7 @@ private:
   Eigen::MatrixXd trajectory_;       //< Storage for the actual trajectory
   size_t start_index_;  // Start index (inclusive) of trajectory to be optimized (everything before will be ignored)
   size_t end_index_;    //< End index (inclusive) of trajectory to be optimized (everything after will be ignored)
-  std::vector<size_t> full_trajectory_index_;  //< If this is a "group" trajectory, the indeces from the original traj
+  std::vector<size_t> full_trajectory_index_;  //< If this is a "group" trajectory, the indices from the original traj
 };
 
 ///////////////////////// inline functions follow //////////////////////

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/constrained_planning_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/constrained_planning_state_space.h
@@ -57,7 +57,7 @@ MOVEIT_CLASS_FORWARD(ConstrainedPlanningStateSpace);
  *
  *    ompl_state->as<ompl::base::ConstrainedStateSpace::StateType>()->getState()->as<StateType>()
  *
- * where `getState()` is used to acces the underlying state space, which should be an instance of this class.
+ * where `getState()` is used to access the underlying state space, which should be an instance of this class.
  **/
 class ConstrainedPlanningStateSpace : public ModelBasedStateSpace
 {

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/constrained_planning_state_space_factory.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/joint_space/constrained_planning_state_space_factory.h
@@ -50,7 +50,7 @@ public:
    *
    * This state space factory is currently only used if `use_ompl_constrained_state_space` was set to `true` in
    * ompl_planning.yaml. In that case it is the only factory to choose from, so the priority does not matter.
-   * It returns a low priority so it will never be choosen when others are available.
+   * It returns a low priority so it will never be chosen when others are available.
    * (The second lowest priority is -1 in the PoseModelStateSpaceFactory.)
    *
    * For more details on this state space selection process, see:

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -522,7 +522,7 @@ ModelBasedPlanningContextPtr PlanningContextManager::getPlanningContext(
   // Check if the user wants to use an OMPL ConstrainedStateSpace for planning.
   // This is done by setting 'enforce_constrained_state_space' to 'true' for the desired group in ompl_planing.yaml.
   // If there are no path constraints in the planning request, this option is ignored, as the constrained state space is
-  // only usefull for paths constraints. (And at the moment only a single position constraint is supported, hence:
+  // only useful for paths constraints. (And at the moment only a single position constraint is supported, hence:
   //     req.path_constraints.position_constraints.size() == 1
   // is used in the selection process below.)
   //

--- a/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
@@ -176,7 +176,7 @@ protected:
   {
     moveit_msgs::msg::PositionConstraint pos_con_msg = createPositionConstraint(base_link_name_, ee_link_name_);
 
-    // Make the tolerance on the x dimension smaller than the treshold used to recognize equality constraints.
+    // Make the tolerance on the x dimension smaller than the threshold used to recognize equality constraints.
     // (see docstring EqualityPositionConstraint::equality_constraint_threshold).
     pos_con_msg.constraint_region.primitives.at(0).dimensions[0] = 0.0005;
 

--- a/moveit_planners/ompl/ompl_interface/test/test_state_validity_checker.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_validity_checker.cpp
@@ -154,7 +154,7 @@ public:
 
     ASSERT_NE(planning_context_, nullptr) << "Initialize planning context before adding path constraints.";
 
-    // set the robot to a known position that is withing the joint limits and collision free
+    // set the robot to a known position that is within the joint limits and collision free
     robot_state_->setJointGroupPositions(joint_model_group_, position_in_joint_limits);
 
     // create position constraints around the given robot state
@@ -179,7 +179,7 @@ public:
 
     EXPECT_TRUE(checker->isValid(ompl_state.get()));
 
-    // move the position constraints away from the curren end-effector position to make it fail
+    // move the position constraints away from the current end-effector position to make it fail
     moveit_msgs::msg::Constraints path_constraints_2(path_constraints);
     path_constraints_2.position_constraints.at(0).constraint_region.primitive_poses.at(0).position.z += 0.2;
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -75,7 +75,7 @@ public:
   size_t getCount() const;
 
   /**
-   * @brief Returns wether the container is empty
+   * @brief Returns whether the container is empty
    * @return true if empty, false otherwise
    */
   bool empty() const;

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -55,7 +55,7 @@ namespace pilz_industrial_motion_planner
  * corresponds to the requested motion command
  * set as planner_id in the MotionPlanRequest).
  * It can be easily extended with additional commands by creating a class
- * inherting from PlanningContextLoader.
+ * inheriting from PlanningContextLoader.
  */
 class CommandPlanner : public planning_interface::PlannerManager
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_base.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_base.h
@@ -94,7 +94,7 @@ public:
   /**
    * @brief Will terminate solve()
    * @return
-   * @note Currently will not stop a runnning solve but not start future solves.
+   * @note Currently will not stop a running solve but not start future solves.
    */
   bool terminate() override;
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender_transition_window.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender_transition_window.h
@@ -47,7 +47,7 @@ namespace pilz_industrial_motion_planner
  * @brief Trajectory blender implementing transition window algorithm
  *
  * See doc/MotionBlendAlgorithmDescription.pdf for a mathematical description of
- * the algorithmn.
+ * the algorithm.
  */
 class TrajectoryBlenderTransitionWindow : public TrajectoryBlender
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -77,7 +77,7 @@ bool computePoseIK(const planning_scene::PlanningSceneConstPtr& scene, const std
  * @brief compute the pose of a link at give robot state
  * @param robot_model: kinematic model of the robot
  * @param link_name: target link name
- * @param joint_state: joint positons of this group
+ * @param joint_state: joint positions of this group
  * @param pose: pose of the link in base frame of robot model
  * @return true if succeed
  */

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -181,15 +181,15 @@ private:
    * failure
    *    - req.start_state.joint_state is all zero,
    * moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE on failure
-   *    - req.goal_constraints must have exactly 1 defined cartesian oder joint
+   *    - req.goal_constraints must have exactly 1 defined cartesian order joint
    * constraint
    *      moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS on failure
    * A joint goal is checked for:
    *    - StartState joint-names matching goal joint-names,
    * moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS on
    * failure
-   *    - Beeing defined in the req.group_name JointModelGroup
-   *    - Beeing with the defined limits
+   *    - Being defined in the req.group_name JointModelGroup
+   *    - Being with the defined limits
    * A cartesian goal is checked for:
    *    - A defined link_name for the constraint,
    * moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS on failure
@@ -223,7 +223,7 @@ private:
    * These requirements are:
    *     - Names of the joints and given joint position match in size and are
    * non-zero
-   *     - The start state is withing the position limits
+   *     - The start state is within the position limits
    *     - The start state velocity is below
    * TrajectoryGenerator::VELOCITY_TOLERANCE
    */

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/velocity_profile_atrap.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/velocity_profile_atrap.h
@@ -98,7 +98,7 @@ public:
    * @param acc_duration: time of acceleration phase
    * @param const_duration: time of constant phase
    * @param dec_duration: time of deceleration phase
-   * @return ture if the combination of three durations is valid
+   * @return true if the combination of three durations is valid
    */
   bool setProfileAllDurations(double pos1, double pos2, double duration1, double duration2, double duration3);
 

--- a/moveit_planners/pilz_industrial_motion_planner/plugins/sequence_capability_plugin_description.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/plugins/sequence_capability_plugin_description.xml
@@ -8,6 +8,6 @@
   <class name="pilz_industrial_motion_planner/MoveGroupSequenceService"
          type="pilz_industrial_motion_planner::MoveGroupSequenceService"
          base_class_type="move_group::MoveGroupCapability">
-    <description>Plan a sequence of trajectory via ROS serivce</description>
+    <description>Plan a sequence of trajectory via ROS service</description>
   </class>
 </library>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -178,7 +178,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::validate
           req.first_trajectory->getLastWayPoint(), req.second_trajectory->getFirstWayPoint(), req.group_name, EPSILON))
   {
     RCLCPP_ERROR_STREAM(
-        LOGGER, "During blending the last point of the preceding and the first point of the succeding trajectory");
+        LOGGER, "During blending the last point of the preceding and the first point of the succeeding trajectory");
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
@@ -608,11 +608,11 @@ TEST_F(IntegrationTestCommandListManager, TestGripperCmdBlending)
 
 /**
  * @brief Tests the execution of a sequence in which each group states a start
- * state only consisting of joints of the corresonding group.
+ * state only consisting of joints of the corresponding group.
  *
  * Test Sequence:
  *    1. Create sequence request for which each start state only consists of
- *        joints of the corresonding group
+ *        joints of the corresponding group
  *
  * Expected Results:
  *    1. Trajectory generation is successful, result trajectory is not empty.

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_planning.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_planning.cpp
@@ -241,7 +241,7 @@ TEST_F(IntegrationTestCommandPlanning, PtpJointCart)
  *
  * Expected Results:
  *  1. Planning request is successful.
- *  2. Goal position correponds with the given goal position.
+ *  2. Goal position corresponds with the given goal position.
  *  3. Trajectory is a straight line.
  */
 TEST_F(IntegrationTestCommandPlanning, LinJoint)
@@ -292,7 +292,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
  *
  * Expected Results:
  *  1. Planning request is successful.
- *  2. Goal position correponds with the given goal position.
+ *  2. Goal position corresponds with the given goal position.
  *  3. Trajectory is a straight line.
  */
 TEST_F(IntegrationTestCommandPlanning, LinJointCart)

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_service_capability.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_service_capability.cpp
@@ -325,7 +325,7 @@ TEST_F(IntegrationTestSequenceService, TestInvalidLinkName)
  * @brief Tests the execution of a sequence with more than two commands.
  *
  * Test Sequence:
- *    1. Call service with serveral requests.
+ *    1. Call service with several requests.
  *    2. Evaluate the result.
  *
  * Expected Results:

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -282,9 +282,9 @@ bool testutils::checkCartesianLinearity(const moveit::core::RobotModelConstPtr& 
                  .norm()) > fabs(translation_norm_tolerance))
     {
       std::cout << "Translational linearity is violated. \n"
-                << "goal tanslation: " << goal_pose_expect.translation() << '\n'
+                << "goal translation: " << goal_pose_expect.translation() << '\n'
                 << "start translation: " << start_pose.translation() << '\n'
-                << "acutual translation " << way_point_pose.translation() << '\n';
+                << "actual translation " << way_point_pose.translation() << '\n';
       return false;
     }
 
@@ -393,7 +393,7 @@ bool testutils::isTrajectoryConsistent(const trajectory_msgs::msg::JointTrajecto
     }
   }
 
-  // TODO check value is consistant (time, position, velocity, acceleration)
+  // TODO check value is consistent (time, position, velocity, acceleration)
 
   return true;
 }
@@ -1311,7 +1311,7 @@ void testutils::checkRobotModel(const moveit::core::RobotModelConstPtr& robot_mo
   // that the trapezoid is not degenerated.
   if (std::distance(it_first_const, it_last_const) < 3)
   {
-    return ::testing::AssertionFailure() << "Exptected the have at least 3 points during the phase of "
+    return ::testing::AssertionFailure() << "Expected the have at least 3 points during the phase of "
                                             "constant "
                                             "velocity.";
   }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
@@ -99,7 +99,7 @@ protected:
 };
 
 /**
- * @brief Check postion
+ * @brief Check position
  */
 TEST_F(JointLimitsContainerTest, CheckPositionUnification)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
@@ -45,7 +45,7 @@ class JointLimitsValidatorTest : public ::testing::Test
 };
 
 /**
- * @brief Check postion equality
+ * @brief Check position equality
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionEquality)
 {
@@ -66,7 +66,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionEquality)
 }
 
 /**
- * @brief Check postion inequality in min_position detection
+ * @brief Check position inequality in min_position detection
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMinPosition)
 {
@@ -92,7 +92,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMinPosition)
 }
 
 /**
- * @brief Check postion inequality in max_position detection
+ * @brief Check position inequality in max_position detection
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition1)
 {
@@ -118,7 +118,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition1)
 }
 
 /**
- * @brief Check postion inequality in max_position detection (using 3 limits)
+ * @brief Check position inequality in max_position detection (using 3 limits)
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition2)
 {
@@ -150,7 +150,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition2)
 }
 
 /**
- * @brief Check postion inequality in has_position_limits false detection
+ * @brief Check position inequality in has_position_limits false detection
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityHasPositionLimits)
 {
@@ -255,7 +255,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxVelocity2)
 }
 
 /**
- * @brief Check postion inequality in has_position_limits false detection
+ * @brief Check position inequality in has_position_limits false detection
  */
 TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityHasVelocityLimits)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner.cpp
@@ -93,7 +93,8 @@ protected:
     try
     {
       planner_instance_.reset(planner_plugin_loader_->createUnmanagedInstance(planner_plugin_name_));
-      ASSERT_TRUE(planner_instance_->initialize(robot_model_, node_, "")) << "Initialzing the planner instance failed.";
+      ASSERT_TRUE(planner_instance_->initialize(robot_model_, node_, ""))
+          << "Initializing the planner instance failed.";
     }
     catch (pluginlib::PluginlibException& ex)
     {
@@ -183,7 +184,7 @@ TEST_F(CommandPlannerTest, CheckEmptyPlannerIdForServiceRequest)
 }
 
 /**
- * @brief Check integrety against empty input
+ * @brief Check integrity against empty input
  */
 TEST_F(CommandPlannerTest, CheckPlanningContextRequestNull)
 {
@@ -193,7 +194,7 @@ TEST_F(CommandPlannerTest, CheckPlanningContextRequestNull)
 }
 
 /**
- * @brief Check that for the announced algorithmns getPlanningContext does not
+ * @brief Check that for the announced algorithms getPlanningContext does not
  * return nullptr
  */
 TEST_F(CommandPlannerTest, CheckPlanningContextRequest)

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
@@ -50,7 +50,7 @@ TEST(CommandPlannerTestDirect, ExceptionCoverage)
 
 /**
  *  This test uses pilz_industrial_motion_planner::CommandPlanner directly and
- * is thus seperated from
+ * is thus separated from
  * unittest_pilz_industrial_motion_planner.cpp since plugin loading via
  * pluginlib does not allow loading of classes
  * already
@@ -66,7 +66,7 @@ TEST(CommandPlannerTestDirect, ExceptionCoverage)
  */
 TEST(CommandPlannerTestDirect, CheckDoubleLoadingException)
 {
-  /// Registed a found loader
+  /// Registered a found loader
   pilz_industrial_motion_planner::CommandPlanner planner;
   pilz_industrial_motion_planner::PlanningContextLoaderPtr planning_context_loader(
       new pilz_industrial_motion_planner::PlanningContextLoaderPTP());
@@ -102,7 +102,7 @@ TEST(CommandPlannerTestDirect, FailOnLoadContext)
     }
   };
 
-  /// Registed a found loader
+  /// Registered a found loader
   pilz_industrial_motion_planner::PlanningContextLoaderPtr planning_context_loader(new TestPlanningContextLoader());
   planner.registerContextLoader(planning_context_loader);
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -456,7 +456,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testComputePoseIKInvalidFrameId)
 //   tf2::fromMsg(pose, pose_expect);
 //
 //   // compute the ik without self collision check and expect the resulting pose
-//   // to be in self collission.
+//   // to be in self collision.
 //   std::map<std::string, double> ik_actual1;
 //   EXPECT_TRUE(pilz_industrial_motion_planner::computePoseIK(planning_scene_, planning_group_, tcp_link_, pose_expect,
 //                                                             frame_id, ik_seed, ik_actual1, false));

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
@@ -736,7 +736,7 @@ TEST_F(TrajectoryGeneratorCIRCTest, InterimPointJointGoal)
  * @brief test the circ planner with interim point with joint goal and a close
  * to zero velocity of the start state
  *
- * The generator is expected to be robust against a velocity beeing almost zero.
+ * The generator is expected to be robust against a velocity being almost zero.
  */
 TEST_F(TrajectoryGeneratorCIRCTest, InterimPointJointGoalStartVelNearZero)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_velocity_profile_atrap.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_velocity_profile_atrap.cpp
@@ -370,7 +370,7 @@ TEST(ATrapTest, Test_setProfileStartVelocity1)
   pilz_industrial_motion_planner::VelocityProfileATrap vp =
       pilz_industrial_motion_planner::VelocityProfileATrap(4, 2, 1);
 
-  // invalide cases
+  // invalid cases
   EXPECT_FALSE(vp.setProfileStartVelocity(3.0, 5.0, -1.0));
 
   // only deceleration

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/async_test.h
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/async_test.h
@@ -71,7 +71,7 @@ class AsyncTest
 {
 public:
   /**
-   * @brief Triggeres a clear event. If a call to barricade is currently pending it will unblock as soon as all clear
+   * @brief Triggers a clear event. If a call to barricade is currently pending it will unblock as soon as all clear
    * events are triggered. Else the event is put on the waitlist. This waitlist is emptied upon a call to barricade.
    *
    * @param event The event that is triggered

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/goalconstraintsmsgconvertible.h
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/goalconstraintsmsgconvertible.h
@@ -44,7 +44,7 @@ namespace pilz_industrial_motion_planner_testutils
 {
 /**
  * @brief Interface class to express that a derived class can be converted
- * into a moveit_msgs::msg::Constaints.
+ * into a moveit_msgs::msg::Constraints.
  */
 class GoalConstraintMsgConvertible
 {

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/cartesianconfiguration.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/cartesianconfiguration.cpp
@@ -67,7 +67,7 @@ CartesianConfiguration::CartesianConfiguration(const std::string& group_name, co
 
   if (robot_model && (!moveit::core::RobotState(robot_model_).knowsFrameTransform(link_name_)))
   {
-    std::string msg{ "Tranform of \"" };
+    std::string msg{ "Transform of \"" };
     msg.append(link_name).append("\" is unknown");
     throw std::invalid_argument(msg);
   }

--- a/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/dummy_environment.h
+++ b/moveit_planners/sbpl/core/sbpl_interface/include/sbpl_interface/dummy_environment.h
@@ -64,13 +64,13 @@ public:
       most searches do not require this, so it is not necessary to support this
   */
   virtual void GetSuccs(int SourceStateID, std::vector<int>* SuccIDV, std::vector<int>* CostV){};
-  /** \brief see comments for GetSuccs functon
+  /** \brief see comments for GetSuccs function
    */
   virtual void GetPreds(int TargetStateID, std::vector<int>* PredIDV, std::vector<int>* CostV){};
-  /** \brief see comments for GetSuccs functon
+  /** \brief see comments for GetSuccs function
    */
   virtual void SetAllActionsandAllOutcomes(CMDPSTATE* state){};
-  /** \brief see comments for GetSuccs functon
+  /** \brief see comments for GetSuccs function
    */
   virtual void SetAllPreds(CMDPSTATE* state){};
 

--- a/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
+++ b/moveit_planners/sbpl/core/sbpl_interface/src/environment_chain3d.cpp
@@ -493,7 +493,7 @@ bool EnvironmentChain3D::setupForMotionPlan(const planning_scene::PlanningSceneC
   }
   setMotionPrimitives(planning_group_);
 
-  // can only do bfs if not using standard collison checking
+  // can only do bfs if not using standard collision checking
   if (planning_parameters_.use_standard_collision_checking_)
   {
     planning_parameters_.use_bfs_ = false;

--- a/moveit_planners/trajopt/src/problem_description.cpp
+++ b/moveit_planners/trajopt/src/problem_description.cpp
@@ -129,7 +129,7 @@ TrajOptProblem::TrajOptProblem(const ProblemInfo& problem_info)
 
   sco::VarVector trajvarvec = createVariables(names, vlower, vupper);
   matrix_traj_vars = trajopt::VarArray(n_steps, dof_ + (problem_info.basic_info.use_time ? 1 : 0), trajvarvec.data());
-  // matrix_traj_vars is essentialy a matrix of elements like:
+  // matrix_traj_vars is essentially a matrix of elements like:
   // j_0_0, j_0_1 ...
   // j_1_0, j_1_1 ...
   // its size is n_steps by n_dof
@@ -447,7 +447,7 @@ void JointVelTermInfo::addObjectiveTerms(TrajOptProblem& prob)
   {
     unsigned num_vels = last_step - first_step;
 
-    // Apply seperate cost to each joint b/c that is how the error function is currently written
+    // Apply separate cost to each joint b/c that is how the error function is currently written
     for (size_t j = 0; j < n_dof; ++j)
     {
       // Get a vector of a single column of vars
@@ -478,7 +478,7 @@ void JointVelTermInfo::addObjectiveTerms(TrajOptProblem& prob)
   {
     unsigned num_vels = last_step - first_step;
 
-    // Apply seperate cnt to each joint b/c that is how the error function is currently written
+    // Apply separate cnt to each joint b/c that is how the error function is currently written
     for (size_t j = 0; j < n_dof; ++j)
     {
       // Get a vector of a single column of vars

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -98,7 +98,7 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
   current_state->copyJointGroupPositions(joint_model_group, current_joint_values);
 
   // Current state is different from star state in general
-  ROS_INFO(" ======================================= Extract start state infromation");
+  ROS_INFO(" ======================================= Extract start state information");
   trajopt::DblVec start_joint_values = extractStartJointValues(req, group_joint_names);
 
   // check the start state for being empty or joint limit violiation
@@ -199,7 +199,7 @@ bool TrajOptInterface::solve(const planning_scene::PlanningSceneConstPtr& planni
   problem_info.cnt_infos.push_back(joint_start_pos);
 
   ROS_INFO(" ======================================= Velocity Constraints, hard-coded");
-  // TODO: should be defined by user, its parametes should be added to setup.yaml
+  // TODO: should be defined by user, its parameters should be added to setup.yaml
   JointVelTermInfoPtr joint_vel(new JointVelTermInfo);
 
   joint_vel->coeffs = std::vector<double>(dof, 5.0);
@@ -457,7 +457,7 @@ trajopt::DblVec TrajOptInterface::extractStartJointValues(const planning_interfa
 
 void callBackFunc(sco::OptProb* opt_prob, sco::OptResults& opt_res)
 {
-  // TODO: Create the actuall implementation
+  // TODO: Create the actual implementation
 }
 
 }  // namespace trajopt_interface

--- a/moveit_planners/trajopt/src/trajopt_planning_context.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planning_context.cpp
@@ -66,7 +66,7 @@ bool TrajOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 
 bool TrajOptPlanningContext::terminate()
 {
-  ROS_ERROR_STREAM_NAMED("trajopt_planning_context", "TrajOpt is not interruptable yet");
+  ROS_ERROR_STREAM_NAMED("trajopt_planning_context", "TrajOpt is not interruptible yet");
   return false;
 }
 void TrajOptPlanningContext::clear()

--- a/moveit_planners/trajopt/test/trajectory_test.cpp
+++ b/moveit_planners/trajopt/test/trajectory_test.cpp
@@ -173,7 +173,7 @@ TEST_F(TrajectoryTest, goalTolerance)
                                                                           << "Available plugins: " << ss.str());
   }
 
-  // Creat planning context
+  // Create planning context
   // ========================================================================================
   planning_interface::PlanningContextPtr context =
       planner_instance->getPlanningContext(planning_scene, req, res.error_code_);

--- a/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -49,7 +49,7 @@ namespace
 /**
  * @brief Create a string by adding a provided separator character between each of a variable number of input arguments.
  * @param separator Char to use as the separator.
- * @param content Variable number of input arguments to concatentate.
+ * @param content Variable number of input arguments to concatenate.
  * @return Concatenated result string.
  */
 template <typename... T>

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -327,7 +327,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
             checkHeader(req.motion_plan_request.goal_constraints[j], options_.planning_frame);
         }
 
-        ROS_INFO("Benckmarking query '%s' (%d of %d)", planning_queries_names[i].c_str(), (int)i + 1,
+        ROS_INFO("Benchmarking query '%s' (%d of %d)", planning_queries_names[i].c_str(), (int)i + 1,
                  (int)planning_queries_names.size());
         runBenchmark(req);
       }
@@ -406,7 +406,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
             checkHeader(req.motion_plan_request.goal_constraints[0], options_.planning_frame);
           req.filename = options_.output + "." + boost::lexical_cast<std::string>(++n_call) + ".log";
 
-          ROS_INFO("Benckmarking goal '%s' (%d of %d)", cnames[i].c_str(), (int)i + 1, (int)cnames.size());
+          ROS_INFO("Benchmarking goal '%s' (%d of %d)", cnames[i].c_str(), (int)i + 1, (int)cnames.size());
           runBenchmark(req);
         }
       }
@@ -494,7 +494,7 @@ void moveit_benchmarks::BenchmarkExecution::runAllBenchmarks(BenchmarkType type)
             req.motion_plan_request.allowed_planning_time = options_.timeout;
           req.filename = options_.output + ".trajectory." + boost::lexical_cast<std::string>(i + 1) + ".log";
 
-          ROS_INFO("Benckmarking trajectory '%s' (%d of %d)", cnames[i].c_str(), (int)i + 1, (int)cnames.size());
+          ROS_INFO("Benchmarking trajectory '%s' (%d of %d)", cnames[i].c_str(), (int)i + 1, (int)cnames.size());
           runBenchmark(req);
         }
       }
@@ -1117,7 +1117,7 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
 
           // collect data
           start = ros::WallTime::now();
-          runs[run_id].insert(parameter_data.begin(), parameter_data.end());  // initalize this run's data with the
+          runs[run_id].insert(parameter_data.begin(), parameter_data.end());  // initialize this run's data with the
                                                                               // chosen parameters, if we have any
 
           collectMetrics(runs[run_id], mp_res, solved, total_time);
@@ -1134,7 +1134,7 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
       // this vector of runs represents all the runs*parameters
       data.push_back(runs);
 
-    }  // end j - planning algoritms
+    }  // end j - planning algorithms
   }    // end i - planning plugins
 
   double duration = (ros::WallTime::now() - startTime).toSec();
@@ -1452,7 +1452,7 @@ std::size_t moveit_benchmarks::BenchmarkExecution::generateParamCombinations()
     param_instance[param_options_[i].key] = param_options_[i].start;
   }
 
-  // call recusive function for every param option available
+  // call recursive function for every param option available
   int initial_options_id = 0;
   recursiveParamCombinations(initial_options_id, param_instance);
 

--- a/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
+++ b/moveit_ros/benchmarks/scripts/moveit_benchmark_statistics.py
@@ -334,7 +334,7 @@ def readBenchmarkLog(dbname, filenames):
                 c.execute("PRAGMA table_info(progress)")
                 columnNames = [col[1] for col in c.fetchall()]
 
-                # read progress properties and add columns as necesary
+                # read progress properties and add columns as necessary
                 numProgressProperties = int(nextLine.split()[0])
                 progressPropertyNames = ["runid"]
                 for i in range(numProgressProperties):

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
@@ -53,12 +53,12 @@ bool MoveItPlanningPipeline::initialize(const rclcpp::Node::SharedPtr& node)
   // TODO(andyz): how to standardize this for planning pipelines other than ompl?
   // Maybe use loadPlanningPipelines() from moveit_cpp.cpp
 
-  // Declare planning pipeline paramter
+  // Declare planning pipeline parameter
   node->declare_parameter<std::vector<std::string>>(PLANNING_PIPELINES_NS + "pipeline_names",
                                                     std::vector<std::string>({ UNDEFINED }));
   node->declare_parameter<std::string>(PLANNING_PIPELINES_NS + "namespace", UNDEFINED);
 
-  // Default PlanRequestParameters. These can be overriden when plan() is called
+  // Default PlanRequestParameters. These can be overridden when plan() is called
   node->declare_parameter<std::string>(PLAN_REQUEST_PARAM_NS + "planner_id", UNDEFINED);
   node->declare_parameter<std::string>(PLAN_REQUEST_PARAM_NS + "planning_pipeline", UNDEFINED);
   node->declare_parameter<int>(PLAN_REQUEST_PARAM_NS + "planning_attempts", 5);

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -71,7 +71,7 @@ public:
 
   /**
    * Load and initialized planner logic plugin and ROS 2 action and topic interfaces
-   * @return Initialization successfull yes/no
+   * @return Initialization successful yes/no
    */
   bool initialize();
 

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -315,7 +315,7 @@ void HybridPlanningManager::hybridPlanningRequestCallback(
 
 void HybridPlanningManager::sendHybridPlanningResponse(bool success)
 {
-  // Return hybrid planning action result dependend on the function's argument
+  // Return hybrid planning action result dependent on the function's argument
   auto result = std::make_shared<moveit_msgs::action::HybridPlanner::Result>();
   if (success)
   {

--- a/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/moveit_ros/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -233,7 +233,7 @@ bool ApproachAndTranslateStage::evaluate(const ManipulationPlanPtr& plan) const
                   &plan->approach_posture_, _1, _2, _3);
   plan->goal_sampler_->setVerbose(verbose_);
   std::size_t attempted_possible_goal_states = 0;
-  do  // continously sample possible goal states
+  do  // continuously sample possible goal states
   {
     for (std::size_t i = attempted_possible_goal_states; i < plan->possible_goal_states_.size() && !signal_stop_;
          ++i, ++attempted_possible_goal_states)

--- a/moveit_ros/manipulation/pick_place/src/place.cpp
+++ b/moveit_ros/manipulation/pick_place/src/place.cpp
@@ -155,7 +155,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr& planning_scene
           if (!attached_bodies.empty())
           {
             // if the user specified the name of the attached object to place, we check that indeed
-            // the group contains this attachd body
+            // the group contains this attached body
             if (!attached_object_name.empty())
             {
               bool found = false;

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -134,7 +134,7 @@ bool MoveGroupCartesianPathService::computeService(const std::shared_ptr<rmw_req
     {
       if (req->max_step < std::numeric_limits<double>::epsilon())
       {
-        RCLCPP_ERROR(LOGGER, "Maximum step to take between consecutive configrations along Cartesian path"
+        RCLCPP_ERROR(LOGGER, "Maximum step to take between consecutive configurations along Cartesian path"
                              "was not specified (this value needs to be > 0)");
         res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
       }

--- a/moveit_ros/move_group/src/move_group_capability.cpp
+++ b/moveit_ros/move_group/src/move_group_capability.cpp
@@ -131,7 +131,7 @@ std::string move_group::MoveGroupCapability::getActionResultString(const moveit_
     else
     {
       if (plan_only)
-        return "Motion plan was computed succesfully.";
+        return "Motion plan was computed successfully.";
       else
         return "Solution was found and executed.";
     }

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -100,7 +100,7 @@ public:
   /** \brief A method for a different thread to stop motion and return early from control loop */
   void stopMotion();
 
-  /** \brief Change PID parameters. Motion is stopped before the udpate */
+  /** \brief Change PID parameters. Motion is stopped before the update */
   void updatePIDConfig(const double x_proportional_gain, const double x_integral_gain, const double x_derivative_gain,
                        const double y_proportional_gain, const double y_integral_gain, const double y_derivative_gain,
                        const double z_proportional_gain, const double z_integral_gain, const double z_derivative_gain,

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -343,7 +343,7 @@ protected:
   // True -> allow drift in this dimension. In the command frame. [x, y, z, roll, pitch, yaw]
   std::array<bool, 6> drift_dimensions_ = { { false, false, false, false, false, false } };
 
-  // The dimesions to control. In the command frame. [x, y, z, roll, pitch, yaw]
+  // The dimensions to control. In the command frame. [x, y, z, roll, pitch, yaw]
   std::array<bool, 6> control_dimensions_ = { { true, true, true, true, true, true } };
 
   // main_loop_mutex_ is used to protect the input state and dynamic parameters

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -608,7 +608,7 @@ bool ServoCalcs::jointServoCalcs(const control_msgs::msg::JointJog& cmd,
   // Apply user-defined scaling
   delta_theta_ = scaleJointCommand(cmd);
 
-  // Perform interal servo with the command
+  // Perform internal servo with the command
   return internalServoUpdate(delta_theta_, joint_trajectory, ServoType::JOINT_SPACE);
 }
 
@@ -638,7 +638,7 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   }
   delta_theta *= collision_scale;
 
-  // Loop thru joints and update them, calculate velocities, and filter
+  // Loop through joints and update them, calculate velocities, and filter
   if (!applyJointUpdate(delta_theta, internal_joint_state_, prev_joint_velocity_))
     return false;
 

--- a/moveit_ros/moveit_servo/test/test_servo_collision.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_collision.cpp
@@ -145,7 +145,7 @@ TEST_F(ServoFixture, ExternalCollision)
 int main(int argc, char** argv)
 {
   // It is important we init ros before google test because we are going to
-  // create a node durring the google test init.
+  // create a node during the google test init.
   rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
+++ b/moveit_ros/moveit_servo/test/unit_test_servo_calcs.hpp
@@ -48,7 +48,7 @@ const std::vector<std::string> PANDA_JOINT_NAMES{ "panda_finger_joint1", "panda_
                                                   "panda_joint2",        "panda_joint3",        "panda_joint4",
                                                   "panda_joint5",        "panda_joint6",        "panda_joint7" };
 
-// subclassing and friending so we can access member varibles
+// subclassing and friending so we can access member variables
 class FriendServoCalcs : public moveit_servo::ServoCalcs
 {
   FRIEND_TEST(ServoCalcsTestFixture, TestRemoveSingleDimension);

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -166,7 +166,7 @@ public:
   void stopMonitor();
 
   /** @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
-   *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance. */
+   *  pointer. The value of this pointer stays the same throughout the existence of the monitor instance. */
   const collision_detection::OccMapTreePtr& getOcTreePtr()
   {
     return tree_;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -125,7 +125,7 @@ OccupancyMapMonitor::OccupancyMapMonitor(std::unique_ptr<MiddlewareHandle> middl
       continue;
     }
 
-    // Add the succesfully initialized updater
+    // Add the successfully initialized updater
     addUpdater(occupancy_map_updater);
   }
 
@@ -155,7 +155,7 @@ void OccupancyMapMonitor::addUpdater(const OccupancyMapUpdaterPtr& updater)
     if (map_updaters_.size() > 1)
     {
       mesh_handles_.resize(map_updaters_.size());
-      // when we had one updater only, we passed direcly the transform cache callback to that updater
+      // when we had one updater only, we passed directly the transform cache callback to that updater
       if (map_updaters_.size() == 2)
       {
         map_updaters_[0]->setTransformCacheCallback(

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -298,7 +298,7 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
         failed_tf_++;
         if (failed_tf_ > good_tf_)
           RCLCPP_WARN_THROTTLE(LOGGER, *node_->get_clock(), 1000,
-                               "More than half of the image messages discared due to TF being unavailable (%u%%). "
+                               "More than half of the image messages discarded due to TF being unavailable (%u%%). "
                                "Transform error of sensor data: %s; quitting callback.",
                                (100 * failed_tf_) / (good_tf_ + failed_tf_), err.c_str());
         else

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_mesh.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_mesh.h
@@ -59,7 +59,7 @@ class GLMesh
 {
 public:
   /**
-   * \brief Constucts a GLMesh object for given mesh and label
+   * \brief Constructs a GLMesh object for given mesh and label
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \param[in] mesh
    * \param[in] mesh_label

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.h
@@ -89,7 +89,7 @@ public:
                  const std::string& render_vertex_shader = "", const std::string& render_fragment_shader = "",
                  const std::string& filter_vertex_shader = "", const std::string& filter_fragment_shader = "");
 
-  /** \brief Desctructor */
+  /** \brief Destructor */
   ~MeshFilterBase();
 
   /**

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/transform_provider.h
@@ -90,7 +90,7 @@ public:
   void setFrame(const std::string& frame);
 
   /**
-   * \brief starts the updating process. Done in a seperate thread
+   * \brief starts the updating process. Done in a separate thread
    * \author Suat Gedikli (gedikli@willowgarage.com)
    */
   void start();

--- a/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
+++ b/moveit_ros/perception/mesh_filter/test/mesh_filter_test.cpp
@@ -132,7 +132,7 @@ MeshFilterTest<Type>::MeshFilterTest(unsigned width, unsigned height, double nea
   shapes::Mesh mesh = createMesh(0);
   handle_ = filter_.addMesh(mesh);
 
-  // make it random but reproducable
+  // make it random but reproducible
   srand(0);
   Type t_near = near_ / FilterTraits<Type>::ToMetricScale;
   Type t_far = far_ / FilterTraits<Type>::ToMetricScale;

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -219,7 +219,7 @@ private:
   // double goal_joint_tolerance_;
   // double goal_position_tolerance_;
   // double goal_orientation_tolerance_;
-  // TODO(henningkayser): implment path/trajectory constraints
+  // TODO(henningkayser): implement path/trajectory constraints
   // std::unique_ptr<moveit_msgs::msg::Constraints> path_constraints_;
   // std::unique_ptr<moveit_msgs::msg::TrajectoryConstraints> trajectory_constraints_;
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -95,7 +95,7 @@ bool MoveItCpp::loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& opti
 {
   planning_scene_monitor_ =
       std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(node_, options.robot_description, options.name);
-  // Allows us to sycronize to Rviz and also publish collision objects to ourselves
+  // Allows us to synchronize to Rviz and also publish collision objects to ourselves
   RCLCPP_DEBUG(LOGGER, "Configuring Planning Scene Monitor");
   if (planning_scene_monitor_->getPlanningScene())
   {
@@ -117,7 +117,7 @@ bool MoveItCpp::loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& opti
     return false;
   }
 
-  // Wait for complete state to be recieved
+  // Wait for complete state to be received
   // TODO(henningkayser): Fix segfault in waitForCurrentState()
   // if (options.wait_for_initial_state_timeout > 0.0)
   // {

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -299,7 +299,7 @@ bool PlanningComponent::execute(bool blocking)
 {
   if (!last_plan_solution_)
   {
-    RCLCPP_ERROR(LOGGER, "There is no successfull plan to execute");
+    RCLCPP_ERROR(LOGGER, "There is no successful plan to execute");
     return false;
   }
 

--- a/moveit_ros/planning/moveit_cpp/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning/moveit_cpp/test/moveit_cpp_test.cpp
@@ -151,7 +151,7 @@ TEST_F(MoveItCppTest, TestSetStartStateFromRobotState)
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));
 }
 
-// Test settting the goal of the plan using a moveit::core::RobotState
+// Test setting the goal of the plan using a moveit::core::RobotState
 TEST_F(MoveItCppTest, TestSetGoalFromRobotState)
 {
   auto target_state = *(moveit_cpp_ptr->getCurrentState());

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -113,7 +113,7 @@ std::string plan_execution::PlanExecution::getErrorCodeString(const moveit_msgs:
   else if (error_code.val == moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN)
     return "Invalid motion plan";
   else if (error_code.val == moveit_msgs::msg::MoveItErrorCodes::UNABLE_TO_AQUIRE_SENSOR_DATA)
-    return "Unable to aquire sensor data";
+    return "Unable to acquire sensor data";
   else if (error_code.val == moveit_msgs::msg::MoveItErrorCodes::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE)
     return "Motion plan invalidated by environment change";
   else if (error_code.val == moveit_msgs::msg::MoveItErrorCodes::CONTROL_FAILED)
@@ -355,7 +355,7 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
   for (std::size_t i = 0; i < plan.plan_components_.size(); ++i)
   {
     // \todo should this be in trajectory_execution ? Maybe. Then that will have to use kinematic_trajectory too;
-    // spliting trajectories for controllers becomes interesting: tied to groups instead of joints. this could cause
+    // splitting trajectories for controllers becomes interesting: tied to groups instead of joints. this could cause
     // some problems
     // in the meantime we do a hack:
 

--- a/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/compare_collision_speed_checking_fcl_bullet.cpp
@@ -224,7 +224,7 @@ void runCollisionDetection(unsigned int trials, const planning_scene::PlanningSc
   ROS_INFO("Performed %lf collision checks per second", (double)trials * states.size() / duration);
   ROS_INFO_STREAM("Total number was " << trials * states.size() << " checks.");
   ROS_INFO_STREAM("We had " << states.size() << " different robot states which were "
-                            << (res.collision ? "in collison " : "not in collision ") << "with " << res.contact_count);
+                            << (res.collision ? "in collision " : "not in collision ") << "with " << res.contact_count);
 
   // color collided objects red
   for (auto& contact : res.contacts)

--- a/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/moveit_ros/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
       "trials", boost::program_options::value<unsigned int>(&trials)->default_value(trials),
       "Number of collision checks to perform with each thread")("wait",
                                                                 "Wait for a user command (so the planning scene can be "
-                                                                "updated in thre background)")("help", "this screen");
+                                                                "updated in the background)")("help", "this screen");
   boost::program_options::variables_map vm;
   boost::program_options::parsed_options po = boost::program_options::parse_command_line(argc, argv, desc);
   boost::program_options::store(po, vm);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -303,7 +303,7 @@ public:
     return error_;
   }
 
-  /** @brief Allow the joint_state arrrays velocity and effort to be copied into the robot state
+  /** @brief Allow the joint_state arrays velocity and effort to be copied into the robot state
    *  this is useful in some but not all applications
    */
   void enableCopyDynamics(bool enabled)

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -488,7 +488,7 @@ void CurrentStateMonitor::transformCallback(const tf2_msgs::msg::TFMessage::Cons
     catch (tf2::TransformException& ex)
     {
       std::string temp = ex.what();
-      RCLCPP_ERROR(LOGGER, "Failure to set recieved transform from %s to %s with error: %s\n",
+      RCLCPP_ERROR(LOGGER, "Failure to set received transform from %s to %s with error: %s\n",
                    transform.child_frame_id.c_str(), transform.header.frame_id.c_str(), temp.c_str());
     }
   }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -839,7 +839,7 @@ void PlanningSceneMonitor::includeAttachedBodiesInOctree()
 
   boost::recursive_mutex::scoped_lock _(shape_handles_lock_);
 
-  // clear information about any attached body, without refering to the AttachedBody* ptr (could be invalid)
+  // clear information about any attached body, without referring to the AttachedBody* ptr (could be invalid)
   for (std::pair<const moveit::core::AttachedBody* const,
                  std::vector<std::pair<occupancy_map_monitor::ShapeHandle, std::size_t>>>& attached_body_shape_handle :
        attached_body_shape_handles_)

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
@@ -150,7 +150,7 @@ TEST(CurrentStateMonitorTests, DestructStopTest)
 
 TEST(CurrentStateMonitorTests, NoModelTest)
 {
-  // GIVEN an unitialized robot model
+  // GIVEN an uninitialized robot model
   moveit::core::RobotModelPtr robot_model = nullptr;
 
   // WHEN the CurrentStateMonitor is constructed with it

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
@@ -53,7 +53,7 @@ using StringCallback = std::function<void(const std::string&)>;
  *
  * You can specify how long to wait for a subscribed message with NAME_timeout (double in seconds)
  *
- * By default, the subscription will be killed after the first message is recieved.
+ * By default, the subscription will be killed after the first message is received.
  * If the parameter NAME_continuous is true, then the parent_callback will be called on every subsequent message.
  */
 class SynchronizedStringParameter

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -81,7 +81,7 @@ std::string SynchronizedStringParameter::loadInitialValue(const std::shared_ptr<
   if (!waitForMessage(timeout))
   {
     RCLCPP_ERROR_ONCE(node_->get_logger(),
-                      "Could not find parameter %s and did not recieve %s via std_msgs::msg::String subscription "
+                      "Could not find parameter %s and did not receive %s via std_msgs::msg::String subscription "
                       "within %f seconds.",
                       name_.c_str(), name_.c_str(), d_timeout);
   }

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -51,7 +51,7 @@ TEST(RDFIntegration, default_arguments)
 TEST(RDFIntegration, non_existent)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("non_existent");
-  rdf_loader::RDFLoader loader(node, "DNE");
+  rdf_loader::RDFLoader loader(node, "does_not_exist");
   ASSERT_EQ(nullptr, loader.getURDF());
   ASSERT_EQ(nullptr, loader.getSRDF());
 }

--- a/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/roscpp_initializer.h
+++ b/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/roscpp_initializer.h
@@ -46,7 +46,7 @@ namespace py_bindings_tools
 {
 /** \brief The constructor of this class ensures that ros::init() has
     been called.  Thread safety and multiple initialization is
-    properly handled. When the process terminates, ros::shotdown() is
+    properly handled. When the process terminates, ros::shutdown() is
     also called, if needed. */
 class ROScppInitializer
 {

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -69,7 +69,7 @@
 #include <tf2_eigen/tf2_eigen.h>
 #endif
 
-// 10um acuracy tested for position and orientation
+// 10um accuracy tested for position and orientation
 constexpr double EPSILON = 1e-5;
 
 static const std::string PLANNING_GROUP = "panda_arm";
@@ -194,7 +194,7 @@ TEST_F(MoveGroupTestFixture, PathConstraintCollisionTest)
 
   ////////////////////////////////////////////////////////////////////
   // set a custom start state
-  // this simplifies planning for the orientation constraint bellow
+  // this simplifies planning for the orientation constraint below
   geometry_msgs::Pose start_pose;
   start_pose.orientation.w = 1.0;
   start_pose.position.x = 0.3;

--- a/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
@@ -33,7 +33,7 @@
  *********************************************************************/
 
 /* Author: Boston Cleek
-   Desc: move group interace ompl constrained planning capabilities for planning and execution
+   Desc: move group interface ompl constrained planning capabilities for planning and execution
 */
 
 // Testing
@@ -54,7 +54,7 @@
 #include <moveit/macros/console_colors.h>
 #include <moveit_msgs/msg/constraints.hpp>
 
-// acuracy tested for position and orientation
+// accuracy tested for position and orientation
 static const double EPSILON = 1e-2;
 
 static const std::string PLANNING_GROUP = "panda_arm";

--- a/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/moveit_cpp_test.cpp
@@ -153,7 +153,7 @@ TEST_F(MoveItCppTest, TestSetStartStateFromRobotState)
   ASSERT_TRUE(static_cast<bool>(planning_component_ptr->plan()));
 }
 
-// Test settting the goal of the plan using a moveit::core::RobotState
+// Test setting the goal of the plan using a moveit::core::RobotState
 TEST_F(MoveItCppTest, TestSetGoalFromRobotState)
 {
   auto target_state = *(moveit_cpp_ptr->getCurrentState());

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -214,7 +214,7 @@ private:
   // This mutex is locked every time markers are read or updated;
   // This includes the active_* arrays and shown_markers_
   // Please note that this mutex *MUST NOT* be locked while operations
-  // on the interative marker server are called because the server
+  // on the interactive marker server are called because the server
   // also locks internally and we could othewrise end up with a problem
   // of Thread 1: Lock A,         Lock B, Unlock B, Unloack A
   //    Thread 2:         Lock B, Lock A

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -470,7 +470,7 @@ void MyInfo::waitThreadFunc(robot_interaction::LockedRobotState* locked_state, i
   cnt_lock_.unlock();
 }
 
-// Run several threads and ensure they modify the state consistantly
+// Run several threads and ensure they modify the state consistently
 //   ncheck - # of checkThreadFunc threads to run
 //   nset   - # of setThreadFunc threads to run
 //   nmod   - # of modifyThreadFunc threads to run

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -78,7 +78,7 @@ namespace moveit_rviz_plugin
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.motion_planning_display");
 
 // ******************************************************************************************
-// Base class contructor
+// Base class constructor
 // ******************************************************************************************
 MotionPlanningDisplay::MotionPlanningDisplay()
   : PlanningSceneDisplay()
@@ -143,7 +143,7 @@ MotionPlanningDisplay::MotionPlanningDisplay()
                                                 SLOT(changedQueryGoalState()), this);
   query_marker_scale_property_ = new rviz_common::properties::FloatProperty(
       "Interactive Marker Size", 0.0f,
-      "Specifies scale of the interactive marker overlayed on the robot. 0 is auto scale.", plan_category_,
+      "Specifies scale of the interactive marker overlaid on the robot. 0 is auto scale.", plan_category_,
       SLOT(changedQueryMarkerScale()), this);
   query_marker_scale_property_->setMin(0.0f);
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -100,7 +100,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz_c
   node_->get_parameter(planning_display_->getMoveGroupNS() + "/move_group/default_planning_pipeline",
                        default_planning_pipeline_);
 
-  // connect bottons to actions; each action usually registers the function pointer for the actual computation,
+  // connect buttons to actions; each action usually registers the function pointer for the actual computation,
   // to keep the GUI more responsive (using the background job processing)
   connect(ui_->plan_button, SIGNAL(clicked()), this, SLOT(planButtonClicked()));
   connect(ui_->execute_button, SIGNAL(clicked()), this, SLOT(executeButtonClicked()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -160,7 +160,7 @@ bool MotionPlanningFrame::computeCartesianPlan()
     trajectory_processing::IterativeParabolicTimeParameterization iptp;
     bool success =
         iptp.computeTimeStamps(rt, ui_->velocity_scaling_factor->value(), ui_->acceleration_scaling_factor->value());
-    RCLCPP_INFO(LOGGER, "Computing time stamps %s", success ? "SUCCEDED" : "FAILED");
+    RCLCPP_INFO(LOGGER, "Computing time stamps %s", success ? "SUCCEEDED" : "FAILED");
 
     // Store trajectory in current_plan_
     current_plan_ = std::make_shared<moveit::planning_interface::MoveGroupInterface::Plan>();
@@ -255,7 +255,7 @@ void MotionPlanningFrame::onFinishedExecution(bool success)
   // disable stop button
   ui_->stop_button->setEnabled(false);
 
-  // update query start state to current if neccessary
+  // update query start state to current if necessary
   if (ui_->start_state_combo_box->currentText() == "<current>")
     startStateTextChanged(ui_->start_state_combo_box->currentText());
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -61,7 +61,7 @@ namespace moveit_rviz_plugin
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros_visualization.planning_scene_display");
 // ******************************************************************************************
-// Base class contructor
+// Base class constructor
 // ******************************************************************************************
 PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool show_scene_robot)
   : Display(), planning_scene_needs_render_(true), current_scene_time_(0.0f)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -59,7 +59,7 @@
 namespace moveit_rviz_plugin
 {
 // ******************************************************************************************
-// Base class contructor
+// Base class constructor
 // ******************************************************************************************
 RobotStateDisplay::RobotStateDisplay() : Display(), update_state_(false)
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -155,7 +155,7 @@ protected:
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr robot_state_;
 
-  // Pointers from parent display taht we save
+  // Pointers from parent display that we save
   rviz_common::Display* display_;  // the parent display that this class populates
   rviz_common::properties::Property* widget_;
   Ogre::SceneNode* scene_node_;

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.hpp
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.hpp
@@ -218,7 +218,7 @@ public:
   /// Full file-system path to urdf
   std::string urdf_path_;
 
-  /// Name of package containig urdf (note: this may be empty b/c user may not have urdf in pkg)
+  /// Name of package containing urdf (note: this may be empty b/c user may not have urdf in pkg)
   std::string urdf_pkg_name_;
 
   /// Path relative to urdf package (note: this may be same as urdf_path_)
@@ -490,7 +490,7 @@ public:
   bool deleteROSController(const std::string& controller_name);
 
   /**
-   * \brief Used for adding a sensor plugin configuation prameter to the sensor plugin configuration parameter list
+   * \brief Used for adding a sensor plugin configuration parameter to the sensor plugin configuration parameter list
    */
   void addGenericParameterToSensorPluginConfig(const std::string& name, const std::string& value = "",
                                                const std::string& comment = "");
@@ -501,7 +501,7 @@ public:
   void clearSensorPluginConfig();
 
   /**
-   * \brief Used for adding a sensor plugin configuation parameter to the sensor plugin configuration parameter list
+   * \brief Used for adding a sensor plugin configuration parameter to the sensor plugin configuration parameter list
    */
   std::vector<std::map<std::string, GenericParameter> > getSensorPluginConfig();
 

--- a/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/src/collisions_updater.cpp
@@ -108,7 +108,7 @@ bool setup(moveit_setup_assistant::MoveItConfigData& config_data, bool keep_old,
 moveit_setup_assistant::LinkPairMap compute(moveit_setup_assistant::MoveItConfigData& config_data, uint32_t trials,
                                             double min_collision_fraction, bool verbose)
 {
-  // TODO: spin thread and print progess if verbose
+  // TODO: spin thread and print progress if verbose
   unsigned int collision_progress;
   return moveit_setup_assistant::computeDefaultCollisions(config_data.getPlanningScene(), &collision_progress,
                                                           trials > 0, trials, min_collision_fraction, verbose);

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -345,7 +345,7 @@ void computeConnectionGraph(const moveit::core::LinkModel* start_link, LinkGraph
 {
   link_graph.clear();  // make sure the edges structure is clear
 
-  // Recurively build adj list of link connections
+  // Recursively build adj list of link connections
   computeConnectionGraphRec(start_link, link_graph);
 
   // Repeatidly check for links with no geometry and remove them, then re-check until no more removals are detected
@@ -368,7 +368,7 @@ void computeConnectionGraph(const moveit::core::LinkModel* start_link, LinkGraph
           temp_list.push_back(adj_it);
         }
 
-        // Make all preceeding and succeeding links to the no-shape link fully connected
+        // Make all preceding and succeeding links to the no-shape link fully connected
         // so that they don't collision check with themselves
         for (std::size_t i = 0; i < temp_list.size(); ++i)
         {
@@ -439,7 +439,7 @@ unsigned int disableAdjacentLinks(planning_scene::PlanningScene& scene, LinkGrap
       }
     }
   }
-  // RCLCPP_INFO_STREAM(LOGGER, "Disabled %d adjancent link pairs from collision checking", num_disabled);
+  // RCLCPP_INFO_STREAM(LOGGER, "Disabled %d adjacent link pairs from collision checking", num_disabled);
 
   return num_disabled;
 }

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -685,7 +685,7 @@ std::vector<OMPLPlannerDescription> MoveItConfigData::getOMPLPlanners()
                     "dist new state to nearest neighbor to disqualify as frontier. "
                     "default: 0.0 set in setup()");
   trrt.addParameter("frountierNodeRatio", "0.1", "1/10, or 1 nonfrontier for every 10 frontier. default: 0.1");
-  trrt.addParameter("k_constant", "0.0", "value used to normalize expresssion. default: 0.0 set in setup()");
+  trrt.addParameter("k_constant", "0.0", "value used to normalize expression. default: 0.0 set in setup()");
   planner_des.push_back(trrt);
 
   OMPLPlannerDescription prm("PRM", "geometric");
@@ -1771,7 +1771,7 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
     RCLCPP_ERROR_STREAM(LOGGER, e.what());
   }
 
-  return false;  // if it gets to this point an error has occured
+  return false;  // if it gets to this point an error has occurred
 }
 
 // ******************************************************************************************
@@ -1880,7 +1880,7 @@ bool MoveItConfigData::input3DSensorsYAML(const std::string& default_file_path, 
     RCLCPP_ERROR_STREAM(LOGGER, "Error parsing sensors yaml: " << e.what());
   }
 
-  return false;  // if it gets to this point an error has occured
+  return false;  // if it gets to this point an error has occurred
 }
 
 // ******************************************************************************************
@@ -1983,7 +1983,7 @@ std::vector<ROSControlConfig>& MoveItConfigData::getROSControllers()
 }
 
 // ******************************************************************************************
-// Used to add a sensor plugin configuation parameter to the sensor plugin configuration parameter list
+// Used to add a sensor plugin configuration parameter to the sensor plugin configuration parameter list
 // ******************************************************************************************
 void MoveItConfigData::addGenericParameterToSensorPluginConfig(const std::string& name, const std::string& value,
                                                                const std::string& /*comment*/)

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -224,7 +224,7 @@ bool ConfigurationFilesWidget::loadGenFiles()
   gen_files_.push_back(file);
 
   // -------------------------------------------------------------------------------------------------------------------
-  // CONIG FILES -------------------------------------------------------------------------------------------------------
+  // CONFIG FILES -------------------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------------------------------
   std::string config_path = "config";
 
@@ -779,7 +779,7 @@ bool ConfigurationFilesWidget::checkGenFiles()
   if (config_data_->config_pkg_path_.empty())
     return false;  // this is a new package
 
-  // Check if we have the previous modification timestamp to compare agains
+  // Check if we have the previous modification timestamp to compare against
   if (config_data_->config_pkg_generated_timestamp_ == 0)
     return false;  // this package has not been generated with a timestamp, backwards compatible.
 
@@ -999,7 +999,7 @@ bool ConfigurationFilesWidget::generatePackage()
     // Run the generate function
     if (!file->gen_func_(absolute_path))
     {
-      // Error occured
+      // Error occurred
       QMessageBox::critical(this, "Error Generating File",
                             QString("Failed to generate folder or file: '")
                                 .append(file->rel_path_.c_str())

--- a/moveit_setup_assistant/src/widgets/double_list_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/double_list_widget.cpp
@@ -233,7 +233,7 @@ void DoubleListWidget::setTable(const std::vector<std::string>& items, QTableWid
 
   table->setRowCount(row);
 
-  // Reenable
+  // Re-enable
   table->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   table->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
 }

--- a/moveit_setup_assistant/src/widgets/double_list_widget.h
+++ b/moveit_setup_assistant/src/widgets/double_list_widget.h
@@ -64,7 +64,7 @@ public:
   DoubleListWidget(QWidget* parent, const MoveItConfigDataPtr& config_data, const QString& long_name,
                    const QString& short_name, bool add_ok_cancel = true);
 
-  /// Loads the availble data list
+  /// Loads the available data list
   void setAvailable(const std::vector<std::string>& items);
 
   /// Set the right box

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -416,7 +416,7 @@ srdf::Model::EndEffector* EndEffectorsWidget::findEffectorByName(const std::stri
   // Check if effector was found
   if (searched_group == nullptr)  // not found
   {
-    QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
+    QMessageBox::critical(this, "Error Saving", "An internal error has occurred while saving. Quitting.");
     QApplication::quit();
   }
 
@@ -635,7 +635,7 @@ void EndEffectorsWidget::loadDataTable()
     ++row;
   }
 
-  // Reenable
+  // Re-enable
   data_table_->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   data_table_->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
 

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.h
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.h
@@ -120,7 +120,7 @@ private:
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;
 
-  /// Orignal name of effector currently being edited. This is used to find the element in the vector
+  /// Original name of effector currently being edited. This is used to find the element in the vector
   std::string current_edit_effector_;
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/header_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/header_widget.cpp
@@ -134,7 +134,7 @@ LoadPathWidget::LoadPathWidget(const QString& title, const QString& instructions
   connect(browse_button, SIGNAL(clicked()), this, SLOT(btnFileDialog()));
   hlayout->addWidget(browse_button);
 
-  // Add horizontal layer to verticle layer
+  // Add horizontal layer to vertical layer
   layout->addLayout(hlayout);
 
   setLayout(layout);

--- a/moveit_setup_assistant/src/widgets/header_widget.h
+++ b/moveit_setup_assistant/src/widgets/header_widget.h
@@ -53,7 +53,7 @@ class HeaderWidget : public QWidget
   Q_OBJECT
 
 public:
-  /// Contructor
+  /// Constructor
   HeaderWidget(const std::string& title, const std::string& instructions, QWidget* parent);
 };
 

--- a/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
+++ b/moveit_setup_assistant/src/widgets/kinematic_chain_widget.h
@@ -63,7 +63,7 @@ public:
   /// Constructor
   KinematicChainWidget(QWidget* parent, const MoveItConfigDataPtr& config_data);
 
-  /// Loads the availble data list
+  /// Loads the available data list
   void setAvailable();
 
   /// Set the link field with previous value

--- a/moveit_setup_assistant/src/widgets/passive_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/passive_joints_widget.h
@@ -84,7 +84,7 @@ private:
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;
 
-  /// Orignal name of vjoint currently being edited. This is used to find the element in the vector
+  /// Original name of vjoint currently being edited. This is used to find the element in the vector
   std::string current_edit_vjoint_;
 };
 

--- a/moveit_setup_assistant/src/widgets/perception_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/perception_widget.cpp
@@ -127,7 +127,7 @@ PerceptionWidget::PerceptionWidget(QWidget* parent, const MoveItConfigDataPtr& c
   max_update_rate_field_->setMaximumWidth(400);
   point_cloud_form_layout->addRow("Max Update Rate:", max_update_rate_field_);
 
-  // Piont Cloud form layout
+  // Point Cloud form layout
   point_cloud_group_->setLayout(point_cloud_form_layout);
   layout->addWidget(point_cloud_group_);
 
@@ -298,11 +298,11 @@ void PerceptionWidget::loadSensorPluginsComboBox()
   // Add None option, the default
   sensor_plugin_field_->addItem("None");
 
-  // Add the two avilable plugins to combo box
+  // Add the two available plugins to combo box
   sensor_plugin_field_->addItem("Point Cloud");
   sensor_plugin_field_->addItem("Depth Map");
 
-  // Load deafult config, or use the one in the config package if exists
+  // Load default config, or use the one in the config package if exists
   std::vector<std::map<std::string, GenericParameter> > sensors_vec_map = config_data_->getSensorPluginConfig();
   for (std::map<std::string, GenericParameter>& sensor_plugin_config : sensors_vec_map)
   {

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -258,7 +258,7 @@ void PlanningGroupsWidget::loadGroupsTree()
     loadGroupsTreeRecursive(group, nullptr);
   }
 
-  // Reenable Tree
+  // Re-enable Tree
   groups_tree_->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   groups_tree_->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
 
@@ -483,7 +483,7 @@ void PlanningGroupsWidget::editSelected()
       loadGroupScreen(plan_group.group_);
       break;
     default:
-      QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading.");
+      QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading.");
       return;
   }
   return_screen_ = 0;  // return to main screen directly
@@ -702,7 +702,7 @@ void PlanningGroupsWidget::deleteGroup()
           if (QMessageBox::question(
                   this, "Confirm Group State Deletion",
                   QString("The group that is about to be deleted has robot poses (robot states) that depend on this "
-                          "group. Are you sure you want to delete this group as well as all dependend robot poses?"),
+                          "group. Are you sure you want to delete this group as well as all dependent robot poses?"),
                   QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel)
           {
             return;
@@ -738,7 +738,7 @@ void PlanningGroupsWidget::deleteGroup()
           if (QMessageBox::question(
                   this, "Confirm End Effector Deletion",
                   QString("The group that is about to be deleted has end effectors (grippers) that depend on this "
-                          "group. Are you sure you want to delete this group as well as all dependend end effectors?"),
+                          "group. Are you sure you want to delete this group as well as all dependent end effectors?"),
                   QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel)
           {
             return;
@@ -817,7 +817,7 @@ void PlanningGroupsWidget::addGroup()
 }
 
 // ******************************************************************************************
-// Call when joints edit sceen is done and needs to be saved
+// Call when joints edit screen is done and needs to be saved
 // ******************************************************************************************
 void PlanningGroupsWidget::saveJointsScreen()
 {
@@ -845,7 +845,7 @@ void PlanningGroupsWidget::saveJointsScreen()
 }
 
 // ******************************************************************************************
-// Call when links edit sceen is done and needs to be saved
+// Call when links edit screen is done and needs to be saved
 // ******************************************************************************************
 void PlanningGroupsWidget::saveLinksScreen()
 {
@@ -874,7 +874,7 @@ void PlanningGroupsWidget::saveLinksScreen()
 }
 
 // ******************************************************************************************
-// Call when chains edit sceen is done and needs to be saved
+// Call when chains edit screen is done and needs to be saved
 // ******************************************************************************************
 void PlanningGroupsWidget::saveChainScreen()
 {
@@ -950,7 +950,7 @@ void PlanningGroupsWidget::saveChainScreen()
 }
 
 // ******************************************************************************************
-// Call when subgroups edit sceen is done and needs to be saved
+// Call when subgroups edit screen is done and needs to be saved
 // ******************************************************************************************
 void PlanningGroupsWidget::saveSubgroupsScreen()
 {
@@ -1045,7 +1045,7 @@ void PlanningGroupsWidget::saveSubgroupsScreen()
 }
 
 // ******************************************************************************************
-// Call when groups edit sceen is done and needs to be saved
+// Call when groups edit screen is done and needs to be saved
 // ******************************************************************************************
 bool PlanningGroupsWidget::saveGroupScreen()
 {

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -727,7 +727,7 @@ void RobotPosesWidget::loadDataTable()
     ++row;
   }
 
-  // Reenable
+  // Re-enable
   data_table_->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   data_table_->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
 
@@ -830,7 +830,7 @@ SliderWidget::SliderWidget(QWidget* parent, const moveit::core::JointModel* join
   const std::vector<moveit_msgs::msg::JointLimits>& limits = joint_model_->getVariableBoundsMsg();
   if (limits.empty())
   {
-    QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading the joints");
+    QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading the joints");
     return;
   }
 

--- a/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/ros_controllers_widget.cpp
@@ -218,7 +218,7 @@ void ROSControllersWidget::loadControllersTree()
     loadToControllersTree(controller);
   }
 
-  // Reenable Tree
+  // Re-enable Tree
   controllers_tree_->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   controllers_tree_->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
   current_edit_controller_.clear();            // no controller is being edited
@@ -408,7 +408,7 @@ void ROSControllersWidget::addController()
 void ROSControllersWidget::addDefaultControllers()
 {
   if (!config_data_->addDefaultControllers())
-    QMessageBox::warning(this, "Error adding contollers", "No Planning Groups configured!");
+    QMessageBox::warning(this, "Error adding controllers", "No Planning Groups configured!");
   loadControllersTree();
 }
 
@@ -572,7 +572,7 @@ void ROSControllersWidget::saveControllerScreenGroups()
 }
 
 // ******************************************************************************************
-// Call when joints edit sceen is done and needs to be saved
+// Call when joints edit screen is done and needs to be saved
 // ******************************************************************************************
 void ROSControllersWidget::saveJointsScreen()
 {
@@ -597,7 +597,7 @@ void ROSControllersWidget::saveJointsScreen()
 }
 
 // ******************************************************************************************
-// Call when joints edit sceen is done and needs to be saved
+// Call when joints edit screen is done and needs to be saved
 // ******************************************************************************************
 void ROSControllersWidget::saveJointsGroupsScreen()
 {
@@ -633,7 +633,7 @@ void ROSControllersWidget::saveJointsGroupsScreen()
 }
 
 // ******************************************************************************************
-// Call when joints edit sceen is done and needs to be saved
+// Call when joints edit screen is done and needs to be saved
 // ******************************************************************************************
 void ROSControllersWidget::saveControllerScreenEdit()
 {
@@ -646,7 +646,7 @@ void ROSControllersWidget::saveControllerScreenEdit()
 }
 
 // ******************************************************************************************
-// Call when controller edit sceen is done and needs to be saved
+// Call when controller edit screen is done and needs to be saved
 // ******************************************************************************************
 bool ROSControllersWidget::saveControllerScreen()
 {
@@ -776,7 +776,7 @@ void ROSControllersWidget::editSelected()
   }
   else
   {
-    QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading.");
+    QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading.");
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -137,7 +137,7 @@ void SimulationWidget::generateURDFClick()
     std::regex start_reg_ex("<inertial");
     std::regex end_reg_ex("</inertial");
 
-    // Search for inertial elemnts using regex
+    // Search for inertial elements using regex
     std::regex_search(gazebo_compatible_urdf_string, start_match, start_reg_ex);
     std::regex_search(gazebo_compatible_urdf_string, end_match, end_reg_ex);
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -191,7 +191,7 @@ StartScreenWidget::StartScreenWidget(QWidget* parent, const MoveItConfigDataPtr&
   hlayout->addLayout(right_layout);
   layout->addLayout(hlayout);
 
-  // Verticle Spacer
+  // Vertical Spacer
   layout->addItem(new QSpacerItem(20, 20, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
   // Attach bottom layout
@@ -329,7 +329,7 @@ bool StartScreenWidget::loadPackageSettings(bool show_warnings)
   if (!config_data_->setPackagePath(package_path_input))
   {
     if (show_warnings)
-      QMessageBox::critical(this, "Error Loading Files", "The specified path is not a directory or is not accessable");
+      QMessageBox::critical(this, "Error Loading Files", "The specified path is not a directory or is not accessible");
     return false;
   }
 
@@ -360,7 +360,7 @@ bool StartScreenWidget::loadPackageSettings(bool show_warnings)
 }
 
 // ******************************************************************************************
-// Load exisiting package files
+// Load existing package files
 // ******************************************************************************************
 bool StartScreenWidget::loadExistingFiles()
 {
@@ -377,18 +377,18 @@ bool StartScreenWidget::loadExistingFiles()
 
   // Get the URDF path using the loaded .setup_assistant data and check it
   if (!createFullURDFPath())
-    return false;  // error occured
+    return false;  // error occurred
 
   // use xacro args from GUI
   config_data_->xacro_args_ = stack_path_->getArgs().toStdString();
 
   // Load the URDF
   if (!loadURDFFile(config_data_->urdf_path_, config_data_->xacro_args_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Get the SRDF path using the loaded .setup_assistant data and check it
   if (!createFullSRDFPath(config_data_->config_pkg_path_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Progress Indicator
   progress_bar_->setValue(50);
@@ -396,7 +396,7 @@ bool StartScreenWidget::loadExistingFiles()
 
   // Load the SRDF
   if (!loadSRDFFile(config_data_->srdf_path_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Progress Indicator
   progress_bar_->setValue(60);
@@ -808,7 +808,7 @@ SelectModeWidget::SelectModeWidget(QWidget* parent) : QFrame(parent)
   btn_exist_->setCheckable(true);
   hlayout->addWidget(btn_exist_);
 
-  // Add horizontal layer to verticle layer
+  // Add horizontal layer to vertical layer
   layout->addLayout(hlayout);
   setLayout(layout);
   btn_new_->setCheckable(true);

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.h
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.h
@@ -139,7 +139,7 @@ private:
   /// Load chosen files for creating new package
   bool loadNewFiles();
 
-  /// Load exisiting package files
+  /// Load existing package files
   bool loadExistingFiles();
 
   /// Load URDF File to Parameter Server

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -368,7 +368,7 @@ srdf::Model::VirtualJoint* VirtualJointsWidget::findVJointByName(const std::stri
   // Check if vjoint was found
   if (searched_group == nullptr)  // not found
   {
-    QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
+    QMessageBox::critical(this, "Error Saving", "An internal error has occurred while saving. Quitting.");
     QApplication::quit();
   }
 
@@ -575,7 +575,7 @@ void VirtualJointsWidget::loadDataTable()
     ++row;
   }
 
-  // Reenable
+  // Re-enable
   data_table_->setUpdatesEnabled(true);  // prevent table from updating until we are completely done
   data_table_->setDisabled(false);       // make sure we disable it so that the cellChanged event is not called
 

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.h
@@ -127,7 +127,7 @@ private:
   /// Contains all the configuration data for the setup assistant
   moveit_setup_assistant::MoveItConfigDataPtr config_data_;
 
-  /// Orignal name of vjoint currently being edited. This is used to find the element in the vector
+  /// Original name of vjoint currently being edited. This is used to find the element in the vector
   std::string current_edit_vjoint_;
 
   // ******************************************************************************************

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -21,7 +21,7 @@
 
   <arg name="capabilities" default=""/>
   <arg name="disable_capabilities" default=""/>
-  <!-- load these non-default MoveGroup capabilities (space seperated) -->
+  <!-- load these non-default MoveGroup capabilities (space separated) -->
   <!--
   <arg name="capabilities" value="
                 a_package/AwsomeMotionPlanningCapability
@@ -29,7 +29,7 @@
                 " />
   -->
 
-  <!-- inhibit these default MoveGroup capabilities (space seperated) -->
+  <!-- inhibit these default MoveGroup capabilities (space separated) -->
   <!--
   <arg name="disable_capabilities" value="
                 move_group/MoveGroupKinematicsService

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/trajopt_planning_pipeline.launch.xml
@@ -3,10 +3,10 @@
   <!-- TrajOpt Plugin for MoveIt -->
   <arg name="planning_plugin" value="trajopt_interface/TrajOptPlanner" />
 
-  <!-- define capabilites that are loaded on start (space seperated) -->
+  <!-- define capabilities that are loaded on start (space separated) -->
   <arg name="capabilities" default=""/>
 
-  <!-- inhibit capabilites (space seperated) -->
+  <!-- inhibit capabilities (space separated) -->
   <arg name="disable_capabilities" default=""/>
 
   <!-- The request adapters (plugins) used when planning with TrajOpt.


### PR DESCRIPTION
### Description

As requested here: https://github.com/ros-planning/moveit2_tutorials/pull/244

We add the codespell module to .pre-commit-config.yaml and then fix a bunch of spelling errors. 

#### Top Spelling Errors Seen
 19 occured/occurred
 12 seperator/separator
  9 sceen/screen
  9 succesfully/successfully
  8 postion/position
  6 Reenable/Re-enable
  5 collison/collision
  4 Containter/Container


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
