### PR TITLE
WIP: [hybrid planning] Handle multiple waypoints, stream outgoing commands at the right rate

### DIFF
--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/include/moveit/global_planner/moveit_planning_pipeline.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/include/moveit/global_planner/moveit_planning_pipeline.h
@@ -60,5 +60,6 @@ public:
 private:
   rclcpp::Node::SharedPtr node_ptr_;
   std::shared_ptr<moveit_cpp::MoveItCpp> moveit_cpp_;
+  bool global_traj_pass_through_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
@@ -179,6 +179,7 @@ moveit_msgs::msg::MotionPlanResponse MoveItPlanningPipeline::plan(
 
     // Copy goal constraint into planning component
     planning_components->setGoal(motion_plan_req.goal_constraints);
+    planning_components->setPathConstraints(motion_plan_req.path_constraints);
 
     // Plan motion
     auto plan_solution = planning_components->plan(plan_params);

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
@@ -109,6 +109,15 @@ moveit_msgs::msg::MotionPlanResponse MoveItPlanningPipeline::plan(
     response.group_name = motion_plan_req.group_name;
     response.planning_time = motion_plan_req.allowed_planning_time;
     response.error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+    moveit::core::RobotStatePtr current_state;
+    if (!moveit_cpp_->getCurrentState(current_state, 0.5))
+    {
+      RCLCPP_ERROR(LOGGER, "Could not retrieve the current robot state.");
+      std::exit(EXIT_FAILURE);
+    }
+    moveit_msgs::msg::RobotState current_state_msg;
+    moveit::core::robotStateToRobotStateMsg(*current_state, current_state_msg);
+    response.trajectory_start = current_state_msg;
 
     moveit_msgs::msg::Constraints goal_constraints =
         global_goal_handle->get_goal()->motion_sequence.items.at(0).req.goal_constraints.at(0);

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp
@@ -54,7 +54,7 @@ bool MoveItPlanningPipeline::initialize(const rclcpp::Node::SharedPtr& node)
   // Maybe use loadPlanningPipelines() from moveit_cpp.cpp
 
   // Allow incoming trajectories to pass straight to the local planner without a global re-plan?
-  global_traj_pass_through_ = node->declare_parameter<bool>("allow_traj_pass_through", false);
+  global_traj_pass_through_ = node->declare_parameter<bool>("global_traj_pass_through", false);
 
   // Declare planning pipeline parameter
   node->declare_parameter<std::vector<std::string>>(PLANNING_PIPELINES_NS + "pipeline_names",
@@ -100,9 +100,8 @@ moveit_msgs::msg::MotionPlanResponse MoveItPlanningPipeline::plan(
     return response;
   }
 
-  // If multiple waypoints were requested, assume we have a fully planned trajectory already.
-  // Just forward to the local planner.
-  // This works only for a JointConstraint type.
+  // If global_traj_pass_through_ and multiple waypoints were requested, assume we have a fully planned trajectory
+  // already. Just forward it to the local planner. This works only for a JointConstraint type.
   size_t num_waypoints = global_goal_handle->get_goal()->motion_sequence.items.size();
   if (global_traj_pass_through_ && num_waypoints > 1)
   {
@@ -131,7 +130,7 @@ moveit_msgs::msg::MotionPlanResponse MoveItPlanningPipeline::plan(
     }
 
     // Get joint names
-    for (auto constraint : goal_constraints.joint_constraints)
+    for (const auto& constraint : goal_constraints.joint_constraints)
     {
       response.trajectory.joint_trajectory.joint_names.push_back(constraint.joint_name);
     }

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -128,8 +128,8 @@ bool HybridPlanningManager::initialize()
     RCLCPP_ERROR(LOGGER, "global_planning_action_name parameter was not defined");
     return false;
   }
-  global_planner_action_client_ = rclcpp_action::create_client<moveit_msgs::action::GlobalPlanner>(
-      this, global_planning_action_name);
+  global_planner_action_client_ =
+      rclcpp_action::create_client<moveit_msgs::action::GlobalPlanner>(this, global_planning_action_name);
   if (!global_planner_action_client_->wait_for_action_server(2s))
   {
     RCLCPP_ERROR(LOGGER, "Global planner action server not available after waiting");

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -129,7 +129,7 @@ bool HybridPlanningManager::initialize()
     return false;
   }
   global_planner_action_client_ = rclcpp_action::create_client<moveit_msgs::action::GlobalPlanner>(
-      this, "/test/hybrid_planning/global_planning_action" /*global_planning_action_name*/);
+      this, global_planning_action_name);
   if (!global_planner_action_client_->wait_for_action_server(2s))
   {
     RCLCPP_ERROR(LOGGER, "Global planner action server not available after waiting");

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -87,7 +87,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
   // If this flag is set, ignore collisions
   if (!stop_before_collision_)
   {
-    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), 0.0);
+    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), local_trajectory.getWayPointDurationFromPrevious(0));
   }
   else
   {
@@ -111,7 +111,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         path_invalidation_event_send_ = false;  // Reset flag
       }
       // Forward next waypoint to the robot controller
-      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), 0.0);
+      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), local_trajectory.getWayPointDurationFromPrevious(0));
     }
     else
     {
@@ -132,7 +132,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         current_state_command.zeroAccelerations();
       }
       robot_command.empty();
-      robot_command.addSuffixWayPoint(*current_state, 0.0);
+      robot_command.addSuffixWayPoint(*current_state, local_trajectory.getWayPointDurationFromPrevious(0));
     }
 
     // Detect if the local solver is stuck

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -155,7 +155,10 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
           RCLCPP_INFO(LOGGER, "The local planner has been stuck for several iterations. Aborting.");
         }
       }
-      prev_waypoint_target_ = robot_command.getFirstWayPointPtr();
+      else
+      {
+        prev_waypoint_target_ = robot_command.getFirstWayPointPtr();
+      }
     }
   }
 

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -40,8 +40,8 @@ namespace
 {
 const rclcpp::Logger LOGGER = rclcpp::get_logger("local_planner_component");
 // If stuck for this many iterations or more, abort the local planning action
-constexpr size_t STUCK_ITERATIONS_THRESHOLD = 10;
-constexpr double STUCK_THRESHOLD_RAD = 1e-4;  // L1-norm sum across all joints
+constexpr size_t STUCK_ITERATIONS_THRESHOLD = 100;
+constexpr double STUCK_THRESHOLD_RAD = 1e-6;  // L1-norm sum across all joints
 }  // namespace
 
 namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -41,7 +41,7 @@ namespace
 const rclcpp::Logger LOGGER = rclcpp::get_logger("local_planner_component");
 // If stuck for this many iterations or more, abort the local planning action
 constexpr size_t STUCK_ITERATIONS_THRESHOLD = 100;
-constexpr double STUCK_THRESHOLD_RAD = 1e-6;  // L1-norm sum across all joints
+constexpr double STUCK_THRESHOLD_RAD = 1e-4;  // L1-norm sum across all joints
 }  // namespace
 
 namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -87,7 +87,8 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
   // If this flag is set, ignore collisions
   if (!stop_before_collision_)
   {
-    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), local_trajectory.getWayPointDurationFromPrevious(0));
+    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0),
+                                    local_trajectory.getWayPointDurationFromPrevious(0));
   }
   else
   {
@@ -111,7 +112,8 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         path_invalidation_event_send_ = false;  // Reset flag
       }
       // Forward next waypoint to the robot controller
-      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), local_trajectory.getWayPointDurationFromPrevious(0));
+      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0),
+                                      local_trajectory.getWayPointDurationFromPrevious(0));
     }
     else
     {

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
@@ -184,7 +184,6 @@ private:
 
   // TF
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   // Global solution listener
   rclcpp::Subscription<moveit_msgs::msg::MotionPlanResponse>::SharedPtr global_solution_subscriber_;

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
@@ -206,5 +206,7 @@ private:
 
   // Trajectory_operator instance handle trajectory matching and blending
   std::shared_ptr<TrajectoryOperatorInterface> trajectory_operator_instance_;
+
+  std::shared_ptr<rclcpp::Rate> prev_waypoint_duration_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -56,6 +56,7 @@ constexpr float PROGRESS_THRESHOLD = 0.995;
 LocalPlannerComponent::LocalPlannerComponent(const rclcpp::NodeOptions& options)
   : node_{ std::make_shared<rclcpp::Node>("local_planner_component", options) }
 {
+  prev_waypoint_duration_ = nullptr;
   state_ = LocalPlannerState::UNCONFIGURED;
   local_planner_feedback_ = std::make_shared<moveit_msgs::action::LocalPlanner::Feedback>();
 
@@ -168,6 +169,7 @@ bool LocalPlannerComponent::initialize()
         // Start local planning loop when an action request is received
         timer_ = node_->create_wall_timer(1s / config_.local_planning_frequency,
                                           std::bind(&LocalPlannerComponent::executeIteration, this));
+        prev_waypoint_duration_ = nullptr;
       });
 
   // Initialize global trajectory listener
@@ -267,6 +269,7 @@ void LocalPlannerComponent::executeIteration()
 
       // Solve local planning problem
       trajectory_msgs::msg::JointTrajectory local_solution;
+      local_solution.header.stamp = node_->now();
 
       // Feedback is only sent when the hybrid planning architecture should react to a discrete event that occurred
       // while computing a local solution
@@ -278,6 +281,15 @@ void LocalPlannerComponent::executeIteration()
       {
         local_planning_goal_handle_->publish_feedback(local_planner_feedback_);
       }
+
+      // Publish at the period given in the previous waypoint
+      // If initialized. Else, publish immediately.
+      if (prev_waypoint_duration_)
+      {
+        prev_waypoint_duration_->sleep();
+      }
+      rclcpp::Duration waypoint_duration = rclcpp::Duration(local_solution.points.at(0).time_from_start);
+      prev_waypoint_duration_ = std::make_shared<rclcpp::Rate>(1 / waypoint_duration.seconds());
 
       // Use a configurable message interface like MoveIt servo
       // (See https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_calcs.cpp)

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -247,7 +247,6 @@ void LocalPlannerComponent::executeIteration()
       // Check if the global goal is reached
       if (trajectory_operator_instance_->getTrajectoryProgress(current_robot_state) > PROGRESS_THRESHOLD)
       {
-        RCLCPP_ERROR(LOGGER, "Global goal is reached.");
         local_planning_goal_handle_->succeed(result);
         reset();
         break;
@@ -271,7 +270,6 @@ void LocalPlannerComponent::executeIteration()
 
       // Feedback is only sent when the hybrid planning architecture should react to a discrete event that occurred
       // while computing a local solution
-      RCLCPP_ERROR(LOGGER, "Calling solve() for the local planner");
       *local_planner_feedback_ = local_constraint_solver_instance_->solve(
           local_trajectory, local_planning_goal_handle_->get_goal(), local_solution);
 

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -247,6 +247,7 @@ void LocalPlannerComponent::executeIteration()
       // Check if the global goal is reached
       if (trajectory_operator_instance_->getTrajectoryProgress(current_robot_state) > PROGRESS_THRESHOLD)
       {
+        RCLCPP_ERROR(LOGGER, "Global goal is reached.");
         local_planning_goal_handle_->succeed(result);
         reset();
         break;
@@ -268,8 +269,9 @@ void LocalPlannerComponent::executeIteration()
       // Solve local planning problem
       trajectory_msgs::msg::JointTrajectory local_solution;
 
-      // Feedback is only send when the hybrid planning architecture should react to a discrete event that occurred
+      // Feedback is only sent when the hybrid planning architecture should react to a discrete event that occurred
       // while computing a local solution
+      RCLCPP_ERROR(LOGGER, "Calling solve() for the local planner");
       *local_planner_feedback_ = local_constraint_solver_instance_->solve(
           local_trajectory, local_planning_goal_handle_->get_goal(), local_solution);
 

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
@@ -63,7 +63,7 @@ private:
   std::size_t
       next_waypoint_index_;  // Indicates which reference trajectory waypoint is the current local goal constrained
   bool pass_through_;  // If true, the reference_trajectory is simply forwarded each time the getLocalTrajectory() function is called
-  double waypoint_radian_tolerance_;  // If closer than this, move to the next waypoint
+  double waypoint_radian_tolerance_;                      // If closer than this, move to the next waypoint
   moveit_msgs::action::LocalPlanner::Feedback feedback_;  // Empty feedback
   trajectory_processing::TimeOptimalTrajectoryGeneration time_parametrization_;
   const moveit::core::JointModelGroup* joint_group_;

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
@@ -63,6 +63,7 @@ private:
   std::size_t
       next_waypoint_index_;  // Indicates which reference trajectory waypoint is the current local goal constrained
   bool pass_through_;  // If true, the reference_trajectory is simply forwarded each time the getLocalTrajectory() function is called
+  double waypoint_radian_tolerance_;  // If closer than this, move to the next waypoint
   moveit_msgs::action::LocalPlanner::Feedback feedback_;  // Empty feedback
   trajectory_processing::TimeOptimalTrajectoryGeneration time_parametrization_;
   const moveit::core::JointModelGroup* joint_group_;

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -71,8 +71,7 @@ SimpleSampler::addTrajectorySegment(const robot_trajectory::RobotTrajectory& new
   // Throw away old reference trajectory and use trajectory update
   reference_trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(new_trajectory);
 
-  // If there are very few waypoints, time-parameterize the trajectory (calculate velocity and accelerations)
-  if (reference_trajectory_->getWayPointCount() <= 2 && !time_parametrization_.computeTimeStamps(*reference_trajectory_))
+  if (!time_parametrization_.computeTimeStamps(*reference_trajectory_))
   {
     feedback_.feedback = "Time parameterization failed.";
   }

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -76,10 +76,6 @@ SimpleSampler::addTrajectorySegment(const robot_trajectory::RobotTrajectory& new
     RCLCPP_ERROR(LOGGER, "Time parameterization failed.");
     feedback_.feedback = "Time parameterization failed.";
   }
-  else
-  {
-    RCLCPP_ERROR(LOGGER, "Time parameterization was successful!");
-  }
 
   // If no errors, return empty feedback
   return feedback_;

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -73,7 +73,12 @@ SimpleSampler::addTrajectorySegment(const robot_trajectory::RobotTrajectory& new
 
   if (!time_parametrization_.computeTimeStamps(*reference_trajectory_))
   {
+    RCLCPP_ERROR(LOGGER, "Time parameterization failed.");
     feedback_.feedback = "Time parameterization failed.";
+  }
+  else
+  {
+    RCLCPP_ERROR(LOGGER, "Time parameterization was successful!");
   }
 
   // If no errors, return empty feedback

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -68,21 +68,16 @@ SimpleSampler::addTrajectorySegment(const robot_trajectory::RobotTrajectory& new
   // Reset trajectory operator to delete old reference trajectory
   reset();
 
-  std::cout << "Num waypoints in new_trajectory: " << new_trajectory.getWayPointCount() << std::endl;
-
   // Throw away old reference trajectory and use trajectory update
   reference_trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(new_trajectory);
 
-  // If there are very few waypoitns, time-parameterize the trajectory (calculate velocity and accelerations)
+  // If there are very few waypoints, time-parameterize the trajectory (calculate velocity and accelerations)
   if (reference_trajectory_->getWayPointCount() <= 2 && !time_parametrization_.computeTimeStamps(*reference_trajectory_))
   {
-    std::cout << "Time parameterization failed!" << std::endl;
     feedback_.feedback = "Time parameterization failed.";
   }
 
-  std::cout << "Num waypoints after addTrajectorySegment(): " << reference_trajectory_->getWayPointCount() << std::endl;
-
-  // Return empty feedback
+  // If no errors, return empty feedback
   return feedback_;
 }
 
@@ -130,7 +125,6 @@ SimpleSampler::getLocalTrajectory(const moveit::core::RobotState& current_state,
 double SimpleSampler::getTrajectoryProgress(const moveit::core::RobotState& current_state)
 {
   // Check if trajectory is unwound
-  std::cout << "Waypoint count: " << reference_trajectory_->getWayPointCount() << "  Next waypt index: " << next_waypoint_index_ << std::endl;
   if (next_waypoint_index_ >= reference_trajectory_->getWayPointCount() - 1)
   {
     return 1.0;

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -47,14 +47,14 @@ bool SimpleSampler::initialize(const rclcpp::Node::SharedPtr& node, const moveit
                                const std::string& group_name)
 {
   // Load parameter & initialize member variables
-  node->declare_parameter("pass_through");
+  node->declare_parameter("pass_through", false);
   if (!node->get_parameter<bool>("pass_through", pass_through_))
   {
     RCLCPP_ERROR(LOGGER, "pass_through parameter was not defined.");
     return false;
   }
 
-  node->declare_parameter("waypoint_radian_tolerance");
+  node->declare_parameter("waypoint_radian_tolerance", 0.0);
   if (!node->get_parameter<double>("waypoint_radian_tolerance", waypoint_radian_tolerance_))
   {
     RCLCPP_ERROR(LOGGER, "waypoint_radian_tolerance parameter was not defined.");

--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -16,14 +16,14 @@
   <build_depend>moveit_common</build_depend>
 
   <depend>ament_index_cpp</depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
-  <depend>rclcpp_components</depend>
   <depend>moveit_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>

--- a/moveit_ros/hybrid_planning/test/config/global_planner.yaml
+++ b/moveit_ros/hybrid_planning/test/config/global_planner.yaml
@@ -1,5 +1,9 @@
 global_planner_name: "moveit_hybrid_planning/MoveItPlanningPipeline"
 
+# Allow an incoming trajectory with multiple waypoints to pass straight to the local planner
+# without a global replan
+global_traj_pass_through: false
+
 # The rest of these parameters are typical for moveit_cpp
 planning_scene_monitor_options:
   name: "planning_scene_monitor"

--- a/moveit_ros/hybrid_planning/test/config/local_planner.yaml
+++ b/moveit_ros/hybrid_planning/test/config/local_planner.yaml
@@ -11,6 +11,8 @@ group_name: "panda_arm"
 
 # SimpleSampler param
 pass_through: false
+# When this close to the target waypoint, move on to the next. An L1 norm across all joints
+waypoint_radian_tolerance: 0.4
 
 # ForwardTrajectory param
 stop_before_collision: true


### PR DESCRIPTION
- If an incoming request contains multiple waypoints, pass it straight to local planning. Do not re-plan a global trajectory.

The previous implementation of the default global planning plugin could only take one waypoint at a time (see https://github.com/ros-planning/moveit2/blob/c8d3b19da0b902c2ac2ab6791bcd5891bebcc505/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/src/moveit_planning_pipeline.cpp#L101).

We want to take the output of MoveIt Task Constructor and pass an entire trajectory to hybrid planning for execution. This PR just passes an incoming request straight through to the local planner if it has multiple waypoints.

- Stream the outgoing commands at the proper rate.

Prior to this PR, the robot would jump immediately to the target position. With this PR, it follows the target waypoint timestamps.

Previously - jump instantly to the target pose
https://user-images.githubusercontent.com/11284393/148585450-c11676cb-acc4-4a8e-93e2-2fa2f9fd40ed.mp4

With this PR
https://user-images.githubusercontent.com/11284393/148585490-de3adede-a786-4d8c-9c78-f1de0ad4ec42.mp4


