### PR TITLE
Remove IKFast CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
             CCOV: true
             ROS_DISTRO: rolling
           - IMAGE: rolling-ci-testing
-            IKFAST_TEST: true
             ROS_DISTRO: rolling
           - IMAGE: galactic-ci
             CLANG_TIDY: pedantic


### PR DESCRIPTION
This is not even ported to ROS2 and we are using some extra time to build dependencies. This is also causing the current CI failures.