### PR TITLE
Add reference to MoveIt for ROS one back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://moveit.ros.org/assets/logo/moveit_logo-black.png" alt="MoveIt Logo" width="200"/>
 
-The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ros.org).
+The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ros.org). For the ROS 1 repository see [MoveIt 1](https://github.com/ros-planning/moveit).
 
 *Easy-to-use open source robotics manipulation platform for developing commercial applications, prototyping designs, and benchmarking algorithms.*
 


### PR DESCRIPTION
https://github.com/ros-planning/moveit2/pull/1307 removed the link and I would like to add it back as reference.
I will also add a more prominent link to the moveit/README.md in a moment.