### PR TITLE
publish robot description config

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -423,6 +423,8 @@ class MoveItConfigsBuilder(ParameterBuilder):
         publish_geometry_updates: bool = True,
         publish_state_updates: bool = True,
         publish_transforms_updates: bool = True,
+        publish_robot_description: bool = False,
+        publish_robot_description_semantic: bool = False,
     ):
         self.__moveit_configs.planning_scene_monitor = {
             # TODO: Fix parameter namespace upstream -- see planning_scene_monitor.cpp:262
@@ -431,6 +433,8 @@ class MoveItConfigsBuilder(ParameterBuilder):
             "publish_geometry_updates": publish_geometry_updates,
             "publish_state_updates": publish_state_updates,
             "publish_transforms_updates": publish_transforms_updates,
+            "publish_robot_description": publish_robot_description,
+            "publish_robot_description_semantic": publish_robot_description_semantic,
             # }
         }
         return self


### PR DESCRIPTION
- Add options to config for publishing description
- Fix clang-format-12 errors

This fix adds support to moveit_config_utils for the two parameters that determine if the robot description is published on a latched topic. This is useful for reducing the amount of boilerplate in launch files and in some cases making so some launch files don't need to be written at all.

This change is necesary for keeping the tutorials I am writing simple.

I also included two changes from running clang-format-12 over moveit in this. I've tested this change on 22.04 on Rolling.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)