### PR TITLE
[moveit_cpp] Add setLastPlanSolution

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -177,9 +177,8 @@ private:
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
   // Planning
-  std::map<std::string, planning_pipeline::PlanningPipelinePtr> planning_pipelines_;
-  std::map<std::string, std::set<std::string>> groups_pipelines_map_;
-  std::map<std::string, std::set<std::string>> groups_algorithms_map_;
+  std::map<std::string, planning_pipeline::PlanningPipelinePtr> planning_pipelines_;  // pipeline name: pipeline pointer.
+  std::map<std::string, std::set<std::string>> groups_pipelines_map_;                 // group name: set{pipeline name}.
 
   // Execution
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
@@ -193,6 +192,7 @@ private:
   /** \brief Initialize and setup the planning pipelines */
   bool loadPlanningPipelines(const PlanningPipelineOptions& options);
 };
+
 }  // namespace moveit_cpp
 
 namespace moveit

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -192,8 +192,14 @@ public:
    * after the execution is complete. The execution can be run in background by setting blocking to false. */
   bool execute(bool blocking = true);
 
-  /** \brief Return the last plan solution*/
+  /** \brief Return the last plan solution */
   const PlanSolutionPtr getLastPlanSolution();
+
+  /** \brief Set the last plan solution, which is then used by execute() */
+  void setLastPlanSolution(const PlanSolution& plan_solution)
+  {
+    last_plan_solution_ = std::make_shared<PlanSolution>(plan_solution);
+  }
 
 private:
   // Core properties and instances


### PR DESCRIPTION
Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

Without this function, it is not possible to execute another plan that the last computed one. I don't like the name (but I don't like the idea of having `execute()`  not taking a plan as input either), maybe `setNextPlanToExecute()` could be an alternative. So, it's more to start a discussion.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
