### PR TITLE
[moveit_cpp] Fix return value of execute

### DIFF
--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -43,6 +43,8 @@
 #endif
 #include <geometry_msgs/msg/quaternion_stamped.hpp>
 
+#include <moveit/controller_manager/controller_manager.h>
+
 namespace moveit_cpp
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros_planning_interface.moveit_cpp");
@@ -270,7 +272,8 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   {
     trajectory_execution_manager_->push(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
-    return trajectory_execution_manager_->waitForExecution();
+
+    return (trajectory_execution_manager_->waitForExecution() == moveit_controller_manager::ExecutionStatus::SUCCEEDED);
   }
   trajectory_execution_manager_->pushAndExecute(robot_trajectory_msg);
   return true;


### PR DESCRIPTION
Previously, `MoveItCpp::execute()` would return true only if
`waitForExecution()` would return `UNKNOWN`.
This sort of break the API because users that did use the return value
of `execute` had to use an inverted logic.
These users will quickly notice the change.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

Previously, `MoveItCpp::execute()` would return true only if
`waitForExecution()` would return `UNKNOWN`.
This sort of break the API because users that did use the return value
of `execute` had to use an inverted logic.
These users will quickly notice the change.

The returned value is not documented in the [API documentation](https://moveit.picknik.ai/galactic/api/html/classmoveit__cpp_1_1MoveItCpp.html#a5ca934bc472fc16cb8ca62c5263448cd).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
