### PR TITLE
Remove include of OgrePrerequisites header

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -42,7 +42,6 @@
 #include <rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp>
 #include <rviz_common/properties/color_property.hpp>
 #include <moveit/rviz_plugin_render_tools/octomap_render.h>
-#include <OGRE/OgrePrerequisites.h>
 
 namespace octomap
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -41,7 +41,6 @@
 #include <octomap/octomap.h>
 #include <rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp>
 #include <rviz_common/properties/color_property.hpp>
-#include <moveit/rviz_plugin_render_tools/octomap_render.h>
 
 namespace octomap
 {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -37,10 +37,11 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <octomap/octomap.h>
-#include <rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp>
+#include <OgrePrerequisites.h>
 #include <rviz_common/properties/color_property.hpp>
+#include <rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp>
+#include <vector>
 
 namespace octomap
 {


### PR DESCRIPTION
It fixes this specific build error on our project's CI setup:

```
  --- stderr: moveit_task_constructor_visualization
  In file included from /opt/ros/galactic/include/moveit/rviz_plugin_render_tools/render_shapes.h:39,
                   from /opt/ros/galactic/include/moveit/rviz_plugin_render_tools/planning_scene_render.h:41,
                   from /home/runner/work/lab0_harvester/lab0_harvester/.work/upstream_ws/src/moveit_task_constructor/visualization/visualization_tools/src/task_solution_visualization.cpp:42:
  /opt/ros/galactic/include/moveit/rviz_plugin_render_tools/octomap_render.h:45:10: fatal error: OGRE/OgrePrerequisites.h: No such file or directory
     45 | #include <OGRE/OgrePrerequisites.h>
```

@jliukkonen and @tylerjw know the context and more details on the CI situation. I don't know so much about it.
