### PR TITLE
Don't cache docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,7 +55,7 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |
@@ -107,7 +107,7 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |
@@ -160,7 +160,7 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: true
           cache-from: type=registry,ref=${{ env.GH_IMAGE }}
           cache-to: type=inline
           tags: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,7 @@ on:
     # 5 PM UTC every Sunday
     - cron:  '0 17 * * 6'
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
### Description

@henningkayser I think this is what is causing CI to fail.  The docker image caching is not being disabled and the ros2_control packages are still in /opt/ros even though they are in the repos file.  I think maybe we should just not cache our docker builds.