### PR TITLE
Drop outdated/unnecessary workspace dependencies

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -15,11 +15,3 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/launch_param_builder
     version: main
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 2.1.0
-  ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: main


### PR DESCRIPTION
Drop OMPL and ros2_control when both are available as debians.
