### PR TITLE
Don't cache docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,19 +24,8 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
-      - name: Check for apt updates
-        uses: addnab/docker-run-action@v3
-        continue-on-error: true
-        id: apt
-        with:
-          image: ${{ env.GH_IMAGE }}
-          run: |
-            apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -50,14 +39,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
-          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
-          cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -76,19 +62,8 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
-      - name: Check for apt updates
-        uses: addnab/docker-run-action@v3
-        continue-on-error: true
-        id: apt
-        with:
-          image: ${{ env.GH_IMAGE }}
-          run: |
-            apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -102,14 +77,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
-          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
-          cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -129,19 +101,8 @@ jobs:
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
 
     steps:
-      - name: Check for apt updates
-        uses: addnab/docker-run-action@v3
-        continue-on-error: true
-        id: apt
-        with:
-          image: ${{ env.GH_IMAGE }}
-          run: |
-            apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "::set-output name=no_cache::$have_updates"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
       - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -155,14 +116,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
-          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
-          cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -205,8 +163,7 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
-          cache-to: type=inline
+          no-cache: true
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}


### PR DESCRIPTION
### Description

Disable cache in docker builds.  Pushed into the main repo to rebuild docker image with secrets.

I believe this is the reason the hybrid planner test is failing on main.  We were caching the docker builds and the ros2_control packages were still in /opt/ros in the docker images even though we added them to our repos file.