### PR TITLE
Add a warning for TOTG if vel/accel limits aren't specified.

### DIFF
--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -941,6 +941,12 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
       max_velocity[j] =
           std::min(std::fabs(bounds.max_velocity_), std::fabs(bounds.min_velocity_)) * velocity_scaling_factor;
     }
+    else
+    {
+      RCLCPP_WARN_STREAM_ONCE(
+          LOGGER, "Joint velocity limits are not defined. Using the default "
+                      << max_velocity[j] << " rad/s. You can define velocity limits in the URDF or joint_limits.yaml.");
+    }
 
     max_acceleration[j] = 1.0;
     if (bounds.acceleration_bounded_)
@@ -953,6 +959,13 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
       }
       max_acceleration[j] = std::min(std::fabs(bounds.max_acceleration_), std::fabs(bounds.min_acceleration_)) *
                             acceleration_scaling_factor;
+    }
+    else
+    {
+      RCLCPP_WARN_STREAM_ONCE(LOGGER,
+                              "Joint acceleration limits are not defined. Using the default "
+                                  << max_acceleration[j]
+                                  << " rad/s^2. You can define acceleration limits in the URDF or joint_limits.yaml.");
     }
   }
 


### PR DESCRIPTION
### Description

Add a warning for TOTG time parameterization if a vel/accel limit is not defined and a default is being assumed. This is the same warning the recent Ruckig plugin provides.

I could add something similar to IPTP or ISTP but I hope they get deprecated soon.