### PR TITLE
Sync with MoveIt

### DIFF
--- a/moveit_commander/setup.py
+++ b/moveit_commander/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/moveit_commander/src/moveit_commander/interpreter.py
+++ b/moveit_commander/src/moveit_commander/interpreter.py
@@ -715,13 +715,13 @@ class MoveGroupCommandInterpreter(object):
     def command_current(self, g):
         res = (
             "joints = ["
-            + " ".join([str(x) for x in g.get_current_joint_values()])
+            + ", ".join([str(x) for x in g.get_current_joint_values()])
             + "]"
         )
         if len(g.get_end_effector_link()) > 0:
             res = (
                 res
-                + "\n"
+                + "\n\n"
                 + g.get_end_effector_link()
                 + " pose = [\n"
                 + str(g.get_current_pose())

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -210,13 +210,7 @@ class MoveGroupCommander(object):
         allows setting the joint target of the group by calling IK. This does not send a pose to the planner and the planner will do no IK.
         Instead, one IK solution will be computed first, and that will be sent to the planner.
         """
-        if isinstance(arg1, RobotState):
-            if not self._g.set_state_value_target(conversions.msg_to_string(arg1)):
-                raise MoveItCommanderException(
-                    "Error setting state target. Is the target state within bounds?"
-                )
-
-        elif isinstance(arg1, JointState):
+        if isinstance(arg1, JointState):
             if arg2 is not None or arg3 is not None:
                 raise MoveItCommanderException("Too many arguments specified")
             if not self._g.set_joint_value_target_from_joint_state_message(

--- a/moveit_core/collision_detection/test/test_world.cpp
+++ b/moveit_core/collision_detection/test/test_world.cpp
@@ -39,9 +39,11 @@
 #include <geometric_shapes/shapes.h>
 #include <functional>
 
+using namespace collision_detection;
+
 TEST(World, AddRemoveShape)
 {
-  collision_detection::World world;
+  World world;
 
   // Create some shapes
   shapes::ShapePtr ball = std::make_shared<shapes::Sphere>(1.0);
@@ -138,7 +140,7 @@ TEST(World, AddRemoveShape)
   EXPECT_EQ(3u, world.size());
 
   {
-    collision_detection::World::ObjectConstPtr obj = world.getObject("mix1");
+    World::ObjectConstPtr obj = world.getObject("mix1");
     EXPECT_EQ(2, obj.use_count());
 
     ASSERT_EQ(2u, obj->shapes_.size());
@@ -151,7 +153,7 @@ TEST(World, AddRemoveShape)
     move_ok = world.moveShapeInObject("mix1", ball, Eigen::Isometry3d(Eigen::Translation3d(0, 0, 5)));
     EXPECT_TRUE(move_ok);
 
-    collision_detection::World::ObjectConstPtr obj2 = world.getObject("mix1");
+    World::ObjectConstPtr obj2 = world.getObject("mix1");
     EXPECT_EQ(2, obj2.use_count());
     EXPECT_EQ(1, obj.use_count());
 
@@ -179,7 +181,7 @@ TEST(World, AddRemoveShape)
     EXPECT_TRUE(world.hasObject("ball2"));
 
     // ask for nonexistent object
-    collision_detection::World::ObjectConstPtr obj3 = world.getObject("abc");
+    World::ObjectConstPtr obj3 = world.getObject("abc");
     EXPECT_FALSE(obj3);
   }
 
@@ -205,8 +207,8 @@ TEST(World, AddRemoveShape)
 /* structure to hold copy of callback args */
 struct TestAction
 {
-  collision_detection::World::Object obj_;
-  collision_detection::World::Action action_;
+  World::Object obj_;
+  World::Action action_;
   int cnt_;
   TestAction() : obj_(""), cnt_(0)
   {
@@ -222,8 +224,7 @@ struct TestAction
 };
 
 /* notification callback */
-static void TrackChangesNotify(TestAction& ta, const collision_detection::World::ObjectConstPtr& obj,
-                               collision_detection::World::Action action)
+static void TrackChangesNotify(TestAction& ta, const World::ObjectConstPtr& obj, World::Action action)
 {
   ta.obj_ = *obj;
   ta.action_ = action;
@@ -232,14 +233,13 @@ static void TrackChangesNotify(TestAction& ta, const collision_detection::World:
 
 TEST(World, TrackChanges)
 {
-  collision_detection::World world;
+  World world;
 
   TestAction ta;
-  collision_detection::World::ObserverHandle observer_ta;
-  observer_ta = world.addObserver(
-      [&ta](const collision_detection::World::ObjectConstPtr& object, collision_detection::World::Action action) {
-        return TrackChangesNotify(ta, object, action);
-      });
+  World::ObserverHandle observer_ta;
+  observer_ta = world.addObserver([&ta](const World::ObjectConstPtr& object, World::Action action) {
+    return TrackChangesNotify(ta, object, action);
+  });
 
   // Create some shapes
   shapes::ShapePtr ball = std::make_shared<shapes::Sphere>(1.0);
@@ -250,7 +250,7 @@ TEST(World, TrackChanges)
 
   EXPECT_EQ(1, ta.cnt_);
   EXPECT_EQ("obj1", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE | collision_detection::World::ADD_SHAPE, ta.action_);
+  EXPECT_EQ(World::CREATE | World::ADD_SHAPE, ta.action_);
   ta.reset();
 
   bool move_ok = world.moveShapeInObject("obj1", ball, Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)));
@@ -258,43 +258,42 @@ TEST(World, TrackChanges)
 
   EXPECT_EQ(2, ta.cnt_);
   EXPECT_EQ("obj1", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::MOVE_SHAPE, ta.action_);
+  EXPECT_EQ(World::MOVE_SHAPE, ta.action_);
   ta.reset();
 
   world.addToObject("obj1", box, Eigen::Isometry3d::Identity());
 
   EXPECT_EQ(3, ta.cnt_);
   EXPECT_EQ("obj1", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::ADD_SHAPE, ta.action_);
+  EXPECT_EQ(World::ADD_SHAPE, ta.action_);
   ta.reset();
 
   TestAction ta2;
-  collision_detection::World::ObserverHandle observer_ta2;
-  observer_ta2 = world.addObserver(
-      [&ta2](const collision_detection::World::ObjectConstPtr& object, collision_detection::World::Action action) {
-        return TrackChangesNotify(ta2, object, action);
-      });
+  World::ObserverHandle observer_ta2;
+  observer_ta2 = world.addObserver([&ta2](const World::ObjectConstPtr& object, World::Action action) {
+    return TrackChangesNotify(ta2, object, action);
+  });
 
   world.addToObject("obj2", cyl, Eigen::Isometry3d::Identity());
 
   EXPECT_EQ(4, ta.cnt_);
   EXPECT_EQ("obj2", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE | collision_detection::World::ADD_SHAPE, ta.action_);
+  EXPECT_EQ(World::CREATE | World::ADD_SHAPE, ta.action_);
   ta.reset();
   EXPECT_EQ(1, ta2.cnt_);
   EXPECT_EQ("obj2", ta2.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE | collision_detection::World::ADD_SHAPE, ta2.action_);
+  EXPECT_EQ(World::CREATE | World::ADD_SHAPE, ta2.action_);
   ta2.reset();
 
   world.addToObject("obj3", box, Eigen::Isometry3d::Identity());
 
   EXPECT_EQ(5, ta.cnt_);
   EXPECT_EQ("obj3", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE | collision_detection::World::ADD_SHAPE, ta.action_);
+  EXPECT_EQ(World::CREATE | World::ADD_SHAPE, ta.action_);
   ta.reset();
   EXPECT_EQ(2, ta2.cnt_);
   EXPECT_EQ("obj3", ta2.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE | collision_detection::World::ADD_SHAPE, ta2.action_);
+  EXPECT_EQ(World::CREATE | World::ADD_SHAPE, ta2.action_);
   ta2.reset();
 
   // remove nonexistent obj
@@ -310,26 +309,25 @@ TEST(World, TrackChanges)
   EXPECT_EQ(2, ta2.cnt_);
 
   TestAction ta3;
-  collision_detection::World::ObserverHandle observer_ta3;
-  observer_ta3 = world.addObserver(
-      [&ta3](const collision_detection::World::ObjectConstPtr& object, collision_detection::World::Action action) {
-        return TrackChangesNotify(ta3, object, action);
-      });
+  World::ObserverHandle observer_ta3;
+  observer_ta3 = world.addObserver([&ta3](const World::ObjectConstPtr& object, World::Action action) {
+    return TrackChangesNotify(ta3, object, action);
+  });
 
   bool rm_good = world.removeShapeFromObject("obj2", cyl);
   EXPECT_TRUE(rm_good);
 
   EXPECT_EQ(6, ta.cnt_);
   EXPECT_EQ("obj2", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::DESTROY, ta.action_);
+  EXPECT_EQ(World::DESTROY, ta.action_);
   ta.reset();
   EXPECT_EQ(3, ta2.cnt_);
   EXPECT_EQ("obj2", ta2.obj_.id_);
-  EXPECT_EQ(collision_detection::World::DESTROY, ta2.action_);
+  EXPECT_EQ(World::DESTROY, ta2.action_);
   ta2.reset();
   EXPECT_EQ(1, ta3.cnt_);
   EXPECT_EQ("obj2", ta3.obj_.id_);
-  EXPECT_EQ(collision_detection::World::DESTROY, ta3.action_);
+  EXPECT_EQ(World::DESTROY, ta3.action_);
   ta3.reset();
 
   world.removeObserver(observer_ta2);
@@ -339,25 +337,25 @@ TEST(World, TrackChanges)
 
   EXPECT_EQ(7, ta.cnt_);
   EXPECT_EQ("obj1", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::REMOVE_SHAPE, ta.action_);
+  EXPECT_EQ(World::REMOVE_SHAPE, ta.action_);
   ta.reset();
   EXPECT_EQ(3, ta2.cnt_);
 
   EXPECT_EQ(2, ta3.cnt_);
   EXPECT_EQ("obj1", ta3.obj_.id_);
-  EXPECT_EQ(collision_detection::World::REMOVE_SHAPE, ta3.action_);
+  EXPECT_EQ(World::REMOVE_SHAPE, ta3.action_);
   ta3.reset();
 
   // remove all 2 objects (should make 2 DESTROY callbacks per ta)
   world.clearObjects();
 
   EXPECT_EQ(9, ta.cnt_);
-  EXPECT_EQ(collision_detection::World::DESTROY, ta.action_);
+  EXPECT_EQ(World::DESTROY, ta.action_);
   ta.reset();
   EXPECT_EQ(3, ta2.cnt_);
 
   EXPECT_EQ(4, ta3.cnt_);
-  EXPECT_EQ(collision_detection::World::DESTROY, ta3.action_);
+  EXPECT_EQ(World::DESTROY, ta3.action_);
   ta3.reset();
 
   world.removeObserver(observer_ta);
@@ -376,14 +374,13 @@ TEST(World, TrackChanges)
 
 TEST(World, ObjectPoseAndSubframes)
 {
-  collision_detection::World world;
+  World world;
 
   TestAction ta;
-  collision_detection::World::ObserverHandle observer_ta;
-  observer_ta = world.addObserver(
-      [&ta](const collision_detection::World::ObjectConstPtr& object, collision_detection::World::Action action) {
-        return TrackChangesNotify(ta, object, action);
-      });
+  World::ObserverHandle observer_ta;
+  observer_ta = world.addObserver([&ta](const World::ObjectConstPtr& object, World::Action action) {
+    return TrackChangesNotify(ta, object, action);
+  });
 
   // Create shapes
   shapes::ShapePtr ball = std::make_shared<shapes::Sphere>(1.0);
@@ -395,7 +392,7 @@ TEST(World, ObjectPoseAndSubframes)
 
   EXPECT_EQ(1, ta.cnt_);
   EXPECT_EQ("mix1", ta.obj_.id_);
-  EXPECT_EQ(collision_detection::World::CREATE, ta.action_);
+  EXPECT_EQ(World::CREATE, ta.action_);
 
   // Move multi-shape objects, use object pose, use subframes
   world.addToObject("mix1", box, Eigen::Isometry3d::Identity());
@@ -436,7 +433,7 @@ TEST(World, ObjectPoseAndSubframes)
   EXPECT_TRUE(found_ok);
   EXPECT_EQ(1.0, pose(2, 3));  // z
 
-  collision_detection::World::ObjectConstPtr obj = world.getObject("mix1");
+  World::ObjectConstPtr obj = world.getObject("mix1");
   EXPECT_EQ(0.0, obj->shape_poses_[0](2, 3));  // Internal shape poses do *not* change
   EXPECT_EQ(2.0, obj->shape_poses_[1](2, 3));
 

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -25,10 +25,10 @@ target_link_libraries(${MOVEIT_LIB_NAME}
 install(DIRECTORY include/ DESTINATION include)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(orocos_kdl REQUIRED)
   find_package(angles REQUIRED)
   find_package(tf2_kdl REQUIRED)
-
   include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
 
   if(WIN32)
@@ -37,7 +37,7 @@ if(BUILD_TESTING)
     set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/../utils;${CMAKE_CURRENT_BINARY_DIR}/../robot_state;${CMAKE_CURRENT_BINARY_DIR}/../planning_scene;${CMAKE_CURRENT_BINARY_DIR}/../robot_model;${CMAKE_CURRENT_BINARY_DIR}/../kinematics_constraint")
   endif()
 
-  ament_add_gtest(test_constraint_samplers
+  ament_add_gmock(test_constraint_samplers
     test/test_constraint_samplers.cpp
     test/pr2_arm_kinematics_plugin.cpp
     test/pr2_arm_ik.cpp

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -43,6 +43,8 @@
 
 namespace constraint_samplers
 {
+random_numbers::RandomNumberGenerator createSeededRNG([[maybe_unused]] const std::string& seed_param);
+
 MOVEIT_CLASS_FORWARD(JointConstraintSampler);  // Defines JointConstraintSamplerPtr, ConstPtr, WeakPtr... etc
 
 /**
@@ -69,8 +71,10 @@ public:
    */
   JointConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
+    , random_number_generator_(createSeededRNG("~joint_constraint_sampler_random_seed"))
   {
   }
+
   /**
    * \brief Configures a joint constraint given a Constraints message.
    *
@@ -305,6 +309,7 @@ public:
    */
   IKConstraintSampler(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name)
     : ConstraintSampler(scene, group_name)
+    , random_number_generator_(createSeededRNG("~ik_constraint_sampler_random_seed"))
   {
   }
 

--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -43,6 +43,21 @@
 namespace constraint_samplers
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.default_constraint_samplers");
+
+random_numbers::RandomNumberGenerator createSeededRNG([[maybe_unused]] const std::string& seed_param)
+{
+  // int rng_seed;
+  // if (ros::param::get(seed_param, rng_seed))
+  // {
+  //   ROS_DEBUG_STREAM_NAMED("constraint_samplers", "Creating random number generator with seed " << rng_seed);
+  //   return random_numbers::RandomNumberGenerator(rng_seed);
+  // }
+  // else
+  // {
+  return random_numbers::RandomNumberGenerator(12345);
+  // }
+}
+
 bool JointConstraintSampler::configure(const moveit_msgs::msg::Constraints& constr)
 {
   // construct the constraints

--- a/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/test/test_constraint_samplers.cpp
@@ -46,6 +46,7 @@
 #include <geometric_shapes/shape_operations.h>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
@@ -1127,6 +1128,116 @@ TEST_F(LoadPlanningModelsPr2, SubgroupPoseConstraintsSampler)
   RCLCPP_INFO(rclcpp::get_logger("pr2_arm_kinematics_plugin"),
               "Success rate for IK Constraint Sampler with position & orientation constraints for both arms: %lf",
               (double)succ / (double)NT);
+}
+
+TEST_F(LoadPlanningModelsPr2, DISABLED_JointConstraintsSamplerSeeded)
+{
+  // ros::param::set("~joint_constraint_sampler_random_seed", 12345);
+  constraint_samplers::JointConstraintSampler seeded_sampler1(ps_, "right_arm");
+  kinematic_constraints::JointConstraint jc(robot_model_);
+  moveit_msgs::msg::JointConstraint jcm;
+  jcm.position = 0.42;
+  jcm.tolerance_above = 0.01;
+  jcm.tolerance_below = 0.05;
+  jcm.weight = 1.0;
+  jcm.joint_name = "r_shoulder_pan_joint";
+  EXPECT_TRUE(jc.configure(jcm));
+  std::vector<kinematic_constraints::JointConstraint> js;
+  js.push_back(jc);
+  EXPECT_TRUE(seeded_sampler1.configure(js));
+
+  moveit::core::RobotState ks(robot_model_);
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler1.sample(ks, ks, 1));
+  const double* joint_positions = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v(joint_positions, joint_positions + ks.getVariableCount());
+
+  constraint_samplers::JointConstraintSampler seeded_sampler2(ps_, "right_arm");
+  EXPECT_TRUE(seeded_sampler2.configure(js));
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler2.sample(ks, ks, 1));
+  const double* joint_positions2 = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v2(joint_positions2, joint_positions2 + ks.getVariableCount());
+  using namespace testing;
+  EXPECT_THAT(joint_positions_v, ContainerEq(joint_positions_v2));
+
+  // ros::param::del("~joint_constraint_sampler_random_seed");
+  constraint_samplers::JointConstraintSampler seeded_sampler3(ps_, "right_arm");
+  EXPECT_TRUE(seeded_sampler3.configure(js));
+  ks.setToDefaultValues();
+  EXPECT_TRUE(seeded_sampler3.sample(ks, ks, 5));
+  const double* joint_positions3 = ks.getVariablePositions();
+  const std::vector<double> joint_positions_v3(joint_positions3, joint_positions3 + ks.getVariableCount());
+  EXPECT_THAT(joint_positions_v, Not(ContainerEq(joint_positions_v3)));
+  EXPECT_THAT(joint_positions_v2, Not(ContainerEq(joint_positions_v3)));
+}
+
+TEST_F(LoadPlanningModelsPr2, DISABLED_IKConstraintsSamplerSeeded)
+{
+  // ros::param::set("~ik_constraint_sampler_random_seed", 12345);
+  kinematic_constraints::PositionConstraint pc(robot_model_);
+  moveit_msgs::msg::PositionConstraint pcm;
+
+  pcm.link_name = "l_wrist_roll_link";
+  pcm.target_point_offset.x = 0;
+  pcm.target_point_offset.y = 0;
+  pcm.target_point_offset.z = 0;
+  pcm.constraint_region.primitives.resize(1);
+  pcm.constraint_region.primitives[0].type = shape_msgs::msg::SolidPrimitive::SPHERE;
+  pcm.constraint_region.primitives[0].dimensions.resize(1);
+  pcm.constraint_region.primitives[0].dimensions[0] = 0.001;
+
+  pcm.constraint_region.primitive_poses.resize(1);
+  pcm.constraint_region.primitive_poses[0].position.x = 0.55;
+  pcm.constraint_region.primitive_poses[0].position.y = 0.2;
+  pcm.constraint_region.primitive_poses[0].position.z = 1.25;
+  pcm.constraint_region.primitive_poses[0].orientation.x = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.y = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.z = 0.0;
+  pcm.constraint_region.primitive_poses[0].orientation.w = 1.0;
+  pcm.weight = 1.0;
+
+  pcm.header.frame_id = robot_model_->getModelFrame();
+  moveit::core::Transforms& tf = ps_->getTransformsNonConst();
+  EXPECT_TRUE(pc.configure(pcm, tf));
+
+  constraint_samplers::IKConstraintSampler seeded_sampler1(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler1.configure(constraint_samplers::IKSamplingPose(pc)));
+
+  moveit::core::RobotState ks(robot_model_);
+  ks.setToDefaultValues();
+  ks.update();
+
+  EXPECT_TRUE(seeded_sampler1.sample(ks, ks, 1));
+  ks.update();
+  bool found = false;
+  const Eigen::Isometry3d root_to_left_tool1 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  constraint_samplers::IKConstraintSampler seeded_sampler2(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler2.configure(constraint_samplers::IKSamplingPose(pc)));
+  ks.setToDefaultValues();
+  ks.update();
+  EXPECT_TRUE(seeded_sampler2.sample(ks, ks, 1));
+  ks.update();
+  found = false;
+  const Eigen::Isometry3d root_to_left_tool2 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  // ros::param::del("~ik_constraint_sampler_random_seed");
+  constraint_samplers::IKConstraintSampler seeded_sampler3(ps_, "left_arm");
+  EXPECT_TRUE(seeded_sampler3.configure(constraint_samplers::IKSamplingPose(pc)));
+  ks.setToDefaultValues();
+  ks.update();
+  EXPECT_TRUE(seeded_sampler3.sample(ks, ks, 5));
+  ks.update();
+  found = false;
+  const Eigen::Isometry3d root_to_left_tool3 = ks.getFrameTransform("l_gripper_tool_frame", &found);
+  EXPECT_TRUE(found);
+
+  EXPECT_TRUE((root_to_left_tool1 * root_to_left_tool2.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_to_left_tool1 * root_to_left_tool3.inverse()).matrix().isIdentity(1e-7));
+  EXPECT_FALSE((root_to_left_tool2 * root_to_left_tool3.inverse()).matrix().isIdentity(1e-7));
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -67,6 +67,7 @@
   <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl_vendor</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_index_cpp</test_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -668,12 +668,13 @@ private:
 bool PlanningScene::getCollisionObjectMsg(moveit_msgs::msg::CollisionObject& collision_obj, const std::string& ns) const
 {
   collision_detection::CollisionEnv::ObjectConstPtr obj = world_->getObject(ns);
+  if (!obj)
+    return false;
   collision_obj.header.frame_id = getPlanningFrame();
   collision_obj.pose = tf2::toMsg(obj->pose_);
   collision_obj.id = ns;
   collision_obj.operation = moveit_msgs::msg::CollisionObject::ADD;
-  if (!obj)
-    return false;
+
   ShapeVisitorAddToCollisionObject sv(&collision_obj);
   for (std::size_t j = 0; j < obj->shapes_.size(); ++j)
   {

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -295,6 +295,14 @@ TEST(PlanningScene, switchCollisionDetectorType)
   }
 }
 
+TEST(PlanningScene, FailRetrievingNonExistentObject)
+{
+  moveit::core::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("pr2");
+  planning_scene::PlanningScene ps{ robot_model };
+  moveit_msgs::msg::CollisionObject obj;
+  EXPECT_FALSE(ps.getCollisionObjectMsg(obj, "non_existent_object"));
+}
+
 class CollisionDetectorTests : public testing::TestWithParam<const char*>
 {
 };

--- a/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/moveit_ros/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -889,13 +889,13 @@ void moveit_benchmarks::BenchmarkExecution::collectMetrics(RunData& rundata,
 
 namespace
 {
-bool isIKSolutionCollisionFree(const planning_scene::PlanningScene* scene, moveit::core::RobotState* state,
-                               const moveit::core::JointModelGroup* group, const double* ik_solution, bool* reachable)
+bool isIKSolutionCollisionFree(const planning_scene::PlanningScene& scene, moveit::core::RobotState& state,
+                               const moveit::core::JointModelGroup* group, const double* ik_solution, bool& reachable)
 {
-  state->setJointGroupPositions(group, ik_solution);
-  state->update();
-  *reachable = true;
-  if (scene->isStateColliding(*state, group->getName(), false))
+  state.setJointGroupPositions(group, ik_solution);
+  state.update();
+  reachable = true;
+  if (scene.isStateColliding(state, group->getName(), false))
     return false;
   else
     return true;

--- a/moveit_ros/planning_interface/setup.py
+++ b/moveit_ros/planning_interface/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -292,7 +292,9 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
   auto add_active_end_effectors_for_single_group = [&](const moveit::core::JointModelGroup* single_group) {
     bool found_eef{ false };
     for (const srdf::Model::EndEffector& eef : eefs)
-      if (single_group->hasLinkModel(eef.parent_link_) && single_group->getName() == eef.parent_group_ &&
+    {
+      if (single_group->hasLinkModel(eef.parent_link_) &&
+          (eef.parent_group_.empty() || single_group->getName() == eef.parent_group_) &&
           single_group->canSetStateFromIK(eef.parent_link_))
       {
         // We found an end-effector whose parent is the group.
@@ -304,6 +306,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string& group, Intera
         active_eef_.push_back(ee);
         found_eef = true;
       }
+    }
 
     // No end effectors found. Use last link in group as the "end effector".
     if (!found_eef && !single_group->getLinkModelNames().empty())

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -62,7 +62,7 @@ void MotionPlanningFrame::detectObjectsButtonClicked()
   //    const planning_scene_monitor::LockedPlanningSceneRO& ps = planning_display_->getPlanningSceneRO();
   //    if (ps)
   //    {
-  //      semantic_world_.reset(new moveit::semantic_world::SemanticWorld(ps));
+  //      semantic_world_ = std::make_shared<moveit::semantic_world::SemanticWorld>(ps);
   //    }
   //    if (semantic_world_)
   //    {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -217,13 +217,15 @@ void MotionPlanningFrame::computeExecuteButtonClicked()
 
 void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
 {
-  if (!move_group_)
+  // ensures the MoveGroupInterface is not destroyed while executing
+  moveit::planning_interface::MoveGroupInterfacePtr mgi(move_group_);
+  if (!mgi)
     return;
   configureForPlanning();
   planning_display_->rememberPreviousStartState();
   // move_group::move() on the server side, will always start from the current state
   // to suppress a warning, we pass an empty state (which encodes "start from current state")
-  move_group_->setStartStateToCurrentState();
+  mgi->setStartStateToCurrentState();
   ui_->stop_button->setEnabled(true);
   if (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState())
   {
@@ -232,7 +234,7 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   }
   else
   {
-    bool success = move_group_->move() == moveit::core::MoveItErrorCode::SUCCESS;
+    bool success = mgi->move() == moveit::core::MoveItErrorCode::SUCCESS;
     onFinishedExecution(success);
   }
   ui_->plan_and_execute_button->setEnabled(true);

--- a/moveit_ros/visualization/setup.py
+++ b/moveit_ros/visualization/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -191,8 +191,6 @@ int main(int argc, char** argv)
       RCLCPP_INFO(LOGGER, " * %s", name.c_str());
   }
 
-  using std::placeholders::_1;
-  using std::placeholders::_2;
   auto save_cb = [&](const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request> request,
                      std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response> response) -> bool {
     return storeState(request, response, rs);


### PR DESCRIPTION
### Description

Sync the following commits - 
```
* [2022-05-13] [c88f6fb64] | CI: Restore original version names (#3136) {{Robert Haschke}}  (moveit1/noetic-devel, moveit1/master)
* [2022-05-13] [85c88a28c] | Fix flaky constraint sampler test (#3135) {{Tahsincan Köse}} 
* [2022-05-12] [0d46974ac] | MoveItCpp: Allow multiple pipelines (#3131) {{Michael Görner}} 
* [2022-05-10] [5bf60e7b5] | moveit_commander: make current joint state copy-paste-able (#3133) {{Michael Görner}} 
* [2022-05-09] [dd0fb2a3a] | Constraint samplers with seed (#3112) {{Tahsincan Köse}} 
* [2022-05-09] [f69f47d95] | Remove broken branch from python (#3130) {{Michael Görner}} 
* [2022-05-05] [0f66b999c] | Fix clang-tidy warning (#3129) {{Robert Haschke}} 
* [2022-05-05] [4c777b756] | CI: Fix GHA failing to check out sources (#3126) {{Robert Haschke}} 
* [2022-05-03] [bb9a7675b] | Fix namespace of planning plugin for benchmarks examples (#3128) {{Robert Haschke}} 
* [2022-04-29] [21acae7fb] | Fix rviz segfault when changing move group during execution (#3123) {{bsygo}} 
* [2022-04-06] [fcb2dfce0] | Find end-effectors for empty parent_group (#3108) {{Michael Görner}} 
*   [2022-04-02] [cce0ffe58] | Merge pull request #3106 from v4hn/pr-master-bind-them-all / banish bind() {{Michael Görner}} 
|\  
| * [2022-04-02] [9e3d71b1c] | Fix clang-tidy {{Robert Haschke}} 
| * [2022-04-01] [c07be63b6] | Cleanup OMPL's PlanningContextManager's protected API {{Robert Haschke}} 
| * [2022-04-01] [9804c19e1] | using namespace collision_detection {{Robert Haschke}} 
| * [2022-04-01] [7f71a6c89] | add clang-tidy check for bind() {{v4hn}} 
| * [2022-04-01] [a2911c80c] | banish bind() {{v4hn}} 
| * [2022-03-31] [1a8e5715e] | various: prefer objects and references over pointers {{v4hn}} 
| * [2022-03-31] [a183bc16f] | planning_context_manager: rename protected methods {{v4hn}} 
| * [2022-03-31] [ddb68b617] | kinematics test: remove unused argument {{v4hn}} 
| * [2022-03-31] [6436597d5] | Migrate PRA internals to lambdas {{v4hn}} 
| * [2022-03-31] [6805b7edc] | drop unused arguments not needed for lambda binding {{v4hn}} 
| * [2022-03-31] [0322d6324] | simplify distance field method binding {{v4hn}} 
|/  
* [2022-03-29] [5398531a6] | Formatting (#3105) {{Stephanie Eng}} 
* [2022-03-29] [9aec3932f] | pre-commit: Update black version {{Robert Haschke}} 
* [2022-03-29] [08331b461] | Replace obsolete distutils.core with setuptools (#3103) {{Michael Görner}} 
* [2022-03-29] [bf05364ba] | Fix null pointer access to CollisionEnvObject in PlanningScene (#3104) {{Tahsincan Köse}} 
```
Currently, most of the changes from commit [dd0fb2a3a](https://github.com/ros-planning/moveit/commit/dd0fb2a3a91f2dad7275c70efd52754a01517116) has been commented out since it adds setting/getting a ROS parameter in `moveit_core`. Tests from this commit are also disables since they fail.

TODO:
- [ ] Make an issue to un-comment the changes from commit [dd0fb2a3a](https://github.com/ros-planning/moveit/commit/dd0fb2a3a91f2dad7275c70efd52754a01517116)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
