### PR TITLE
Fix double delete in PILZ CIRC generation

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
@@ -65,8 +65,6 @@ std::unique_ptr<KDL::Path> PathCircleGenerator::circleFromCenter(const KDL::Fram
   }
   catch (KDL::Error_MotionPlanning&)
   {
-    delete rot_interpo;  // in case we could not construct the Path object, avoid
-                         // a memory leak
     KDL::epsilon = old_kdl_epsilon;
     throw;  // and pass the exception on to the caller
   }
@@ -121,22 +119,9 @@ std::unique_ptr<KDL::Path> PathCircleGenerator::circleFromInterim(const KDL::Fra
   }
 
   KDL::RotationalInterpolation* rot_interpo = new KDL::RotationalInterpolation_SingleAxis();
-  try
-  {
-    return std::unique_ptr<KDL::Path>(
-        std::make_unique<KDL::Path_Circle>(start_pose, center_point, kdl_aux_point, goal_pose.M, alpha, rot_interpo,
-                                           eqradius, true /* take ownership of RotationalInterpolation */));
-  }
-  catch (KDL::Error_MotionPlanning&)  // LCOV_EXCL_START // The cases where
-                                      // KDL would throw are already handled
-                                      // above,
-                                      // we keep these lines to be safe
-  {
-    delete rot_interpo;  // in case we could not construct the Path object, avoid
-                         // a memory leak
-    throw;               // and pass the exception on to the caller
-    // LCOV_EXCL_STOP
-  }
+  return std::unique_ptr<KDL::Path>(
+      std::make_unique<KDL::Path_Circle>(start_pose, center_point, kdl_aux_point, goal_pose.M, alpha, rot_interpo,
+                                         eqradius, true /* take ownership of RotationalInterpolation */));
 }
 
 double PathCircleGenerator::cosines(const double a, const double b, const double c)


### PR DESCRIPTION
With https://github.com/orocos/orocos_kinematics_dynamics/commit/d54536898cadf3aed1a75cfed7b7ff14d3c29b20 KDL already takes care of deleting the passed object, so we don't need to do this in case of an exception. This fixes the current CI failure affecting the PILZ tests.