### PR TITLE
Allow for TLDs between 2 and 63 characters for emails

### DIFF
--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -700,7 +700,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   }
 
   // Check that email information is filled
-  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b");
+  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,63}\\b");
   mail_regex.setCaseSensitivity(Qt::CaseInsensitive);
   mail_regex.setPatternSyntax(QRegExp::RegExp);
   QString test_email = QString::fromStdString(config_data_->author_email_);

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -700,7 +700,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   }
 
   // Check that email information is filled
-  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}\\b");
+  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]+\\b");
   mail_regex.setCaseSensitivity(Qt::CaseInsensitive);
   mail_regex.setPatternSyntax(QRegExp::RegExp);
   QString test_email = QString::fromStdString(config_data_->author_email_);

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -700,7 +700,7 @@ bool ConfigurationFilesWidget::checkDependencies()
   }
 
   // Check that email information is filled
-  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]+\\b");
+  QRegExp mail_regex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b");
   mail_regex.setCaseSensitivity(Qt::CaseInsensitive);
   mail_regex.setPatternSyntax(QRegExp::RegExp);
   QString test_email = QString::fromStdString(config_data_->author_email_);


### PR DESCRIPTION
### Description

My work email address is "tyler@urbanmachine.build". The setup assistant's pattern for email addresses only allows TLDs on emails to be between 2 and 4 characters in length, meaning that it thinks my email address is invalid. This updates the regular expression to accept between 2 and 63 characters, which is the maximum length of a TLD [1].

1. https://datatracker.ietf.org/doc/html/rfc1034#section-3.1

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
