### PR TITLE
Make moveit_common a 'depend' rather than 'build_depend'

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -25,7 +25,7 @@
   <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>angles</depend>
   <depend>rclcpp</depend>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -22,7 +22,7 @@
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>class_loader</depend>

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -14,7 +14,7 @@
   <author email="gjones@willowgarage.com">Gil Jones</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>chomp_motion_planner</depend>
   <depend>moveit_core</depend>

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -15,7 +15,7 @@
   <author email="mail@mrinal.net">Mrinal Kalakrishnan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -11,7 +11,7 @@
   <author email="raghavendersahdev@gmail.com">Raghavender Sahdev</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>chomp_motion_planner</depend>

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -17,7 +17,7 @@
   <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_msgs</depend>

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <!-- TODO(henning): Enable when this is available
   <depend>joint_limits_interface</depend>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_plugins/moveit_ros_control_interface/package.xml
+++ b/moveit_plugins/moveit_ros_control_interface/package.xml
@@ -13,7 +13,7 @@
   <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
   <depend>rclcpp_action</depend>
   <depend>controller_manager_msgs</depend>
   <depend>moveit_core</depend>

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -18,7 +18,7 @@
   <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -17,7 +17,7 @@
   <author email="rluna@rice.edu">Ryan Luna</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
   <build_depend>moveit_core</build_depend>
 
   <build_depend>libboost-dev</build_depend>

--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -13,7 +13,7 @@
   <url type="repository">https://github.com/ros-planning/moveit2</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>ament_index_cpp</depend>
   <depend>moveit_msgs</depend>

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -19,7 +19,7 @@
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -21,7 +21,7 @@
   <author email="adam.pettinger@utexas.edu">Adam Pettinger</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -21,7 +21,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -19,7 +19,7 @@
   <author email="gedikli@willowgarage.com">Suat Gedikli</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -20,7 +20,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -19,7 +19,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -18,7 +18,7 @@
   <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>moveit_ros_planning</depend>
   <depend>rclcpp</depend>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -21,7 +21,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <build_depend>class_loader</build_depend>
   <build_depend>eigen</build_depend>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -17,7 +17,7 @@
   <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
 
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>

--- a/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/package.xml
@@ -19,7 +19,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>moveit_common</build_depend>
+  <depend>moveit_common</depend>
   <build_depend>ompl</build_depend>
 
   <depend>ament_index_cpp</depend>


### PR DESCRIPTION
### Description

Fix: #1094

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
