### PR TITLE
Fix hybrid planning launching (simple file renaming)

### DIFF
--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
@@ -78,7 +78,7 @@ def generate_common_hybrid_launch_description():
     planning_pipelines_config["ompl"].update(ompl_planning_yaml)
 
     moveit_simple_controllers_yaml = load_yaml(
-        "moveit_resources_panda_moveit_config", "config/panda_controllers.yaml"
+        "moveit_resources_panda_moveit_config", "config/moveit_controllers.yaml"
     )
     moveit_controllers = {
         "moveit_simple_controller_manager": moveit_simple_controllers_yaml,


### PR DESCRIPTION
Test with:

ros2 launch moveit_hybrid_planning hybrid_planning_demo.launch.py
