### PR TITLE
Don't merge: Remove srdfdom from ci docker and trigger a docker build

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -36,6 +36,8 @@ RUN \
     rosdep update && \
     DEBIAN_FRONTEND=noninteractive \
     rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # Remove srdfdom binaries
+    apt-get -q remove ros-rolling-srdfdom && \
     # Remove the source code from this container
     rm -rf src && \
     #

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,7 @@ on:
     # 5 PM UTC every Sunday
     - cron:  '0 17 * * 6'
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
#1151 is failing a CI because the srdfdom binaries are installed in CI docker, which overrides the source built version that needs to be used. This PR removes srdfdom from CI docker and triggers a docker build for #1151. Not to be merged.