### PR TITLE
Remove 'using namespace' from header files.

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -49,8 +49,6 @@
 #include "pilz_industrial_motion_planner/trajectory_functions.h"
 #include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
 
-using namespace pilz_industrial_motion_planner;
-
 namespace pilz_industrial_motion_planner
 {
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(TrajectoryGeneratorInvalidLimitsException,

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
@@ -41,8 +41,6 @@
 
 #include "pilz_industrial_motion_planner/trajectory_generator.h"
 
-using namespace pilz_industrial_motion_planner;
-
 namespace pilz_industrial_motion_planner
 {
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(CircleNoPlane, moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
@@ -41,8 +41,6 @@
 #include "pilz_industrial_motion_planner/trajectory_generator.h"
 #include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
 
-using namespace pilz_industrial_motion_planner;
-
 namespace pilz_industrial_motion_planner
 {
 // TODO date type of units

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
@@ -41,8 +41,6 @@
 #include "pilz_industrial_motion_planner/trajectory_generator.h"
 #include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
 
-using namespace pilz_industrial_motion_planner;
-
 namespace pilz_industrial_motion_planner
 {
 // TODO date type of units

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_aggregator.cpp
@@ -57,7 +57,7 @@ pilz_industrial_motion_planner::JointLimitsAggregator::getAggregatedLimits(
   // Iterate over all joint models and generate the map
   for (auto joint_model : joint_models)
   {
-    JointLimit joint_limit;
+    pilz_industrial_motion_planner::JointLimit joint_limit;
 
     // NOTE: declareParameters fails (=returns false) if the parameters have already been declared.
     // The function should be checked in the if condition below when we disable

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
@@ -40,7 +40,8 @@
 namespace pilz_industrial_motion_planner
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.pilz_industrial_motion_planner.joint_limits_container");
-bool JointLimitsContainer::addLimit(const std::string& joint_name, JointLimit joint_limit)
+bool JointLimitsContainer::addLimit(const std::string& joint_name,
+                                    pilz_industrial_motion_planner::JointLimit joint_limit)
 {
   if (joint_limit.has_deceleration_limits && joint_limit.max_deceleration >= 0)
   {
@@ -73,7 +74,7 @@ bool JointLimitsContainer::empty() const
 
 JointLimit JointLimitsContainer::getCommonLimit() const
 {
-  JointLimit common_limit;
+  pilz_industrial_motion_planner::JointLimit common_limit;
   for (const auto& limit : container_)
   {
     updateCommonLimit(limit.second, common_limit);
@@ -83,7 +84,7 @@ JointLimit JointLimitsContainer::getCommonLimit() const
 
 JointLimit JointLimitsContainer::getCommonLimit(const std::vector<std::string>& joint_names) const
 {
-  JointLimit common_limit;
+  pilz_industrial_motion_planner::JointLimit common_limit;
   for (const auto& joint_name : joint_names)
   {
     updateCommonLimit(container_.at(joint_name), common_limit);

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_validator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_validator.cpp
@@ -74,7 +74,7 @@ bool pilz_industrial_motion_planner::JointLimitsValidator::validateWithEqualFunc
     return true;
   }
 
-  JointLimit reference = joint_limits.begin()->second;
+  pilz_industrial_motion_planner::JointLimit reference = joint_limits.begin()->second;
 
   for (auto it = std::next(joint_limits.begin()); it != joint_limits.end(); ++it)
   {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -76,7 +76,7 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const moveit::core::RobotModelCon
       continue;
     }
 
-    JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
+    pilz_industrial_motion_planner::JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
 
     if (!most_strict_limit.has_velocity_limits)
     {

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -59,7 +59,7 @@ testutils::createFakeLimits(const std::vector<std::string>& joint_names)
 
   for (const std::string& name : joint_names)
   {
-    JointLimit limit;
+    pilz_industrial_motion_planner::JointLimit limit;
     limit.has_position_limits = true;
     limit.max_position = 2.967;
     limit.min_position = -2.967;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
@@ -44,25 +44,25 @@ class JointLimitsContainerTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    JointLimit lim1;
+    pilz_industrial_motion_planner::JointLimit lim1;
     lim1.has_position_limits = true;
     lim1.min_position = -2;
     lim1.max_position = 2;
     lim1.has_acceleration_limits = true;
     lim1.max_acceleration = 3;  //<- Expected for common_limit_.max_acceleration
 
-    JointLimit lim2;
+    pilz_industrial_motion_planner::JointLimit lim2;
     lim2.has_position_limits = true;
     lim2.min_position = -1;  //<- Expected for common_limit_.min_position
     lim2.max_position = 1;   //<- Expected for common_limit_.max_position
     lim2.has_deceleration_limits = true;
     lim2.max_deceleration = -5;  //<- Expected for common_limit_.max_deceleration
 
-    JointLimit lim3;
+    pilz_industrial_motion_planner::JointLimit lim3;
     lim3.has_velocity_limits = true;
     lim3.max_velocity = 10;
 
-    JointLimit lim4;
+    pilz_industrial_motion_planner::JointLimit lim4;
     lim4.has_position_limits = true;
     lim4.min_position = -1;
     lim4.max_position = 1;
@@ -71,14 +71,14 @@ protected:
     lim4.has_deceleration_limits = false;
     lim4.max_deceleration = -1;
 
-    JointLimit lim5;
+    pilz_industrial_motion_planner::JointLimit lim5;
     lim5.has_position_limits = true;
     lim5.min_position = -1;
     lim5.max_position = 1;
     lim5.has_acceleration_limits = false;
     lim5.max_acceleration = 1;
 
-    JointLimit lim6;
+    pilz_industrial_motion_planner::JointLimit lim6;
     lim6.has_velocity_limits = true;
     lim6.max_velocity = 2;  //<- Expected for common_limit_.max_velocity
     lim6.has_deceleration_limits = true;
@@ -95,7 +95,7 @@ protected:
   }
 
   pilz_industrial_motion_planner::JointLimitsContainer container_;
-  JointLimit common_limit_;
+  pilz_industrial_motion_planner::JointLimit common_limit_;
 };
 
 /**
@@ -136,15 +136,15 @@ TEST_F(JointLimitsContainerTest, CheckDecelerationUnification)
  */
 TEST_F(JointLimitsContainerTest, CheckAddLimitDeceleration)
 {
-  JointLimit lim_invalid1;
+  pilz_industrial_motion_planner::JointLimit lim_invalid1;
   lim_invalid1.has_deceleration_limits = true;
   lim_invalid1.max_deceleration = 0;
 
-  JointLimit lim_invalid2;
+  pilz_industrial_motion_planner::JointLimit lim_invalid2;
   lim_invalid2.has_deceleration_limits = true;
   lim_invalid2.max_deceleration = 1;
 
-  JointLimit lim_valid;
+  pilz_industrial_motion_planner::JointLimit lim_valid;
   lim_valid.has_deceleration_limits = true;
   lim_valid.max_deceleration = -1;
 
@@ -160,7 +160,7 @@ TEST_F(JointLimitsContainerTest, CheckAddLimitDeceleration)
  */
 TEST_F(JointLimitsContainerTest, CheckAddLimitAlreadyContained)
 {
-  JointLimit lim_valid;
+  pilz_industrial_motion_planner::JointLimit lim_valid;
   lim_valid.has_deceleration_limits = true;
   lim_valid.max_deceleration = -1;
 
@@ -175,7 +175,7 @@ TEST_F(JointLimitsContainerTest, CheckAddLimitAlreadyContained)
 TEST_F(JointLimitsContainerTest, CheckEmptyContainer)
 {
   pilz_industrial_motion_planner::JointLimitsContainer container;
-  JointLimit limits = container.getCommonLimit();
+  pilz_industrial_motion_planner::JointLimit limits = container.getCommonLimit();
   EXPECT_FALSE(limits.has_position_limits);
   EXPECT_FALSE(limits.has_velocity_limits);
   EXPECT_FALSE(limits.has_acceleration_limits);
@@ -186,9 +186,9 @@ TEST_F(JointLimitsContainerTest, CheckEmptyContainer)
  */
 TEST_F(JointLimitsContainerTest, FirstPositionEmpty)
 {
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_position_limits = true;
   lim2.min_position = -1;  //<- Expected for common_limit_.min_position
   lim2.max_position = 1;   //<- Expected for common_limit_.max_position
@@ -197,7 +197,7 @@ TEST_F(JointLimitsContainerTest, FirstPositionEmpty)
   container.addLimit("joint1", lim1);
   container.addLimit("joint2", lim2);
 
-  JointLimit limits = container.getCommonLimit();
+  pilz_industrial_motion_planner::JointLimit limits = container.getCommonLimit();
   EXPECT_TRUE(limits.has_position_limits);
   EXPECT_EQ(1, limits.max_position);
   EXPECT_EQ(-1, limits.min_position);

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
@@ -51,7 +51,7 @@ TEST_F(JointLimitsValidatorTest, CheckPositionEquality)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_position_limits = true;
   lim1.min_position = -1;
   lim1.max_position = 1;
@@ -72,12 +72,12 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMinPosition)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_position_limits = true;
   lim1.min_position = -1;
   lim1.max_position = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_position_limits = true;
   lim2.min_position = -2;
   lim2.max_position = 1;
@@ -98,12 +98,12 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition1)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_position_limits = true;
   lim1.min_position = -1;
   lim1.max_position = 2;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_position_limits = true;
   lim2.min_position = -1;
   lim2.max_position = 1;
@@ -124,17 +124,17 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxPosition2)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_position_limits = true;
   lim1.min_position = -1;
   lim1.max_position = 2;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_position_limits = true;
   lim2.min_position = -1;
   lim2.max_position = 1;
 
-  JointLimit lim3;
+  pilz_industrial_motion_planner::JointLimit lim3;
   lim3.has_position_limits = true;
   lim3.min_position = -1;
   lim3.max_position = 1;
@@ -156,12 +156,12 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityHasPositionLimits)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_position_limits = true;
   lim1.min_position = -1;
   lim1.max_position = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_position_limits = false;
   lim2.min_position = -1;
   lim2.max_position = 1;
@@ -188,7 +188,7 @@ TEST_F(JointLimitsValidatorTest, CheckVelocityEquality)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_velocity_limits = true;
   lim1.max_velocity = 1;
 
@@ -208,11 +208,11 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxVelocity1)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_velocity_limits = true;
   lim1.max_velocity = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_velocity_limits = true;
   lim2.max_velocity = 2;
 
@@ -232,15 +232,15 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxVelocity2)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_velocity_limits = true;
   lim1.max_velocity = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_velocity_limits = true;
   lim2.max_velocity = 2;
 
-  JointLimit lim3;
+  pilz_industrial_motion_planner::JointLimit lim3;
   lim3.has_velocity_limits = true;
   lim3.max_velocity = 2;
 
@@ -261,10 +261,10 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityHasVelocityLimits)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_velocity_limits = true;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_velocity_limits = false;
 
   container.addLimit("joint1", lim1);
@@ -289,7 +289,7 @@ TEST_F(JointLimitsValidatorTest, CheckAccelerationEquality)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_acceleration_limits = true;
   lim1.max_acceleration = 1;
 
@@ -309,11 +309,11 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxAcceleration1)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_acceleration_limits = true;
   lim1.max_acceleration = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_acceleration_limits = true;
   lim2.max_acceleration = 2;
 
@@ -333,15 +333,15 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityMaxAcceleration2)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_acceleration_limits = true;
   lim1.max_acceleration = 1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_acceleration_limits = true;
   lim2.max_acceleration = 2;
 
-  JointLimit lim3;
+  pilz_industrial_motion_planner::JointLimit lim3;
   lim3.has_acceleration_limits = true;
   lim3.max_acceleration = 2;
 
@@ -363,10 +363,10 @@ TEST_F(JointLimitsValidatorTest, CheckPositionInEqualityHasAccelerationLimits)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_acceleration_limits = true;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_acceleration_limits = false;
 
   container.addLimit("joint1", lim1);
@@ -391,7 +391,7 @@ TEST_F(JointLimitsValidatorTest, CheckDecelerationEquality)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_deceleration_limits = true;
   lim1.max_deceleration = 1;
 
@@ -411,11 +411,11 @@ TEST_F(JointLimitsValidatorTest, CheckInEqualityMaxDeceleration1)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_deceleration_limits = true;
   lim1.max_deceleration = -1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_deceleration_limits = true;
   lim2.max_deceleration = -2;
 
@@ -435,15 +435,15 @@ TEST_F(JointLimitsValidatorTest, CheckInEqualityMaxDeceleration2)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_deceleration_limits = true;
   lim1.max_deceleration = -1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_deceleration_limits = true;
   lim2.max_deceleration = -2;
 
-  JointLimit lim3;
+  pilz_industrial_motion_planner::JointLimit lim3;
   lim3.has_deceleration_limits = true;
   lim3.max_deceleration = -2;
 
@@ -465,11 +465,11 @@ TEST_F(JointLimitsValidatorTest, CheckInEqualityHasDecelerationLimits)
 {
   JointLimitsContainer container;
 
-  JointLimit lim1;
+  pilz_industrial_motion_planner::JointLimit lim1;
   lim1.has_deceleration_limits = true;
   lim1.max_deceleration = -1;
 
-  JointLimit lim2;
+  pilz_industrial_motion_planner::JointLimit lim2;
   lim2.has_deceleration_limits = false;
 
   container.addLimit("joint1", lim1);

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -576,7 +576,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testVerifySampleJointLimitsVeloc
   double duration_last{ 0.0 };
   pilz_industrial_motion_planner::JointLimitsContainer joint_limits;
 
-  JointLimit test_joint_limits;
+  pilz_industrial_motion_planner::JointLimit test_joint_limits;
   // Calculate the max allowed velocity in such a way that it is always smaller
   // than the current velocity.
   test_joint_limits.max_velocity =
@@ -612,7 +612,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testVerifySampleJointLimitsAccel
   std::map<std::string, double> velocity_last{ { test_joint_name, 9.0 } };
   pilz_industrial_motion_planner::JointLimitsContainer joint_limits;
 
-  JointLimit test_joint_limits;
+  pilz_industrial_motion_planner::JointLimit test_joint_limits;
   // Calculate the max allowed velocity in such a way that it is always bigger
   // than the current velocity.
   test_joint_limits.max_velocity = velocity_current + 1.0;
@@ -655,7 +655,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testVerifySampleJointLimitsDecel
   std::map<std::string, double> velocity_last{ { test_joint_name, 19.0 } };
   pilz_industrial_motion_planner::JointLimitsContainer joint_limits;
 
-  JointLimit test_joint_limits;
+  pilz_industrial_motion_planner::JointLimit test_joint_limits;
   // Calculate the max allowed velocity in such a way that it is always bigger
   // than the current velocity.
   test_joint_limits.max_velocity = fabs(velocity_current) + 1.0;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
@@ -97,7 +97,7 @@ protected:
     for (const auto& jmg : robot_model_->getJointModelGroups())
     {
       std::vector<std::string> joint_names = jmg->getActiveJointModelNames();
-      JointLimit joint_limit;
+      pilz_industrial_motion_planner::JointLimit joint_limit;
       joint_limit.max_position = 3.124;
       joint_limit.min_position = -3.124;
       joint_limit.has_velocity_limits = true;
@@ -214,7 +214,7 @@ TEST_F(TrajectoryGeneratorPTPTest, missingVelocityLimits)
 
   JointLimitsContainer joint_limits;
   auto joint_models = robot_model_->getActiveJointModels();
-  JointLimit joint_limit;
+  pilz_industrial_motion_planner::JointLimit joint_limit;
   joint_limit.has_velocity_limits = false;
   joint_limit.has_acceleration_limits = true;
   joint_limit.max_deceleration = -1;
@@ -238,7 +238,7 @@ TEST_F(TrajectoryGeneratorPTPTest, missingDecelerationimits)
 
   JointLimitsContainer joint_limits;
   const auto& joint_models = robot_model_->getActiveJointModels();
-  JointLimit joint_limit;
+  pilz_industrial_motion_planner::JointLimit joint_limit;
   joint_limit.has_velocity_limits = true;
   joint_limit.has_acceleration_limits = true;
   joint_limit.has_deceleration_limits = false;
@@ -272,7 +272,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testInsufficientLimit)
   ASSERT_TRUE(joint_models.size());
 
   // joint limit with insufficient limits (no acc/dec limits)
-  JointLimit insufficient_limit;
+  pilz_industrial_motion_planner::JointLimit insufficient_limit;
   insufficient_limit.has_position_limits = true;
   insufficient_limit.max_position = 2.5;
   insufficient_limit.min_position = -2.5;
@@ -300,7 +300,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testInsufficientLimit)
   /* Step 2 */
   /**********/
   // joint limit with sufficient limits
-  JointLimit sufficient_limit;
+  pilz_industrial_motion_planner::JointLimit sufficient_limit;
   sufficient_limit.has_position_limits = true;
   sufficient_limit.max_position = 2.356;
   sufficient_limit.min_position = -2.356;
@@ -486,7 +486,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testJointGoalAlreadyReached)
 TEST_F(TrajectoryGeneratorPTPTest, testScalingFactor)
 {
   // create ptp generator with different limits
-  JointLimit joint_limit;
+  pilz_industrial_motion_planner::JointLimit joint_limit;
   JointLimitsContainer joint_limits;
 
   // set the joint limits

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -63,8 +63,6 @@
 
 #pragma once
 
-using namespace std::chrono_literals;
-
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo_launch_test_common.hpp");
 
 namespace moveit_servo
@@ -143,7 +141,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_servo_start_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
 
     // If we setup the start client, also setup the stop client...
@@ -156,7 +154,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_servo_stop_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
 
     // Status sub (we need this to check that we've started / stopped)
@@ -177,7 +175,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_servo_pause_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
     return true;
   }
@@ -193,7 +191,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_servo_unpause_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
     return true;
   }
@@ -210,7 +208,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_change_control_dims_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
     return true;
   }
@@ -227,7 +225,7 @@ public:
         return false;
       }
       RCLCPP_INFO(LOGGER, "client_change_drift_dims_ service not available, waiting again...");
-      rclcpp::sleep_for(500ms);
+      rclcpp::sleep_for(std::chrono::milliseconds(500));
     }
     return true;
   }

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -38,6 +38,8 @@
 
 #include "servo_launch_test_common.hpp"
 
+using namespace std::chrono_literals;
+
 namespace moveit_servo
 {
 TEST_F(ServoFixture, SendTwistStampedTest)


### PR DESCRIPTION
- Remove 'using namespace pilz_industrial_motion_planner' from header files.
- Remove 'using namespace std::chrono_literals' from header files.

### Description

This PR addresses https://github.com/ros-planning/moveit2/issues/853.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
