### PR TITLE
[MSA] Existing Package Loading Tweaks

### DIFF
--- a/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files.hpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files.hpp
@@ -60,6 +60,11 @@ public:
     package_settings_->setPackagePath(package_path);
   }
 
+  void setPackageName(const std::string& package_name)
+  {
+    package_settings_->setPackageName(package_name);
+  }
+
   /// Populate the 'Files to be generated' list
   void loadFiles();
 

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
@@ -186,7 +186,28 @@ void ConfigurationFilesWidget::setCheckSelected(bool checked)
 
 void ConfigurationFilesWidget::onPackagePathChanged(const QString& path)
 {
-  setup_step_.setPackagePath(path.toStdString());
+  std::string package_path = path.toStdString();
+  if (package_path == setup_step_.getPackagePath())
+  {
+    return;
+  }
+  setup_step_.setPackagePath(package_path);
+
+  // Determine new potential package name
+  boost::filesystem::path fs_package_path;
+
+  // Remove end slash if there is one
+  if (!package_path.compare(package_path.size() - 1, 1, "/"))
+  {
+    fs_package_path = boost::filesystem::path(package_path.substr(0, package_path.size() - 1));
+  }
+  else
+  {
+    fs_package_path = boost::filesystem::path(package_path);
+  }
+
+  setup_step_.setPackageName(fs_package_path.filename().string());
+
   focusGiven();
 }
 

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/data/package_settings_config.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/data/package_settings_config.hpp
@@ -44,17 +44,35 @@ const std::string SETUP_ASSISTANT_FILE = ".setup_assistant";
 class PackageSettingsConfig : public SetupConfig
 {
 public:
+  /**
+   * @brief Overridden method to load THIS config's data variables.
+   *
+   * Not to be confused with loadExisting which is a PackageSettingsConfig-specific
+   * method for loading ALL configs and their data.
+   */
   void loadPrevious(const std::string& package_path, const YAML::Node& node) override;
   YAML::Node saveToYaml() const override;
 
-  void loadExisting(const std::string& package_path);
+  /**
+   * @brief Method for loading the contents of the .setup_assistant file into all the configs
+   *
+   * @param package_path_or_name Either the path to the MoveIt config package folder OR the name of the package.
+   */
+  void loadExisting(const std::string& package_path_or_name);
 
   const std::string& getPackagePath() const
   {
     return config_pkg_path_;
   }
 
+  const std::string& getPackageName() const
+  {
+    return new_package_name_;
+  }
+
   void setPackagePath(const std::string& package_path);
+
+  void setPackageName(const std::string& package_name);
 
   const std::time_t& getGenerationTime() const
   {
@@ -199,7 +217,7 @@ protected:
   std::string config_pkg_path_;
 
   /// Name of the new package that is being (or going) to be generated, based on user specified save path
-  std::string new_package_name_;
+  std::string new_package_name_{ "unnamed_moveit_config" };
 
   /// Name of the author of this config
   std::string author_name_;


### PR DESCRIPTION
### Description
The key change in this PR is basically one line:
```
extractPackageNameFromPath(config_pkg_path_, new_package_name_, relative_path);
```
which sets the package name for the MoveIt config to be the existing package name when loading from an existing MoveIt config. Easy enough....

...except `new_package_name_` was also set in `setPackagePath`, called automatically from the `ConfigurationFilesWidget`. But that caused problems because the value of the package path was automatically derived from the existing package path, which means that the `new_package_name_` would not reflect the actual package name, but instead reflect the name of the folder. 

This is most notable with the `moveit_resources` where the folder is `panda_moveit_config` but the actual package name is [`moveit_resources_panda_moveit_config`](https://github.com/ros-planning/moveit_resources/blob/394a3c6aba9da34d5317697fdb0db2c9acc8ebd8/panda_moveit_config/package.xml#L3)

Anyway, so this PR splits the functionality into two distinct paths, one for setting the package path, and one for setting the package name. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
