### PR TITLE
Remove MoveIt exceptions

### DIFF
--- a/moveit/scripts/create_readme_table.py
+++ b/moveit/scripts/create_readme_table.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Usage: python moveit/moveit/scripts/create_readme_table.py > /tmp/table.md
-# First update supported_distro_ubuntu_dict below!
 
 # Copyright 2021 PickNik Inc.
 #
@@ -30,6 +28,9 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+
+# Usage: python moveit/moveit/scripts/create_readme_table.py > /tmp/table.md
+# First update supported_distro_ubuntu_dict below!
 
 
 from __future__ import print_function


### PR DESCRIPTION
This is as part of #1038. I think using something like std::optional or std::expected is much nicer than throwing exceptions, especially with constructors. There are still some other core classes that use exceptions, with this I wanted to continue the discussion about API changes like this.