### PR TITLE
[WIP] Refactor Ruckig smoothing to prevent the final position error

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -110,11 +110,9 @@ private:
    * \brief Decrease ruckig_input.target_velocity and ruckig_input.target_acceleration
    * \param num_dof       Degrees of freedom of the robot
    * \param timestep      Ruckig timestep (sec)
-   * \param ruckig_output Output state from Ruckig. Used to update acceleration after the velocity change is made
    * \param rucking_input Target state to be adjusted
    */
   static void decreaseTargetStateVelocity(const size_t num_dof, const double timestep,
-                                          const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output,
                                           ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input);
 
   /**

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -74,9 +74,9 @@ private:
    * \param ruckig_output Output parameters from Ruckig
    * \return              true if lagging motion is detected on any joint
    */
-  static bool checkForLaggingMotion(const size_t num_dof,
-                                    const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input,
-                                    const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output);
+  static bool checkForBackwardMotion(const size_t num_dof,
+                                     const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input,
+                                     const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output);
 
   /**
    * \brief Return L2-norm of velocity, taking all joints into account.

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -53,6 +53,7 @@ constexpr double IDENTICAL_POSITION_EPSILON = 1e-3;  // rad
 constexpr double MAX_DURATION_EXTENSION_FACTOR = 5.0;
 constexpr double DURATION_EXTENSION_FRACTION = 1.1;
 constexpr double MINIMUM_VELOCITY_SEARCH_MAGNITUDE = 1e-5;  // rad/s. Stop searching when velocity drops below this
+constexpr size_t MAX_ITERATIONS_PER_WAYPOINT = 1000;  // Return failure if more than this many adjustments are needed
 }  // namespace
 
 bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
@@ -139,8 +140,12 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       continue;
     }
 
-    while ((backward_motion_detected || (ruckig_result != ruckig::Result::Finished)) && rclcpp::ok())
+    size_t num_iterations = 0;
+    while ((backward_motion_detected || (ruckig_result != ruckig::Result::Finished)) &&
+           (num_iterations < MAX_ITERATIONS_PER_WAYPOINT))
     {
+      ++num_iterations;
+
       // If the requested velocity is too great, a joint can actually "move backward" to give itself more time to
       // accelerate to the target velocity. Iterate and decrease velocities until that behavior is gone.
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -155,7 +155,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       {
         RCLCPP_WARN_STREAM(LOGGER, "Inserting a new waypoint");
         // Insert a new waypoint after waypoint_idx+1
-        trajectory.insertWayPoint(waypoint_idx + 1, *next_waypoint, timestep);
+        trajectory.insertWayPoint(waypoint_idx + 2, *next_waypoint, timestep);
         ++num_waypoints;
 
         // Overwrite pos/vel/acc of waypoint_idx from previous Ruckig output


### PR DESCRIPTION
Fixes #767 by using `ruckig::Result::Finished` properly. Also improves readability with more helper functions.

Here's a video of the smoothing in action. I think it looks good except the pauses at higher velocities -- which were implemented to prevent backward motion.

https://user-images.githubusercontent.com/11284393/154006400-2f3c5604-e9c8-4f56-9fa6-6ebe783e16ab.mp4



