### PR TITLE
[Fix Rolling CI] Update moveit_configs_utils dependencies

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -6,17 +6,18 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 find_package(ament_cmake REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(orocos_kdl REQUIRED)
-find_package(tf2_kdl REQUIRED)
-find_package(kdl_parser REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(random_numbers REQUIRED)
 find_package(class_loader REQUIRED)
-find_package(pluginlib REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(kdl_parser REQUIRED)
+find_package(moveit_configs_utils REQUIRED)
 find_package(moveit_core REQUIRED)
-find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(orocos_kdl REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(random_numbers REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_kdl REQUIRED)
 
 # Finds Boost Components
 include(ConfigExtras.cmake)
@@ -38,6 +39,7 @@ set(THIS_PACKAGE_LIBRARIES
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
+  moveit_configs_utils
   moveit_core
   moveit_ros_planning
   Boost

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>urdfdom</exec_depend> <!-- provides check_urdf -->
   <exec_depend>python3-lxml</exec_depend>
 
+  <test_depend>moveit_configs_utils</test_depend>
   <test_depend>moveit_ros_planning</test_depend>
   <test_depend>moveit_resources_fanuc_description</test_depend>
   <test_depend>moveit_resources_fanuc_moveit_config</test_depend>

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(ament_cmake REQUIRED)
 find_package(control_msgs REQUIRED)
 find_package(control_toolbox REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(moveit_configs_utils REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
@@ -53,6 +54,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   control_msgs
   control_toolbox
   geometry_msgs
+  moveit_configs_utils
   moveit_core
   moveit_msgs
   moveit_ros_planning

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -26,8 +26,9 @@
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
   <depend>geometry_msgs</depend>
-  <depend>moveit_msgs</depend>
+  <depend>moveit_configs_utils</depend>
   <depend>moveit_core</depend>
+  <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>pluginlib</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
### Description

Add `moveit_configs_utils` dependencies. Should fix CI failures like this:

```
build/moveit_kinematics/test_results/moveit_kinematics/test_launch_fanuc-kdl-singular.test.py.xunit.xml: 1 test, 1 error, 0 failures, 0 skipped
- moveit_kinematics test_launch_fanuc-kdl-singular.test.py.xunit.missing_result
  <<< error message
...
    ModuleNotFoundError: No module named 'moveit_configs_utils'
```
