### PR TITLE
RDFLoader Broken with Xacro Files

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -164,7 +164,7 @@ bool RDFLoader::loadXacroFileToString(std::string& buffer, const std::string& pa
     return false;
   }
 
-  std::string cmd = "ros2 run xacro xacro";
+  std::string cmd = "ros2 run xacro xacro ";
   for (const std::string& xacro_arg : xacro_args)
     cmd += xacro_arg + " ";
   cmd += path;

--- a/moveit_ros/planning/rdf_loader/test/data/robin.srdf.xacro
+++ b/moveit_ros/planning/rdf_loader/test/data/robin.srdf.xacro
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="robin" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="srdf_macro">
+    <group name="group0">
+      <chain base_link="base_link" tip_link="flipper"/>
+    </group>
+  </xacro:macro>
+  <xacro:srdf_macro />
+</robot>

--- a/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
+++ b/moveit_ros/planning/rdf_loader/test/test_rdf_integration.cpp
@@ -90,6 +90,15 @@ TEST(RDFIntegration, executor)
   EXPECT_EQ("gonzo", loader.getSRDF()->getName());
 }
 
+TEST(RDFIntegration, xacro_test)
+{
+  std::string output;
+  std::vector<std::string> xacro_args;
+  ASSERT_TRUE(rdf_loader::RDFLoader::loadPkgFileToString(output, "moveit_ros_planning",
+                                                         "rdf_loader/test/data/robin.srdf.xacro", xacro_args));
+  EXPECT_GT(output.size(), 0u);
+}
+
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);


### PR DESCRIPTION
### Description

`RDFLoader` fails to properly load xacro files. This initial PR is for a test that shows the broken functionality. A one character fix will be added once CI completes on the initial test. 


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
