### PR TITLE
move_group_interface: No need to spin after publishing

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1008,7 +1008,6 @@ public:
       std_msgs::msg::String event;
       event.data = "stop";
       trajectory_event_publisher_->publish(event);
-      rclcpp::spin_some(pnode_);
     }
   }
 
@@ -1035,7 +1034,6 @@ public:
       aco.touch_links = touch_links;
     aco.object.operation = moveit_msgs::msg::CollisionObject::ADD;
     attached_object_publisher_->publish(aco);
-    rclcpp::spin_some(pnode_);
     return true;
   }
 
@@ -1056,13 +1054,11 @@ public:
       {
         aco.link_name = lname;
         attached_object_publisher_->publish(aco);
-        rclcpp::spin_some(pnode_);
       }
     }
     else
     {
       attached_object_publisher_->publish(aco);
-      rclcpp::spin_some(pnode_);
     }
     return true;
   }


### PR DESCRIPTION
### Description

Publishing doesn't require spinning, this is sometimes causing an exception `Node '/move_group_interface_node' has already been added to an executor`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
