### PR TITLE
CI: More generically fix permission errors

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -28,13 +28,11 @@ RUN \
         clang clang-format-12 clang-tidy clang-tools \
         ccache && \
     #
-    # Fetch all dependencies from moveit2.repos
-    # As of 5/2/2022, permissions need to be set explicitly.
-    # See https://github.com/actions/checkout/issues/760.
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/geometric_shapes && \
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/moveit_resources && \
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/srdfdom && \
+    # Globally disable git security
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced
+    git config --global --add safe.directory "*" && \
     #
+    # Fetch all dependencies from moveit2.repos
     vcs import src < src/moveit2/moveit2.repos && \
     if [ -r src/moveit2/moveit2_${ROS_DISTRO}.repos ] ; then vcs import src < src/moveit2/moveit2_${ROS_DISTRO}.repos ; fi && \
     #

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -19,14 +19,7 @@ COPY . src/moveit2
 RUN --mount=type=cache,target=/root/.ccache/ \
     # Enable ccache
     PATH=/usr/lib/ccache:$PATH && \
-    #
-    # Fetch all dependencies from moveit2.repos
-    # As of 5/2/2022, permissions need to be set explicitly.
-    # See https://github.com/actions/checkout/issues/760.
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/geometric_shapes && \
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/moveit_resources && \
-    git config --global --add safe.directory /home/runner/work/moveit2/moveit2/.work/upstream_ws/src/srdfdom && \
-    #
+    # Fetch required upstream sources for building
     vcs import src < src/moveit2/moveit2.repos && \
     if [ -r src/moveit2/moveit2_${ROS_DISTRO}.repos ] ; then vcs import src < src/moveit2/moveit2_${ROS_DISTRO}.repos ; fi && \
     #


### PR DESCRIPTION
Generalize #1206, disabling git security check for any folder.
We are running our self-generated docker container on GHA. Chances are low that this gets compromised.
This should also solve https://github.com/ros-planning/moveit2_tutorials/pull/355.