### PR TITLE
Use CallbackGroup in PlanningSceneMonitor

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -482,12 +482,10 @@ protected:
 
   std::shared_ptr<rclcpp::Node> node_;
 
-  // TODO: (anasarrak) callbacks on ROS2?
-  // https://answers.ros.org/question/300874/how-do-you-use-callbackgroups-as-a-replacement-for-callbackqueues-in-ros2/
-  // ros::CallbackQueue queue_;
-  std::shared_ptr<rclcpp::Node> pnode_;
-  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> private_executor_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::executors::SingleThreadedExecutor private_executor_;
   std::thread private_executor_thread_;
+  rclcpp::SubscriptionOptions subscription_options_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;


### PR DESCRIPTION
Similar to #1305, this replaces the private node with a CallbackGroup. There are still some issues with the synced parameters that I need to look into before this is really ready. Also, the CallbackGroup should be applied to the CSM as well.
