### PR TITLE
Static variable to manage creation of multiple nodes

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -1009,12 +1009,12 @@ public:
 protected:
   /** return the full RobotState of the joint-space target, only for internal use */
   const moveit::core::RobotState& getTargetRobotState() const;
+  static size_t number_of_objects_;
 
 private:
   std::map<std::string, std::vector<double> > remembered_joint_values_;
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;
-  static size_t node_num;
 };
 }  // namespace planning_interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -1014,6 +1014,7 @@ private:
   std::map<std::string, std::vector<double> > remembered_joint_values_;
   class MoveGroupInterfaceImpl;
   MoveGroupInterfaceImpl* impl_;
+  static size_t node_num;
 };
 }  // namespace planning_interface
 }  // namespace moveit

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -77,6 +77,8 @@ namespace moveit
 {
 namespace planning_interface
 {
+size_t MoveGroupInterface::node_num = 0;
+
 const std::string MoveGroupInterface::ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
 
@@ -103,7 +105,16 @@ public:
                          const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers)
     : opt_(opt), node_(node), tf_buffer_(tf_buffer)
   {
-    pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
+    if (node_num == 0)
+    {
+      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
+    }
+    else
+    {
+      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node_" + std::to_string(node_num));
+    }
+    node_num++;
+
     robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(node_, opt.robot_description_);
     if (!getRobotModel())
     {

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -77,7 +77,7 @@ namespace moveit
 {
 namespace planning_interface
 {
-size_t MoveGroupInterface::node_num = 0;
+size_t MoveGroupInterface::number_of_objects_ = 0;
 
 const std::string MoveGroupInterface::ROBOT_DESCRIPTION =
     "robot_description";  // name of the robot description (a param name, so it can be changed externally)
@@ -105,15 +105,15 @@ public:
                          const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers)
     : opt_(opt), node_(node), tf_buffer_(tf_buffer)
   {
-    if (node_num == 0)
+    if (!number_of_objects_)
     {
       pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node");
     }
     else
     {
-      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node_" + std::to_string(node_num));
+      pnode_ = std::make_shared<rclcpp::Node>("move_group_interface_node_" + std::to_string(number_of_objects_));
     }
-    node_num++;
+    number_of_objects_++;
 
     robot_model_ = opt.robot_model_ ? opt.robot_model_ : getSharedRobotModel(node_, opt.robot_description_);
     if (!getRobotModel())


### PR DESCRIPTION
### Description

The problem is when creating multiple MoveGroupInterface objects, the node gets created with the same name, so since this a shared library, whenever an object's (any where) created a counter gets incremented an give the node a name based on the order of creation.
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
