### PR TITLE
Use kinematics plugin instead of inverse Jacobian for servo IK

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -65,6 +65,9 @@
 #endif
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 
+// moveit_core
+#include <moveit/kinematics_base/kinematics_base.h>
+
 // moveit_servo
 #include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/status_codes.h>
@@ -367,5 +370,8 @@ protected:
 
   // Load a smoothing plugin
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;
+
+  kinematics::KinematicsBaseConstPtr ik_solver_;
+  bool use_inv_jacobian_ = false;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -372,6 +372,7 @@ protected:
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;
 
   kinematics::KinematicsBaseConstPtr ik_solver_;
+  Eigen::Isometry3d ik_base_to_tip_frame_;
   bool use_inv_jacobian_ = false;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -625,9 +625,9 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
                                      solution, err, opts))
     {
       // find the difference in joint positions that will get us to the desired pose
-      for (size_t i = 0; i < num_joints_; i++)
+      for (size_t i = 0; i < num_joints_; ++i)
       {
-        delta_theta_[i] = solution[i] - internal_joint_state_.position[i];
+        delta_theta_.coeffRef(i) = solution.at(i) - internal_joint_state_.position.at(i);
       }
     }
     else

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -106,6 +106,7 @@ def generate_servo_test_description(
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.joint_limits,
+            moveit_config.robot_description_kinematics,
         ],
     )
 

--- a/moveit_ros/moveit_servo/test/launch/unit_test_servo_calcs.test.py
+++ b/moveit_ros/moveit_servo/test/launch/unit_test_servo_calcs.test.py
@@ -16,6 +16,11 @@ def generate_test_description():
         .yaml("config/panda_simulated_config.yaml", parameter_namespace="moveit_servo")
         .to_dict()
     )
+    moveit_config = (
+        MoveItConfigsBuilder("moveit_resources_panda")
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .to_moveit_configs()
+    )
 
     test_binary_dir_arg = launch.actions.DeclareLaunchArgument(
         name="test_binary_dir",
@@ -29,7 +34,10 @@ def generate_test_description():
                 "unit_test_servo_calcs",
             ]
         ),
-        parameters=[servo_params],
+        parameters=[
+            servo_params,
+            moveit_config.robot_description_kinematics,
+        ],
         output="screen",
         # prefix="kitty gdb -e run --args"
     )

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -161,16 +161,23 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
   std::function<void(const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
       [&/* this */](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) {
         EXPECT_EQ(msg->header.frame_id, "panda_link0");
-        // Check for an expected joint position command
-        // As of now, the robot doesn't actually move because there are no controllers enabled.
-        double angle_tolerance = 0.08;  // rad
-        EXPECT_NEAR(msg->points[0].positions[0], 0, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[1], -0.785, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[2], 0, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[3], -2.360, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[4], 0, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[5], 1.571, angle_tolerance);
-        EXPECT_NEAR(msg->points[0].positions[6], 0.785, angle_tolerance);
+
+        // Exact joint positions may vary based on IK solver
+        // so check that the EE transform is as expected
+        moveit::core::RobotStatePtr temp_state(planning_scene_monitor_->getStateMonitor()->getCurrentState());
+        const std::string group_name = "panda_arm";
+        // copyJointGroupPositions can't take a const vector, make a copy
+        std::vector<double> positions(msg->points[0].positions);
+        temp_state->copyJointGroupPositions(group_name, positions);
+        Eigen::Isometry3d hand_tf = temp_state->getFrameTransform("panda_hand");
+
+        moveit::core::RobotStatePtr test_state(planning_scene_monitor_->getStateMonitor()->getCurrentState());
+        std::vector<double> test_positions = { 0, -0.785, 0, -2.360, 0, 1.571, 0.758 };
+        test_state->copyJointGroupPositions(group_name, test_positions);
+        Eigen::Isometry3d test_hand_tf = test_state->getFrameTransform("panda_hand");
+
+        double precision = 0.02;  // Hilbert-Schmidt norm
+        EXPECT_TRUE(test_hand_tf.isApprox(hand_tf, precision));
 
         this->tracker_->stopMotion();
         return;


### PR DESCRIPTION
### Description

This changes servo to utilize a kinematics plugin if one is defined. If one is not present or doesn't support the group, default to inverse Jacobian

Also updated servo_example launch file to use MoveItConfigsBuilder.

To test, the current moveit_servo tutorial can be used as is. The modification of the servo_example launch file in this repository also includes a reference to kinematics.yaml for the servo node.

The kinematics plugin used by the servo node is defined via ROS parameters, which may be loaded from a yaml file. If using `MoveItConfigsBuilder` in your servo launch file (as is done in `servo_example.launch.py` in this PR), you can pass the necessary parameters as such:


```python
moveit_config = (
        MoveItConfigsBuilder("moveit_resources_panda")
        .robot_description(file_path="config/panda.urdf.xacro")
        .to_moveit_configs()
    )

servo_node = Node(
        package="moveit_servo",
        executable="servo_node_main",
        parameters=[
            servo_params,
            moveit_config.robot_description,
            moveit_config.robot_description_semantic,
            moveit_config.robot_description_kinematics, # here is where kinematics plugin parameters are passed
        ],
```

In the above example, the `kinematics.yaml` file is taken from the `moveit_resources` repository in the workspace, specifically `moveit_resources/panda_moveit_config/config/kinematics.yaml`. By default, this yaml file defines the KDL plugin to be used. To use `bio_ik` as the solver, first clone the `ros2` branch of [the repository](https://github.com/PickNikRobotics/bio_ik) into your workspace. Then edit the above yaml file to contain the following:

```yaml
panda_arm:
  kinematics_solver: bio_ik/BioIKKinematicsPlugin
  kinematics_solver_search_resolution: 0.005
  kinematics_solver_timeout: 0.05 # this timeout parameter is actually ignored by servo
  kinematics_solver_attempts: 1.0
  mode: gd_c # see bio_ik for other modes, but gd_c (gradient descent) has the best performance
```
The timeout parameter is ignored for servo, as it uses a fraction of the publish period instead.

The actual ROS parameter names that get passed by loading the yaml file are of the form `robot_description_kinematics.<group_name>.<param_name>`, e.g. `robot_description_kinematics.panda_arm.kinematics_solver`


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
