### PR TITLE
Remove geometric_shapes from repos file

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -1,8 +1,4 @@
 repositories:
-  geometric_shapes:
-    type: git
-    url: https://github.com/ros-planning/geometric_shapes
-    version: 2.1.2
   moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs


### PR DESCRIPTION
### Description

I don't think we need to build geometric_shapes from source so this PR removes it from the repos file.

