### PR TITLE
[pilz_industrial_motion_planner] Fix logging

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
@@ -79,13 +79,19 @@ bool CommandPlanner::initialize(const moveit::core::RobotModelConstPtr& model, c
 
   // List available plugins
   const std::vector<std::string>& factories = planner_context_loader->getDeclaredClasses();
-  std::stringstream ss;
-  for (const auto& factory : factories)
+  if (factories.empty())
   {
-    ss << factory << " ";
+    RCLCPP_WARN(LOGGER, "No available plugins");
   }
-
-  RCLCPP_INFO_STREAM(LOGGER, "Available plugins: " << ss.str());
+  else
+  {
+    std::ostringstream ss;
+    for (const auto& factory : factories)
+    {
+      ss << factory << " ";
+    }
+    RCLCPP_INFO(LOGGER, "Available plugins: %s", ss.str().c_str());
+  }
 
   // Load each factory
   for (const auto& factory : factories)


### PR DESCRIPTION
The name `ss` cannot be used with `RCLCPP_INFO_STREAM`.
This is a bug in rclcpp.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

This is a backport of #1140, as mergify seems to not allow backporting closed PRs.
The changes only apply to the galactic branch, not to the main branch