### PR TITLE
Fix PlanarJointModel::satisfiesPositionBounds

### DIFF
--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -271,7 +271,7 @@ double PlanarJointModel::distance(const double* values1, const double* values2) 
 bool PlanarJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
   for (unsigned int i = 0; i < 3; ++i)
-    if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
+    if (values[i] < bounds[i].min_position_ - margin || values[i] > bounds[i].max_position_ + margin)
       return false;
   return true;
 }


### PR DESCRIPTION
### Description

Fixes `PlanarJointModel::satisfiesPositionBounds` to correctly check for all 3 positions instead of the 0-th position 3 times.

Replaces https://github.com/ros-planning/moveit2/pull/1327

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
