### PR TITLE
RCLCPP Upgrade Bugfixes

### DIFF
--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -138,7 +138,7 @@ public:
    * Return true if the execution is complete (whether successful or not).
    * Return false if timeout was reached.
    * If timeout is -1 (default argument), wait until the execution is complete (no timeout). */
-  virtual bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration(-1)) = 0;
+  virtual bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration::from_nanoseconds(-1)) = 0;
 
   /** \brief Return the execution status of the last trajectory sent to the controller. */
   virtual ExecutionStatus getLastExecutionStatus() = 0;

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -150,7 +150,7 @@ public:
     rclcpp_action::Client<control_msgs::action::GripperCommand>::SendGoalOptions send_goal_options;
     // Active callback
     send_goal_options.goal_response_callback =
-        [this](std::shared_future<rclcpp_action::Client<control_msgs::action::GripperCommand>::GoalHandle::SharedPtr>
+        [this](rclcpp_action::Client<control_msgs::action::GripperCommand>::GoalHandle::SharedPtr
                /* unused-arg */) { RCLCPP_DEBUG_STREAM(LOGGER, name_ << " started execution"); };
     // Send goal
     auto current_goal_future = controller_action_client_->async_send_goal(goal, send_goal_options);

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -66,11 +66,8 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::ms
   rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SendGoalOptions send_goal_options;
   // Active callback
   send_goal_options.goal_response_callback =
-      [this](
-          std::shared_future<rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle::SharedPtr>
-              future) {
+      [this](rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle::SharedPtr goal_handle) {
         RCLCPP_INFO_STREAM(LOGGER, name_ << " started execution");
-        const auto& goal_handle = future.get();
         if (!goal_handle)
           RCLCPP_WARN(LOGGER, "Goal request rejected");
         else

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -212,8 +212,7 @@ bool HybridPlanningManager::sendGlobalPlannerAction()
 
   // Add goal response callback
   global_goal_options.goal_response_callback =
-      [this](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::GlobalPlanner>::SharedPtr> future) {
-        auto const& goal_handle = future.get();
+      [this](rclcpp_action::ClientGoalHandle<moveit_msgs::action::GlobalPlanner>::SharedPtr goal_handle) {
         auto planning_progress = std::make_shared<moveit_msgs::action::HybridPlanner::Feedback>();
         auto& feedback = planning_progress->feedback;
         if (!goal_handle)
@@ -283,8 +282,7 @@ bool HybridPlanningManager::sendLocalPlannerAction()
 
   // Add goal response callback
   local_goal_options.goal_response_callback =
-      [this](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr> future) {
-        auto const& goal_handle = future.get();
+      [this](rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr goal_handle) {
         auto planning_progress = std::make_shared<moveit_msgs::action::HybridPlanner::Feedback>();
         auto& feedback = planning_progress->feedback;
         if (!goal_handle)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -762,8 +762,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr> future) {
-          const auto& goal_handle = future.get();
+        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr goal_handle) {
           if (!goal_handle)
           {
             done = true;
@@ -841,8 +840,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr> future) {
-          const auto& goal_handle = future.get();
+        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr goal_handle) {
           if (!goal_handle)
           {
             done = true;
@@ -906,9 +904,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::ExecuteTrajectory>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](std::shared_future<rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::SharedPtr>
-                future) {
-          const auto& goal_handle = future.get();
+        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::SharedPtr goal_handle) {
           if (!goal_handle)
           {
             done = true;


### PR DESCRIPTION
### Description

[CI is failing on #1176](https://github.com/ros-planning/moveit2/runs/5997775137?check_suite_focus=true#step:12:420) with the errors
```
/home/runner/work/moveit2/moveit2/.work/target_ws/install/moveit_core/include/moveit/controller_manager/controller_manager.h:141:67: error: no matching conversion for functional-style cast from 'int' to 'rclcpp::Duration'
    virtual bool waitForExecution(const rclcpp::Duration& timeout = rclcpp::Duration(-1)) = 0;
```
and
```
/home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h:152:46: error: no viable overloaded '='
      send_goal_options.goal_response_callback =
```

I believe this is caused by https://github.com/ros2/rclcpp/pull/1913 and rclcpp getting a new release. 

Closes #1178 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
