### PR TITLE
Fixes for using generate-state_database

### DIFF
--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -476,7 +476,7 @@ static bool collectConstraints(const rclcpp::Node::SharedPtr& node, const std::v
 {
   for (const auto& constraint_id : constraint_ids)
   {
-    const auto constraint_param = ".constraints." + constraint_id;
+    const auto constraint_param = "constraints." + constraint_id;
     if (!node->has_parameter(constraint_param + ".type"))
     {
       RCLCPP_ERROR(LOGGER, "constraint parameter does not specify its type");

--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -198,7 +198,9 @@ void computeDB(const rclcpp::Node::SharedPtr& node, const planning_scene::Planni
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("generate_state_database");
+  rclcpp::NodeOptions opt;
+  opt.automatically_declare_parameters_from_overrides(true);
+  std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("generate_state_database", opt);
 
   GenerateStateDatabaseParameters params;
   if (!params.setFromNode(node))

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -54,7 +54,7 @@ void msgToHex(const T& msg, std::string& hex)
 {
   static const char SYMBOL[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
   auto type_support = rosidl_typesupport_cpp::get_message_type_support_handle<T>();
-  rmw_serialized_message_t serialized_msg;
+  rmw_serialized_message_t serialized_msg = { nullptr, 0, 0, rcutils_get_default_allocator() };
   rmw_ret_t result = rmw_serialize(&msg, type_support, &serialized_msg);
   if (result != RMW_RET_OK)
   {


### PR DESCRIPTION
On galactic the generate_state_database script is not working. 
This PR solves 3 issues that were blocking it from working properly.

#### Issue 1: planning_group parameter not declared

To reproduce simply run the generate_state_database node as follows

```shell
ros2 run moveit_planners_ompl generate_state_database --ros-args -p planning_group:=mygroup
```

The error you get is
```
[FATAL] [1656670955.089432190] [moveit.planners_ompl.generate_state_database]: ~planning_group parameter has to be specified.
```
This happens because none of the parameters that this node uses are declared before the `get_parameter` method is called.
The first commit simply adds the `automatically_declare_paramters_from_override(true)` to the node option.
This should be fine for such an isolated script. 

#### Issue 2: planning constraints parameters are not found

Once the previous issue is fixed, you get the following error, even with the parameters passed correctly. 
```shell
ros2 run moveit_planners_ompl generate_state_database --ros-args --params-file constraints.yaml 
[ERROR] [1656671355.887499755] [moveit_kinematic_constraints.utils]: constraint parameter does not specify its type
[FATAL] [1656671355.887591347] [moveit.planners_ompl.generate_state_database]: Could not find valid constraint description in parameter '/generate_state_database.constraints'. Please upload correct correct constraint description or remap the parameter.
```
The params file being:
```yaml

generate_state_database:
  ros__parameters:
    planning_group: mygroup
    use_current_scene: false
    constraints:
      name: some_constraints
      constraint_ids: [constraint_2]
      constraints:
        constraint_2:
          type: joint
          frame_id: base_link
          joint_name: jr_link3_robot
          position: 0.0
          tolerance: 0.3
          weight: 1.0

```

This is because the constraints parameters are not looked up correctly. The second commit fixes that.
However I'm not 100% sure about what format what expected by the constraint loader. After my fix, the above param file now works.

#### Issue 3: Failed to serialize message when writing the database file

Once issue2 is fixed, we get the following error:

```shell
[INFO] [1656677299.939890208] [moveit_rdf_loader.rdf_loader]: Loaded robot model in 0.00282835 seconds
[INFO] [1656677299.940199400] [moveit_robot_model.robot_model]: Loading robot model 'robot'...
[WARN] [1656677299.940807662] [moveit_robot_model.robot_model]: Link base_link has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
[WARN] [1656677299.941647022] [moveit_robot_model.robot_model]: Link link1 has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
[WARN] [1656677299.943386970] [moveit_robot_model.robot_model]: Link link2 has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
[WARN] [1656677299.943607031] [moveit_robot_model.robot_model]: Link link3 has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
[WARN] [1656677299.949846154] [moveit_ros.robot_model_loader]: No kinematics plugins defined. Fill and load kinematics.yaml!
[INFO] [1656677299.967788637] [moveit_planning_interface.planning_interface]: The timeout for planning must be positive (0.000000 specified). Assuming one second instead.
[WARN] [1656677299.967832315] [moveit.ompl_planning.model_based_planning_context]: It looks like the planning volume was not specified.
Debug:   Starting goal sampling thread
Debug:   Waiting for space information to be set up before the sampling thread can begin computation...
[INFO] [1656677299.969216385] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'robot' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
Debug:   robot/robot: Planner range detected to be 121.256637
[INFO] [1656677299.969750299] [moveit.planners_ompl.generate_state_database]: Generating Joint Space Constraint Approximation Database for constraint:
some_constraints
Debug:   Attempting to stop goal sampling thread...
Warning: Goal sampling thread never did any work.
         at line 129 in /tmp/binarydeb/ros-galactic-ompl-1.5.2/src/ompl/base/goals/src/GoalLazySamples.cpp
Debug:   Stopped goal sampling thread after 0 sampling attempts
[INFO] [1656677299.980057213] [moveit.ompl_planning.constraints_library]: Generated 0 states in 0.000005 seconds
[INFO] [1656677299.980093963] [moveit.ompl_planning.constraints_library]: Constrained sampling rate: 0.000000
[ERROR] [1656677299.980100348] [moveit.ompl_planning.constraints_library]: No StateStoragePtr found - implement better solution here.
[INFO] [1656677299.980183606] [moveit.ompl_planning.constraints_library]: Spent 0.000632 seconds constructing the database
[INFO] [1656677299.980375629] [moveit.ompl_planning.constraints_library]: Saving 1 constrained space approximations to 'constraint_approximation_database'
[ERROR] [1656677299.984306434] [moveit.ompl_planning.constraints_library]: Failed to serialize message!
Debug:   Serializing 0 states
[INFO] [1656677299.984615310] [moveit.planners_ompl.generate_state_database]: Successfully generated Joint Space Constraint Approximation Database for constraint:
some_constraints
[INFO] [1656677299.984625655] [moveit.planners_ompl.generate_state_database]: The database has been saved in your local folder 'constraint_approximation_database'

```

This is because the `rmw_serialized_message_t` is not instantiated correctly (see [here](https://github.com/ros-planning/moveit2/blob/048ef9881e4257856814cd0f582af267fb9a4f52/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp#L57)). 
Third commit fixes it.