### PR TITLE
Fix Moveit Configs Utils Bug

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -229,7 +229,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
             self.__urdf_file_path = self.__config_dir_path / (
                 self.__robot_name + ".urdf"
             )
-            self.__srdf_filename = self.__config_dir_path / (
+            self.__srdf_file_path = self.__config_dir_path / (
                 self.__robot_name + ".srdf"
             )
         else:
@@ -246,7 +246,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
                     "relative_path"
                 ]
             )
-            self.__srdf_filename = Path(
+            self.__srdf_file_path = Path(
                 setup_assistant_yaml["moveit_setup_assistant_config"]["SRDF"][
                     "relative_path"
                 ]
@@ -283,7 +283,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
         self.__moveit_configs.robot_description_semantic = {
             self.__robot_description
             + "_semantic": load_xacro(
-                self._package_path / (file_path or self.__srdf_filename),
+                self._package_path / (file_path or self.__srdf_file_path),
                 mappings=mappings,
             )
         }


### PR DESCRIPTION
### Description

The declared variable name for the srdf file is [`__srdf_file_path`](https://github.com/ros-planning/moveit2/blob/a0c4d34ddb4698589202784810c3379f83107c27/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py#L211) but it is actually instantiated with `__srdf_filename`. Since `__srdf_filename` does not match `__urdf_file_path`, we change it be consistent with the declaration. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
