### PR TITLE
Servo: re-order velocity limit check & minor cleanup

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -7,9 +7,9 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.4  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.8 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
-  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  linear:  0.4  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
 
 ## Properties of outgoing commands

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -7,9 +7,9 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.6  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.3 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
-  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  linear:  0.6  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
 
 ## Properties of outgoing commands

--- a/moveit_ros/moveit_servo/include/moveit_servo/enforce_limits.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/enforce_limits.hpp
@@ -46,15 +46,11 @@
 namespace moveit_servo
 {
 /**
- * @brief      Scale the delta theta to match joint velocity/acceleration limits
- *
- * @param[in]  joint_model_group   The joint model group
- * @param[in]  publish_period      The publish period of servo (used for calculating joint velocity)
- * @param[in]  delta_theta         The delta theta input
- *
- * @return     The delta theta output
+ * @brief Decrease robot position change and velocity, if needed, to satisfy joint velocity limits
+ * @param joint_model_group Active joint group. Used to retrieve limits.
+ * @param joint_state The command that will go to the robot.
  */
-Eigen::ArrayXd enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, double publish_period,
-                                     const Eigen::ArrayXd& delta_theta);
+void enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const double publish_period,
+                           sensor_msgs::msg::JointState& joint_state);
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -148,11 +148,13 @@ protected:
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
+   * @return a vector of position deltas
    */
   Eigen::VectorXd scaleCartesianCommand(const geometry_msgs::msg::TwistStamped& command);
 
   /** \brief If incoming velocity commands are from a unitless joystick, scale them to physical units.
    * Also, multiply by timestep to calculate a position change.
+   * @return a vector of position deltas
    */
   Eigen::VectorXd scaleJointCommand(const control_msgs::msg::JointJog& command);
 
@@ -201,8 +203,7 @@ protected:
    * @param previous_vel Eigen vector of previous velocities being updated
    * @return Returns false if there is a problem, true otherwise
    */
-  bool applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state,
-                        Eigen::ArrayXd& previous_vel);
+  bool applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state);
 
   /** \brief Gazebo simulations have very strict message timestamp requirements.
    * Satisfy Gazebo by stuffing multiple messages into one.
@@ -334,7 +335,6 @@ protected:
 
   // Use ArrayXd type to enable more coefficient-wise operations
   Eigen::ArrayXd delta_theta_;
-  Eigen::ArrayXd prev_joint_velocity_;
 
   const int gazebo_redundant_message_count_ = 30;
 

--- a/moveit_ros/moveit_servo/src/enforce_limits.cpp
+++ b/moveit_ros/moveit_servo/src/enforce_limits.cpp
@@ -47,7 +47,7 @@ namespace moveit_servo
 {
 namespace
 {
-double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model_group, const Eigen::ArrayXd& velocity)
+double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model_group, const Eigen::VectorXd& velocity)
 {
   std::size_t joint_delta_index{ 0 };
   double velocity_scaling_factor{ 1.0 };
@@ -69,17 +69,27 @@ double getVelocityScalingFactor(const moveit::core::JointModelGroup* joint_model
 
 }  // namespace
 
-Eigen::ArrayXd enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, double publish_period,
-                                     const Eigen::ArrayXd& delta_theta)
+void enforceVelocityLimits(const moveit::core::JointModelGroup* joint_model_group, const double publish_period,
+                           sensor_msgs::msg::JointState& joint_state)
 {
-  // Convert to joint angle velocities for checking and applying joint specific velocity limits.
-  Eigen::ArrayXd velocity = delta_theta / publish_period;
-
   // Get the velocity scaling factor
+  Eigen::VectorXd velocity =
+      Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(joint_state.velocity.data(), joint_state.velocity.size());
   double velocity_scaling_factor = getVelocityScalingFactor(joint_model_group, velocity);
 
-  // Scale the resulting detas to avoid violating limits.
-  return velocity_scaling_factor * velocity * publish_period;
+  // Take a smaller step if the velocity scaling factor is less than 1
+  if (velocity_scaling_factor < 1)
+  {
+    Eigen::VectorXd velocity_residuals = (1 - velocity_scaling_factor) * velocity;
+    Eigen::VectorXd positions =
+        Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(joint_state.position.data(), joint_state.position.size());
+    positions -= velocity_residuals * publish_period;
+
+    velocity *= velocity_scaling_factor;
+    // Back to sensor_msgs type
+    joint_state.velocity = std::vector<double>(velocity.data(), velocity.data() + velocity.size());
+    joint_state.position = std::vector<double>(positions.data(), positions.data() + positions.size());
+  }
 }
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -611,8 +611,6 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   }
   delta_theta *= collision_scale;
 
-  // Loop through joints and update them, calculate velocities, and filter
-  if (!applyJointUpdate(delta_theta, internal_joint_state_, prev_joint_velocity_))
   // Loop thru joints and update them, calculate velocities, and filter
   if (!applyJointUpdate(delta_theta, internal_joint_state_))
     return false;

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -119,7 +119,6 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
     RCLCPP_ERROR_STREAM(LOGGER, "Invalid move group name: `" << parameters_->move_group_name << "`");
     throw std::runtime_error("Invalid move group name");
   }
-  prev_joint_velocity_ = Eigen::ArrayXd::Zero(joint_model_group_->getActiveJointModels().size());
 
   // Subscribe to command topics
   using std::placeholders::_1;
@@ -149,10 +148,6 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
       node_->create_subscription<std_msgs::msg::Float64>("~/collision_velocity_scale", rclcpp::SystemDefaultsQoS(),
                                                          std::bind(&ServoCalcs::collisionVelocityScaleCB, this, _1));
 
-  // Publish to collision_check for worst stop time
-  worst_case_stop_time_pub_ =
-      node_->create_publisher<std_msgs::msg::Float64>("~/worst_case_stop_time", rclcpp::SystemDefaultsQoS());
-
   // Publish freshly-calculated joints to the robot.
   // Put the outgoing msg in the right format (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
   if (parameters_->command_out_type == "trajectory_msgs/JointTrajectory")
@@ -179,25 +174,6 @@ ServoCalcs::ServoCalcs(rclcpp::Node::SharedPtr node,
   {
     // A map for the indices of incoming joint commands
     joint_state_name_map_[internal_joint_state_.name[i]] = i;
-  }
-
-  // Load the smoothing plugin
-  try
-  {
-    smoother_ = smoothing_loader_.createSharedInstance(parameters_->smoothing_filter_plugin_name);
-  }
-  catch (pluginlib::PluginlibException& ex)
-  {
-    RCLCPP_ERROR(LOGGER, "Exception while loading the smoothing plugin '%s': '%s'",
-                 parameters_->smoothing_filter_plugin_name.c_str(), ex.what());
-    std::exit(EXIT_FAILURE);
-  }
-
-  // Initialize the smoothing plugin
-  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), num_joints_))
-  {
-    RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
-    std::exit(EXIT_FAILURE);
   }
 
   // Load the smoothing plugin
@@ -619,9 +595,6 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   // Set internal joint state from original
   internal_joint_state_ = original_joint_state_;
 
-  // Enforce SRDF Velocity, Acceleration limits
-  delta_theta = enforceVelocityLimits(joint_model_group_, parameters_->publish_period, delta_theta);
-
   // Apply collision scaling
   double collision_scale = collision_velocity_scale_;
   if (collision_scale > 0 && collision_scale < 1)
@@ -640,10 +613,15 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
 
   // Loop through joints and update them, calculate velocities, and filter
   if (!applyJointUpdate(delta_theta, internal_joint_state_, prev_joint_velocity_))
+  // Loop thru joints and update them, calculate velocities, and filter
+  if (!applyJointUpdate(delta_theta, internal_joint_state_))
     return false;
 
   // Mark the lowpass filters as updated for this cycle
   updated_filters_ = true;
+
+  // Enforce SRDF velocity limits
+  enforceVelocityLimits(joint_model_group_, parameters_->publish_period, internal_joint_state_);
 
   // Enforce SRDF position limits, might halt if needed, set prev_vel to 0
   const auto joints_to_halt = enforcePositionLimits(internal_joint_state_);
@@ -654,13 +632,10 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
         (servo_type == ServoType::CARTESIAN_SPACE && !parameters_->halt_all_joints_in_cartesian_mode))
     {
       suddenHalt(internal_joint_state_, joints_to_halt);
-      prev_joint_velocity_ =
-          Eigen::ArrayXd::Map(internal_joint_state_.velocity.data(), internal_joint_state_.velocity.size());
     }
     else
     {
       suddenHalt(internal_joint_state_, joint_model_group_->getActiveJointModels());
-      prev_joint_velocity_.setZero();
     }
   }
 
@@ -676,13 +651,11 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   return true;
 }
 
-bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state,
-                                  Eigen::ArrayXd& previous_vel)
+bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs::msg::JointState& joint_state)
 {
   // All the sizes must match
   if (joint_state.position.size() != static_cast<std::size_t>(delta_theta.size()) ||
-      joint_state.velocity.size() != joint_state.position.size() ||
-      static_cast<std::size_t>(previous_vel.size()) != joint_state.position.size())
+      joint_state.velocity.size() != joint_state.position.size())
   {
     rclcpp::Clock& clock = *node_->get_clock();
     RCLCPP_ERROR_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
@@ -703,9 +676,6 @@ bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs
     // Calculate joint velocity
     joint_state.velocity[i] =
         (joint_state.position.at(i) - original_joint_state_.position.at(i)) / parameters_->publish_period;
-
-    // Save this velocity for future accel calculations
-    previous_vel[i] = joint_state.velocity[i];
   }
 
   return true;
@@ -1008,7 +978,7 @@ bool ServoCalcs::checkValidCommand(const geometry_msgs::msg::TwistStamped& cmd)
   return true;
 }
 
-// Scale the incoming jog command
+// Scale the incoming jog command. Returns a vector of position deltas
 Eigen::VectorXd ServoCalcs::scaleCartesianCommand(const geometry_msgs::msg::TwistStamped& command)
 {
   Eigen::VectorXd result(6);

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -592,6 +592,13 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
                                      trajectory_msgs::msg::JointTrajectory& joint_trajectory,
                                      const ServoType servo_type)
 {
+  // The order of operations here is:
+  // 1. apply velocity scaling for collisions (in the position domain)
+  // 2. low-pass filter the position command in applyJointUpdate()
+  // 3. calculate velocities in applyJointUpdate()
+  // 4. apply velocity limits
+  // 5. apply position limits. This is a higher priority than velocity limits, so check it last.
+
   // Set internal joint state from original
   internal_joint_state_ = original_joint_state_;
 

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -122,19 +122,18 @@ void ServoParameters::declare(const std::string& ns,
   node_parameters->declare_parameter(ns + ".scale.linear", ParameterValue{ parameters.linear_scale },
                                      ParameterDescriptorBuilder{}
                                          .type(PARAMETER_DOUBLE)
-                                         .description("Max linear velocity. Meters per publish_period. Unit is [m/s]. "
+                                         .description("Max linear velocity. Unit is [m/s]. "
                                                       "Only used for Cartesian commands."));
   node_parameters->declare_parameter(ns + ".scale.rotational", ParameterValue{ parameters.rotational_scale },
                                      ParameterDescriptorBuilder{}
                                          .type(PARAMETER_DOUBLE)
-                                         .description("Max angular velocity. Rads per publish_period. Unit is [rad/s]. "
+                                         .description("Max angular velocity. Unit is [rad/s]. "
                                                       "Only used for Cartesian commands."));
-  node_parameters->declare_parameter(
-      ns + ".scale.joint", ParameterValue{ parameters.joint_scale },
-      ParameterDescriptorBuilder{}
-          .type(PARAMETER_DOUBLE)
-          .description("Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint "
-                       "commands on joint_command_in_topic."));
+  node_parameters->declare_parameter(ns + ".scale.joint", ParameterValue{ parameters.joint_scale },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description("Max joint angular/linear velocity. Only used for joint "
+                                                      "commands on joint_command_in_topic."));
 
   // Properties of outgoing commands
   node_parameters->declare_parameter(


### PR DESCRIPTION
This is a simplified version of #886. It removes the latency compensation parameter that was controversial with reviewers for some reason (despite fixing some hardware issues and being backed as similar to what the robot manufacturers use  :/  ). By splitting it out, I hope the review is faster.

The various fixes here are:

- Re-order the checking of velocity limits. These limits should be checked **after** the other operations that affect velocity. Otherwise they aren't accurate.

- Delete a block of code that was accidentally duplicated.

- Clean up some comments.

- Delete a couple unused things.

You can test this PR with the tutorial:  https://moveit.picknik.ai/main/doc/realtime_servo/realtime_servo_tutorial.html

If you're familiar with the tutorial, you'll notice that motion is faster.