### PR TITLE
Alternate Package Name Specification

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -240,8 +240,13 @@ class MoveItConfigsBuilder(ParameterBuilder):
     __config_dir_path = Path("config")
 
     # Look-up for robot_name_moveit_config package
-    def __init__(self, robot_name: str, robot_description="robot_description"):
-        super().__init__(robot_name + "_moveit_config")
+    def __init__(
+        self,
+        robot_name: str,
+        robot_description="robot_description",
+        package_name: Optional(str) = None,
+    ):
+        super().__init__(package_name or (robot_name + "_moveit_config"))
         self.__moveit_configs.package_path = self._package_path
         self.__robot_name = robot_name
         setup_assistant_file = self._package_path / ".setup_assistant"

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -244,7 +244,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
         self,
         robot_name: str,
         robot_description="robot_description",
-        package_name: Optional(str) = None,
+        package_name: Optional[str] = None,
     ):
         super().__init__(package_name or (robot_name + "_moveit_config"))
         self.__moveit_configs.package_path = self._package_path


### PR DESCRIPTION
### Description

Additional argument in `MoveItConfigsBuilder` constructor to allow for arbitrary path names, and not just those ending in `_moveit_config`. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
