### PR TITLE
Sync with MoveIt

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1652,8 +1652,10 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
       for (std::size_t i = 0; i < shape_vector.size(); ++i)
       {
         if (i >= shape_poses_vector.size())
+        {
           append(shapes::constructShapeFromMsg(shape_vector[i]),
                  geometry_msgs::msg::Pose());  // Empty shape pose => Identity
+        }
         else
           append(shapes::constructShapeFromMsg(shape_vector[i]), shape_poses_vector[i]);
       }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -473,7 +473,7 @@ void RobotState::setVariableEffort(const std::map<std::string, double>& variable
 {
   markEffort();
   for (const std::pair<const std::string, double>& it : variable_map)
-    acceleration_[robot_model_->getVariableIndex(it.first)] = it.second;
+    effort_[robot_model_->getVariableIndex(it.first)] = it.second;
 }
 
 void RobotState::setVariableEffort(const std::map<std::string, double>& variable_map,

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -940,15 +940,16 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
     max_velocity[j] = 1.0;
     if (bounds.velocity_bounded_)
     {
-      max_velocity[j] = std::min(fabs(bounds.max_velocity_), fabs(bounds.min_velocity_)) * velocity_scaling_factor;
+      max_velocity[j] =
+          std::min(std::fabs(bounds.max_velocity_), std::fabs(bounds.min_velocity_)) * velocity_scaling_factor;
       max_velocity[j] = std::max(0.01, max_velocity[j]);
     }
 
     max_acceleration[j] = 1.0;
     if (bounds.acceleration_bounded_)
     {
-      max_acceleration[j] =
-          std::min(fabs(bounds.max_acceleration_), fabs(bounds.min_acceleration_)) * acceleration_scaling_factor;
+      max_acceleration[j] = std::min(std::fabs(bounds.max_acceleration_), std::fabs(bounds.min_acceleration_)) *
+                            acceleration_scaling_factor;
       max_acceleration[j] = std::max(0.01, max_acceleration[j]);
     }
   }
@@ -960,13 +961,17 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   {
     moveit::core::RobotStatePtr waypoint = trajectory.getWayPointPtr(p);
     Eigen::VectorXd new_point(num_joints);
+    // The first point should always be kept
     bool diverse_point = (p == 0);
 
     for (size_t j = 0; j < num_joints; ++j)
     {
       new_point[j] = waypoint->getVariablePosition(idx[j]);
-      if (p > 0 && std::abs(new_point[j] - points.back()[j]) > min_angle_change_)
+      // If any joint angle is different, it's a unique waypoint
+      if (p > 0 && std::fabs(new_point[j] - points.back()[j]) > min_angle_change_)
+      {
         diverse_point = true;
+      }
     }
 
     if (diverse_point)

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -267,7 +267,7 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
   }
 }
 
-void TrajectoryGeneratorPTP::plan(const planning_scene::PlanningSceneConstPtr& scene,
+void TrajectoryGeneratorPTP::plan(const planning_scene::PlanningSceneConstPtr& /*scene*/,
                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
                                   const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/launch/python_move_group_planning.test
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/launch/python_move_group_planning.test
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Start joint_state_publisher, robot_state_publisher, and MoveGroup -->
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/test_environment.launch"/>
+
+  <!-- Test MoveGroupInterface for Python -->
+  <test pkg="pilz_industrial_motion_planner" type="python_move_group_planning.py" test-name="python_move_group_planning"
+        time-limit="300" args=""/>
+</launch>

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/python_move_group_planning.py
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/python_move_group_planning.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2021, Cristian C. Beltran-Hernandez
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Cristian C. Beltran-Hernandez nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Cristian C. Beltran-Hernandez
+#
+# This test is used to ensure planning with an attached object
+# correctly validates collision states between the attached objects
+# and the environment
+
+import unittest
+import numpy as np
+import rospy
+import rostest
+import os
+
+from moveit_msgs.msg import MoveItErrorCodes
+import moveit_commander
+
+from geometry_msgs.msg import PoseStamped
+
+
+class PythonMoveGroupPlanningTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        PLANNING_GROUP = "panda_arm"
+        self.group = moveit_commander.MoveGroupCommander(PLANNING_GROUP)
+        self.planning_scene_interface = moveit_commander.PlanningSceneInterface(
+            synchronous=True
+        )
+
+    @classmethod
+    def tearDown(self):
+        pass
+
+    def test_planning_with_collision_objects(self):
+        # Add obstacle to the world
+        ps = PoseStamped()
+        ps.header.frame_id = "world"
+        ps.pose.position.x = 0.4
+        ps.pose.position.y = 0.1
+        ps.pose.position.z = 0.25
+        self.planning_scene_interface.add_box(
+            name="box1", pose=ps, size=(0.1, 0.1, 0.5)
+        )
+
+        # Attach object to robot's TCP
+        ps2 = PoseStamped()
+        tcp_link = self.group.get_end_effector_link()
+        ps2.header.frame_id = tcp_link
+        ps2.pose.position.z = 0.15
+        self.planning_scene_interface.attach_box(
+            link=tcp_link,
+            name="box2",
+            pose=ps2,
+            size=(0.1, 0.1, 0.1),
+            touch_links=["panda_rightfinger", "panda_leftfinger"],
+        )
+
+        # Plan a motion where the attached object 'box2' collides with the obstacle 'box1'
+        target_pose = self.group.get_current_pose(tcp_link)
+        target_pose.pose.position.y += 0.1
+
+        # # Set planner to be Pilz's Linear Planner
+        # self.group.set_planning_pipeline_id("pilz_industrial_motion_planner")
+        # self.group.set_planner_id("LIN")
+        # self.group.set_pose_target(target_pose)
+        # success, plan, time, error_code = self.group.plan()
+
+        # # Planning should fail
+        # self.assertEqual(error_code.val, MoveItErrorCodes.INVALID_MOTION_PLAN)
+
+        # Set planner to be Pilz's Point-To-Point Planner
+        self.group.set_planning_pipeline_id("pilz_industrial_motion_planner")
+        self.group.set_planner_id("PTP")
+        self.group.set_pose_target(target_pose)
+        success, plan, time, error_code = self.group.plan()
+
+        # Planning should fail
+        self.assertFalse(success)
+        self.assertEqual(error_code.val, MoveItErrorCodes.INVALID_MOTION_PLAN)
+
+
+if __name__ == "__main__":
+    PKGNAME = "moveit_ros_planning_interface"
+    NODENAME = "moveit_test_python_move_group"
+    rospy.init_node(NODENAME)
+    rostest.rosrun(PKGNAME, NODENAME, PythonMoveGroupPlanningTest)

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -231,7 +231,7 @@ bool testutils::checkCartesianLinearity(const moveit::core::RobotModelConstPtr& 
                                         const trajectory_msgs::msg::JointTrajectory& trajectory,
                                         const planning_interface::MotionPlanRequest& req,
                                         const double translation_norm_tolerance, const double rot_axis_norm_tolerance,
-                                        const double rot_angle_tolerance)
+                                        const double /*rot_angle_tolerance*/)
 {
   std::string link_name;
   Eigen::Isometry3d goal_pose_expect;
@@ -1126,7 +1126,8 @@ bool testutils::checkBlendResult(const pilz_industrial_motion_planner::Trajector
                                  const pilz_industrial_motion_planner::TrajectoryBlendResponse& blend_res,
                                  const pilz_industrial_motion_planner::LimitsContainer& limits,
                                  double joint_velocity_tolerance, double joint_acceleration_tolerance,
-                                 double cartesian_velocity_tolerance, double cartesian_angular_velocity_tolerance)
+                                 double /*cartesian_velocity_tolerance*/,
+                                 double /*cartesian_angular_velocity_tolerance*/)
 {
   // ++++++++++++++++++++++
   // + Check trajectories +

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -790,12 +790,21 @@ public:
   /** \brief Stop any trajectory execution, if one is active */
   void stop();
 
-  /** \brief Specify whether the robot is allowed to look around before moving if it determines it should (default is
-   * true) */
-  void allowLooking(bool flag);
-
   /** \brief Specify whether the robot is allowed to replan if it detects changes in the environment */
   void allowReplanning(bool flag);
+
+  /** \brief Maximum number of replanning attempts */
+  void setReplanAttempts(int32_t attempts);
+
+  /** \brief Sleep this duration between replanning attempts (in walltime seconds) */
+  void setReplanDelay(double delay);
+
+  /** \brief Specify whether the robot is allowed to look around
+      before moving if it determines it should (default is false) */
+  void allowLooking(bool flag);
+
+  /** \brief How often is the system allowed to move the camera to update environment model when looking */
+  void setLookAroundAttempts(int32_t attempts);
 
   /** \brief Build the MotionPlanRequest that would be sent to the move_group action with plan() or move() and store it
       in \e request */

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -160,18 +160,10 @@ public:
       {
         if (std::find(object_ids.begin(), object_ids.end(), collision_object.id) != object_ids.end())
         {
-          if (collision_object.mesh_poses.empty() && collision_object.primitive_poses.empty())
-            continue;
-          if (!collision_object.mesh_poses.empty())
-            result[collision_object.id] = collision_object.mesh_poses[0];
-          else
-            result[collision_object.id] = collision_object.primitive_poses[0];
+          result[collision_object.id] = collision_object.pose;
         }
       }
     }
-    else
-      RCLCPP_WARN(LOGGER, "Could not call planning scene service to get object names");
-
     return result;
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -245,6 +245,19 @@ void MotionPlanningDisplay::onInitialize()
 
   rviz_common::WindowManagerInterface* window_context = context_->getWindowManager();
   frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
+
+  std::string host_param;
+  if (node_->get_parameter("warehouse_host", host_param))
+  {
+    frame_->ui_->database_host->setText(QString::fromStdString(host_param));
+  }
+
+  int port;
+  if (node_->get_parameter("warehouse_port", port))
+  {
+    frame_->ui_->database_port->setValue(port);
+  }
+
   connect(frame_, SIGNAL(configChanged()), this->getModel(), SIGNAL(configChanged()));
   resetStatusTextColor();
   addStatusText("Initialized.");
@@ -1323,18 +1336,6 @@ void MotionPlanningDisplay::load(const rviz_common::Config& config)
   PlanningSceneDisplay::load(config);
   if (frame_)
   {
-    QString host;
-    std::string host_param;
-    if (config.mapGetString("MoveIt_Warehouse_Host", &host))
-      frame_->ui_->database_host->setText(host);
-    else if (node_->get_parameter("warehouse_host", host_param))
-    {
-      host = QString::fromStdString(host_param);
-      frame_->ui_->database_host->setText(host);
-    }
-    int port;
-    if (config.mapGetInt("MoveIt_Warehouse_Port", &port) || node_->get_parameter("warehouse_port", port))
-      frame_->ui_->database_port->setValue(port);
     float d;
     if (config.mapGetFloat("MoveIt_Planning_Time", &d))
       frame_->ui_->planning_time->setValue(d);
@@ -1382,7 +1383,6 @@ void MotionPlanningDisplay::load(const rviz_common::Config& config)
     }
     else
     {
-      std::string node_name = rclcpp::names::append(getMoveGroupNS(), "move_group");
       double val;
       if (node_->get_parameter("default_workspace_bounds", val))
       {
@@ -1399,9 +1399,6 @@ void MotionPlanningDisplay::save(rviz_common::Config config) const
   PlanningSceneDisplay::save(config);
   if (frame_)
   {
-    config.mapSetValue("MoveIt_Warehouse_Host", frame_->ui_->database_host->text());
-    config.mapSetValue("MoveIt_Warehouse_Port", frame_->ui_->database_port->value());
-
     // "Options" Section
     config.mapSetValue("MoveIt_Planning_Time", frame_->ui_->planning_time->value());
     config.mapSetValue("MoveIt_Planning_Attempts", frame_->ui_->planning_attempts->value());

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -147,7 +147,7 @@
           <item>
            <widget class="QLineEdit" name="database_host">
             <property name="text">
-             <string>127.0.0.1</string>
+             <string></string>
             </property>
            </widget>
           </item>
@@ -164,7 +164,7 @@
              <number>65535</number>
             </property>
             <property name="value">
-             <number>33829</number>
+             <number>0</number>
             </property>
            </widget>
           </item>

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -200,7 +200,7 @@ void PlanningSceneDisplay::onInitialize()
   node_ = ros_node_abstraction->get_raw_node();
   planning_scene_topic_property_->initialize(ros_node_abstraction);
 
-  // the scene node that contains everything
+  // the scene node that contains everything and is located at the planning frame
   planning_scene_node_ = scene_node_->createChildSceneNode();
 
   if (robot_category_)
@@ -652,6 +652,8 @@ void PlanningSceneDisplay::update(float wall_dt, float ros_dt)
 
   executeMainLoopJobs();
 
+  calculateOffsetPosition();
+
   if (planning_scene_monitor_)
     updateInternal(wall_dt, ros_dt);
 }
@@ -664,7 +666,6 @@ void PlanningSceneDisplay::updateInternal(float wall_dt, float /*ros_dt*/)
        planning_scene_needs_render_))
   {
     renderPlanningScene();
-    calculateOffsetPosition();
     current_scene_time_ = 0.0f;
     robot_state_needs_render_ = false;
     planning_scene_needs_render_ = false;

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -666,7 +666,7 @@ bool StartScreenWidget::extractPackageNameFromPath()
     {
       QMessageBox::warning(this, "Package Not Found In ROS Workspace",
                            QString("ROS was unable to find the package name '")
-                               .append(config_data_->urdf_pkg_name_.c_str())
+                               .append(package_name.c_str())
                                .append("' within the ROS workspace. This may cause issues later."));
     }
 

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/move_group.launch
@@ -47,23 +47,22 @@
   <group ns="move_group/planning_pipelines">
 
     <!-- OMPL -->
-    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
+    <include file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
     <!-- CHOMP -->
-    <include ns="chomp" file="$(dirname)/planning_pipeline.launch.xml">
+    <include file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
     <!-- Pilz Industrial Motion -->
-    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
+    <include file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Support custom planning pipeline -->
-    <include ns="$(arg pipeline)" if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])"
-	     file="$(dirname)/planning_pipeline.launch.xml">
+    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
   </group>

--- a/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
+++ b/moveit_setup_assistant/templates/moveit_config_pkg_template/launch/planning_pipeline.launch.xml
@@ -5,6 +5,6 @@
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include ns="$(arg pipeline)" file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>


### PR DESCRIPTION
### Description

Synced the following commits from MoveIt
```
* [2021-10-19] [a0ee2020c] | Remove '-W*' options from cmake files (#2903) {{Leroy Rügemer}} 
* [2021-10-19] [38b3010cb] | Add test for pilz planner with attached objects (#2878) {{cambel}} 
* [2021-10-18] [56ffde678] | RobotState: write to correct array (#2909) {{Michael Görner}} 
* [2021-10-05] [d57721cf8] | fix uninitialized orientation in default shape pose (#2896) {{Michael Görner}} 
* [2021-10-04] [35275a0b9] | MGI: add missing replan/look options to interface (#2892) {{Michael Görner}} 
* [2021-10-04] [000bb45ce] | pin openssl 1.1.1* for now (#2895) {{Wolf Vollprecht}} 
* [2021-09-28] [049be73b8] | Load all planning pipelines into their own namespace (#2888) {{Robert Haschke}} 
* [2021-09-28] [37aa5e49a] | MSA: Correctly state not-found package name {{Robert Haschke}} 
* [2021-09-23] [d1e1c3d27] | Fixup docker build {{Robert Haschke}} 
* [2021-09-22] [daa87acbf] | Temporarily pin orocos-kdl version to fix cross-platform CI (#2883) {{Tobias Fischer}} 
* [2021-09-21] [8ed1826cf] | Readability and consistency improvements in TOTG (#2882) {{AndyZe}} 
* [2021-09-20] [8c499f5d3] | MPD: do not save/restore warehouse parameters (#2865) {{Michael Görner}} 
* [2021-09-17] [c5ea816fe] | PSI: get object.pose from new msg field (#2877) {{Gauthier Hentz}} 
* [2021-09-15] [cce943457] | PlanningSceneDisplay: always update the main scene node's pose (#2876) {{Robert Haschke}} 
```

Commit [38b3010cb](https://github.com/ros-planning/moveit/commit/38b3010cb38c6928d0286f990b3aeb8862bc6861) has not been ported to ROS2 and added with other integration tests which are also not ported in PILZ planner.
We could open an issue to port them all in one go