### PR TITLE
ros_planning: Get kinematic params from move_group node

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -1,8 +1,15 @@
 set(MOVEIT_LIB_NAME moveit_kdl_kinematics_plugin)
 
+find_package(orocos_kdl REQUIRED)
+
+include_directories(${orocos_kdl_INCLUDE_DIRS})
+link_directories(${orocos_kdl_LIBRARY_DIRS})
+
 add_library(${MOVEIT_LIB_NAME} SHARED
   src/kdl_kinematics_plugin.cpp
   src/chainiksolver_vel_mimic_svd.cpp)
+
+target_link_libraries(${MOVEIT_LIB_NAME} orocos-kdl)
 
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -406,7 +406,7 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
           {
               std::string base_param_name = known_group.name_;
 
-              RCLCPP_DEBUG(LOGGER, "Looking for param %s in move_greoup node", (base_param_name + ksolver_param_suffix).c_str());
+              RCLCPP_DEBUG(LOGGER, "Looking for param %s in move_group node", (base_param_name + ksolver_param_suffix).c_str());
 
               auto future = parameters_client->get_parameters({
                       base_param_name + ksolver_param_suffix,


### PR DESCRIPTION
### Description

This makes it so that the kinematics loader, and therefore the MoveIt RViz plugin can pull the appropriate kinematics parameters from the `move_group` node, so that they don't need to be replicated in RViz's parameter space.

If this is a pattern the maintainers like, I'll clean up formatting and add further documentation. If not, feel free to close.

The main functional change is here:
https://github.com/ros-planning/moveit2/pull/1074/files#diff-25706feb6b355123a5ae63dfa987a1cdd5754087392e9623960ed74a31b56d75R409-R428

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
