### PR TITLE
Add a debug print for OMPL

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -750,6 +750,11 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   {
     RCLCPP_WARN(LOGGER, "Computed solution is approximate");
   }
+
+  // Debug OMPL setup and solution
+  std::stringstream debug_out;
+  ompl_simple_setup_->print(debug_out);
+  RCLCPP_DEBUG(LOGGER, "%s", rclcpp::get_c_string(debug_out.str()));
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)


### PR DESCRIPTION
### Description

Add an OMPL print at the DEBUG level. This would have helped us in tracking down a recent bug.

### PR Verification

I modified `moveit_resources_panda_moveit_config/launch/demo.launch.py` to print at the DEBUG level:

```
.
.
.
    move_group_node = Node(
        package="moveit_ros_move_group",
        executable="move_group",
        output="screen",
        parameters=[moveit_config.to_dict()],
        arguments=["--ros-args", "--log-level", "debug"],
    )
.
.
.
```

Run the demo to see the printout. You will see the printout upon clicking Plan:

`ros2 launch moveit_resources_panda_moveit_config demo.launch.py`

The printout from OMPL looks like this:

```
[move_group-4]   - signature: 2 0 7 
[move_group-4]   - dimension: 7
[move_group-4]   - extent: 33.5633
[move_group-4]   - sanity checks for state space passed
[move_group-4]   - probability of valid states: 0.88
[move_group-4]   - average length of a valid motion: 10.622
[move_group-4]   - average number of samples drawn per second: sampleUniform()=2.26639e+07 sampleUniformNear()=1.64018e+07 sampleGaussian()=7.21038e+06
[move_group-4] Settings for the state space 'panda_arm_JointModel'
[move_group-4]   - state validity check resolution: 1%
[move_group-4]   - valid segment count factor: 1
[move_group-4]   - state space:
[move_group-4] ModelBasedStateSpace 'panda_arm_JointModel' at 0x7ff444003530
[move_group-4] 
[move_group-4] Declared parameters:
[move_group-4] longest_valid_segment_fraction = 0.01
[move_group-4] tag_snap_to_segment = 0.95
[move_group-4] valid_segment_count_factor = 1
[move_group-4] Valid state sampler named uniform with parameters:
[move_group-4] nr_attempts = 100
[move_group-4] Planner panda_arm/panda_arm specs:
[move_group-4] Multithreaded:                 No
[move_group-4] Reports approximate solutions: No
[move_group-4] Can optimize solutions:        No
[move_group-4] Aware of the following parameters: intermediate_states range
[move_group-4] Declared parameters for planner panda_arm/panda_arm:
[move_group-4] intermediate_states = 0
[move_group-4] range = 6.71266
[move_group-4] Start states:
[move_group-4] panda_joint1 = 0 
[move_group-4] panda_joint2 = -0.785 
[move_group-4] panda_joint3 = 0 
[move_group-4] panda_joint4 = -2.356 
[move_group-4] panda_joint5 = 0 
[move_group-4] panda_joint6 = 1.571 
[move_group-4] panda_joint7 = 0.785 
[move_group-4] * valid state 
[move_group-4] Tag: -1
[move_group-4] 10 goal states, threshold = 2.22045e-16, memory address = 0x7ff44400df10
[move_group-4] panda_joint1 = -0.0435932 
[move_group-4] panda_joint2 = -0.755479 
[move_group-4] panda_joint3 = -0.105317 
[move_group-4] panda_joint4 = -2.45022 
[move_group-4] panda_joint5 = -0.0726383 
[move_group-4] panda_joint6 = 1.69726 
[move_group-4] panda_joint7 = 0.673878 
[move_group-4] * valid state 
[move_group-4] Tag: -1

```
