### PR TITLE
fix usage of placeholder

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -163,8 +163,8 @@ void MoveGroupSequenceAction::executeSequenceCallbackPlanAndExecute(
   opt.replan_delay_ = goal->planning_options.replan_delay;
   opt.before_execution_callback_ = boost::bind(&MoveGroupSequenceAction::startMoveExecutionCallback, this);
 
-  opt.plan_callback_ =
-      boost::bind(&MoveGroupSequenceAction::planUsingSequenceManager, this, boost::cref(goal->request), _1);
+  opt.plan_callback_ = boost::bind(&MoveGroupSequenceAction::planUsingSequenceManager, this, boost::cref(goal->request),
+                                   boost::placeholders::_1);
 
   if (goal->planning_options.look_around && context_->plan_with_sensing_)
   {


### PR DESCRIPTION
I was hitting a compilation error because `_1` wasn't properly available. I think this fixes it for us (RoboStack project).