### PR TITLE
Change condition for loading default OMPL config

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -479,7 +479,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
         # Special rule to add ompl planner_configs
         if "ompl" in self.__moveit_configs.planning_pipelines:
             ompl_config = self.__moveit_configs.planning_pipelines["ompl"]
-            if "planner_configs" not in ompl_config.get("move_group", {}):
+            if "planner_configs" not in ompl_config:
                 ompl_config.update(load_yaml(default_folder / "ompl_defaults.yaml"))
 
         return self


### PR DESCRIPTION
moveit_configs_utils doesn't seem to respect the `ompl_planning.yaml` in the robot_moveit_config/config folder and instead loads the default planner configs even if they are defined in the robot's `ompl_planning.yaml` - I encountered this issue when trying to use the panda demo launch from moveit_resources.

Not sure if this is the correct way to go about fixing this, but as far as I can tell, if the planning pipeline from [moveit_configs_utils](https://github.com/ros-planning/moveit2/blob/78574bc1459eb34ac0aeecbb04cc96715ce0b713/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py#L475-L477) is used, the `"move_group"` key is never added to the moveit_configs.planning_pipelines. The `"move_group"` key was added [in the launch file](https://github.com/ros-planning/moveit_resources/blob/d4f0468d98374b531b66dcaad10a7604116316a0/panda_moveit_config/launch/demo.launch.py#L78).

From [discussions](https://github.com/ros-planning/moveit2/pull/1131/files#r845565105) in #1131, my understanding of the intent of this line is to use the request adapters from `ompl_planning.yaml` and the defaults if `planner_configs` are not defined in that file.