### PR TITLE
Set controller status before it is cheked on trajectory execution.

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -569,6 +569,17 @@ void TrajectoryExecutionManager::reloadControllerInformation()
       known_controllers_[ci.name_] = ci;
     }
 
+    names.clear();
+    controller_manager_->getActiveControllers(names);
+    for (std::map<std::string, ControllerInformation>::iterator it = known_controllers_.begin();
+         it != known_controllers_.end(); ++it)
+    {
+      if (std::find(names.begin(), names.end(), it->first) != names.end())
+      {
+        it->second.state_.active_ = true;
+      }
+    }
+
     for (std::map<std::string, ControllerInformation>::iterator it = known_controllers_.begin();
          it != known_controllers_.end(); ++it)
       for (std::map<std::string, ControllerInformation>::iterator jt = known_controllers_.begin();
@@ -1577,6 +1588,7 @@ bool TrajectoryExecutionManager::executePart(std::size_t part_index)
   }
   else
   {
+    RCLCPP_ERROR(LOGGER, "Active status of required controllers can not be assured.");
     last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
     return false;
   }
@@ -1804,8 +1816,12 @@ bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::
     std::set<std::string> originally_active;
     for (std::map<std::string, ControllerInformation>::const_iterator it = known_controllers_.begin();
          it != known_controllers_.end(); ++it)
+    {
       if (it->second.state_.active_)
+      {
         originally_active.insert(it->first);
+      }
+    }
     return std::includes(originally_active.begin(), originally_active.end(), controllers.begin(), controllers.end());
   }
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -571,12 +571,12 @@ void TrajectoryExecutionManager::reloadControllerInformation()
 
     names.clear();
     controller_manager_->getActiveControllers(names);
-    for (std::map<std::string, ControllerInformation>::iterator it = known_controllers_.begin();
-         it != known_controllers_.end(); ++it)
+    for (const auto & active_name : names)
     {
-      if (std::find(names.begin(), names.end(), it->first) != names.end())
+      auto found_it  = std::find_if(known_controllers_.begin(), known_controllers_.end(), [&](const auto & known_controller) { return known_controller.first == active_name; } );
+      if (found_it != known_controllers_.end())
       {
-        it->second.state_.active_ = true;
+        found_it->second.state_.active_ = true;
       }
     }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -571,9 +571,10 @@ void TrajectoryExecutionManager::reloadControllerInformation()
 
     names.clear();
     controller_manager_->getActiveControllers(names);
-    for (const auto & active_name : names)
+    for (const auto& active_name : names)
     {
-      auto found_it  = std::find_if(known_controllers_.begin(), known_controllers_.end(), [&](const auto & known_controller) { return known_controller.first == active_name; } );
+      auto found_it = std::find_if(known_controllers_.begin(), known_controllers_.end(),
+                                   [&](const auto& known_controller) { return known_controller.first == active_name; });
       if (found_it != known_controllers_.end())
       {
         found_it->second.state_.active_ = true;


### PR DESCRIPTION
### Description

This PR enalbes trajectory execution when using simulation.
The PR adds controllers' status before it is checked if all needed controller are activated.

This is neede to use MoveIt with Ignition Simulation (I will link UR example later today for this).
Though, the interesting part is, why trajectory execution is working without this changes when using "FakeSystem" or hardware.
It looks to me that the same checks should fail in any case.

I tested this with and without "moveit_manage_controllers" parameter set. And the changes are required in both cases.

I using "moveit_simple_controller_manager/MoveItSimpleControllerManager" in our setup. Is this maybe an issue?
Should another controller manager be used.

BTW, I see that MoveIs is not activelly checking which controllers are active and which not, although there is a management code for this implemented in `ensureActiveControllers` (line: 1718) of `trajectory_execution_manager.cpp`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
