### PR TITLE
Fix moveit_configs_utils parameter ordering

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -219,8 +219,8 @@ def generate_move_group_launch(moveit_config):
     }
 
     move_group_params = [
-        move_group_configuration,
         moveit_config.to_dict(),
+        move_group_configuration,
     ]
 
     add_debuggable_node(


### PR DESCRIPTION
Because https://github.com/ros-planning/moveit2/pull/1265 added a value for `publish_robot_description_semantic`, the value specified in the [move_group launch](https://github.com/ros-planning/moveit2/blob/7427a8ead23955f69bf9e530bbd06e93f8dcfae0/moveit_configs_utils/moveit_configs_utils/launches.py#L205) is overwritten. 

Either we should fix this by changing the order the parameters are loaded (as in this PR) OR the default value of `publish_robot_description_semantic` should be true. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
