### PR TITLE
MoveGroupInterface objects counter to create more than one ros2 node …

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -1023,6 +1023,7 @@ protected:
   const moveit::core::RobotState& getTargetRobotState() const;
 
 private:
+  static size_t node_num;
   std::map<std::string, std::vector<double> > remembered_joint_values_;
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -72,6 +72,8 @@ namespace moveit
 {
 namespace planning_interface
 {
+size_t MoveGroupInterface::node_num = 0;
+
 const std::string MoveGroupInterface::ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
 
@@ -96,7 +98,15 @@ public:
                          const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers)
     : opt_(opt), node_(node), tf_buffer_(tf_buffer)
   {
-    pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
+    if (node_num == 0)
+    {
+      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
+    }
+    else
+    {
+      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node_" + std::to_string(node_num));
+    }
+    node_num++;
     robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(node_, opt.robot_description_);
     if (!getRobotModel())
     {


### PR DESCRIPTION
MoveGroupInterface objects counter to create more than one ros2 node without getting ROS warnings

### Description

While using MoveGroupInterface I noticed if I created more than one object of MoveGroupInterface in C++, I face the issue that it creates three nodes with the same name which causes some ROS warnings and other problems.
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [//] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
