### PR TITLE
[MSA] Upgrade templates to ROS 2

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/package_settings_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/package_settings_config.cpp
@@ -180,7 +180,7 @@ void PackageSettingsConfig::collectVariables(std::vector<TemplateVariable>& vari
   std::stringstream deps;
   for (const auto& dependency : package_dependencies_)
   {
-    deps << "  <run_depend>" << dependency << "</run_depend>\n";
+    deps << "  <exec_depend>" << dependency << "</exec_depend>\n";
   }
   variables.push_back(TemplateVariable("OTHER_DEPENDENCIES", deps.str()));
 }

--- a/moveit_setup_assistant/moveit_setup_framework/templates/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.10.2)
 project([GENERATED_PACKAGE_NAME])
 
-find_package(catkin REQUIRED)
+find_package(ament_cmake REQUIRED)
 
-catkin_package()
+ament_package()
 
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}
   PATTERN "setup_assistant.launch" EXCLUDE)
-install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+install(FILES .setup_assistant DESTINATION share/${PROJECT_NAME})

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>[GENERATED_PACKAGE_NAME]</name>
   <version>0.3.0</version>
   <description>
      An automatically generated package with all the configuration and launch files for using the [ROBOT_NAME] with the MoveIt Motion Planning Framework
   </description>
-  <author email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</author>
   <maintainer email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</maintainer>
 
   <license>BSD</license>
@@ -13,6 +13,8 @@
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
+
+  <author email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -1,5 +1,5 @@
-<package>
-
+<?xml version="1.0"?>
+<package format="3">
   <name>[GENERATED_PACKAGE_NAME]</name>
   <version>0.3.0</version>
   <description>
@@ -14,26 +14,29 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_kinematics</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_setup_assistant</run_depend>
-  <run_depend>moveit_simple_controller_manager</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>joint_state_publisher_gui</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_kinematics</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_setup_assistant</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <run_depend>joint_trajectory_controller</run_depend> -->
-  <!-- <run_depend>gazebo_ros_control</run_depend> -->
+  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
-  <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
+  <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
   [OTHER_DEPENDENCIES]
 
+  <export>
+      <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -18,14 +18,14 @@
 
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_kinematics</exec_depend>
-  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_planners</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz</exec_depend>
+  <exec_depend>rviz2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.


### PR DESCRIPTION
### Description

Change the templates (and dependency block generating code) to ROS 2 standards. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
