### PR TITLE
Only target Rolling in docker and pre-release jobs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling, galactic]
+        ROS_DISTRO: [rolling]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling, galactic]
+        ROS_DISTRO: [rolling]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling, galactic]
+        ROS_DISTRO: [rolling]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling, galactic]
+        ROS_DISTRO: [rolling]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [foxy, galactic, rolling]
+        distro: [rolling]
 
     env:
       ROS_DISTRO: ${{ matrix.distro }}


### PR DESCRIPTION
Moving forward, I think that docker images for Galactic should be based on the `galactic` branch. We can discuss if we still want a separate source-build version based on main, but I don't really see the use of that. The galactic jobs on `main` can stay enabled as long as we want to support it, but I assume that we will drop them over the next months. I also removed the `Foxy` and `Galactic` builds from the pre-release test here. Each branch should only test against the targeted distro.