### PR TITLE
Dynamic joint velocity/acceleration limits

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -73,17 +73,17 @@ struct VariableBounds
   double max_position_;
   bool position_bounded_;
 
-  double min_velocity_;
-  double max_velocity_;
-  bool velocity_bounded_;
+  mutable double min_velocity_;
+  mutable double max_velocity_;
+  mutable bool velocity_bounded_;
 
-  double min_acceleration_;
-  double max_acceleration_;
-  bool acceleration_bounded_;
+  mutable double min_acceleration_;
+  mutable double max_acceleration_;
+  mutable bool acceleration_bounded_;
 
-  double min_jerk_;
-  double max_jerk_;
-  bool jerk_bounded_;
+  mutable double min_jerk_;
+  mutable double max_jerk_;
+  mutable bool jerk_bounded_;
 };
 
 class LinkModel;

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -456,8 +456,17 @@ public:
     return joint_model_vector_[common_joint_roots_[a->getJointIndex() * joint_model_vector_.size() + b->getJointIndex()]];
   }
 
-  /// A map of known kinematics solvers (associated to their group name)
+  /** \brief A map of known kinematics solvers (associated to their group name) */
   void setKinematicsAllocators(const std::map<std::string, SolverAllocatorFn>& allocators);
+
+  /** \brief Update velocity bounds */
+  void updateVelocityBounds(const std::vector<double>& new_velocity_bounds) const;
+
+  /** \brief Update acceleration bounds */
+  void updateAccelerationBounds(const std::vector<double>& new_acceleration_bounds) const;
+
+  /** \brief Update jerk bounds */
+  void updateJerkBounds(const std::vector<double>& new_jerk_bounds) const;
 
 protected:
   /** \brief Get the transforms between link and all its rigidly attached descendants */
@@ -570,8 +579,9 @@ protected:
 
   std::vector<int> active_joint_model_start_index_;
 
-  /** \brief The bounds for all the active joint models */
-  JointBoundsVector active_joint_models_bounds_;
+  /** \brief The bounds for all the active joint models
+   * Mutable so bounds can be modified at runtime */
+  mutable JointBoundsVector active_joint_models_bounds_;
 
   /** \brief The joints that correspond to each variable index */
   std::vector<const JointModel*> joints_of_variable_;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1480,6 +1480,51 @@ void RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAlloc
   }
 }
 
+void RobotModel::updateVelocityBounds(const std::vector<double>& new_velocity_bounds) const
+{
+  assert(active_joint_models_bounds_.size() == new_velocity_bounds.size());
+  assert(joints_of_variable_.size() == new_velocity_bounds.size());
+
+  //    using JointBoundsVector = std::vector<const JointModel::Bounds*>;
+  for (size_t joint_idx = 0; joint_idx < new_velocity_bounds.size(); ++joint_idx)
+  {
+    assert(new_velocity_bounds.at(joint_idx) > 0);
+    // Update bounds of active joint models
+    auto active_joint_bounds = active_joint_models_bounds_.at(joint_idx);
+    active_joint_bounds->at(0).velocity_bounded_ = true;
+    active_joint_bounds->at(0).min_velocity_ = -new_velocity_bounds.at(joint_idx);
+    active_joint_bounds->at(0).max_velocity_ = new_velocity_bounds.at(joint_idx);
+  }
+}
+
+void RobotModel::updateAccelerationBounds(const std::vector<double>& new_acceleration_bounds) const
+{
+  assert(active_joint_models_bounds_.size() == new_acceleration_bounds.size());
+
+  for (size_t joint_idx = 0; joint_idx < new_acceleration_bounds.size(); ++joint_idx)
+  {
+    assert(new_acceleration_bounds.at(joint_idx) > 0);
+    // Update bounds of active joint models
+    auto joint_bounds = active_joint_models_bounds_.at(joint_idx);
+    joint_bounds->at(0).min_acceleration_ = -new_acceleration_bounds.at(joint_idx);
+    joint_bounds->at(0).max_acceleration_ = new_acceleration_bounds.at(joint_idx);
+  }
+}
+
+void RobotModel::updateJerkBounds(const std::vector<double>& new_jerk_bounds) const
+{
+  assert(active_joint_models_bounds_.size() == new_jerk_bounds.size());
+
+  for (size_t joint_idx = 0; joint_idx < new_jerk_bounds.size(); ++joint_idx)
+  {
+    assert(new_jerk_bounds.at(joint_idx) > 0);
+    // Update bounds of active joint models
+    auto joint_bounds = active_joint_models_bounds_.at(joint_idx);
+    joint_bounds->at(0).min_jerk_ = -new_jerk_bounds.at(joint_idx);
+    joint_bounds->at(0).max_jerk_ = new_jerk_bounds.at(joint_idx);
+  }
+}
+
 void RobotModel::printModelInfo(std::ostream& out) const
 {
   out << "Model " << model_name_ << " in frame " << model_frame_ << ", using " << getVariableCount() << " variables\n";

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -921,6 +921,14 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   const unsigned num_joints = group->getVariableCount();
   const unsigned num_points = trajectory.getWayPointCount();
 
+  // TODO(andyz): remove when done testing
+  std::vector<double> new_velocity_bounds{ 11, 11, 11, 11, 11, 11, 11 };
+  rmodel.updateVelocityBounds(new_velocity_bounds);
+  std::vector<double> new_acceleration_bounds{ 100, 100, 100, 100, 100, 100, 100 };
+  rmodel.updateAccelerationBounds(new_acceleration_bounds);
+  std::vector<double> new_jerk_bounds{ 1e4, 1e4, 1e4, 1e4, 1e4, 1e4, 1e4 };
+  rmodel.updateJerkBounds(new_jerk_bounds);
+
   // Get the limits (we do this at same time, unlike IterativeParabolicTimeParameterization)
   Eigen::VectorXd max_velocity(num_joints);
   Eigen::VectorXd max_acceleration(num_joints);
@@ -940,6 +948,8 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
       }
       max_velocity[j] =
           std::min(std::fabs(bounds.max_velocity_), std::fabs(bounds.min_velocity_)) * velocity_scaling_factor;
+      // TODO(andyz): remove when done testing
+      RCLCPP_ERROR_STREAM(LOGGER, "New vel bounds: " << max_velocity[j]);
     }
 
     max_acceleration[j] = 1.0;


### PR DESCRIPTION
### Description

Update velocity/accel/jerk limits dynamically, like this:

```
  std::vector<double> new_velocity_bounds{ 10, 10, 10, 10, 10, 10, 10 };
  rmodel.updateVelocityBounds(new_velocity_bounds);
```
Fixes #1180 

### Testing

Requires moveit_resources.

`ros2 launch moveit_resources_panda_moveit_config demo launch.py`