### PR TITLE
fix regression from #1331

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -239,6 +239,7 @@ void PlanningSceneDisplay::addBackgroundJob(const std::function<void()>& job, co
 void PlanningSceneDisplay::spawnBackgroundJob(const std::function<void()>& job)
 {
   std::thread t(job);
+  t.detach();
 }
 
 void PlanningSceneDisplay::addMainLoopJob(const std::function<void()>& job)


### PR DESCRIPTION
### Description

The noted PR swapped boost::thread to std::thread - however
std::thread will cause the program to crash with a note that
TERMINATE CALLED WITHOUT ACTIVE EXCEPTION if the thread object
goes out of scope while not joinable. Detaching the thread
restores the original workflow prior to the PR and allows
users to send more than one trajectory via the motion planning
plugin in RVIZ (otherwise, it crashes on the first trajectory).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
