### PR TITLE
[foxy]: mesh_shape: Fix resource group for meshes (backport #672)

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -74,7 +74,7 @@ void MeshShape::beginTriangles()
   if (!started_)
   {
     started_ = true;
-    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST, "rviz_rendering");
   }
 }
 
@@ -126,7 +126,7 @@ void MeshShape::endTriangles()
     entity_ = scene_manager_->createEntity(name);
     if (entity_)
     {
-      entity_->setMaterialName(material_name_);
+      entity_->setMaterialName(material_name_, "rviz_rendering");
       offset_node_->attachObject(entity_);
     }
     else


### PR DESCRIPTION
### Description

Fixes: https://github.com/ros-planning/moveit2/issues/1164