### PR TITLE
Changed 'return false' in plan, move and execute such that MoveItErrorCode is returned

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -794,7 +794,7 @@ public:
     if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
       RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::plan() failed or timeout reached");
-      return false;
+      return res->error_code;
     }
 
     plan.trajectory_ = res->planned_trajectory;
@@ -873,7 +873,6 @@ public:
     if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
       RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::move() failed or timeout reached");
-      return false;
     }
     return res->error_code;
   }
@@ -941,7 +940,6 @@ public:
     if (code != rclcpp_action::ResultCode::SUCCEEDED)
     {
       RCLCPP_ERROR_STREAM(LOGGER, "MoveGroupInterface::execute() failed or timeout reached");
-      return false;
     }
     return res->error_code;
   }


### PR DESCRIPTION
### Description
Provided a fix for [issue  #1239](https://github.com/ros-planning/moveit2/issues/1239#issue-1232732923).