### PR TITLE
Fix docker cleanup action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -175,21 +175,21 @@ jobs:
       - source
     steps:
       - name: Delete Untagged Images
-        uses: actions/github-script@v3
+        uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
           script: |
-            const response = await github.request("GET /${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions",
-              { per_page: ${{ env.PER_PAGE }}
-            });
+            const response = await github.request("GET /orgs/${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions", {
+                per_page: ${{ env.PER_PAGE }}
+              });
             for(version of response.data) {
                 if (version.metadata.container.tags.length == 0) {
                     console.log("delete " + version.id)
-                    const deleteResponse = await github.request("DELETE /${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions/" + version.id, { });
+                    const deleteResponse = await github.request("DELETE /orgs/${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions/" + version.id, { });
                     console.log("status " + deleteResponse.status)
                 }
             }
         env:
           OWNER: ros-planning
           PACKAGE_NAME: moveit2
-          PER_PAGE: 1000
+          PER_PAGE: 100


### PR DESCRIPTION
Fixes the failing docker delete action. I found out GH recently broke REST API and I had to do some minor changes and update github script version. Here is a successful run I tried with this: https://github.com/ros-planning/moveit2/actions/runs/1813877611