### PR TITLE
[MSA] Clean up extra parentheses

### DIFF
--- a/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_config.cpp
@@ -57,7 +57,7 @@ void PerceptionConfig::loadPrevious(const std::filesystem::path& package_path, c
   }
   catch (const std::runtime_error& e)
   {
-    RCLCPP_ERROR_STREAM((*logger_), e.what());
+    RCLCPP_ERROR_STREAM(*logger_, e.what());
   }
 }
 

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -51,7 +51,7 @@ void MoveItControllersConfig::loadPrevious(const std::filesystem::path& package_
   std::ifstream input_stream(ros_controllers_yaml_path);
   if (!input_stream.good())
   {
-    RCLCPP_WARN_STREAM((*logger_), "Does not exist " << ros_controllers_yaml_path);
+    RCLCPP_WARN_STREAM(*logger_, "Does not exist " << ros_controllers_yaml_path);
     return;
   }
 
@@ -71,8 +71,7 @@ void MoveItControllersConfig::loadPrevious(const std::filesystem::path& package_
       const YAML::Node& cnode = controllers[controller_name];
       if (!cnode.IsDefined())
       {
-        RCLCPP_WARN_STREAM((*logger_),
-                           "Configuration for controller " << controller_name << " does not exist! Ignoring.");
+        RCLCPP_WARN_STREAM(*logger_, "Configuration for controller " << controller_name << " does not exist! Ignoring.");
         continue;
       }
 
@@ -84,7 +83,7 @@ void MoveItControllersConfig::loadPrevious(const std::filesystem::path& package_
   }
   catch (YAML::ParserException& e)  // Catch errors
   {
-    RCLCPP_ERROR_STREAM((*logger_), e.what());
+    RCLCPP_ERROR_STREAM(*logger_, e.what());
   }
 }
 
@@ -99,7 +98,7 @@ bool MoveItControllersConfig::parseController(const std::string& name, const YAM
   getYamlProperty(controller_node, "type", control_setting.type_);
   if (control_setting.type_.empty())
   {
-    RCLCPP_ERROR_STREAM((*logger_), "Couldn't parse type for controller " << name << " in moveit_controllers.yaml");
+    RCLCPP_ERROR_STREAM(*logger_, "Couldn't parse type for controller " << name << " in moveit_controllers.yaml");
     return false;
   }
 
@@ -115,7 +114,7 @@ bool MoveItControllersConfig::parseController(const std::string& name, const YAM
   }
   if (control_setting.joints_.empty())
   {
-    RCLCPP_ERROR_STREAM((*logger_), "Couldn't parse joints for controller " << name << " in moveit_controllers.yaml");
+    RCLCPP_ERROR_STREAM(*logger_, "Couldn't parse joints for controller " << name << " in moveit_controllers.yaml");
     return false;
   }
   // All required fields were parsed correctly

--- a/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
@@ -55,7 +55,7 @@ void ROS2ControllersConfig::loadPrevious(const std::filesystem::path& package_pa
   std::ifstream input_stream(ros_controllers_yaml_path);
   if (!input_stream.good())
   {
-    RCLCPP_WARN_STREAM((*logger_), "Does not exist " << ros_controllers_yaml_path);
+    RCLCPP_WARN_STREAM(*logger_, "Does not exist " << ros_controllers_yaml_path);
     return;
   }
 
@@ -123,7 +123,7 @@ void ROS2ControllersConfig::loadPrevious(const std::filesystem::path& package_pa
   }
   catch (YAML::ParserException& e)  // Catch errors
   {
-    RCLCPP_ERROR_STREAM((*logger_), e.what());
+    RCLCPP_ERROR_STREAM(*logger_, e.what());
   }
 }
 

--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -104,7 +104,7 @@ void SRDFConfig::loadSRDFFile(const std::filesystem::path& srdf_file_path, const
 
   updateRobotModel();
 
-  RCLCPP_INFO_STREAM((*logger_), "Robot semantic model successfully loaded.");
+  RCLCPP_INFO_STREAM(*logger_, "Robot semantic model successfully loaded.");
 }
 
 void SRDFConfig::getRelativePath()

--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -105,7 +105,7 @@ void URDFConfig::setPackageName()
 
     if (robot_desc_pkg_path.empty())
     {
-      RCLCPP_WARN((*logger_),
+      RCLCPP_WARN(*logger_,
                   "Package Not Found In ROS Workspace. ROS was unable to find the package name '%s'"
                   " within the ROS workspace. This may cause issues later.",
                   urdf_pkg_name_.c_str());
@@ -126,8 +126,8 @@ void URDFConfig::loadFromPackage(const std::filesystem::path& package_name, cons
 
 void URDFConfig::load()
 {
-  RCLCPP_DEBUG_STREAM((*logger_), "URDF Package Name: " << urdf_pkg_name_);
-  RCLCPP_DEBUG_STREAM((*logger_), "URDF Package Path: " << urdf_pkg_relative_path_);
+  RCLCPP_DEBUG_STREAM(*logger_, "URDF Package Name: " << urdf_pkg_name_);
+  RCLCPP_DEBUG_STREAM(*logger_, "URDF Package Path: " << urdf_pkg_relative_path_);
 
   if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string_, urdf_path_, xacro_args_vec_))
   {
@@ -149,7 +149,7 @@ void URDFConfig::load()
   // Set parameter
   parent_node_->set_parameter(rclcpp::Parameter("robot_description", urdf_string_));
 
-  RCLCPP_INFO_STREAM((*logger_), "Loaded " << urdf_model_->getName() << " robot model.");
+  RCLCPP_INFO_STREAM(*logger_, "Loaded " << urdf_model_->getName() << " robot model.");
 }
 
 bool URDFConfig::isXacroFile() const

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/planning_groups.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/planning_groups.cpp
@@ -99,7 +99,7 @@ void PlanningGroups::renameGroup(const std::string& old_group_name, const std::s
     // Check if this eef's parent group references old group name. if so, update it
     if (eef.parent_group_ == old_group_name)  // same name
     {
-      RCLCPP_DEBUG_STREAM((*logger_), "Changed eef '" << eef.name_ << "' to new parent group name " << new_group_name);
+      RCLCPP_DEBUG_STREAM(*logger_, "Changed eef '" << eef.name_ << "' to new parent group name " << new_group_name);
       eef.parent_group_ = new_group_name;  // updated
       changes |= END_EFFECTORS;
     }
@@ -107,7 +107,7 @@ void PlanningGroups::renameGroup(const std::string& old_group_name, const std::s
     // Check if this eef's group references old group name. if so, update it
     if (eef.component_group_.compare(old_group_name) == 0)  // same name
     {
-      RCLCPP_DEBUG_STREAM((*logger_), "Changed eef '" << eef.name_ << "' to new group name " << new_group_name);
+      RCLCPP_DEBUG_STREAM(*logger_, "Changed eef '" << eef.name_ << "' to new group name " << new_group_name);
       eef.component_group_ = new_group_name;  // updated
       changes |= END_EFFECTORS;
     }
@@ -119,8 +119,8 @@ void PlanningGroups::renameGroup(const std::string& old_group_name, const std::s
     // Check if this eef's parent group references old group name. if so, update it
     if (gs.group_ == old_group_name)  // same name
     {
-      RCLCPP_DEBUG_STREAM((*logger_), "Changed group state group '" << gs.group_ << "' to new parent group name "
-                                                                    << new_group_name);
+      RCLCPP_DEBUG_STREAM(*logger_, "Changed group state group '" << gs.group_ << "' to new parent group name "
+                                                                  << new_group_name);
       gs.group_ = new_group_name;  // updated
       changes |= POSES;
     }


### PR DESCRIPTION
### Description

I had a lot of extra parentheses because of the bug fixed here: https://github.com/ros2/rclcpp/pull/1820

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
