### PR TITLE
Uncomment moveit_ros_perception dependency

### DIFF
--- a/moveit_runtime/package.xml
+++ b/moveit_runtime/package.xml
@@ -19,10 +19,7 @@
   <exec_depend>moveit_planners</exec_depend>
   <exec_depend>moveit_plugins</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
-  <!--
-  TODO(henningkayser): enable after #307 is merged
   <exec_depend>moveit_ros_perception</exec_depend>
-  -->
   <exec_depend>moveit_ros_planning</exec_depend>
   <exec_depend>moveit_ros_planning_interface</exec_depend>
   <exec_depend>moveit_ros_warehouse</exec_depend>


### PR DESCRIPTION
### Description
Uncomment a dependency since the package is available now.

The comment referred to `moveit_ros_perception` which has been available for awhile now, already.  (https://github.com/ros-planning/moveit2/pull/307)
