### PR TITLE
Ruckig smoothing cleanup

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
-/* Author: Jack Center, Wyatt Rees, Andy Zelenak */
+/* Author: Jack Center, Wyatt Rees, Andy Zelenak, Stephanie Eng */
 
 #pragma once
 
@@ -61,35 +61,6 @@ private:
                                  const moveit::core::RobotStatePtr& next_waypoint,
                                  const moveit::core::JointModelGroup* joint_group,
                                  ruckig::InputParameter<0>& ruckig_input);
-
-  /**
-   * \brief Check for lagging motion of any joint at a waypoint.
-   * \param joint_group     The MoveIt JointModelGroup of interest
-   * \param ruckig_input  Input parameters to Ruckig
-   * \param ruckig_output Output parameters from Ruckig
-   * \return              true if lagging motion is detected on any joint
-   */
-  static bool checkForLaggingMotion(const moveit::core::JointModelGroup* joint_group,
-                                    const ruckig::InputParameter<0>& ruckig_input,
-                                    const ruckig::OutputParameter<0>& ruckig_output);
-
-  /**
-   * \brief Return L2-norm of velocity, taking all joints into account.
-   * \param ruckig_input  Input parameters to Ruckig
-   * \param joint_group   The MoveIt JointModelGroup of interest
-   */
-  static double getTargetVelocityMagnitude(const ruckig::InputParameter<0>& ruckig_input,
-                                           const moveit::core::JointModelGroup* joint_group);
-
-  /**
-   * \brief Check if the joint positions of two waypoints are very similar.
-   * \param prev_waypoint State at waypoint i-1
-   * \param prev_waypoint State at waypoint i
-   * \joint_group         The MoveIt JointModelGroup of interest
-   */
-  static bool checkForIdenticalWaypoints(const moveit::core::RobotState& prev_waypoint,
-                                         const moveit::core::RobotState& next_waypoint,
-                                         const moveit::core::JointModelGroup* joint_group);
 
   /**
    * \brief Initialize Ruckig position/vel/accel. This initializes ruckig_input and ruckig_output to the same values

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -46,8 +46,8 @@ class RuckigSmoothing
 {
 public:
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
-                             const double max_velocity_scaling_factor = 1.0,
-                             const double max_acceleration_scaling_factor = 1.0);
+                             double const max_velocity_scaling_factor = 1.0,
+                             double const max_acceleration_scaling_factor = 1.0);
 
 private:
   /**

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -46,8 +46,8 @@ class RuckigSmoothing
 {
 public:
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
-                             double const max_velocity_scaling_factor = 1.0,
-                             double const max_acceleration_scaling_factor = 1.0);
+                             const double max_velocity_scaling_factor = 1.0,
+                             const double max_acceleration_scaling_factor = 1.0);
 
 private:
   /**

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -45,12 +45,12 @@ namespace trajectory_processing
 {
 namespace
 {
-rclcpp::Logger const LOGGER = rclcpp::get_logger("moveit_trajectory_processing.ruckig_traj_smoothing");
-double constexpr DEFAULT_MAX_VELOCITY = 5;       // rad/s
-double constexpr DEFAULT_MAX_ACCELERATION = 10;  // rad/s^2
-double constexpr DEFAULT_MAX_JERK = 200;         // rad/s^3
-double constexpr MAX_DURATION_EXTENSION_FACTOR = 10.0;
-double constexpr DURATION_EXTENSION_FRACTION = 1.1;
+const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.ruckig_traj_smoothing");
+constexpr double DEFAULT_MAX_VELOCITY = 5;       // rad/s
+constexpr double DEFAULT_MAX_ACCELERATION = 10;  // rad/s^2
+constexpr double DEFAULT_MAX_JERK = 200;         // rad/s^3
+constexpr double MAX_DURATION_EXTENSION_FACTOR = 10.0;
+constexpr double DURATION_EXTENSION_FRACTION = 1.1;
 }  // namespace
 
 bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
@@ -64,7 +64,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
     return false;
   }
 
-  size_t const num_waypoints = trajectory.getWayPointCount();
+  const size_t num_waypoints = trajectory.getWayPointCount();
   if (num_waypoints < 2)
   {
     RCLCPP_WARN(LOGGER,
@@ -76,7 +76,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   robot_trajectory::RobotTrajectory original_trajectory =
       robot_trajectory::RobotTrajectory(trajectory, true /* deep copy */);
 
-  size_t const num_dof = group->getVariableCount();
+  const size_t num_dof = group->getVariableCount();
 
   // This lib does not actually work properly when angles wrap around, so we need to unwind the path first
   trajectory.unwind();
@@ -89,15 +89,14 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   ruckig::OutputParameter<ruckig::DynamicDOFs> ruckig_output{ num_dof };
 
   // Initialize the smoother
-  const std::vector<int>& idx = group->getVariableIndexList();
   initializeRuckigState(ruckig_input, ruckig_output, *trajectory.getFirstWayPointPtr(), group);
 
   // Kinematic limits (vel/accel/jerk)
-  std::vector<std::string> const& vars = group->getVariableNames();
-  moveit::core::RobotModel const& rmodel = group->getParentModel();
+  const std::vector<std::string>& vars = group->getVariableNames();
+  const moveit::core::RobotModel& rmodel = group->getParentModel();
   for (size_t i = 0; i < num_dof; ++i)
   {
-    moveit::core::VariableBounds const& bounds = rmodel.getVariableBounds(vars.at(i));
+    const moveit::core::VariableBounds& bounds = rmodel.getVariableBounds(vars.at(i));
 
     // This assumes min/max bounds are symmetric
     if (bounds.velocity_bounded_)
@@ -159,7 +158,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
               duration_extension_factor * original_trajectory.getWayPointDurationFromPrevious(time_stretch_idx));
           // re-calculate waypoint velocity and acceleration
           auto target_state = trajectory.getWayPointPtr(time_stretch_idx);
-          auto const prev_state = trajectory.getWayPointPtr(time_stretch_idx - 1);
+          const auto prev_state = trajectory.getWayPointPtr(time_stretch_idx - 1);
           timestep = trajectory.getAverageSegmentDuration();
           for (size_t joint = 0; joint < num_dof; ++joint)
           {

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -115,14 +115,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
     {
       ruckig_input.max_acceleration.at(i) = max_acceleration_scaling_factor * DEFAULT_MAX_ACCELERATION;
     }
-    if (bounds.jerk_bounded_)
-    {
-      ruckig_input.max_jerk.at(i) = bounds.max_jerk_;
-    }
-    else
-    {
-      ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
-    }
+    ruckig_input.max_jerk.at(i) = bounds.jerk_bounded_ ? bounds.max_jerk_ : DEFAULT_MAX_JERK;
   }
 
   ruckig::Result ruckig_result;

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -97,9 +97,6 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   moveit::core::RobotModel const& rmodel = group->getParentModel();
   for (size_t i = 0; i < num_dof; ++i)
   {
-    // TODO(andyz): read this from the joint group if/when jerk limits are added to the JointModel
-    ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
-
     moveit::core::VariableBounds const& bounds = rmodel.getVariableBounds(vars.at(i));
 
     // This assumes min/max bounds are symmetric
@@ -118,6 +115,14 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
     else
     {
       ruckig_input.max_acceleration.at(i) = max_acceleration_scaling_factor * DEFAULT_MAX_ACCELERATION;
+    }
+    if (bounds.jerk_bounded_)
+    {
+      ruckig_input.max_jerk.at(i) = bounds.max_jerk_;
+    }
+    else
+    {
+      ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
     }
   }
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -94,6 +94,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   // Kinematic limits (vel/accel/jerk)
   const std::vector<std::string>& vars = group->getVariableNames();
   const moveit::core::RobotModel& rmodel = group->getParentModel();
+  const std::vector<int>& move_group_idx = group->getVariableIndexList();
   for (size_t i = 0; i < num_dof; ++i)
   {
     const moveit::core::VariableBounds& bounds = rmodel.getVariableBounds(vars.at(i));
@@ -185,7 +186,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
           target_state->update();
         }
         ruckig_ptr = std::make_unique<ruckig::Ruckig<ruckig::DynamicDOFs>>(num_dof, timestep);
-        initializeRuckigState(ruckig_input, ruckig_output, *trajectory.getFirstWayPointPtr(), num_dof, move_group_idx);
+        initializeRuckigState(ruckig_input, ruckig_output, *trajectory.getFirstWayPointPtr(), group);
         // Begin the while() loop again
         break;
       }

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
-/* Author: Jack Center, Wyatt Rees, Andy Zelenak */
+/* Author: Jack Center, Wyatt Rees, Andy Zelenak, Stephanie Eng */
 
 #include <algorithm>
 #include <cmath>
@@ -46,13 +46,11 @@ namespace trajectory_processing
 namespace
 {
 const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.ruckig_traj_smoothing");
-constexpr double DEFAULT_MAX_VELOCITY = 5;           // rad/s
-constexpr double DEFAULT_MAX_ACCELERATION = 10;      // rad/s^2
-constexpr double DEFAULT_MAX_JERK = 20;              // rad/s^3
-constexpr double IDENTICAL_POSITION_EPSILON = 1e-3;  // rad
-constexpr double MAX_DURATION_EXTENSION_FACTOR = 5.0;
+constexpr double DEFAULT_MAX_VELOCITY = 5;       // rad/s
+constexpr double DEFAULT_MAX_ACCELERATION = 10;  // rad/s^2
+constexpr double DEFAULT_MAX_JERK = 200;         // rad/s^3
+constexpr double MAX_DURATION_EXTENSION_FACTOR = 10.0;
 constexpr double DURATION_EXTENSION_FRACTION = 1.1;
-constexpr double MINIMUM_VELOCITY_SEARCH_MAGNITUDE = 0.01;  // rad/s. Stop searching when velocity drops below this
 }  // namespace
 
 bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
@@ -69,9 +67,13 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   const size_t num_waypoints = trajectory.getWayPointCount();
   if (num_waypoints < 2)
   {
-    RCLCPP_ERROR(LOGGER, "Trajectory does not have enough points to smooth with Ruckig");
-    return false;
+    RCLCPP_WARN(LOGGER,
+                "Trajectory does not have enough points to smooth with Ruckig. Returning an unmodified trajectory.");
+    return true;
   }
+
+  // Cache the trajectory in case we need to reset it
+  robot_trajectory::RobotTrajectory original_trajectory = trajectory;
 
   const size_t num_dof = group->getVariableCount();
 
@@ -79,11 +81,11 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   trajectory.unwind();
 
   // Instantiate the smoother
-  double timestep = trajectory.getAverageSegmentDuration();
-  std::unique_ptr<ruckig::Ruckig<0>> ruckig_ptr;
-  ruckig_ptr = std::make_unique<ruckig::Ruckig<0>>(num_dof, timestep);
-  ruckig::InputParameter<0> ruckig_input{ num_dof };
-  ruckig::OutputParameter<0> ruckig_output{ num_dof };
+  double timestep = trajectory.getWayPointDurationFromStart(num_waypoints - 1) / (trajectory.getWayPointCount() - 1);
+  std::unique_ptr<ruckig::Ruckig<ruckig::DynamicDOFs>> ruckig_ptr;
+  ruckig_ptr = std::make_unique<ruckig::Ruckig<ruckig::DynamicDOFs>>(num_dof, timestep);
+  ruckig::InputParameter<ruckig::DynamicDOFs> ruckig_input{ num_dof };
+  ruckig::OutputParameter<ruckig::DynamicDOFs> ruckig_output{ num_dof };
 
   // Initialize the smoother
   const std::vector<int>& idx = group->getVariableIndexList();
@@ -119,8 +121,8 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   }
 
   ruckig::Result ruckig_result;
-  bool smoothing_complete = false;
   double duration_extension_factor = 1;
+  bool smoothing_complete = false;
   while ((duration_extension_factor < MAX_DURATION_EXTENSION_FACTOR) && !smoothing_complete)
   {
     for (size_t waypoint_idx = 0; waypoint_idx < num_waypoints - 1; ++waypoint_idx)
@@ -132,76 +134,48 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       // Run Ruckig
       ruckig_result = ruckig_ptr->update(ruckig_input, ruckig_output);
 
-      // If the requested velocity is too great, a joint can actually "move backward" to give itself more time to
-      // accelerate to the target velocity. Iterate and decrease velocities until that behavior is gone.
-      bool backward_motion_detected = checkForLaggingMotion(group, ruckig_input, ruckig_output);
-
-      double velocity_magnitude = getTargetVelocityMagnitude(ruckig_input, group);
-      while (backward_motion_detected && (velocity_magnitude > MINIMUM_VELOCITY_SEARCH_MAGNITUDE))
+      if ((waypoint_idx == num_waypoints - 2) && ruckig_result == ruckig::Result::Finished)
       {
-        // Skip repeated waypoints with no change in position. Ruckig does not handle this well and there's really no
-        // need to smooth it Simply set it equal to the previous (identical) waypoint.
-        if (checkForIdenticalWaypoints(*trajectory.getWayPointPtr(waypoint_idx), *next_waypoint, trajectory.getGroup()))
+        smoothing_complete = true;
+        break;
+      }
+
+      // Extend the trajectory duration if Ruckig could not reach the waypoint successfully
+      if (ruckig_result != ruckig::Result::Finished)
+      {
+        duration_extension_factor *= DURATION_EXTENSION_FRACTION;
+        // Reset the trajectory
+        trajectory = robot_trajectory::RobotTrajectory(original_trajectory, true /* deep copy */);
+        for (size_t time_stretch_idx = 1; time_stretch_idx < num_waypoints; ++time_stretch_idx)
         {
-          *next_waypoint = trajectory.getWayPoint(waypoint_idx);
-          continue;
+          trajectory.setWayPointDurationFromPrevious(
+              time_stretch_idx,
+              duration_extension_factor * original_trajectory.getWayPointDurationFromPrevious(time_stretch_idx));
+          // re-calculate waypoint velocity and acceleration
+          auto target_state = trajectory.getWayPointPtr(time_stretch_idx);
+          auto const prev_state = trajectory.getWayPointPtr(time_stretch_idx - 1);
+          timestep = trajectory.getWayPointDurationFromStart(num_waypoints - 1) / (trajectory.getWayPointCount() - 1);
+          for (size_t joint = 0; joint < num_dof; ++joint)
+          {
+            target_state->setVariableVelocity(move_group_idx.at(joint),
+                                              (1 / duration_extension_factor) *
+                                                  target_state->getVariableVelocity(move_group_idx.at(joint)));
+
+            double prev_velocity = prev_state->getVariableVelocity(move_group_idx.at(joint));
+            double curr_velocity = target_state->getVariableVelocity(move_group_idx.at(joint));
+            target_state->setVariableAcceleration(move_group_idx.at(joint), (curr_velocity - prev_velocity) / timestep);
+          }
+          target_state->update();
         }
-
-        // decrease target velocity
-        for (size_t joint = 0; joint < num_dof; ++joint)
-        {
-          ruckig_input.target_velocity.at(joint) *= 0.9;
-          // Propagate the change in velocity to acceleration, too.
-          // We don't change the position to ensure the exact target position is achieved.
-          ruckig_input.target_acceleration.at(joint) =
-              (ruckig_input.target_velocity.at(joint) - ruckig_output.new_velocity.at(joint)) / timestep;
-        }
-        velocity_magnitude = getTargetVelocityMagnitude(ruckig_input, group);
-        // Run Ruckig
-        ruckig_result = ruckig_ptr->update(ruckig_input, ruckig_output);
-
-        // check for backward motion
-        backward_motion_detected = checkForLaggingMotion(group, ruckig_input, ruckig_output);
+        ruckig_ptr = std::make_unique<ruckig::Ruckig<ruckig::DynamicDOFs>>(num_dof, timestep);
+        waypoint_idx = 0;
+        initializeRuckigState(ruckig_input, ruckig_output, *trajectory.getFirstWayPointPtr(), num_dof, move_group_idx);
+        break;
       }
-
-      // Overwrite pos/vel/accel of the target waypoint
-      for (size_t joint = 0; joint < num_dof; ++joint)
-      {
-        next_waypoint->setVariablePosition(idx.at(joint), ruckig_output.new_position.at(joint));
-        next_waypoint->setVariableVelocity(idx.at(joint), ruckig_output.new_velocity.at(joint));
-        next_waypoint->setVariableAcceleration(idx.at(joint), ruckig_output.new_acceleration.at(joint));
-      }
-      next_waypoint->update();
-    }
-
-    // If ruckig failed, the duration of the seed trajectory likely wasn't long enough.
-    // Try duration extension several times.
-    // TODO: see issue 767.  (https://github.com/ros-planning/moveit2/issues/767)
-    if (ruckig_result == ruckig::Result::Working)
-    {
-      smoothing_complete = true;
-    }
-    else
-    {
-      // If Ruckig failed, it's likely because the original seed trajectory did not have a long enough duration when
-      // jerk is taken into account. Extend the duration and try again.
-      initializeRuckigState(ruckig_input, ruckig_output, *trajectory.getFirstWayPointPtr(), group);
-      duration_extension_factor *= DURATION_EXTENSION_FRACTION;
-      for (size_t waypoint_idx = 1; waypoint_idx < num_waypoints; ++waypoint_idx)
-      {
-        trajectory.setWayPointDurationFromPrevious(
-            waypoint_idx, DURATION_EXTENSION_FRACTION * trajectory.getWayPointDurationFromPrevious(waypoint_idx));
-        // TODO(andyz): re-calculate waypoint velocity and acceleration here?
-      }
-
-      timestep = trajectory.getAverageSegmentDuration();
-      ruckig_ptr = std::make_unique<ruckig::Ruckig<0>>(num_dof, timestep);
     }
   }
 
-  // Either of these results is acceptable.
-  // Working means smoothing worked well but the final target position wasn't exactly achieved (I think) -- Andy Z.
-  if ((ruckig_result != ruckig::Result::Working) && (ruckig_result != ruckig::Result::Finished))
+  if (ruckig_result != ruckig::Result::Finished)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Ruckig trajectory smoothing failed. Ruckig error: " << ruckig_result);
     return false;
@@ -235,44 +209,6 @@ void RuckigSmoothing::initializeRuckigState(ruckig::InputParameter<0>& ruckig_in
   ruckig_output.new_position = ruckig_input.current_position;
   ruckig_output.new_velocity = ruckig_input.current_velocity;
   ruckig_output.new_acceleration = ruckig_input.current_acceleration;
-}
-
-bool RuckigSmoothing::checkForIdenticalWaypoints(const moveit::core::RobotState& prev_waypoint,
-                                                 const moveit::core::RobotState& next_waypoint,
-                                                 const moveit::core::JointModelGroup* joint_group)
-{
-  double magnitude_position_difference = prev_waypoint.distance(next_waypoint, joint_group);
-
-  return (magnitude_position_difference <= IDENTICAL_POSITION_EPSILON);
-}
-
-double RuckigSmoothing::getTargetVelocityMagnitude(const ruckig::InputParameter<0>& ruckig_input,
-                                                   const moveit::core::JointModelGroup* joint_group)
-{
-  const size_t num_dof = joint_group->getVariableCount();
-  double vel_magnitude = 0;
-  for (size_t joint = 0; joint < num_dof; ++joint)
-  {
-    vel_magnitude += ruckig_input.target_velocity.at(joint) * ruckig_input.target_velocity.at(joint);
-  }
-  return sqrt(vel_magnitude);
-}
-
-bool RuckigSmoothing::checkForLaggingMotion(const moveit::core::JointModelGroup* joint_group,
-                                            const ruckig::InputParameter<0>& ruckig_input,
-                                            const ruckig::OutputParameter<0>& ruckig_output)
-{
-  const size_t num_dof = joint_group->getVariableCount();
-  // Check for backward motion of any joint
-  for (size_t joint = 0; joint < num_dof; ++joint)
-  {
-    // This indicates the jerk-limited output lags the target output
-    if ((ruckig_output.new_velocity.at(joint) / ruckig_input.target_velocity.at(joint)) < 1)
-    {
-      return true;
-    }
-  }
-  return false;
 }
 
 void RuckigSmoothing::getNextRuckigInput(const ruckig::OutputParameter<0>& ruckig_output,

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -59,27 +59,6 @@ protected:
 
 }  // namespace
 
-TEST_F(RuckigTests, empty_trajectory)
-{
-  // This should fail because the trajectory is empty
-  EXPECT_FALSE(
-      smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
-}
-
-TEST_F(RuckigTests, not_enough_waypoints)
-{
-  moveit::core::RobotState robot_state(robot_model_);
-  robot_state.setToDefaultValues();
-  // First waypoint is default joint positions
-  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
-
-  robot_state.update();
-
-  // Fails due to not enough waypoints
-  EXPECT_FALSE(
-      smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
-}
-
 TEST_F(RuckigTests, basic_trajectory)
 {
   moveit::core::RobotState robot_state(robot_model_);

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -82,6 +82,34 @@ TEST_F(RuckigTests, basic_trajectory)
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
 }
 
+TEST_F(RuckigTests, single_waypoint)
+{
+  // With only one waypoint, Ruckig cannot smooth the trajectory.
+  // It should simply pass the trajectory through unmodified and return true.
+
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  // First waypoint is default joint positions
+  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
+
+  robot_state.update();
+
+  // Trajectory should not change
+  auto first_waypoint_input = robot_state;
+
+  // Only one waypoint is OK, it does not fail
+  EXPECT_TRUE(
+      smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
+  // And the waypoint did not change
+  auto const new_first_waypoint = trajectory_->getFirstWayPointPtr();
+  auto const& variable_names = new_first_waypoint->getVariableNames();
+  for (std::string const& variable_name : variable_names)
+  {
+    EXPECT_EQ(first_waypoint_input.getVariablePosition(variable_name),
+              new_first_waypoint->getVariablePosition(variable_name));
+  }
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -71,15 +71,41 @@ TEST_F(RuckigTests, basic_trajectory)
   robot_state.copyJointGroupPositions(JOINT_GROUP, joint_positions);
   joint_positions.at(0) += 0.05;
   robot_state.setJointGroupPositions(JOINT_GROUP, joint_positions);
+  robot_state.update();
   trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
 
   joint_positions.at(0) += 0.05;
   robot_state.setJointGroupPositions(JOINT_GROUP, joint_positions);
+  robot_state.update();
   trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
 
-  robot_state.update();
   EXPECT_TRUE(
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
+}
+
+TEST_F(RuckigTests, trajectory_duration)
+{
+  // Ideal duration is calculated from:
+  // x1 = x0 + v0*t + 0.5*a0*t^2
+  // Where x0 and v0 are zero
+  const double IDEAL_DURATION = 0.231;
+
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setToDefaultValues();
+  // Special attention to Joint 0. It is the only joint to move in this test.
+  // Zero velocities and accelerations at the endpoints
+  robot_state.setVariablePosition("panda_joint1", 0.0);
+  robot_state.update();
+  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
+
+  robot_state.setVariablePosition("panda_joint1", 0.1);
+  robot_state.update();
+  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
+
+  EXPECT_TRUE(
+      smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
+  EXPECT_GT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 0.9999 * IDEAL_DURATION);
+  EXPECT_LT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 1.2 * IDEAL_DURATION);
 }
 
 TEST_F(RuckigTests, single_waypoint)
@@ -97,7 +123,7 @@ TEST_F(RuckigTests, single_waypoint)
   // Trajectory should not change
   auto first_waypoint_input = robot_state;
 
-  // Only one waypoint is OK, it does not fail
+  // Only one waypoint is acceptable. True is returned.
   EXPECT_TRUE(
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
   // And the waypoint did not change

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -88,7 +88,7 @@ TEST_F(RuckigTests, trajectory_duration)
   // Ideal duration is calculated from:
   // x1 = x0 + v0*t + 0.5*a0*t^2
   // Where x0 and v0 are zero
-  const double IDEAL_DURATION = 0.231;
+  const double ideal_duration = 0.231;
 
   moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();
@@ -96,7 +96,7 @@ TEST_F(RuckigTests, trajectory_duration)
   // Zero velocities and accelerations at the endpoints
   robot_state.setVariablePosition("panda_joint1", 0.0);
   robot_state.update();
-  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
+  trajectory_->addSuffixWayPoint(robot_state, 0.0);
 
   robot_state.setVariablePosition("panda_joint1", 0.1);
   robot_state.update();
@@ -104,8 +104,8 @@ TEST_F(RuckigTests, trajectory_duration)
 
   EXPECT_TRUE(
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
-  EXPECT_GT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 0.9999 * IDEAL_DURATION);
-  EXPECT_LT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 1.2 * IDEAL_DURATION);
+  EXPECT_GT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 0.9999 * ideal_duration);
+  EXPECT_LT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 1.3 * ideal_duration);
 }
 
 TEST_F(RuckigTests, single_waypoint)

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -74,21 +74,14 @@ TEST_F(RuckigTests, basic_trajectory)
   robot_state.update();
   trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
 
-  joint_positions.at(0) += 0.05;
-  robot_state.setJointGroupPositions(JOINT_GROUP, joint_positions);
-  robot_state.update();
-  trajectory_->addSuffixWayPoint(robot_state, DEFAULT_TIMESTEP);
-
   EXPECT_TRUE(
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
 }
 
 TEST_F(RuckigTests, trajectory_duration)
 {
-  // Ideal duration is calculated from:
-  // x1 = x0 + v0*t + 0.5*a0*t^2
-  // Where x0 and v0 are zero
-  const double ideal_duration = 0.231;
+  // Compare against the OJET online trajectory generator: https://www.trajectorygenerator.com/ojet-online/
+  const double ideal_duration = 0.21025;
 
   moveit::core::RobotState robot_state(robot_model_);
   robot_state.setToDefaultValues();


### PR DESCRIPTION
### Description

Fixes #767 

This fixes some bugs in the Ruckig smoothing plugin and simplifies it. I tried to comment it better and simplify so it will be self-explanatory.

### Testing

You can test this easily with the MoveIt tutorials.

- Add Ruckig to the list of OMPL adapters. In `panda_moveit_config/config/ompl_planning.yaml`, add `AddRuckigTrajectorySmoothing` to the top of the list like this:

```
request_adapters: >-
  default_planner_request_adapters/AddRuckigTrajectorySmoothing
```

- Then launch the Panda with move_group:  `ros2 launch moveit_resources_panda_moveit_config demo.launch.py`

- You will know the Ruckig plugin loaded if you see this in terminal:

`Using planning request adapter 'Add Ruckig trajectory smoothing.`

### Data plots

Representative data from some very large trajectories (1000+ waypoints). We feed 10 waypoints at a time into this smoothing algorithm. Notice jerk decreased from 4000 rad/s^3 to 10 rad/s^3.


![joint_1_positions](https://user-images.githubusercontent.com/11284393/158439711-33899429-4620-43ac-a7fb-06001b090035.png)
![joint_1_vel_accel_jerk](https://user-images.githubusercontent.com/11284393/158439716-5b7f2376-8125-49e8-b2df-9b4cdf0de2ee.png)
![joint_2_positions](https://user-images.githubusercontent.com/11284393/158439717-3add3954-a298-4fdc-9716-0970445a41dd.png)
![joint_2_vel_accel_jerk](https://user-images.githubusercontent.com/11284393/158439721-137f12bb-d8ca-40b6-8501-d6e7b6985fd7.png)

