### PR TITLE
Make lockSceneRead() and lockSceneWrite() protected member functions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,11 @@
 API changes in MoveIt releases
 
 ## ROS Rolling
+- `lockSceneRead()` and `lockSceneWrite()` are now protected member functions, for internal use only. To lock the planning scene, use LockedPlanningSceneRO or LockedPlanningSceneRW:
+```
+      planning_scene_monitor::LockedPlanningSceneRO ls(planning_scene_monitor);
+      moveit::core::RobotModelConstPtr model = ls->getRobotModel();
+```
 - ServoServer was renamed to ServoNode
 - `CollisionObject` messages are now defined with a `Pose`, and shapes and subframes are defined relative to the object's pose. This makes it easier to place objects with subframes and multiple shapes in the scene. This causes several changes:
     - `getFrameTransform()` now returns this pose instead of the first shape's pose.

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -127,11 +127,11 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor =
       moveit_cpp_->getPlanningSceneMonitorNonConst();
   planning_scene_monitor->updateFrameTransforms();
-  planning_scene_monitor->lockSceneRead();  // LOCK planning scene
-  planning_scene::PlanningScenePtr planning_scene =
-      planning_scene::PlanningScene::clone(planning_scene_monitor->getPlanningScene());
-  planning_scene_monitor->unlockSceneRead();  // UNLOCK planning scene
-  planning_scene_monitor.reset();             // release this pointer
+  const planning_scene::PlanningScenePtr planning_scene = [planning_scene_monitor] {
+    planning_scene_monitor::LockedPlanningSceneRO ls(planning_scene_monitor);
+    return planning_scene::PlanningScene::clone(ls);
+  }();
+  planning_scene_monitor.reset();  // release this pointer
 
   // Init MotionPlanRequest
   ::planning_interface::MotionPlanRequest req;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -404,6 +404,17 @@ public:
    */
   bool waitForCurrentRobotState(const rclcpp::Time& t, double wait_time = 1.);
 
+  void clearOctomap();
+
+  // Called to update the planning scene with a new message.
+  bool newPlanningSceneMessage(const moveit_msgs::msg::PlanningScene& scene);
+
+protected:
+  /** @brief Initialize the planning scene monitor
+   *  @param scene The scene instance to fill with data (an instance is allocated if the one passed in is not allocated)
+   */
+  void initialize(const planning_scene::PlanningScenePtr& scene);
+
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();
 
@@ -417,17 +428,6 @@ public:
   /** \brief Lock the scene from writing (only one thread can lock for writing and no other thread can lock for reading)
    */
   void unlockSceneWrite();
-
-  void clearOctomap();
-
-  // Called to update the planning scene with a new message.
-  bool newPlanningSceneMessage(const moveit_msgs::msg::PlanningScene& scene);
-
-protected:
-  /** @brief Initialize the planning scene monitor
-   *  @param scene The scene instance to fill with data (an instance is allocated if the one passed in is not allocated)
-   */
-  void initialize(const planning_scene::PlanningScenePtr& scene);
 
   /** @brief Configure the collision matrix for a particular scene */
   void configureCollisionMatrix(const planning_scene::PlanningScenePtr& scene);
@@ -606,6 +606,9 @@ private:
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr callback_handler_;
 
   bool use_sim_time_;
+
+  friend class LockedPlanningSceneRO;
+  friend class LockedPlanningSceneRW;
 };
 
 /** \brief This is a convenience class for obtaining access to an


### PR DESCRIPTION
### Description

Previously there were 2 ways to lock the planning scene:

- `lockSceneRead()` or `lockSceneWrite()`
- Create a `LockedPlanningSceneRO` or `LockedPlanningSceneRW` object. Internally, this uses `lockSceneRead()` or `lockSceneWrite()`

The [tutorials recommend](https://moveit.picknik.ai/galactic/doc/examples/planning_scene_monitor/planning_scene_monitor_tutorial.html#planningscenemonitor) the LockedPlanningSceneRO approach. @v4hn and I [thought](https://github.com/ros-planning/moveit2/pull/1087#discussion_r812298593) it would be a good idea to make `lockSceneRead()` and `lockSceneWrite()` private so they don't get used by mistake.

`lockSceneRead()` and `lockSceneWrite()` don't get used very much in the codebase so this was actually a pretty simple change.

So far, I've tested with the Move Group C++ interface tutorial.