### PR TITLE
Fix bug in applying planning scene diffs that have attached collision objects (#3124)

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -552,8 +552,8 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::msg::PlanningScene& sce
   else
   {
     scene_msg.robot_state = moveit_msgs::msg::RobotState();
-    scene_msg.robot_state.is_diff = true;
   }
+  scene_msg.robot_state.is_diff = true;
 
   if (acm_)
     acm_->getMessage(scene_msg.allowed_collision_matrix);
@@ -610,6 +610,18 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::msg::PlanningScene& sce
     }
     if (do_omap)
       getOctomapMsg(scene_msg.world.octomap);
+  }
+
+  // Ensure any detached collision objects get detached from the parent planning scene, too
+  for (const auto& collision_object : scene_msg.world.collision_objects)
+  {
+    if (parent_ && parent_->getCurrentState().hasAttachedBody(collision_object.id))
+    {
+      moveit_msgs::msg::AttachedCollisionObject aco;
+      aco.object.id = collision_object.id;
+      aco.object.operation = moveit_msgs::msg::CollisionObject::REMOVE;
+      scene_msg.robot_state.attached_collision_objects.push_back(aco);
+    }
   }
 }
 

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -356,6 +356,130 @@ TEST_P(CollisionDetectorTests, ClearDiff)
   parent.reset();
 }
 
+// Returns a planning scene diff message
+moveit_msgs::msg::PlanningScene create_planning_scene_diff(planning_scene::PlanningScene& ps,
+                                                           const std::string& object_name, const int8_t operation,
+                                                           const bool attach_object = false,
+                                                           const bool create_object = true)
+{
+  // Helper function to create an object for RobotStateDiffBug
+  auto add_object = [](const std::string& object_name, const int8_t operation) {
+    moveit_msgs::msg::CollisionObject co;
+    co.header.frame_id = "panda_link0";
+    co.id = object_name;
+    co.operation = operation;
+    co.primitives.push_back([] {
+      shape_msgs::msg::SolidPrimitive primitive;
+      primitive.type = shape_msgs::msg::SolidPrimitive::SPHERE;
+      primitive.dimensions.push_back(1.0);
+      return primitive;
+    }());
+    co.primitive_poses.push_back([] {
+      geometry_msgs::msg::Pose pose;
+      pose.orientation.w = 1.0;
+      return pose;
+    }());
+    co.pose = co.primitive_poses[0];
+    return co;
+  };
+  // Helper function to create an attached object for RobotStateDiffBug
+  auto add_attached_object = [](const std::string& object_name, const int8_t operation) {
+    moveit_msgs::msg::AttachedCollisionObject aco;
+    aco.object.operation = operation;
+    aco.object.id = object_name;
+    aco.link_name = "panda_link0";
+    return aco;
+  };
+
+  auto new_ps = ps.diff();
+  if (operation == moveit_msgs::msg::CollisionObject::REMOVE ||
+      (operation == moveit_msgs::msg::CollisionObject::ADD && create_object))
+    new_ps->processCollisionObjectMsg(add_object(object_name, operation));
+  if (attach_object)
+    new_ps->processAttachedCollisionObjectMsg(add_attached_object(object_name, operation));
+  moveit_msgs::msg::PlanningScene scene_msg;
+  new_ps->getPlanningSceneDiffMsg(scene_msg);
+  return scene_msg;
+}
+
+// Returns collision objects names sorted alphabetically
+std::set<std::string> get_collision_objects_names(const planning_scene::PlanningScene& ps)
+{
+  std::vector<moveit_msgs::msg::CollisionObject> collision_objects;
+  ps.getCollisionObjectMsgs(collision_objects);
+  std::set<std::string> collision_objects_names;
+  for (const auto& collision_object : collision_objects)
+    collision_objects_names.emplace(collision_object.id);
+  return collision_objects_names;
+}
+
+// Returns attached collision objects names sorted alphabetically
+std::set<std::string> get_attached_collision_objects_names(const planning_scene::PlanningScene& ps)
+{
+  std::vector<moveit_msgs::msg::AttachedCollisionObject> collision_objects;
+  ps.getAttachedCollisionObjectMsgs(collision_objects);
+  std::set<std::string> collision_objects_names;
+  for (const auto& collision_object : collision_objects)
+    collision_objects_names.emplace(collision_object.object.id);
+  return collision_objects_names;
+}
+
+TEST(PlanningScene, RobotStateDiffBug)
+{
+  auto urdf_model = moveit::core::loadModelInterface("panda");
+  auto srdf_model = std::make_shared<srdf::Model>();
+  auto ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
+
+  // It works as expected for collision objects case
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::msg::CollisionObject::ADD);
+    const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD);
+
+    ps->usePlanningSceneMsg(ps2);
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::REMOVE);
+
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
+  }
+
+  // Attached collision objects case
+  ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
+
+  // Test that triggered a bug related to having two diffs that add two different objects
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::msg::CollisionObject::ADD, true);
+    const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD, true);
+
+    ps->usePlanningSceneMsg(ps1);
+    ps->usePlanningSceneMsg(ps2);
+    EXPECT_TRUE(get_collision_objects_names(*ps).empty());
+    // Should print object1 and object2 -- it prints object2 only (or object1 depending on the order of operation)
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+
+  // Test that triggered a bug related to removing an object when having a robot state diff
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::REMOVE, true);
+    ps->usePlanningSceneMsg(ps1);
+
+    EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object2" }));
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
+  }
+
+  {
+    const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD, true, false);
+    ps->usePlanningSceneMsg(ps1);
+
+    EXPECT_TRUE(get_collision_objects_names(*ps).empty());
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+}
+
 #ifndef INSTANTIATE_TEST_SUITE_P  // prior to gtest 1.10
 #define INSTANTIATE_TEST_SUITE_P(...) INSTANTIATE_TEST_CASE_P(__VA_ARGS__)
 #endif


### PR DESCRIPTION
### Description

Backport of https://github.com/ros-planning/moveit/pull/3124

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
