### PR TITLE
Add a "target_pose_lookahead_time" parameter

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -11,6 +11,9 @@ scale:
   rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -11,6 +11,9 @@ scale:
   rotational:  0.3 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -70,6 +70,7 @@ struct ServoParameters
   double linear_scale{ 0.4 };
   double rotational_scale{ 0.8 };
   double joint_scale{ 0.5 };
+  double target_pose_lookahead_time{ 0.0 };
   // Properties of outgoing commands
   std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
   double publish_period{ 0.034 };

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -989,6 +989,11 @@ Eigen::VectorXd ServoCalcs::scaleCartesianCommand(const geometry_msgs::msg::Twis
   Eigen::VectorXd result(6);
   result.setZero();  // Or the else case below leads to misery
 
+  // Add a user-defined, constant delay to the timestep.
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
+
   // Apply user-defined scaling if inputs are unitless [-1:1]
   if (parameters_->command_in_type == "unitless")
   {
@@ -1022,6 +1027,11 @@ Eigen::VectorXd ServoCalcs::scaleJointCommand(const control_msgs::msg::JointJog&
 {
   Eigen::VectorXd result(num_joints_);
   result.setZero();
+
+  // Add a user-defined, constant delay to the timestep.
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
 
   std::size_t c;
   for (std::size_t m = 0; m < command.joint_names.size(); ++m)

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -134,6 +134,12 @@ void ServoParameters::declare(const std::string& ns,
                                          .type(PARAMETER_DOUBLE)
                                          .description("Max joint angular/linear velocity. Only used for joint "
                                                       "commands on joint_command_in_topic."));
+  node_parameters->declare_parameter(
+      ns + ".target_pose_lookahead_time", ParameterValue{ parameters.target_pose_lookahead_time },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("An optional parameter to smooth jitter due to latency in the system "
+                       "or low-level controller ramp up / ramp down"));
 
   // Properties of outgoing commands
   node_parameters->declare_parameter(
@@ -264,6 +270,8 @@ ServoParameters ServoParameters::get(const std::string& ns,
   parameters.linear_scale = node_parameters->get_parameter(ns + ".scale.linear").as_double();
   parameters.rotational_scale = node_parameters->get_parameter(ns + ".scale.rotational").as_double();
   parameters.joint_scale = node_parameters->get_parameter(ns + ".scale.joint").as_double();
+  parameters.target_pose_lookahead_time =
+      node_parameters->get_parameter(ns + ".target_pose_lookahead_time").as_double();
 
   // Properties of outgoing commands
   parameters.command_out_topic = node_parameters->get_parameter(ns + ".command_out_topic").as_string();
@@ -407,6 +415,12 @@ std::optional<ServoParameters> ServoParameters::validate(ServoParameters paramet
   {
     RCLCPP_WARN(LOGGER, "Parameter 'collision_check_rate' should be "
                         "greater than zero. Check yaml file.");
+    return std::nullopt;
+  }
+  if (parameters.target_pose_lookahead_time < 0 || parameters.target_pose_lookahead_time > 0.1)
+  {
+    RCLCPP_WARN(LOGGER,
+                "Parameter 'target_pose_lookahead_time' should be greater than zero and typically less than 0.1s.");
     return std::nullopt;
   }
   return parameters;

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -11,6 +11,9 @@ scale:
   rotational:  0.006 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 low_latency_mode: false  # Set this to true to tie the output rate to the input rate

--- a/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
@@ -11,6 +11,9 @@ scale:
   rotational:  0.006 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.01
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.0
 
 ## Properties of outgoing commands
 low_latency_mode: true  # Set this to true to tie the output rate to the input rate


### PR DESCRIPTION
This work was started in #886. Closes #696.

The new parameter helps account for latency in the control loop. This can compensate for various issues or delays in the control loop that are hard to quantify, including:

 - joint_states publication rate
 - ROS message transmission. I believe there are 2 message hops
 - network latency
 - a little bit of processing time
 - whatever happens in the ros_control interface
 - low-level controller ramp up/ramp down time
