### PR TITLE
[Hybrid Planning] Improve action cancellation

### DIFF
--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -35,13 +35,13 @@ set(LIBRARIES
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
+  moveit_msgs
   moveit_ros_planning
   moveit_ros_planning_interface
-  moveit_msgs
-  rclcpp
-  rclcpp_components
-  rclcpp_action
   pluginlib
+  rclcpp
+  rclcpp_action
+  rclcpp_components
   std_msgs
   std_srvs
   tf2_ros

--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -75,7 +75,7 @@ install(TARGETS ${LIBRARIES}
   RUNTIME DESTINATION lib/${PROJECT_NAME}
   INCLUDES DESTINATION include)
 
-install(TARGETS hybrid_planning_demo_node
+install(TARGETS cancel_action hybrid_planning_demo_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -102,6 +102,9 @@ private:
 
   // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
   std::thread long_callback_thread_;
+
+  // A unique callback group, to avoid mixing callbacks with other action servers
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
 };
 
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -55,10 +55,10 @@ namespace moveit::hybrid_planning
 class GlobalPlannerComponent
 {
 public:
-  /** \brief Destructor */
+  /** \brief Constructor */
   GlobalPlannerComponent(const rclcpp::NodeOptions& options);
 
-  /** \brief Constructor */
+  /** \brief Destructor */
   ~GlobalPlannerComponent()
   {
     // Join the thread used for long-running callbacks

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -62,9 +62,9 @@ public:
   ~GlobalPlannerComponent()
   {
     // Join the thread used for long-running callbacks
-    if (long_callback_thread_ != nullptr)
+    if (long_callback_thread_.joinable())
     {
-      long_callback_thread_->join();
+      long_callback_thread_.join();
     }
   }
 
@@ -101,7 +101,7 @@ private:
   bool initializeGlobalPlanner();
 
   // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
-  std::unique_ptr<std::thread> long_callback_thread_;
+  std::thread long_callback_thread_;
 };
 
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -55,7 +55,18 @@ namespace moveit::hybrid_planning
 class GlobalPlannerComponent
 {
 public:
+  /** \brief Destructor */
   GlobalPlannerComponent(const rclcpp::NodeOptions& options);
+
+  /** \brief Constructor */
+  ~GlobalPlannerComponent()
+  {
+    // Join the thread used for long-running callbacks
+    if (long_callback_thread_ != nullptr)
+    {
+      long_callback_thread_->join();
+    }
+  }
 
   // This function is required to make this class a valid NodeClass
   // see https://docs.ros2.org/foxy/api/rclcpp_components/register__node__macro_8hpp.html
@@ -88,6 +99,9 @@ private:
 
   // Initialize planning scene monitor and load pipelines
   bool initializeGlobalPlanner();
+
+  // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
+  std::unique_ptr<std::thread> long_callback_thread_;
 };
 
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -71,6 +71,7 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
     RCLCPP_ERROR(LOGGER, "global_planning_action_name was not defined");
     return false;
   }
+  cb_group_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   global_planning_request_server_ = rclcpp_action::create_server<moveit_msgs::action::GlobalPlanner>(
       node_, global_planning_action_name,
       // Goal callback
@@ -116,7 +117,8 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
           global_planner_instance_->reset();
         }
         long_callback_thread_ = std::thread(&GlobalPlannerComponent::globalPlanningRequestCallback, this, goal_handle);
-      });
+      },
+      rcl_action_server_get_default_options(), cb_group_);
 
   global_trajectory_pub_ = node_->create_publisher<moveit_msgs::msg::MotionPlanResponse>("global_trajectory", 1);
 

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -86,7 +86,8 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
         return rclcpp_action::CancelResponse::ACCEPT;
       },
       [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>> goal_handle) {
-        return globalPlanningRequestCallback(goal_handle);
+        // this needs to return quickly to avoid blocking the executor, so spin up a new thread
+        std::thread{ &GlobalPlannerComponent::globalPlanningRequestCallback, this, goal_handle }.detach();
       });
 
   global_trajectory_pub_ = node_->create_publisher<moveit_msgs::msg::MotionPlanResponse>("global_trajectory", 1);

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -60,8 +60,8 @@ public:
   /** \brief Constructor */
   HybridPlanningManager(const rclcpp::NodeOptions& options);
 
-  /** \brief Constructor */
-  ~HybridPlanningManager()
+  /** \brief Destructor */
+  ~HybridPlanningManager() override
   {
     // Join the thread used for long-running callbacks
     if (long_callback_thread_.joinable())

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -60,6 +60,16 @@ public:
   /** \brief Constructor */
   HybridPlanningManager(const rclcpp::NodeOptions& options);
 
+  /** \brief Constructor */
+  ~HybridPlanningManager()
+  {
+    // Join the thread used for long-running callbacks
+    if (long_callback_thread_ != nullptr)
+    {
+      long_callback_thread_->join();
+    }
+  }
+
   /**
    * Allows creation of a smart pointer that references to instances of this object
    * @return shared pointer of the HybridPlanningManager instance that called the function
@@ -74,6 +84,11 @@ public:
    * @return Initialization successful yes/no
    */
   bool initialize();
+
+  /**
+   * Cancel any active action goals, including global and local planners
+   */
+  void cancelHybridManagerGoals() noexcept;
 
   /**
    * This handles execution of a hybrid planning goal in a new thread, to avoid blocking the executor.
@@ -131,5 +146,8 @@ private:
 
   // Global solution subscriber
   rclcpp::Subscription<moveit_msgs::msg::MotionPlanResponse>::SharedPtr global_solution_sub_;
+
+  // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
+  std::unique_ptr<std::thread> long_callback_thread_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -64,9 +64,9 @@ public:
   ~HybridPlanningManager()
   {
     // Join the thread used for long-running callbacks
-    if (long_callback_thread_ != nullptr)
+    if (long_callback_thread_.joinable())
     {
-      long_callback_thread_->join();
+      long_callback_thread_.join();
     }
   }
 
@@ -148,6 +148,6 @@ private:
   rclcpp::Subscription<moveit_msgs::msg::MotionPlanResponse>::SharedPtr global_solution_sub_;
 
   // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
-  std::unique_ptr<std::thread> long_callback_thread_;
+  std::thread long_callback_thread_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -76,6 +76,13 @@ public:
   bool initialize();
 
   /**
+   * This handles execution of a hybrid planning goal in a new thread, to avoid blocking the executor.
+   * @param goal_handle The action server goal
+   */
+  void executeHybridPlannerGoal(
+      std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>> goal_handle);
+
+  /**
    * Send global planning request to global planner component
    * @return Global planner successfully started yes/no
    */

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/include/moveit/hybrid_planning_manager/hybrid_planning_manager.h
@@ -149,5 +149,8 @@ private:
 
   // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
   std::thread long_callback_thread_;
+
+  // A unique callback group, to avoid mixing callbacks with other action servers
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -144,6 +144,7 @@ bool HybridPlanningManager::initialize()
     RCLCPP_ERROR(LOGGER, "hybrid_planning_action_name parameter was not defined");
     return false;
   }
+  cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   hybrid_planning_request_server_ = rclcpp_action::create_server<moveit_msgs::action::HybridPlanner>(
       this->get_node_base_interface(), this->get_node_clock_interface(), this->get_node_logging_interface(),
       this->get_node_waitables_interface(), hybrid_planning_action_name,
@@ -167,7 +168,8 @@ bool HybridPlanningManager::initialize()
           cancelHybridManagerGoals();
         }
         long_callback_thread_ = std::thread(&HybridPlanningManager::executeHybridPlannerGoal, this, goal_handle);
-      });
+      },
+      rcl_action_server_get_default_options(), cb_group_);
 
   // Initialize global solution subscriber
   global_solution_sub_ = create_subscription<moveit_msgs::msg::MotionPlanResponse>(

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -159,7 +159,7 @@ bool HybridPlanningManager::initialize()
         RCLCPP_INFO(LOGGER, "Received request to cancel goal");
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      // Request callback
+      // Execution callback
       [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>> goal_handle) {
         // this needs to return quickly to avoid blocking the executor, so spin up a new thread
         if (long_callback_thread_.joinable())

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
@@ -145,6 +145,16 @@ public:
   /** \brief Constructor */
   LocalPlannerComponent(const rclcpp::NodeOptions& options);
 
+  /** \brief Destructor */
+  ~LocalPlannerComponent()
+  {
+    // Join the thread used for long-running callbacks
+    if (long_callback_thread_.joinable())
+    {
+      long_callback_thread_.join();
+    }
+  }
+
   /**
    * Initialize and start planning scene monitor to listen to the planning scene topic.
    * Load trajectory_operator and constraint solver plugin.
@@ -214,5 +224,11 @@ private:
 
   // Trajectory_operator instance handle trajectory matching and blending
   std::shared_ptr<TrajectoryOperatorInterface> trajectory_operator_instance_;
+
+  // This thread is used for long-running callbacks. It's a member so they do not go out of scope.
+  std::thread long_callback_thread_;
+
+  // A unique callback group, to avoid mixing callbacks with other action servers
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
 };
 }  // namespace moveit::hybrid_planning

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -48,6 +48,7 @@ using namespace std::chrono_literals;
 namespace
 {
 const rclcpp::Logger LOGGER = rclcpp::get_logger("local_planner_component");
+const auto JOIN_THREAD_TIMEOUT = std::chrono::seconds(1);
 
 // If the trajectory progress reaches more than 0.X the global goal state is considered as reached
 constexpr float PROGRESS_THRESHOLD = 0.995;
@@ -150,25 +151,53 @@ bool LocalPlannerComponent::initialize()
   }
 
   // Initialize local planning request action server
-  using namespace std::placeholders;
+  cb_group_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   local_planning_request_server_ = rclcpp_action::create_server<moveit_msgs::action::LocalPlanner>(
       node_, config_.local_planning_action_name,
-      [](const rclcpp_action::GoalUUID& /*unused*/,
-         std::shared_ptr<const moveit_msgs::action::LocalPlanner::Goal> /*unused*/) {
+      // Goal callback
+      [this](const rclcpp_action::GoalUUID& /*unused*/,
+             std::shared_ptr<const moveit_msgs::action::LocalPlanner::Goal> /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received local planning goal request");
+        // If another goal is active, cancel it and reject this goal
+        if (long_callback_thread_.joinable())
+        {
+          // Try to terminate the execution thread
+          auto future = std::async(std::launch::async, &std::thread::join, &long_callback_thread_);
+          if (future.wait_for(JOIN_THREAD_TIMEOUT) == std::future_status::timeout)
+          {
+            RCLCPP_WARN(LOGGER, "Another goal was running. Rejecting the new hybrid planning goal.");
+            return rclcpp_action::GoalResponse::REJECT;
+          }
+        }
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
+      // Cancel callback
       [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::LocalPlanner>>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received request to cancel local planning goal");
         state_ = LocalPlannerState::ABORT;
+        if (long_callback_thread_.joinable())
+        {
+          long_callback_thread_.join();
+        }
         return rclcpp_action::CancelResponse::ACCEPT;
       },
+      // Execution callback
       [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::LocalPlanner>> goal_handle) {
         local_planning_goal_handle_ = std::move(goal_handle);
-        // Start local planning loop when an action request is received
-        timer_ =
-            node_->create_wall_timer(1s / config_.local_planning_frequency, [this]() { return executeIteration(); });
-      });
+        // Check if a previous goal was running and needs to be cancelled.
+        if (long_callback_thread_.joinable())
+        {
+          long_callback_thread_.join();
+        }
+        // Start a local planning loop.
+        // This needs to return quickly to avoid blocking the executor, so run the local planner in a new thread.
+        auto local_planner_timer = [&]() {
+          timer_ =
+              node_->create_wall_timer(1s / config_.local_planning_frequency, [this]() { return executeIteration(); });
+        };
+        long_callback_thread_ = std::thread(local_planner_timer);
+      },
+      rcl_action_server_get_default_options(), cb_group_);
 
   // Initialize global trajectory listener
   global_solution_subscriber_ = node_->create_subscription<moveit_msgs::msg::MotionPlanResponse>(

--- a/moveit_ros/hybrid_planning/test/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_executable(cancel_action cancel_action.cpp)
+ament_target_dependencies(cancel_action ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(cancel_action ${LIBRARIES})
+
 add_executable(hybrid_planning_demo_node hybrid_planning_demo_node.cpp)
 ament_target_dependencies(hybrid_planning_demo_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(hybrid_planning_demo_node ${LIBRARIES})

--- a/moveit_ros/hybrid_planning/test/cancel_action.cpp
+++ b/moveit_ros/hybrid_planning/test/cancel_action.cpp
@@ -1,0 +1,68 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Andy Zelenak
+  Description: Cancel any and all hybrid planning actions.
+*/
+
+#include <moveit_msgs/action/hybrid_planner.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+namespace
+{
+using HPAction = moveit_msgs::action::HybridPlanner;
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions node_options;
+  auto node = rclcpp::Node::make_shared("action_server_cancellation", "", node_options);
+
+  rclcpp_action::Client<HPAction>::SharedPtr client_ptr =
+      rclcpp_action::create_client<HPAction>(node, "/test/hybrid_planning/run_hybrid_planning");
+  if (!client_ptr->wait_for_action_server(std::chrono::seconds(5)))
+  {
+    RCLCPP_ERROR(node->get_logger(), "Action server not available after waiting");
+    rclcpp::shutdown();
+  }
+  client_ptr->async_cancel_all_goals();
+  RCLCPP_ERROR(node->get_logger(), "Cancellation was requested.");
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
@@ -1,5 +1,4 @@
 # Return a list of nodes we commonly launch for the demo. Nice for testing use.
-import launch
 import os
 import xacro
 import yaml

--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning_demo.launch.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning_demo.launch.py
@@ -1,9 +1,7 @@
 import launch
 import os
 import sys
-import xacro
 
-from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 
 sys.path.append(os.path.dirname(__file__))
@@ -11,7 +9,6 @@ from hybrid_planning_common import (
     generate_common_hybrid_launch_description,
     get_robot_description,
     get_robot_description_semantic,
-    load_file,
     load_yaml,
 )
 


### PR DESCRIPTION
Action cancellation wasn't working well, so...

- Move long-running callbacks into new threads
- Make a unique callback group for each action server
- Add a script to test cancellation

Test with:

`ros2 launch moveit_hybrid_planning hybrid_planning_demo.launch.py`

`ros2 run moveit_hybrid_planning cancel_action`

This work is sponsored by RE2 Robotics.