### PR TITLE
[hybrid planning] Add a way for local constraint solver to pause waypoint retrieval

### DIFF
--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/trajectory_operator_interface.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/trajectory_operator_interface.h
@@ -101,6 +101,12 @@ public:
    */
   virtual bool reset() = 0;
 
+  /** \brief Set a flag that prevents SimpleSampler from moving to the next waypoint */
+  virtual void preventForwardProgress() = 0;
+
+  /** \brief Set a flag that allows SimpleSampler to move to the next waypoint */
+  virtual void allowForwardProgress() = 0;
+
 protected:
   // Reference trajectory to be precessed
   robot_trajectory::RobotTrajectoryPtr reference_trajectory_;

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -304,11 +304,18 @@ void LocalPlannerComponent::executeIteration()
       *local_planner_feedback_ = local_constraint_solver_instance_->solve(
           local_trajectory, local_planning_goal_handle_->get_goal(), local_solution);
 
-      // Feedback is only send when the hybrid planning architecture should react to a discrete event
+      // Feedback is only sent when the hybrid planning architecture should react to a discrete event
       if (!local_planner_feedback_->feedback.empty())
       {
+        // Prevent the SimpleSampler from moving to the next waypoint, e.g. if a collision is ahead
+        trajectory_operator_instance_->preventForwardProgress();
+
         local_planning_goal_handle_->publish_feedback(local_planner_feedback_);
         return;
+      }
+      else
+      {
+        trajectory_operator_instance_->allowForwardProgress();
       }
 
       // Use a configurable message interface like MoveIt servo

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/include/moveit/trajectory_operator_plugins/simple_sampler.h
@@ -51,13 +51,21 @@ public:
 
   bool initialize([[maybe_unused]] const rclcpp::Node::SharedPtr& node,
                   const moveit::core::RobotModelConstPtr& robot_model, const std::string& group_name) override;
+
   moveit_msgs::action::LocalPlanner::Feedback
   addTrajectorySegment(const robot_trajectory::RobotTrajectory& new_trajectory) override;
+
   moveit_msgs::action::LocalPlanner::Feedback
   getLocalTrajectory(const moveit::core::RobotState& current_state,
                      robot_trajectory::RobotTrajectory& local_trajectory) override;
+
   double getTrajectoryProgress([[maybe_unused]] const moveit::core::RobotState& current_state) override;
+
   bool reset() override;
+
+  void preventForwardProgress() override;
+
+  void allowForwardProgress() override;
 
 private:
   std::size_t
@@ -65,5 +73,6 @@ private:
   moveit_msgs::action::LocalPlanner::Feedback feedback_;  // Empty feedback
   trajectory_processing::TimeOptimalTrajectoryGeneration time_parametrization_;
   const moveit::core::JointModelGroup* joint_group_;
+  std::atomic<bool> prevent_forward_progress_;  // Flag to prevent moving to the next waypoint
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -88,21 +88,15 @@ SimpleSampler::getLocalTrajectory(const moveit::core::RobotState& current_state,
     return feedback_;
   }
 
-  // Some other component has flagged not to move to the next waypoint.
-  // Stay put, keep the same local_trajectory.
-  if (prevent_forward_progress_)
-  {
-    return feedback_;
-  }
-
   // Delete previous local trajectory
   local_trajectory.clear();
 
   // Get next desired robot state
   const moveit::core::RobotState next_desired_goal_state = reference_trajectory_->getWayPoint(next_waypoint_index_);
 
-  // Check if state is reached
-  if (next_desired_goal_state.distance(current_state, joint_group_) <= WAYPOINT_RADIAN_TOLERANCE)
+  // Progress to the next waypoint?
+  if (!prevent_forward_progress_ &&
+      next_desired_goal_state.distance(current_state, joint_group_) <= WAYPOINT_RADIAN_TOLERANCE)
   {
     // Update index (and thus desired robot state)
     next_waypoint_index_ = std::min(next_waypoint_index_ + 1, reference_trajectory_->getWayPointCount() - 1);


### PR DESCRIPTION
**Background on how hybrid planning works:**

- simple_sampler.cpp selects the next target waypoint. The only criteria on this is a tolerance on distance:
```

  if (next_desired_goal_state.distance(current_state, joint_group_) <= WAYPOINT_RADIAN_TOLERANCE)
  {
    // Update index (and thus desired robot state)
    next_waypoint_index_ = std::min(next_waypoint_index_ + 1, reference_trajectory_->getWayPointCount() - 1);
  }
```

- forward_trajectory.cpp checks if the local trajectory is valid, including collision:

`is_path_valid = locked_planning_scene->isPathValid(local_trajectory, local_trajectory.getGroupName(), false);`

**The issue**

The problem here is, `simple_sampler.cpp` only regards the radian tolerance. It doesn't know anything about the collision. So, it is possible for simple_sampler to continue selecting future waypoints even if they would be in collision. If the collision ever clears up, this can result in a sudden jump of the robot.

This PR adds a way for `forward_trajectory` to communicate back to `simple_sampler` that it should stop moving forward to a new waypoint.