### PR TITLE
Depend on the source of our own released repos

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -2,20 +2,8 @@ repositories:
   geometric_shapes:
     type: git
     url: https://github.com/ros-planning/geometric_shapes
-    version: ros2
+    version: 2.1.2
   moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs
-    version: ros2
-  moveit_resources:
-    type: git
-    url: https://github.com/ros-planning/moveit_resources
-    version: ros2
-  warehouse_ros:
-    type: git
-    url: https://github.com/ros-planning/warehouse_ros
-    version: ros2
-  warehouse_ros_mongo:
-    type: git
-    url: https://github.com/ros-planning/warehouse_ros_mongo
-    version: ros2
+    version: 2.2.0


### PR DESCRIPTION
### Description

These versions have been bloomed and are not yet synced.  The debain versions of moveit_resources, warehouse_ros, and warehouse_ros_mongo should work just fine for our CI.

This is a shift in philosophy on how this file is used, but long term it would be really nice if this repos file only has branch versions in it when there was a change in an upstream repo we control that the main branch that we depend on.  Then after blooming (and before the sync) this file points to the newly released tag, then after it is synced we remove the repo from this file.  That way our CI system is building/caching the least amount possible in the upstream step and those who use moveit from source on the main branch are building the least amount possible in their local workspace.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
