### PR TITLE
Add generic cost function to KinematicsBase, CartesianInterpolator, Robot State

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -169,14 +169,17 @@ public:
 
      For absolute jump thresholds, if any individual joint-space motion delta is larger then \e revolute_jump_threshold
      for revolute joints or \e prismatic_jump_threshold for prismatic joints then this step is considered a failure and
-     the returned path is truncated up to just before the jump.*/
+     the returned path is truncated up to just before the jump.
+
+     Kinematics solvers may use cost functions to prioritize certain solutions, which may be specified with \e cost_function. */
   static Distance
   computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
                        std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
                        const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
                        const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular group.
 
@@ -190,7 +193,8 @@ public:
                        const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
                        const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
@@ -204,7 +208,8 @@ public:
                        const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame,
                        const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
                        const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Tests joint space jumps of a trajectory.
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -951,7 +951,8 @@ public:
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::msg::Pose& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -962,7 +963,8 @@ public:
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::msg::Pose& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -972,7 +974,8 @@ public:
       @param timeout The timeout passed to the kinematics solver on each attempt */
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -982,7 +985,8 @@ public:
       @param constraint A state validity constraint to be required for IK solutions */
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -995,7 +999,8 @@ public:
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
                  const std::vector<double>& consistency_limits, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief  Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1009,7 +1014,8 @@ public:
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                  const std::vector<std::string>& tips, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1024,7 +1030,8 @@ public:
   bool setFromIK(const JointModelGroup* group, const EigenSTL::vector_Isometry3d& poses,
                  const std::vector<std::string>& tips, const std::vector<std::vector<double>>& consistency_limits,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
-                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions());
+                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /**
       \brief setFromIK for multiple poses and tips (end effectors) when no solver exists for the jmg that can solver for


### PR DESCRIPTION
### Description

This adds a generic cost function to be utilized by kinematics solvers, `kinematics::KinematicsBase::IKCostFn`. An instance of such may be passed to `KinematicsBase::searchPositionIK`. Additionally, it may be passed to `CartesianInterpolator::computeCartesianPath` and `RobotState::setFromIK`, where it is simply passed through to the kinematics solver.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
