### PR TITLE
msa: add support for action_ns

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers.hpp
@@ -54,6 +54,18 @@ public:
 
   virtual std::string getDefaultType() const = 0;
 
+  virtual std::string getDefaultActionNamespace() const
+  {
+    return std::string();
+  }
+
+  virtual std::string getGripperDefaultType() const = 0;
+
+  virtual std::string getGripperDefaultActionNamespace() const
+  {
+    return std::string();
+  }
+
   bool isReady() const override
   {
     return !srdf_config_->getGroups().empty();

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers_config.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers_config.hpp
@@ -52,6 +52,7 @@ struct ControllerInfo
 {
   std::string name_;                 // controller name
   std::string type_;                 // controller type
+  std::string action_ns_;            // action namespace
   std::vector<std::string> joints_;  // joints controlled by this controller
 };
 
@@ -81,7 +82,8 @@ public:
    * \param joint_names vector of the joint names
    * \return true if inserted correctly
    */
-  bool addController(const std::string& name, const std::string& type, const std::vector<std::string>& joint_names);
+  bool addController(const std::string& name, const std::string& type, const std::vector<std::string>& joint_names,
+                     const std::string& action_ns = std::string());
 
   /**
    * \brief Adds a controller to controllers_ vector

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
@@ -78,6 +78,21 @@ public:
   {
     return "FollowJointTrajectory";
   }
+
+  std::string getDefaultActionNamespace() const override
+  {
+    return "follow_joint_trajectory";
+  }
+
+  std::string getGripperDefaultType() const override
+  {
+    return "GripperCommand";
+  }
+
+  std::string getGripperDefaultActionNamespace() const override
+  {
+    return "command";
+  }
 };
 }  // namespace controllers
 }  // namespace moveit_setup

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/ros2_controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/ros2_controllers.hpp
@@ -79,6 +79,11 @@ public:
   {
     return "joint_trajectory_controller/JointTrajectoryController";
   }
+
+  std::string getGripperDefaultType() const override
+  {
+    return "position_controllers/GripperActionController";
+  }
 };
 }  // namespace controllers
 }  // namespace moveit_setup

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
@@ -65,7 +65,7 @@ bool Controllers::addDefaultControllers()
     // If this group is an end effector, use proper default
     bool is_end_effector = false;
     auto end_effectors = srdf_config_->getEndEffectors();
-    for (auto ee : end_effectors)
+    for (const auto& ee : end_effectors)
     {
       if (ee.component_group_ == group_name)
       {

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
@@ -76,8 +76,8 @@ bool Controllers::addDefaultControllers()
 
     if (is_end_effector)
     {
-      success &= controllers_config_->addController(group_name + "_controller", getGripperDefaultType(),
-                                                    joint_names, getGripperDefaultActionNamespace());
+      success &= controllers_config_->addController(group_name + "_controller", getGripperDefaultType(), joint_names,
+                                                    getGripperDefaultActionNamespace());
     }
     else
     {

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
@@ -61,8 +61,29 @@ bool Controllers::addDefaultControllers()
     {
       continue;
     }
-    bool ret = controllers_config_->addController(group_name + "_controller", getDefaultType(), joint_names);
-    success &= ret;
+
+    // If this group is an end effector, use proper default
+    bool is_end_effector = false;
+    auto end_effectors = srdf_config_->getEndEffectors();
+    for (auto ee : end_effectors)
+    {
+      if (ee.component_group_ == group_name)
+      {
+        is_end_effector = true;
+        break;
+      }
+    }
+
+    if (is_end_effector)
+    {
+      success &= controllers_config_->addController(group_name + "_controller", getGripperDefaultType(),
+                                                    joint_names, getGripperDefaultActionNamespace());
+    }
+    else
+    {
+      success &= controllers_config_->addController(group_name + "_controller", getDefaultType(), joint_names,
+                                                    getDefaultActionNamespace());
+    }
   }
 
   return success;

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers_config.cpp
@@ -43,8 +43,7 @@ namespace moveit_setup
 namespace controllers
 {
 bool ControllersConfig::addController(const std::string& name, const std::string& type,
-                                      const std::vector<std::string>& joint_names,
-                                      const std::string& action_ns)
+                                      const std::vector<std::string>& joint_names, const std::string& action_ns)
 {
   ControllerInfo controller;
   controller.name_ = name;

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers_config.cpp
@@ -43,11 +43,13 @@ namespace moveit_setup
 namespace controllers
 {
 bool ControllersConfig::addController(const std::string& name, const std::string& type,
-                                      const std::vector<std::string>& joint_names)
+                                      const std::vector<std::string>& joint_names,
+                                      const std::string& action_ns)
 {
   ControllerInfo controller;
   controller.name_ = name;
   controller.type_ = type;
+  controller.action_ns_ = action_ns;
   controller.joints_ = joint_names;
   return addController(controller);
 }

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -102,6 +102,8 @@ bool MoveItControllersConfig::parseController(const std::string& name, const YAM
     return false;
   }
 
+  getYamlProperty(controller_node, "action_ns", control_setting.action_ns_);
+
   const YAML::Node& joints_node = controller_node["joints"];
 
   if (joints_node.IsSequence())
@@ -185,8 +187,12 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
           // Depending on the controller type, fill the required data
           if (controller.type_ == "FollowJointTrajectory")
           {
-            emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
+            emitter << YAML::Key << "action_ns" << YAML::Value << controller.action_ns_;
             emitter << YAML::Key << "default" << YAML::Value << "true";
+          }
+          else if (controller.type_ == "GripperCommand")
+          {
+            emitter << YAML::Key << "action_ns" << YAML::Value << controller.action_ns_;
           }
           else
           {


### PR DESCRIPTION
### Description

This implements #1391 and then some extra things:

* add action_ns for moveit controllers
* end effectors are now configured using gripper controllers
* while there is no box to edit the action_ns value, edits to
  YAML files will be preserved when loaded.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"