### PR TITLE
Add ros_testsing to moveit_ros_planning for rdf_loader

### DIFF
--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -45,6 +45,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
 


### PR DESCRIPTION
### Description

Fix buildfarm failure: https://build.ros2.org/job/Rbin_ufv8_uFv8__moveit_ros_planning__ubuntu_focal_arm64__binary/47/consoleFull

I don't understand how the prerelease test passed without this.  We'll probably have to create a patch release after this.