### PR TITLE
Remove position controllers from Hybrid Planning CMake

### DIFF
--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(moveit_msgs REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(position_controllers REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -39,7 +38,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_ros_planning
   moveit_ros_planning_interface
   moveit_msgs
-  position_controllers
   rclcpp
   rclcpp_components
   rclcpp_action


### PR DESCRIPTION
Humble and Rolling [buildfarm](https://build.ros2.org/job/Hbin_uJ64__moveit_hybrid_planning__ubuntu_jammy_amd64__binary/) has been failing with the following error:

```
14:25:06 CMake Error at CMakeLists.txt:15 (find_package):
14:25:06   By not providing "Findposition_controllers.cmake" in CMAKE_MODULE_PATH this
14:25:06   project has asked CMake to find a package configuration file provided by
14:25:06   "position_controllers", but CMake did not find one.
14:25:06 
14:25:06   Could not find a package configuration file provided by
14:25:06   "position_controllers" with any of the following names:
14:25:06 
14:25:06     position_controllersConfig.cmake
14:25:06     position_controllers-config.cmake
14:25:06 
14:25:06   Add the installation prefix of "position_controllers" to CMAKE_PREFIX_PATH
14:25:06   or set "position_controllers_DIR" to a directory containing one of the
14:25:06   above files.  If "position_controllers" provides a separate development
14:25:06   package or SDK, be sure it has been installed.
14:25:06 
```

Although position_controllers is only a run depend, it has been listed in the cmake. This PR removes it in an attempt to fix the buildfarm