### PR TITLE
Clean up Servo initial_positions files

### DIFF
--- a/moveit_ros/moveit_servo/test/config/collision_start_positions.yaml
+++ b/moveit_ros/moveit_servo/test/config/collision_start_positions.yaml
@@ -6,11 +6,3 @@ initial_positions:
   panda_joint5: 0.0
   panda_joint6: 1.1
   panda_joint7: 0.785
-initial_velocities:
-  panda_joint1: 0.0
-  panda_joint2: 0.0
-  panda_joint3: 0.0
-  panda_joint4: 0.0
-  panda_joint5: 0.0
-  panda_joint6: 0.0
-  panda_joint7: 0.0

--- a/moveit_ros/moveit_servo/test/config/singularity_start_positions.yaml
+++ b/moveit_ros/moveit_servo/test/config/singularity_start_positions.yaml
@@ -6,11 +6,3 @@ initial_positions:
   panda_joint5: 0.117
   panda_joint6: 1.439
   panda_joint7: -1.286
-initial_velocities:
-  panda_joint1: 0.0
-  panda_joint2: 0.0
-  panda_joint3: 0.0
-  panda_joint4: 0.0
-  panda_joint5: 0.0
-  panda_joint6: 0.0
-  panda_joint7: 0.0


### PR DESCRIPTION
### Description

Specification of `initial_velocities` isn't necessary. Compare against:  https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/config/initial_positions.yaml
