### PR TITLE
[MSA] Add additional parameters to Controller definitions

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controller_edit_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controller_edit_widget.hpp
@@ -56,7 +56,7 @@ public:
   // ******************************************************************************************
 
   /// Constructor
-  ControllerEditWidget(QWidget* parent);
+  ControllerEditWidget(QWidget* parent, const FieldPointers& additional_fields);
 
   /// Set the previous data
   void setSelected(const std::string& controller_name, const ControllerInfo* info);
@@ -91,11 +91,16 @@ public:
   /// Get controller type
   std::string getControllerType();
 
+  /// Get the names and values for any additional parameters
+  std::map<std::string, std::string> getAdditionalParameters();
+
 private Q_SLOTS:
 
   // ******************************************************************************************
   // Slot Event Functions
   // ******************************************************************************************
+  /// Called when the selected item in the controller_type_field_ combobox is changed
+  void typeChanged(int index);
 
 Q_SIGNALS:
 
@@ -129,6 +134,9 @@ private:
   QPushButton* btn_delete_;      // this button is hidden for new controllers
   QPushButton* btn_save_;        // this button is hidden for new controllers
   QWidget* new_buttons_widget_;  // for showing/hiding the new controllers buttons
+
+  FieldPointers additional_fields_;
+  std::vector<QLineEdit*> additional_fields_inputs_;  // one QLineEdit for each additional field
 
   // ******************************************************************************************
   // Variables

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers.hpp
@@ -43,6 +43,32 @@ namespace moveit_setup
 {
 namespace controllers
 {
+/**
+ * @brief Structure for containing information about types of additional parameters
+ */
+class AdditionalControllerField
+{
+public:
+  AdditionalControllerField(const std::string& display_name, const std::string& parameter_name)
+    : display_name_(display_name), parameter_name_(parameter_name)
+  {
+  }
+
+  /**
+   * @brief Overridable method for changing the default value based on the controller_type
+   */
+  virtual std::string getDefaultValue(const std::string& /*controller_type*/) const
+  {
+    return "";
+  }
+
+  std::string display_name_;
+  std::string parameter_name_;
+};
+
+/// Convenience alias
+using FieldPointers = std::vector<std::shared_ptr<AdditionalControllerField>>;
+
 class Controllers : public SetupStep
 {
 public:
@@ -53,6 +79,14 @@ public:
   virtual std::vector<std::string> getAvailableTypes() const = 0;
 
   virtual std::string getDefaultType() const = 0;
+
+  /**
+   * @brief Define the types of controller fields for the specific types of controllers
+   */
+  virtual FieldPointers getAdditionalControllerFields() const
+  {
+    return FieldPointers();
+  }
 
   bool isReady() const override
   {

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers_config.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/controllers_config.hpp
@@ -53,6 +53,7 @@ struct ControllerInfo
   std::string name_;                 // controller name
   std::string type_;                 // controller type
   std::vector<std::string> joints_;  // joints controlled by this controller
+  std::map<std::string, std::string> parameters_;
 };
 
 /**

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
@@ -78,6 +78,49 @@ public:
   {
     return "FollowJointTrajectory";
   }
+
+  class ActionNamespaceField : public AdditionalControllerField
+  {
+  public:
+    ActionNamespaceField() : AdditionalControllerField("Action Namespace", "action_ns")
+    {
+    }
+    std::string getDefaultValue(const std::string& controller_type) const override
+    {
+      if (controller_type == "FollowJointTrajectory")
+      {
+        return "follow_joint_trajectory";
+      }
+      else if (controller_type == "GripperCommand")
+      {
+        return "gripper_cmd";
+      }
+      else
+      {
+        return "";
+      }
+    }
+  };
+
+  class DefaultField : public AdditionalControllerField
+  {
+  public:
+    DefaultField() : AdditionalControllerField("Default", "default")
+    {
+    }
+    std::string getDefaultValue(const std::string& /*controller_type*/) const override
+    {
+      return "true";
+    }
+  };
+
+  virtual FieldPointers getAdditionalControllerFields() const
+  {
+    FieldPointers fields;
+    fields.push_back(std::make_shared<ActionNamespaceField>());
+    fields.push_back(std::make_shared<DefaultField>());
+    return fields;
+  }
 };
 }  // namespace controllers
 }  // namespace moveit_setup

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
@@ -187,6 +187,16 @@ void ControllerEditWidget::setSelected(const std::string& controller_name, const
     {
       controller_type_field_->setCurrentIndex(type_index);
     }
+
+    for (unsigned int i = 0; i < additional_fields_.size(); i++)
+    {
+      std::string key = additional_fields_[i]->parameter_name_;
+      const auto& it = searched_controller->parameters_.find(key);
+      if (it != searched_controller->parameters_.end())
+      {
+        additional_fields_inputs_[i]->setText(it->second.c_str());
+      }
+    }
   }
   else
   {

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers_widget.cpp
@@ -97,7 +97,7 @@ void ControllersWidget::onInit()
           SLOT(previewSelectedGroup(std::vector<std::string>)));
 
   // Controller Edit Widget
-  controller_edit_widget_ = new ControllerEditWidget(this);
+  controller_edit_widget_ = new ControllerEditWidget(this, setup_step_->getAdditionalControllerFields());
   connect(controller_edit_widget_, SIGNAL(cancelEditing()), this, SLOT(cancelEditing()));
   connect(controller_edit_widget_, SIGNAL(deleteController()), this, SLOT(deleteController()));
   connect(controller_edit_widget_, SIGNAL(save()), this, SLOT(saveControllerScreenEdit()));
@@ -607,6 +607,7 @@ bool ControllersWidget::saveControllerScreen()
   // Get a reference to the supplied strings
   const std::string& controller_name = controller_edit_widget_->getControllerName();
   const std::string& controller_type = controller_edit_widget_->getControllerType();
+  std::map<std::string, std::string> controller_parameters = controller_edit_widget_->getAdditionalParameters();
 
   // Used for editing existing controllers
   ControllerInfo* searched_controller = nullptr;
@@ -650,6 +651,7 @@ bool ControllersWidget::saveControllerScreen()
     ControllerInfo new_controller;
     new_controller.name_ = controller_name;
     new_controller.type_ = controller_type;
+    new_controller.parameters_ = controller_parameters;
     setup_step_->addController(new_controller);
 
     adding_new_controller_ = true;  // remember this controller is new
@@ -662,6 +664,7 @@ bool ControllersWidget::saveControllerScreen()
     // Change controller name
     searched_controller->name_ = controller_name;
     searched_controller->type_ = controller_type;
+    searched_controller->parameters_ = controller_parameters;
   }
 
   // Reload main screen table

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -102,6 +102,14 @@ bool MoveItControllersConfig::parseController(const std::string& name, const YAM
     return false;
   }
 
+  for (const std::string& parameter : { "action_ns", "default" })
+  {
+    if (controller_node[parameter].IsDefined())
+    {
+      control_setting.parameters_[parameter] = controller_node[parameter].as<std::string>();
+    }
+  }
+
   const YAML::Node& joints_node = controller_node["joints"];
 
   if (joints_node.IsSequence())
@@ -173,34 +181,11 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
             emitter << joint;
           }
           emitter << YAML::EndSeq;
-          // Depending on the controller type, fill the required data
-          if (controller.type_ == "FollowJointTrajectory")
+
+          for (const auto& pair : controller.parameters_)
           {
-            emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
-            emitter << YAML::Key << "default" << YAML::Value << "true";
-          }
-          else
-          {
-            // Write gains as they are required for vel and effort controllers
-            emitter << YAML::Key << "gains";
-            emitter << YAML::Value;
-            emitter << YAML::BeginMap;
-            {
-              // Iterate through the joints
-              for (const std::string& joint : controller.joints_)
-              {
-                emitter << YAML::Key << joint << YAML::Value << YAML::BeginMap;
-                emitter << YAML::Key << "p";
-                emitter << YAML::Value << "100";
-                emitter << YAML::Key << "d";
-                emitter << YAML::Value << "1";
-                emitter << YAML::Key << "i";
-                emitter << YAML::Value << "1";
-                emitter << YAML::Key << "i_clamp";
-                emitter << YAML::Value << "1" << YAML::EndMap;
-              }
-            }
-            emitter << YAML::EndMap;
+            emitter << YAML::Key << pair.first;
+            emitter << YAML::Value << pair.second;
           }
         }
         emitter << YAML::EndMap;

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -165,23 +165,14 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
           // Write joints
           emitter << YAML::Key << "joints";
           emitter << YAML::Value;
-          if (controller.joints_.size() != 1)
-          {
-            emitter << YAML::BeginSeq;
+          emitter << YAML::BeginSeq;
 
-            // Iterate through the joints
-            for (const std::string& joint : controller.joints_)
-            {
-              emitter << joint;
-            }
-            emitter << YAML::EndSeq;
-          }
-          else
+          // Iterate through the joints
+          for (const std::string& joint : controller.joints_)
           {
-            emitter << YAML::BeginMap;
-            emitter << controller.joints_[0];
-            emitter << YAML::EndMap;
+            emitter << joint;
           }
+          emitter << YAML::EndSeq;
           // Depending on the controller type, fill the required data
           if (controller.type_ == "FollowJointTrajectory")
           {
@@ -211,8 +202,8 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
             }
             emitter << YAML::EndMap;
           }
-          emitter << YAML::EndMap;
         }
+        emitter << YAML::EndMap;
       }
     }
     emitter << YAML::EndMap;

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -102,7 +102,7 @@ bool MoveItControllersConfig::parseController(const std::string& name, const YAM
     return false;
   }
 
-  for (const std::string& parameter : { "action_ns", "default" })
+  for (const std::string parameter : { "action_ns", "default" })
   {
     if (controller_node[parameter].IsDefined())
     {


### PR DESCRIPTION
### Description

Fixes #1392 

Maybe a bit overengineered, but adds the `action_ns` and `default` parameters to `moveit_controllers.yaml`. 

Also, changed one thing about outputting the joints. I couldn't find any code to support reading a single value for the `joint` parameter so I removed that. I also deleted the `gains` parameter output. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
