### PR TITLE
Test: Revert "Use orocos_kdl_vendor package (#1207)"

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -218,7 +218,7 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Plugin exports
 pluginlib_export_plugin_description_file(moveit_core collision_detector_fcl_description.xml)

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -65,7 +65,7 @@
   <test_depend>moveit_resources_pr2_description</test_depend>
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
-  <test_depend>orocos_kdl_vendor</test_depend>
+  <test_depend>orocos_kdl</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -67,7 +67,7 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -30,7 +30,7 @@
   <depend>eigen</depend>
   <depend>tf2</depend>
   <depend>tf2_kdl</depend>
-  <depend>orocos_kdl_vendor</depend>
+  <depend>orocos_kdl</depend>
   <depend>moveit_msgs</depend>
 
   <!-- some requirements of ikfast scripts -->

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -192,7 +192,7 @@ ament_export_include_directories(
   include
 )
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   # Include Tests

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -28,7 +28,7 @@
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend> <!-- RobotModelLoader -->
   <depend>moveit_ros_move_group</depend> <!-- move_group capability -->
-  <depend>orocos_kdl_vendor</depend>
+  <depend>orocos_kdl</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
Test if commit 78574bc is the cause of Pilz CI failures, e.g. this one:  https://github.com/ros-planning/moveit2/runs/6318123065?check_suite_focus=true