### PR TITLE
[hybrid planning] Adjust planning scene locking

### DIFF
--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -96,6 +96,12 @@ bool LocalPlannerComponent::initialize()
   planning_scene_monitor_->startWorldGeometryMonitor(config_.collision_object_topic);
   planning_scene_monitor_->startStateMonitor(config_.joint_states_topic);
 
+  // Create a copy of the planning scene
+  planning_scene_monitor_->lockSceneRead();  // LOCK planning scene
+  planning_scene::PlanningScenePtr planning_scene = planning_scene_monitor_->getPlanningScene();
+  planning_scene->decoupleParent();
+  planning_scene_monitor_->unlockSceneRead();  // UNLOCK planning scene
+
   // Load trajectory operator plugin
   try
   {
@@ -235,14 +241,11 @@ void LocalPlannerComponent::executeIteration()
     // If the planner received an action request and a global solution it starts to plan locally
     case LocalPlannerState::LOCAL_PLANNING_ACTIVE:
     {
-      // Read current planning scene
+      // Read current robot state
       planning_scene_monitor_->updateSceneWithCurrentState();
       planning_scene_monitor_->lockSceneRead();  // LOCK planning scene
-      planning_scene::PlanningScenePtr planning_scene = planning_scene_monitor_->getPlanningScene();
+      const auto current_robot_state = planning_scene_monitor_->getPlanningScene()->getCurrentState();
       planning_scene_monitor_->unlockSceneRead();  // UNLOCK planning scene
-
-      // Get current state
-      auto current_robot_state = planning_scene->getCurrentStateNonConst();
 
       // Check if the global goal is reached
       if (trajectory_operator_instance_->getTrajectoryProgress(current_robot_state) > PROGRESS_THRESHOLD)

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -96,12 +96,6 @@ bool LocalPlannerComponent::initialize()
   planning_scene_monitor_->startWorldGeometryMonitor(config_.collision_object_topic);
   planning_scene_monitor_->startStateMonitor(config_.joint_states_topic);
 
-  // Create a copy of the planning scene
-  planning_scene_monitor_->lockSceneRead();  // LOCK planning scene
-  planning_scene::PlanningScenePtr planning_scene = planning_scene_monitor_->getPlanningScene();
-  planning_scene->decoupleParent();
-  planning_scene_monitor_->unlockSceneRead();  // UNLOCK planning scene
-
   // Load trajectory operator plugin
   try
   {

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -238,14 +238,13 @@ void LocalPlannerComponent::executeIteration()
       planning_scene_monitor_->updateSceneWithCurrentState();
 
       // Read current robot state
-      moveit::core::RobotStatePtr current_robot_state;
-      {
+      const moveit::core::RobotState current_robot_state = [this] {
         planning_scene_monitor::LockedPlanningSceneRO ls(planning_scene_monitor_);
-        current_robot_state = std::make_shared<moveit::core::RobotState>(ls->getCurrentState());
-      }
+        return ls->getCurrentState();
+      }();
 
       // Check if the global goal is reached
-      if (trajectory_operator_instance_->getTrajectoryProgress(*current_robot_state) > PROGRESS_THRESHOLD)
+      if (trajectory_operator_instance_->getTrajectoryProgress(current_robot_state) > PROGRESS_THRESHOLD)
       {
         local_planning_goal_handle_->succeed(result);
         reset();
@@ -256,7 +255,7 @@ void LocalPlannerComponent::executeIteration()
       robot_trajectory::RobotTrajectory local_trajectory =
           robot_trajectory::RobotTrajectory(planning_scene_monitor_->getRobotModel(), config_.group_name);
       *local_planner_feedback_ =
-          trajectory_operator_instance_->getLocalTrajectory(*current_robot_state, local_trajectory);
+          trajectory_operator_instance_->getLocalTrajectory(current_robot_state, local_trajectory);
 
       // Feedback is only sent when the hybrid planning architecture should react to a discrete event that occurred
       // during the identification of the local planning problem


### PR DESCRIPTION
We have a dual-arm project and found there was a deadlock here where the planning scene locks. This change fixes the deadlock and I think it's nice in a couple other ways, too:

- Make the robot state const.
- Eliminate an intermediate variable.

I'm all-ears in case there is a better way that I could test.
