### PR TITLE
Add rosdistro version to upstream ws cache prefix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,23 +70,11 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
-      - name: Get rosdistro version for a given
-        id: ros_distro_version
-        shell: bash
-        env:
-          ROS_DISTRO: ${{ matrix.env.ROS_DISTRO }}
-        run: |
-          latest-release-date() {
-              echo "$(curl -sL "https://api.github.com/repos/ros/rosdistro/tags?per_page=100" \
-              | grep -o "$1/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" \
-              | cut -d'/' -f2 \
-              | uniq \
-              | sort -t- -k1n -k2n -k3n -z | head -n 1)"
-          }
-          ROS_DISTRO_VERSION=`latest-release-date $ROS_DISTRO`
-          echo "The latest version for $ROS_DISTRO is $ROS_DISTRO_VERSION"
-          echo set-output name=ROS_DISTRO_VERSION::${ROS_DISTRO_VERSION}
-          echo ::set-output name=ROS_DISTRO_VERSION::${ROS_DISTRO_VERSION}
+      - name: Get latest release date for rosdistro
+        id: rosdistro_release_date
+        uses: JafarAbdi/latest-rosdistro-release-date-action@main
+        with:
+          rosdistro: ${{ matrix.env.ROS_DISTRO }}
       - name: Cache upstream workspace
         uses: pat-s/always-upload-cache@v2.1.5
         with:
@@ -94,7 +82,7 @@ jobs:
           key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
           restore-keys: ${{ env.CACHE_PREFIX }}
         env:
-          CACHE_PREFIX: ${{ steps.ros_distro_version.outputs.ROS_DISTRO_VERSION }}-upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
+          CACHE_PREFIX: ${{ steps.rosdistro_release_date.outputs.date }}-upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: Cache target workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,15 @@ jobs:
         env:
           - IMAGE: rolling-ci
             CCOV: true
+            ROS_DISTRO: rolling
           - IMAGE: rolling-ci-testing
             IKFAST_TEST: true
+            ROS_DISTRO: rolling
           - IMAGE: galactic-ci
             CLANG_TIDY: pedantic
+            ROS_DISTRO: galactic
           - IMAGE: galactic-ci-testing
+            ROS_DISTRO: galactic
     env:
       CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-deprecated-copy"
       DOCKER_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.env.IMAGE }}
@@ -66,6 +70,23 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v2
+      - name: Get rosdistro version for a given
+        id: ros_distro_version
+        shell: bash
+        env:
+          ROS_DISTRO: ${{ matrix.env.ROS_DISTRO }}
+        run: |
+          latest-release-date() {
+              echo "$(curl -sL "https://api.github.com/repos/ros/rosdistro/tags?per_page=100" \
+              | grep -o "$1/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" \
+              | cut -d'/' -f2 \
+              | uniq \
+              | sort -t- -k1n -k2n -k3n -z | head -n 1)"
+          }
+          ROS_DISTRO_VERSION=`latest-release-date $ROS_DISTRO`
+          echo "The latest version for $ROS_DISTRO is $ROS_DISTRO_VERSION"
+          echo set-output name=ROS_DISTRO_VERSION::${ROS_DISTRO_VERSION}
+          echo ::set-output name=ROS_DISTRO_VERSION::${ROS_DISTRO_VERSION}
       - name: Cache upstream workspace
         uses: pat-s/always-upload-cache@v2.1.5
         with:
@@ -73,7 +94,7 @@ jobs:
           key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
           restore-keys: ${{ env.CACHE_PREFIX }}
         env:
-          CACHE_PREFIX: upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
+          CACHE_PREFIX: ${{ steps.ros_distro_version.outputs.ROS_DISTRO_VERSION }}-upstream_ws-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: Cache target workspace


### PR DESCRIPTION
### Description

Hopefully fix: https://github.com/ros-planning/moveit2/issues/783 and https://github.com/ros-planning/moveit2/issues/947

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
