### PR TITLE
Sync with MoveIt

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -199,6 +199,10 @@ def generate_move_group_launch(moveit_config):
     # inhibit these default MoveGroup capabilities (space separated)
     ld.add_action(DeclareLaunchArgument("disable_capabilities", default_value=""))
 
+    # do not copy dynamics information from /joint_states to internal robot monitoring
+    # default to false, because almost nothing in move_group relies on this information
+    ld.add_action(DeclareBooleanLaunchArg("monitor_dynamics", default_value=False))
+
     should_publish = LaunchConfiguration("publish_monitored_planning_scene")
 
     move_group_configuration = {
@@ -216,6 +220,7 @@ def generate_move_group_launch(moveit_config):
         "publish_geometry_updates": should_publish,
         "publish_state_updates": should_publish,
         "publish_transforms_updates": should_publish,
+        "monitor_dynamics": False,
     }
 
     move_group_params = [

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -614,7 +614,9 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::msg::PlanningScene& sce
       getOctomapMsg(scene_msg.world.octomap);
   }
 
-  // Ensure any detached collision objects get detached from the parent planning scene, too
+  // Ensure all detached collision objects actually get removed when applying the diff
+  // Because RobotState doesn't handle diffs (yet), we explicitly declare attached objects
+  // as removed, if they show up as "normal" collision objects but were attached in parent
   for (const auto& collision_object : scene_msg.world.collision_objects)
   {
     if (parent_ && parent_->getCurrentState().hasAttachedBody(collision_object.id))

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -392,7 +392,7 @@ TEST_P(CollisionDetectorTests, ClearDiff)
 }
 
 // Returns a planning scene diff message
-moveit_msgs::msg::PlanningScene create_planning_scene_diff(planning_scene::PlanningScene& ps,
+moveit_msgs::msg::PlanningScene create_planning_scene_diff(const planning_scene::PlanningScene& ps,
                                                            const std::string& object_name, const int8_t operation,
                                                            const bool attach_object = false,
                                                            const bool create_object = true)
@@ -427,7 +427,7 @@ moveit_msgs::msg::PlanningScene create_planning_scene_diff(planning_scene::Plann
   };
 
   auto new_ps = ps.diff();
-  if (operation == moveit_msgs::msg::CollisionObject::REMOVE ||
+  if ((operation == moveit_msgs::msg::CollisionObject::REMOVE && !attach_object) ||
       (operation == moveit_msgs::msg::CollisionObject::ADD && create_object))
     new_ps->processCollisionObjectMsg(add_object(object_name, operation));
   if (attach_object)
@@ -465,16 +465,18 @@ TEST(PlanningScene, RobotStateDiffBug)
   auto srdf_model = std::make_shared<srdf::Model>();
   auto ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
 
-  // It works as expected for collision objects case
+  // Adding collision objects incrementally
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::msg::CollisionObject::ADD);
     const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD);
 
-    ps->usePlanningSceneMsg(ps2);
     ps->usePlanningSceneMsg(ps1);
+    ps->usePlanningSceneMsg(ps2);
+
     EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
   }
 
+  // Removing a collision object
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::REMOVE);
 
@@ -482,10 +484,8 @@ TEST(PlanningScene, RobotStateDiffBug)
     EXPECT_EQ(get_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
   }
 
-  // Attached collision objects case
+  // Adding attached collision objects incrementally
   ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
-
-  // Test that triggered a bug related to having two diffs that add two different objects
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object1", moveit_msgs::msg::CollisionObject::ADD, true);
     const auto ps2 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD, true);
@@ -493,11 +493,10 @@ TEST(PlanningScene, RobotStateDiffBug)
     ps->usePlanningSceneMsg(ps1);
     ps->usePlanningSceneMsg(ps2);
     EXPECT_TRUE(get_collision_objects_names(*ps).empty());
-    // Should print object1 and object2 -- it prints object2 only (or object1 depending on the order of operation)
     EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
   }
 
-  // Test that triggered a bug related to removing an object when having a robot state diff
+  // Removing an attached collision object
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::REMOVE, true);
     ps->usePlanningSceneMsg(ps1);
@@ -506,12 +505,33 @@ TEST(PlanningScene, RobotStateDiffBug)
     EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
   }
 
+  // Turn an existing collision object into an attached object
   {
     const auto ps1 = create_planning_scene_diff(*ps, "object2", moveit_msgs::msg::CollisionObject::ADD, true, false);
     ps->usePlanningSceneMsg(ps1);
 
     EXPECT_TRUE(get_collision_objects_names(*ps).empty());
     EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1", "object2" }));
+  }
+
+  // Removing an attached collision object completely
+  {
+    auto ps1 = ps->diff();
+    moveit_msgs::msg::CollisionObject co;
+    co.id = "object2";
+    co.operation = moveit_msgs::msg::CollisionObject::REMOVE;
+    moveit_msgs::msg::AttachedCollisionObject aco;
+    aco.object = co;
+
+    ps1->processAttachedCollisionObjectMsg(aco);  // detach
+    ps1->processCollisionObjectMsg(co);           // and eventually remove object
+
+    moveit_msgs::msg::PlanningScene msg;
+    ps1->getPlanningSceneDiffMsg(msg);
+    ps->usePlanningSceneMsg(msg);
+
+    EXPECT_TRUE(get_collision_objects_names(*ps).empty());
+    EXPECT_EQ(get_attached_collision_objects_names(*ps), (std::set<std::string>{ "object1" }));
   }
 }
 

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -295,6 +295,13 @@ int main(int argc, char** argv)
 
     move_group::MoveGroupExe mge(moveit_cpp, default_planning_pipeline, debug);
 
+    bool monitor_dynamics;
+    if (nh->get_parameter("monitor_dynamics", monitor_dynamics) && monitor_dynamics)
+    {
+      RCLCPP_INFO(LOGGER, "MoveGroup monitors robot dynamics (higher load)");
+      planning_scene_monitor->getStateMonitor()->enableCopyDynamics(true);
+    }
+
     planning_scene_monitor->publishDebugInformation(debug);
 
     mge.status();


### PR DESCRIPTION
### Description
Sync the following commits
```
* [2022-06-14] [a436a9771] | Fix PlanarJointModel::satisfiesPositionBounds (#3160) {{Rufus Wong}}  (moveit1/noetic-devel, moveit1/master)
*   [2022-06-11] [e364749bf] | Merge pull request #3137 from TAMS-Group/pr-master-monitor-dynamics {{Michael Görner}} 
|\  
| * [2022-06-11] [a2d058c13] | document new move_group parameter {{v4hn}} 
| * [2022-05-16] [37864cf0d] | optionally enable dynamics monitoring in move_group node {{Michael Görner}} 
| * [2022-05-16] [1b0a3a47b] | convert move_group to LOGNAME {{Michael Görner}} 
|/  
* [2022-05-30] [a80dd9d6a] | Add missing headers {{Jochen Sprickerhof}} 
* [2022-05-30] [b17b240d9] | Switch to hpp headers of pluginlib {{Jochen Sprickerhof}} 
* [2022-05-18] [3cbcbadf1] | Adds another test case to #3124 and adds some further minor improvements to the original PR (#3142) {{Robert Haschke}} 
* [2022-05-16] [9202830ef] | Fix bug in applying planning scene diffs that have attached collision objects (#3124) {{Jafar}} 
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
