### PR TITLE
Remove TrajOpt Default Parameters

### DIFF
--- a/moveit_configs_utils/default_configs/trajopt_planning.yaml
+++ b/moveit_configs_utils/default_configs/trajopt_planning.yaml
@@ -1,9 +1,0 @@
-planning_plugin: trajopt_interface/TrajOptPlanner
-start_state_max_bounds_error: 0.1
-jiggle_fraction: 0.05
-request_adapters: >-
-    default_planner_request_adapters/AddTimeParameterization
-    default_planner_request_adapters/FixWorkspaceBounds
-    default_planner_request_adapters/FixStartStateBounds
-    default_planner_request_adapters/FixStartStateCollision
-    default_planner_request_adapters/FixStartStatePathConstraints


### PR DESCRIPTION
### Description

Since TrajOpt is [currently out of service in ROS 2](https://github.com/ros-planning/moveit2/blob/99c73e6697927c764ea139bbec32e986563edbf8/moveit_planners/trajopt/README.md?plain=1#L1), remove the default parameters from `moveit_configs_utils`. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
