### PR TITLE
Fix the initialization of SRDF file path

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -162,6 +162,10 @@ class MoveItConfigsBuilder(ParameterBuilder):
             self.__urdf_package = self._package_path
             self.__urdf_file_path = modified_urdf_path
 
+        modified_srdf_path = Path("config") / (self.__robot_name + ".srdf")
+        if (self._package_path / modified_srdf_path).exists():
+            self.__srdf_file_path = modified_srdf_path
+
         if setup_assistant_file.exists():
             setup_assistant_yaml = load_yaml(setup_assistant_file)
             config = setup_assistant_yaml.get("moveit_setup_assistant_config", {})


### PR DESCRIPTION
When I use MoveItConfigsBuilder to provide the configuration of robot, I find that WARN message on the screen:
`WARNING:root:Cannot infer SRDF from <path>. -- using config/moveit_resources_panda.srdf`, even though I provide the path of SRDF file. So I check the code of class MoveItConfigsBuilder, the original codes shown as bellow:
```
        modified_urdf_path = Path("config") / (self.__robot_name + ".urdf.xacro")
        if (self._package_path / modified_urdf_path).exists():
            self.__urdf_package = self._package_path
            self.__urdf_file_path = modified_urdf_path

        if setup_assistant_file.exists():
            setup_assistant_yaml = load_yaml(setup_assistant_file)
            config = setup_assistant_yaml.get("moveit_setup_assistant_config", {})
            urdf_config = config.get("urdf", config.get("URDF"))
            if urdf_config and self.__urdf_package is None:
                self.__urdf_package = Path(
                    get_package_share_directory(urdf_config["package"])
                )
                self.__urdf_file_path = Path(urdf_config["relative_path"])

            srdf_config = config.get("srdf", config.get("SRDF"))
            if srdf_config:
                self.__srdf_file_path = Path(srdf_config["relative_path"])

        if not self.__urdf_package or not self.__urdf_file_path:
            logging.warning(
                f"\x1b[33;21mCannot infer URDF from `{self._package_path}`. -- using config/{robot_name}.urdf\x1b[0m"
            )
            self.__urdf_package = self._package_path
            self.__urdf_file_path = self.__config_dir_path / (
                self.__robot_name + ".urdf"
            )

        if not self.__srdf_file_path:
            logging.warning(
                f"\x1b[33;21mCannot infer SRDF from `{self._package_path}`. -- using config/{robot_name}.srdf\x1b[0m"
            )
            self.__srdf_file_path = self.__config_dir_path / (
                self.__robot_name + ".srdf"
            )
```
From them, we can recognize that the self.__srdf_file_path will always be **None** unless the setup_assistant_file is existed.

I adopted a simply way to avoid the warning message as followed:
```
        modified_srdf_path = Path("config") / (self.__robot_name + ".srdf")
        if (self._package_path / modified_srdf_path).exists():
            self.__srdf_file_path = modified_srdf_path
```
