### PR TITLE
[hybrid planning] Use a map of expected feedback codes

### DIFF
--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/replan_invalidated_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/replan_invalidated_trajectory.cpp
@@ -44,8 +44,8 @@ namespace moveit::hybrid_planning
 {
 ReactionResult ReplanInvalidatedTrajectory::react(const std::string& event)
 {
-  if ((event == FeedbackEnumToString(LocalFeedbackEnum::COLLISION_AHEAD)) ||
-      (event == FeedbackEnumToString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK)))
+  if ((event == toString(LocalFeedbackEnum::COLLISION_AHEAD)) ||
+      (event == toString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK)))
   {
     if (!hybrid_planning_manager_->sendGlobalPlannerAction())  // Start global planning
     {

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/replan_invalidated_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/src/replan_invalidated_trajectory.cpp
@@ -44,8 +44,8 @@ namespace moveit::hybrid_planning
 {
 ReactionResult ReplanInvalidatedTrajectory::react(const std::string& event)
 {
-  if ((event == LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::COLLISION_AHEAD)) ||
-      (event == LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::LOCAL_PLANNER_STUCK)))
+  if ((event == FeedbackEnumToString(LocalFeedbackEnum::COLLISION_AHEAD)) ||
+      (event == FeedbackEnumToString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK)))
   {
     if (!hybrid_planning_manager_->sendGlobalPlannerAction())  // Start global planning
     {

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -118,10 +118,10 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
     {
       if (!path_invalidation_event_send_)
       {  // Send feedback only once
-        feedback_result.feedback = LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::COLLISION_AHEAD);
+        feedback_result.feedback = FeedbackEnumToString(LocalFeedbackEnum::COLLISION_AHEAD);
         path_invalidation_event_send_ = true;  // Set feedback flag
       }
-      RCLCPP_INFO(LOGGER, "Collision ahead, hold current position");
+      RCLCPP_INFO(LOGGER, "Collision ahead, holding current position");
       // Keep current position
       moveit::core::RobotState current_state_command(*current_state);
       if (current_state_command.hasVelocities())
@@ -151,7 +151,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         {
           num_iterations_stuck_ = 0;
           prev_waypoint_target_ = nullptr;
-          feedback_result.feedback = LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::LOCAL_PLANNER_STUCK);
+          feedback_result.feedback = FeedbackEnumToString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK);
           path_invalidation_event_send_ = true;  // Set feedback flag
           RCLCPP_INFO(LOGGER, "The local planner has been stuck for several iterations. Aborting.");
         }

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -33,6 +33,7 @@
  *********************************************************************/
 
 #include <moveit/local_constraint_solver_plugins/forward_trajectory.h>
+#include <moveit/local_planner/feedback_types.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_state/conversions.h>
 
@@ -117,7 +118,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
     {
       if (!path_invalidation_event_send_)
       {  // Send feedback only once
-        feedback_result.feedback = "collision_ahead";
+        feedback_result.feedback = LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::COLLISION_AHEAD);
         path_invalidation_event_send_ = true;  // Set feedback flag
       }
       RCLCPP_INFO(LOGGER, "Collision ahead, hold current position");
@@ -150,7 +151,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         {
           num_iterations_stuck_ = 0;
           prev_waypoint_target_ = nullptr;
-          feedback_result.feedback = "local_planner_stuck";
+          feedback_result.feedback = LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::LOCAL_PLANNER_STUCK);
           path_invalidation_event_send_ = true;  // Set feedback flag
           RCLCPP_INFO(LOGGER, "The local planner has been stuck for several iterations. Aborting.");
         }

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -118,7 +118,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
     {
       if (!path_invalidation_event_send_)
       {  // Send feedback only once
-        feedback_result.feedback = FeedbackEnumToString(LocalFeedbackEnum::COLLISION_AHEAD);
+        feedback_result.feedback = toString(LocalFeedbackEnum::COLLISION_AHEAD);
         path_invalidation_event_send_ = true;  // Set feedback flag
       }
       RCLCPP_INFO(LOGGER, "Collision ahead, holding current position");
@@ -151,7 +151,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         {
           num_iterations_stuck_ = 0;
           prev_waypoint_target_ = nullptr;
-          feedback_result.feedback = FeedbackEnumToString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK);
+          feedback_result.feedback = toString(LocalFeedbackEnum::LOCAL_PLANNER_STUCK);
           path_invalidation_event_send_ = true;  // Set feedback flag
           RCLCPP_INFO(LOGGER, "The local planner has been stuck for several iterations. Aborting.");
         }

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace moveit::hybrid_planning
@@ -53,9 +54,16 @@ enum LocalFeedbackEnum
   LOCAL_PLANNER_STUCK = 2
 };
 
-/**
- * \brief Use this map to look up human-readable strings for each feedback code
- */
-const std::unordered_map<uint, std::string> LOCAL_FEEDBACK_MAP({ { COLLISION_AHEAD, "Collision ahead" },
-                                                                 { LOCAL_PLANNER_STUCK, "Local planner is stuck" } });
+[[nodiscard]] constexpr std::string_view FeedbackEnumToString(const LocalFeedbackEnum& code)
+{
+  switch (code)
+  {
+    case COLLISION_AHEAD:
+      return "Collision ahead";
+    case LOCAL_PLANNER_STUCK:
+      return "Local planner is stuck";
+    default:
+      __builtin_unreachable();
+  }
+}
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, PickNik Inc.
+ *  Copyright (c) 2022, PickNik Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,36 +32,30 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include <moveit/local_planner/feedback_types.h>
-#include <moveit/planner_logic_plugins/replan_invalidated_trajectory.h>
+/* Author: Andy Zelenak
+   Description: Define the expected local planner feedback types (usually equivalent to failure
+   modes).
+ */
 
-namespace
-{
-const rclcpp::Logger LOGGER = rclcpp::get_logger("hybrid_planning_manager");
-}
+#pragma once
+
+#include <string>
+#include <unordered_map>
 
 namespace moveit::hybrid_planning
 {
-ReactionResult ReplanInvalidatedTrajectory::react(const std::string& event)
+/**
+ * \brief Expected feedback types
+ */
+enum LocalFeedbackEnum
 {
-  if ((event == LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::COLLISION_AHEAD)) ||
-      (event == LOCAL_FEEDBACK_MAP.at(LocalFeedbackEnum::LOCAL_PLANNER_STUCK)))
-  {
-    if (!hybrid_planning_manager_->sendGlobalPlannerAction())  // Start global planning
-    {
-      hybrid_planning_manager_->sendHybridPlanningResponse(false);
-    }
-    return ReactionResult(event, "", moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-  }
-  else
-  {
-    return ReactionResult(event, "'ReplanInvalidatedTrajectory' plugin cannot handle this event.",
-                          moveit_msgs::msg::MoveItErrorCodes::FAILURE);
-  }
+  COLLISION_AHEAD = 1,
+  LOCAL_PLANNER_STUCK = 2
 };
+
+/**
+ * \brief Use this map to look up human-readable strings for each feedback code
+ */
+const std::unordered_map<uint, std::string> LOCAL_FEEDBACK_MAP({ { COLLISION_AHEAD, "Collision ahead" },
+                                                                 { LOCAL_PLANNER_STUCK, "Local planner is stuck" } });
 }  // namespace moveit::hybrid_planning
-
-#include <pluginlib/class_list_macros.hpp>
-
-PLUGINLIB_EXPORT_CLASS(moveit::hybrid_planning::ReplanInvalidatedTrajectory,
-                       moveit::hybrid_planning::PlannerLogicInterface)

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/feedback_types.h
@@ -54,7 +54,7 @@ enum LocalFeedbackEnum
   LOCAL_PLANNER_STUCK = 2
 };
 
-[[nodiscard]] constexpr std::string_view FeedbackEnumToString(const LocalFeedbackEnum& code)
+[[nodiscard]] constexpr std::string_view toString(const LocalFeedbackEnum& code)
 {
   switch (code)
   {

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -32,7 +32,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include <moveit/local_planner/feedback_types.h>
 #include <moveit/local_planner/local_planner_component.h>
 
 #include <moveit/planning_scene/planning_scene.h>

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <moveit/local_planner/feedback_types.h>
 #include <moveit/local_planner/local_planner_component.h>
 
 #include <moveit/planning_scene/planning_scene.h>


### PR DESCRIPTION
Get rid of hard-coded string constants