### PR TITLE
Off by one in getAverageSegmentDuration

### DIFF
--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -102,7 +102,7 @@ double RobotTrajectory::getAverageSegmentDuration() const
   {
     if (duration_from_previous_.size() <= 1)
     {
-      RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "Too few waypoints to calculate a duration. Returning 0.");
+      RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "First and only waypoint has a duration of 0.");
       return 0.0;
     }
     else

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -94,7 +94,7 @@ double RobotTrajectory::getAverageSegmentDuration() const
   if (duration_from_previous_.empty())
     return 0.0;
   else
-    return getDuration() / static_cast<double>(duration_from_previous_.size());
+    return getDuration() / static_cast<double>(duration_from_previous_.size() - 1);
 }
 
 void RobotTrajectory::swap(RobotTrajectory& other)

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -91,6 +91,12 @@ double RobotTrajectory::getDuration() const
 
 double RobotTrajectory::getAverageSegmentDuration() const
 {
+  if (duration_from_previous_.empty())
+  {
+    RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "Too few waypoints to calculate a duration. Returning 0.");
+    return 0.0;
+  }
+
   // If the initial segment has a duration of 0, exclude it from the average calculation
   if (duration_from_previous_[0] == 0)
   {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -91,13 +91,19 @@ double RobotTrajectory::getDuration() const
 
 double RobotTrajectory::getAverageSegmentDuration() const
 {
-  if (duration_from_previous_.size() <= 1)
+  // If the initial segment has a duration of 0, exclude it from the average calculation
+  if (duration_from_previous_[0] == 0)
   {
-    RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "Too few waypoints to calculate a duration. Returning 0.");
-    return 0.0;
+    if (duration_from_previous_.size() <= 1)
+    {
+      RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "Too few waypoints to calculate a duration. Returning 0.");
+      return 0.0;
+    }
+    else
+      return getDuration() / static_cast<double>(duration_from_previous_.size() - 1);
   }
   else
-    return getDuration() / static_cast<double>(duration_from_previous_.size() - 1);
+    return getDuration() / static_cast<double>(duration_from_previous_.size());
 }
 
 void RobotTrajectory::swap(RobotTrajectory& other)

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -93,6 +93,7 @@ double RobotTrajectory::getAverageSegmentDuration() const
 {
   if (duration_from_previous_.size() <= 1)
   {
+    RCLCPP_WARN(rclcpp::get_logger("RobotTrajectory"), "Too few waypoints to calculate a duration. Returning 0.");
     return 0.0;
   }
   else

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -91,8 +91,10 @@ double RobotTrajectory::getDuration() const
 
 double RobotTrajectory::getAverageSegmentDuration() const
 {
-  if (duration_from_previous_.empty())
+  if (duration_from_previous_.size() <= 1)
+  {
     return 0.0;
+  }
   else
     return getDuration() / static_cast<double>(duration_from_previous_.size() - 1);
 }


### PR DESCRIPTION
### Description

Corrects an off-by-one error in getAverageSegmentDuration

If we have **n** waypoints, we have **n - 1** timesteps

Assume a trivial case of durations = [1, 2, 3] with a timestamp of 1 and a size of 3

getDuration returns:
3 - 1 = 2

The current return is:
2 / 3 = 0.67

The expected return should be: 
2 / (3 - 1)  = 1

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
