### PR TITLE
msa: fix bug in sensors_3d re-export

### DIFF
--- a/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_config.cpp
@@ -94,6 +94,7 @@ std::vector<SensorParameters> PerceptionConfig::load3DSensorsYAML(const std::fil
         const YAML::Node& sensor = doc[sensor_name.as<std::string>()];
 
         SensorParameters sensor_map;
+        sensor_map["name"] = sensor_name.as<std::string>();
         for (YAML::const_iterator sensor_it = sensor.begin(); sensor_it != sensor.end(); ++sensor_it)
         {
           sensor_map[sensor_it->first.as<std::string>()] = sensor_it->second.as<std::string>();


### PR DESCRIPTION
### Description

Initial export works, but then we lose the sensor names

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
