### PR TITLE
[MSA] Fix SRDF Initialization Bug / Copy Paste Error

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/double_list_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/double_list_widget.cpp
@@ -336,7 +336,8 @@ void DoubleListWidget::previewSelected(const QList<QTableWidgetItem*>& selected)
 
 std::vector<std::string> DoubleListWidget::getSelectedValues() const
 {
-  std::vector<std::string> values(selected_data_table_->rowCount());
+  std::vector<std::string> values;
+  values.reserve(selected_data_table_->rowCount());
   for (int i = 0; i < selected_data_table_->rowCount(); ++i)
   {
     values.push_back(selected_data_table_->item(i, 0)->text().toStdString());

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/planning_groups_widget.cpp
@@ -702,7 +702,7 @@ void PlanningGroupsWidget::saveJointsScreen()
 // ******************************************************************************************
 void PlanningGroupsWidget::saveLinksScreen()
 {
-  setup_step_.setJoints(current_edit_group_, links_widget_->getSelectedValues());
+  setup_step_.setLinks(current_edit_group_, links_widget_->getSelectedValues());
 
   // Switch to main screen
   showMainScreen();


### PR DESCRIPTION
### Description

Fix two bugs found by @mikeferguson 

 * In my helper method `DoubleListWidget::getSelectedValues()`, I was initializing the size of the vector, not reserving it, resulting in blank strings added to the vector. 
 * The code for `PlanningGroupsWidget::saveLinksScreen()` had a copy/paste error from `saveJointsScreen`

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
