### PR TITLE
[moveit_cpp] Return `ExecutionStatus` in `execute`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,7 @@ API changes in MoveIt releases
 - add API for passing RNG to setToRandomPositionsNearBy
 - Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
 - Enhance `RDFLoader` to load from string parameter OR string topic (and add the ability to publish a string topic).
+- `MoveItCpp::execute` now returns a `moveit_controller_manager::ExecutionStatus` rather than a `bool`. A `moveit_controller_manager::ExecutionStatus` is automatically casted to a `bool`, so that no changes in the user's code should be required.
 
 ## ROS Noetic
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,7 +16,6 @@ API changes in MoveIt releases
 - add API for passing RNG to setToRandomPositionsNearBy
 - Static member variable interface of the CollisionDetectorAllocatorTemplate for the string NAME was replaced with a virtual method `getName`.
 - Enhance `RDFLoader` to load from string parameter OR string topic (and add the ability to publish a string topic).
-- `MoveItCpp::execute` now returns a `moveit_controller_manager::ExecutionStatus` rather than a `bool`. A `moveit_controller_manager::ExecutionStatus` is automatically casted to a `bool`, so that no changes in the user's code should be required.
 
 ## ROS Noetic
 - RobotModel no longer overrides empty URDF collision geometry by matching the visual geometry of the link.

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <rclcpp/rclcpp.hpp>
+#include <moveit/controller_manager/controller_manager.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_pipeline/planning_pipeline.h>
 #include <moveit/trajectory_execution_manager/trajectory_execution_manager.h>
@@ -167,8 +168,9 @@ public:
 
   /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.
    * If blocking is set to false, the execution is run in background and the function returns immediately. */
-  bool execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-               bool blocking = true);
+  moveit_controller_manager::ExecutionStatus execute(const std::string& group_name,
+                                                     const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
+                                                     bool blocking = true);
 
 private:
   //  Core properties and instances


### PR DESCRIPTION
Return an `ExecutionStatus` in `MoveItCpp::execute`, which can is
convertible to a bool in the caller code.
This change introduces a forward-compatible API breaking change.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

Return an `ExecutionStatus` in `MoveItCpp::execute`, which can is
convertible to a bool in the caller code.
This change introduces a forward-compatible API breaking change.

Follow-up of #1144.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
