### PR TITLE
CI: Fix clang-tidy warning

### DIFF
--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -247,11 +247,8 @@ bool sampleCloud(const octomap::point3d_list& cloud, const double& spacing, cons
   double a = 0, b = 0, c = 0, r2 = 0, r4 = 0, r6 = 0, a1 = 0, b1 = 0, c1 = 0, a2 = 0, b2 = 0, c2 = 0;
   bool wyvill = true;
 
-  octomap::point3d_list::const_iterator it;
-  for (it = cloud.begin(); it != cloud.end(); ++it)
+  for (const octomath::Vector3& v : cloud)
   {
-    octomath::Vector3 v = (*it);
-
     if (wyvill)
     {
       r2 = r * r;


### PR DESCRIPTION
Fix a clang-tidy warning:
```
moveit_core/collision_detection/src/collision_octomap_filter.cpp:253:23: warning: the variable 'v' is copy-constructed from a const reference but is only used as const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
      octomath::Vector3 v = (*it);
```