### PR TITLE
Remove moveit_msgs and ompl from moveit2.repos

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -3,18 +3,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/geometric_shapes
     version: ros2
-  moveit_msgs:
-    type: git
-    url: https://github.com/ros-planning/moveit_msgs
-    version: 2.2.0
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources
     version: ros2
-  ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: main
   srdfdom:
     type: git
     url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
### Description

 * moveit_msgs has been at 2.2.0 since https://github.com/ros/rosdistro/pull/31470
 * ompl seems to be up to date in rolling since https://github.com/ros/rosdistro/pull/32292


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
