### PR TITLE
msa: fix duplicated ros_control joints

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/control_xacro_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/control_xacro_config.cpp
@@ -125,7 +125,11 @@ void ControlXacroConfig::loadFromDescription()
   {
     for (const std::string& joint_name : srdf_config->getJointNames(group_name, true, false))  // exclude passive
     {
-      joint_names_.push_back(joint_name);
+      if (std::find(joint_names_.begin(), joint_names_.end(), joint_name) == joint_names_.end())
+      {
+        // This is a new joint, add to list of joint names
+        joint_names_.push_back(joint_name);
+      }
     }
   }
 


### PR DESCRIPTION
### Description

When more than one controller can control a joint, that joint would appear multiple times. Fixes #1390

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
