### PR TITLE
Update plugin library paths

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/README.md
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/README.md
@@ -69,7 +69,7 @@ In the catkin `package.xml` file for your plugin, you add these lines just befor
 
 Next, create the file my_ik_plugin.xml with the following contents:
 
-    <library path="lib/libmy_ik_plugin">
+    <library path="my_ik_plugin">
       <class name="cached_ik_kinematics_plugin/CachedMyKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<my_kinematics_plugin::MyKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
         <description>
           A kinematics plugin for persistently caching IK solutions computed with the KDL kinematics plugin.

--- a/moveit_planners/chomp/chomp_optimizer_adapter/chomp_optimizer_adapter_plugin_description.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/chomp_optimizer_adapter_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libmoveit_chomp_optimizer_adapter">
+<library path="moveit_chomp_optimizer_adapter">
 
   <class name="chomp/OptimizerAdapter" type="chomp::OptimizerAdapter"
          base_class_type="planning_request_adapter::PlanningRequestAdapter">

--- a/moveit_ros/perception/moveit_depth_self_filter.xml
+++ b/moveit_ros/perception/moveit_depth_self_filter.xml
@@ -1,4 +1,4 @@
-<library path="lib/libmoveit_depth_self_filter">
+<library path="moveit_depth_self_filter">
     <class name="mesh_filter/DepthSelfFiltering" type="mesh_filter::DepthSelfFiltering" base_class_type="nodelet::Nodelet">
         <description>
             Nodelet for filtering meshes from depth images. e.g. meshes of the robot or any attached object where a transformation can be provided for.


### PR DESCRIPTION
### Description

Remove the "lib"/ "lib/lib" prefix in the plugin library path names according to ROS2 standard: https://docs.ros.org/en/galactic/Tutorials/Pluginlib.html

This resolves https://github.com/ros-planning/moveit2/issues/1260

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
