### PR TITLE
Fix exporting PILZ's move_group capabilities

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(command_list_manager SHARED
   src/command_list_manager.cpp
   src/plan_components_builder.cpp
 )
+target_link_libraries(command_list_manager trajectory_generation_common joint_limits_common)
 ament_target_dependencies(command_list_manager ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 #############
@@ -161,7 +162,7 @@ target_link_libraries(sequence_capability joint_limits_common command_list_manag
 ## Install ##
 #############
 pluginlib_export_plugin_description_file(moveit_core plugins/pilz_industrial_motion_planner_plugin_description.xml)
-pluginlib_export_plugin_description_file(move_group plugins/sequence_capability_plugin_description.xml)
+pluginlib_export_plugin_description_file(moveit_ros_move_group plugins/sequence_capability_plugin_description.xml)
 pluginlib_export_plugin_description_file(pilz_industrial_motion_planner plugins/planning_context_plugin_description.xml)
 
 ## Mark libraries for installation


### PR DESCRIPTION
### Description

Fix: https://github.com/ros-planning/moveit2/issues/1248

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
