### PR TITLE
Mark unlockSceneRead() as deprecated

### DIFF
--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -127,11 +127,11 @@ PlanningComponent::PlanSolution PlanningComponent::plan(const PlanRequestParamet
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor =
       moveit_cpp_->getPlanningSceneMonitorNonConst();
   planning_scene_monitor->updateFrameTransforms();
-  planning_scene_monitor->lockSceneRead();  // LOCK planning scene
-  planning_scene::PlanningScenePtr planning_scene =
-      planning_scene::PlanningScene::clone(planning_scene_monitor->getPlanningScene());
-  planning_scene_monitor->unlockSceneRead();  // UNLOCK planning scene
-  planning_scene_monitor.reset();             // release this pointer
+  const planning_scene::PlanningScenePtr planning_scene = [planning_scene_monitor] {
+    planning_scene_monitor::LockedPlanningSceneRO ls(planning_scene_monitor);
+    return planning_scene::PlanningScene::clone(ls);
+  }();
+  planning_scene_monitor.reset();  // release this pointer
 
   // Init MotionPlanRequest
   ::planning_interface::MotionPlanRequest req;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -405,18 +405,18 @@ public:
   bool waitForCurrentRobotState(const rclcpp::Time& t, double wait_time = 1.);
 
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
-  void lockSceneRead();
+  [[deprecated]] void lockSceneRead();
 
   /** \brief Unlock the scene from reading (multiple threads can lock for reading at the same time) */
-  void unlockSceneRead();
+  [[deprecated]] void unlockSceneRead();
 
   /** \brief Lock the scene for writing (only one thread can lock for writing and no other thread can lock for reading)
    */
-  void lockSceneWrite();
+  [[deprecated]] void lockSceneWrite();
 
   /** \brief Lock the scene from writing (only one thread can lock for writing and no other thread can lock for reading)
    */
-  void unlockSceneWrite();
+  [[deprecated]] void unlockSceneWrite();
 
   void clearOctomap();
 


### PR DESCRIPTION
### Description

This is a follow-on to #1100. It's identical except it only marks the functions as deprecated. It doesn't make them private / protected. I'm not sure we should merge this because it creates a lot of compiler warnings when these functions are used internally.

### Background

Previously there were 2 ways to lock the planning scene:

- `lockSceneRead()` or `lockSceneWrite()`
- Create a `LockedPlanningSceneRO` or `LockedPlanningSceneRW` object. Internally, this uses `lockSceneRead()` or `lockSceneWrite()`

The [tutorials recommend](https://moveit.picknik.ai/galactic/doc/examples/planning_scene_monitor/planning_scene_monitor_tutorial.html#planningscenemonitor) the LockedPlanningSceneRO approach. @v4hn and I [thought](https://github.com/ros-planning/moveit2/pull/1087#discussion_r812298593) it would be a good idea to make `lockSceneRead()` and `lockSceneWrite()` private so they don't get used by mistake.

`lockSceneRead()` and `lockSceneWrite()` don't get used very much in the codebase so this was actually a pretty simple change.

So far, I've tested with the Move Group C++ interface tutorial.
