### PR TITLE
[moveit_cpp] Fix double declaration

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits/joint_limits_rosparam.hpp
@@ -27,6 +27,16 @@
 #include "joint_limits/joint_limits.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+/** declare a parameter if not already declared. */
+#define DECLARE(node, name, type, default_value)                                                                       \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    if (not node->has_parameter(name))                                                                                 \
+    {                                                                                                                  \
+      node->declare_parameter<type>(name, default_value);                                                              \
+    }                                                                                                                  \
+  } while (false);
+
 namespace joint_limits
 {
 inline bool declare_parameters(const std::string& joint_name, const rclcpp::Node::SharedPtr& node,
@@ -35,24 +45,24 @@ inline bool declare_parameters(const std::string& joint_name, const rclcpp::Node
   const std::string param_base_name = (param_ns.empty() ? "" : param_ns + ".") + "joint_limits." + joint_name;
   try
   {
-    node->declare_parameter<bool>(param_base_name + ".has_position_limits", false);
-    node->declare_parameter<double>(param_base_name + ".min_position", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<double>(param_base_name + ".max_position", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<bool>(param_base_name + ".has_velocity_limits", false);
-    node->declare_parameter<double>(param_base_name + ".min_velocity", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<double>(param_base_name + ".max_velocity", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<bool>(param_base_name + ".has_acceleration_limits", false);
-    node->declare_parameter<double>(param_base_name + ".max_acceleration", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<bool>(param_base_name + ".has_jerk_limits", false);
-    node->declare_parameter<double>(param_base_name + ".max_jerk", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<bool>(param_base_name + ".has_effort_limits", false);
-    node->declare_parameter<double>(param_base_name + ".max_effort", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<bool>(param_base_name + ".angle_wraparound", false);
-    node->declare_parameter<bool>(param_base_name + ".has_soft_limits", false);
-    node->declare_parameter<double>(param_base_name + ".k_position", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<double>(param_base_name + ".k_velocity", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<double>(param_base_name + ".soft_lower_limit", std::numeric_limits<double>::quiet_NaN());
-    node->declare_parameter<double>(param_base_name + ".soft_upper_limit", std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".has_position_limits", bool, false);
+    DECLARE(node, param_base_name + ".min_position", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".max_position", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".has_velocity_limits", bool, false);
+    DECLARE(node, param_base_name + ".min_velocity", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".max_velocity", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".has_acceleration_limits", bool, false);
+    DECLARE(node, param_base_name + ".max_acceleration", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".has_jerk_limits", bool, false);
+    DECLARE(node, param_base_name + ".max_jerk", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".has_effort_limits", bool, false);
+    DECLARE(node, param_base_name + ".max_effort", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".angle_wraparound", bool, false);
+    DECLARE(node, param_base_name + ".has_soft_limits", bool, false);
+    DECLARE(node, param_base_name + ".k_position", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".k_velocity", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".soft_lower_limit", double, std::numeric_limits<double>::quiet_NaN());
+    DECLARE(node, param_base_name + ".soft_upper_limit", double, std::numeric_limits<double>::quiet_NaN());
   }
   catch (const std::exception& ex)
   {
@@ -287,5 +297,7 @@ inline bool get_joint_limits(const std::string& joint_name, const rclcpp::Node::
 }
 
 }  // namespace joint_limits
+
+#undef DECLARE
 
 #endif  // JOINT_LIMITS__JOINT_LIMITS_ROSPARAM_HPP_

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits/joint_limits_rosparam.hpp
@@ -27,15 +27,18 @@
 #include "joint_limits/joint_limits.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+namespace
+{
 /** declare a parameter if not already declared. */
-#define DECLARE(node, name, type, default_value)                                                                       \
-  do                                                                                                                   \
-  {                                                                                                                    \
-    if (not node->has_parameter(name))                                                                                 \
-    {                                                                                                                  \
-      node->declare_parameter<type>(name, default_value);                                                              \
-    }                                                                                                                  \
-  } while (false);
+template <typename T>
+void declare_parameter(const rclcpp::Node::SharedPtr& node, const std::string& name, T default_value)
+{
+  if (not node->has_parameter(name))
+  {
+    node->declare_parameter<T>(name, default_value);
+  }
+}
+}  // namespace
 
 namespace joint_limits
 {
@@ -43,26 +46,27 @@ inline bool declare_parameters(const std::string& joint_name, const rclcpp::Node
                                const std::string& param_ns)
 {
   const std::string param_base_name = (param_ns.empty() ? "" : param_ns + ".") + "joint_limits." + joint_name;
+
   try
   {
-    DECLARE(node, param_base_name + ".has_position_limits", bool, false);
-    DECLARE(node, param_base_name + ".min_position", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".max_position", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".has_velocity_limits", bool, false);
-    DECLARE(node, param_base_name + ".min_velocity", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".max_velocity", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".has_acceleration_limits", bool, false);
-    DECLARE(node, param_base_name + ".max_acceleration", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".has_jerk_limits", bool, false);
-    DECLARE(node, param_base_name + ".max_jerk", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".has_effort_limits", bool, false);
-    DECLARE(node, param_base_name + ".max_effort", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".angle_wraparound", bool, false);
-    DECLARE(node, param_base_name + ".has_soft_limits", bool, false);
-    DECLARE(node, param_base_name + ".k_position", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".k_velocity", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".soft_lower_limit", double, std::numeric_limits<double>::quiet_NaN());
-    DECLARE(node, param_base_name + ".soft_upper_limit", double, std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".has_position_limits", false);
+    declare_parameter(node, param_base_name + ".min_position", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".max_position", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".has_velocity_limits", false);
+    declare_parameter(node, param_base_name + ".min_velocity", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".max_velocity", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".has_acceleration_limits", false);
+    declare_parameter(node, param_base_name + ".max_acceleration", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".has_jerk_limits", false);
+    declare_parameter(node, param_base_name + ".max_jerk", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".has_effort_limits", false);
+    declare_parameter(node, param_base_name + ".max_effort", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".angle_wraparound", false);
+    declare_parameter(node, param_base_name + ".has_soft_limits", false);
+    declare_parameter(node, param_base_name + ".k_position", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".k_velocity", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".soft_lower_limit", std::numeric_limits<double>::quiet_NaN());
+    declare_parameter(node, param_base_name + ".soft_upper_limit", std::numeric_limits<double>::quiet_NaN());
   }
   catch (const std::exception& ex)
   {
@@ -297,7 +301,5 @@ inline bool get_joint_limits(const std::string& joint_name, const rclcpp::Node::
 }
 
 }  // namespace joint_limits
-
-#undef DECLARE
 
 #endif  // JOINT_LIMITS__JOINT_LIMITS_ROSPARAM_HPP_


### PR DESCRIPTION
The plugin did throw an error that parameters were already declared, at
least when I used it.
This commit fixes this.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
