### PR TITLE
Fix race condition in SynchronizedStringParameter::waitForMessage

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -119,7 +119,8 @@ bool SynchronizedStringParameter::shouldPublish()
 
 bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
 {
-  string_subscriber_ = node_->create_subscription<std_msgs::msg::String>(
+  auto temp_node = std::make_shared<rclcpp::Node>("synchronized_string_parameter");
+  string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_, rclcpp::QoS(1).transient_local().reliable(),
       std::bind(&SynchronizedStringParameter::stringCallback, this, std::placeholders::_1));
 

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -119,7 +119,7 @@ bool SynchronizedStringParameter::shouldPublish()
 
 bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
 {
-  auto temp_node = std::make_shared<rclcpp::Node>("synchronized_string_parameter");
+  auto const temp_node = std::make_shared<rclcpp::Node>("synchronized_string_parameter");
   string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_, rclcpp::QoS(1).transient_local().reliable(),
       std::bind(&SynchronizedStringParameter::stringCallback, this, std::placeholders::_1));

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -119,7 +119,7 @@ bool SynchronizedStringParameter::shouldPublish()
 
 bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
 {
-  std::string const nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
+  auto const nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
   auto const temp_node = std::make_shared<rclcpp::Node>(nd_name);
   string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_, rclcpp::QoS(1).transient_local().reliable(),

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -119,7 +119,8 @@ bool SynchronizedStringParameter::shouldPublish()
 
 bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
 {
-  auto const temp_node = std::make_shared<rclcpp::Node>("synchronized_string_parameter");
+  std::string const nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
+  auto const temp_node = std::make_shared<rclcpp::Node>(nd_name);
   string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_, rclcpp::QoS(1).transient_local().reliable(),
       std::bind(&SynchronizedStringParameter::stringCallback, this, std::placeholders::_1));

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -66,6 +66,29 @@ TEST(RDFIntegration, topic_based)
   EXPECT_EQ("gonzo", loader.getSRDF()->getName());
 }
 
+TEST(RDFIntegration, executor)
+{
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("executor");
+
+  // Create a thread to spin an Executor.
+  std::promise<void> promise;
+  auto shared_future = promise.get_future().share();
+  auto thread = std::thread([node, shared_future]() {
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(node);
+    executor.spin_until_future_complete(shared_future, std::chrono::seconds(10));
+  });
+
+  rdf_loader::RDFLoader loader(node, "topic_description");
+  promise.set_value();
+  thread.join();
+
+  ASSERT_NE(nullptr, loader.getURDF());
+  EXPECT_EQ("gonzo", loader.getURDF()->name_);
+  ASSERT_NE(nullptr, loader.getSRDF());
+  EXPECT_EQ("gonzo", loader.getSRDF()->getName());
+}
+
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -73,15 +73,14 @@ TEST(RDFIntegration, executor)
   // Create a thread to spin an Executor.
   std::promise<void> promise;
   auto shared_future = promise.get_future().share();
-  auto thread = std::thread([node, shared_future]() {
+  std::thread([node, shared_future]() {
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(node);
     executor.spin_until_future_complete(shared_future, std::chrono::seconds(10));
-  });
+  }).detach();
 
   rdf_loader::RDFLoader loader(node, "topic_description");
   promise.set_value();
-  thread.join();
 
   ASSERT_NE(nullptr, loader.getURDF());
   EXPECT_EQ("gonzo", loader.getURDF()->name_);

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -66,13 +66,11 @@ TEST(RDFIntegration, topic_based)
   EXPECT_EQ("gonzo", loader.getSRDF()->getName());
 }
 
-// RDFLoader should successfully load URDF and SRDF strings from a ROS topic when the node that is passed to it is
-// spinning.
-// GIVEN a node that has been added to an executor that is spinning on another thread
-// WHEN the RDFLoader is created
-// THEN the RDFLoader should return non-null values for the URDF and SRDF model.
 TEST(RDFIntegration, executor)
 {
+  // RDFLoader should successfully load URDF and SRDF strings from a ROS topic when the node that is 
+  // passed to it is spinning.
+  // GIVEN a node that has been added to an executor that is spinning on another thread
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("executor");
 
   // Create a thread to spin an Executor.
@@ -82,8 +80,10 @@ TEST(RDFIntegration, executor)
     executor.spin();
   }).detach();
 
+  // WHEN the RDFLoader is created
   rdf_loader::RDFLoader loader(node, "topic_description");
 
+  // THEN the RDFLoader should return non-null values for the URDF and SRDF model.
   ASSERT_NE(nullptr, loader.getURDF());
   EXPECT_EQ("gonzo", loader.getURDF()->name_);
   ASSERT_NE(nullptr, loader.getSRDF());

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -68,7 +68,7 @@ TEST(RDFIntegration, topic_based)
 
 TEST(RDFIntegration, executor)
 {
-  // RDFLoader should successfully load URDF and SRDF strings from a ROS topic when the node that is 
+  // RDFLoader should successfully load URDF and SRDF strings from a ROS topic when the node that is
   // passed to it is spinning.
   // GIVEN a node that has been added to an executor that is spinning on another thread
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("executor");

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -71,16 +71,13 @@ TEST(RDFIntegration, executor)
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("executor");
 
   // Create a thread to spin an Executor.
-  std::promise<void> promise;
-  auto shared_future = promise.get_future().share();
-  std::thread([node, shared_future]() {
+  std::thread([node]() {
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(node);
-    executor.spin_until_future_complete(shared_future, std::chrono::seconds(10));
+    executor.spin();
   }).detach();
 
   rdf_loader::RDFLoader loader(node, "topic_description");
-  promise.set_value();
 
   ASSERT_NE(nullptr, loader.getURDF());
   EXPECT_EQ("gonzo", loader.getURDF()->name_);

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -66,6 +66,11 @@ TEST(RDFIntegration, topic_based)
   EXPECT_EQ("gonzo", loader.getSRDF()->getName());
 }
 
+// RDFLoader should successfully load URDF and SRDF strings from a ROS topic when the node that is passed to it is
+// spinning.
+// GIVEN a node that has been added to an executor that is spinning on another thread
+// WHEN the RDFLoader is created
+// THEN the RDFLoader should return non-null values for the URDF and SRDF model.
 TEST(RDFIntegration, executor)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("executor");


### PR DESCRIPTION
- Add a test for RDFLoader where the node is spinning in a different thread.
- Detach the thread.
- Create a new node in SynchronizedStringParameter and use it to create subscriptions.

### Description

This PR addresses the issue in https://github.com/ros-planning/moveit2_tutorials/pull/262 where the robot model can't be loaded.  It also represents an improvement on https://github.com/ros-planning/moveit2/pull/1039.  The implementation in https://github.com/ros-planning/moveit2/pull/1039 only worked in the case where `node_` was spinning in a separate thread, and failed when `node_` was not spinning.  The original implementation worked well when `node_` was not spinning, but had a race condition when it was spinning.

`SynchronizedStringParameter` has no control over whether or not `node_` is spinning, so in this PR I created a new node in `SynchronizedStringParamater::waitForMessage`, and used it to create a subscription.  This way, the race condition is eliminated, and we can be sure that `temp_node` isn't spinning.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
