### PR TITLE
Fix reading joint weights in KDLKinematicsPlugin

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -88,11 +88,11 @@ void KDLKinematicsPlugin::getJointWeights()
   const std::vector<std::string>& active_names = joint_model_group_->getActiveJointModelNames();
   std::vector<std::string> names;
   std::vector<double> weights;
-  if (lookupParam(node_, "joint_weights/weights", weights, weights))
+  if (lookupParam(node_, "joint_weights.weights", weights, weights))
   {
-    if (!lookupParam(node_, "joint_weights/names", names, names) || names.size() != weights.size())
+    if (!lookupParam(node_, "joint_weights.names", names, names) || (names.size() != weights.size()))
     {
-      RCLCPP_ERROR(LOGGER, "Expecting list parameter joint_weights/names of same size as list joint_weights/weights");
+      RCLCPP_ERROR(LOGGER, "Expecting list parameter joint_weights.names of same size as list joint_weights.weights");
       // fall back to default weights
       weights.clear();
     }


### PR DESCRIPTION
Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

The KDL kinematics plugin didn't read the `joint_weights` parameters correctly. Trivial change.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
