### PR TITLE
rclcpp::Duration in RobotTrajectory

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -150,7 +150,7 @@ public:
     return duration_from_previous_;
   }
 
-  [[deprecated("getWayPointDurations is deprecated, replaed by getDurationFromPreviousDeque")]] std::deque<double>
+  [[deprecated("getWayPointDurations is deprecated, replaced by getDurationFromPreviousDeque")]] std::deque<double>
   getWayPointDurations() const
   {
     std::deque<double> ret;

--- a/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_spline_parameterization.cpp
@@ -144,7 +144,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
         point.setVariablePosition(idx[j],
                                   (9 * p0->getVariablePosition(idx[j]) + 1 * p1->getVariablePosition(idx[j])) / 10);
       }
-      trajectory.insertWayPoint(1, point, 0.0);
+      trajectory.insertWayPoint(1, point, rclcpp::Duration::from_seconds(0.0));
       num_points++;
 
       // 2nd-last point is 10% of p0, and 90% of p1
@@ -155,7 +155,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
         point.setVariablePosition(idx[j],
                                   (1 * p0->getVariablePosition(idx[j]) + 9 * p1->getVariablePosition(idx[j])) / 10);
       }
-      trajectory.insertWayPoint(num_points - 1, point, 0.0);
+      trajectory.insertWayPoint(num_points - 1, point, rclcpp::Duration::from_seconds(0.0));
       num_points++;
     }
   }
@@ -327,7 +327,7 @@ bool IterativeSplineParameterization::computeTimeStamps(robot_trajectory::RobotT
 
   // Convert back to JointTrajectory form
   for (unsigned int i = 1; i < num_points; ++i)
-    trajectory.setWayPointDurationFromPrevious(i, time_diff[i - 1]);
+    trajectory.setWayPointDurationFromPrevious(i, rclcpp::Duration::from_seconds(time_diff[i - 1]));
   for (unsigned int i = 0; i < num_points; ++i)
   {
     for (unsigned int j = 0; j < num_joints; ++j)

--- a/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/src/iterative_time_parameterization.cpp
@@ -207,12 +207,12 @@ void updateTrajectory(robot_trajectory::RobotTrajectory& rob_trajectory, const s
 
   int num_points = rob_trajectory.getWayPointCount();
 
-  rob_trajectory.setWayPointDurationFromPrevious(0, time_sum);
+  rob_trajectory.setWayPointDurationFromPrevious(0, rclcpp::Duration::from_seconds(time_sum));
 
   // Times
   for (int i = 1; i < num_points; ++i)
     // Update the time between the waypoints in the robot_trajectory.
-    rob_trajectory.setWayPointDurationFromPrevious(i, time_diff[i - 1]);
+    rob_trajectory.setWayPointDurationFromPrevious(i, rclcpp::Duration::from_seconds(time_diff[i - 1]));
 
   // Return if there is only one point in the trajectory!
   if (num_points <= 1)

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1110,7 +1110,7 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
     waypoint.zeroVelocities();
     waypoint.zeroAccelerations();
     trajectory.clear();
-    trajectory.addSuffixWayPoint(waypoint, 0.0);
+    trajectory.addSuffixWayPoint(waypoint, rclcpp::Duration::from_seconds(0.0));
     return true;
   }
 
@@ -1144,7 +1144,7 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
       waypoint.setVariableAcceleration(idx[j], acceleration[j]);
     }
 
-    trajectory.addSuffixWayPoint(waypoint, t - last_t);
+    trajectory.addSuffixWayPoint(waypoint, rclcpp::Duration::from_seconds(t - last_t));
     last_t = t;
   }
 

--- a/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/test/test_ruckig_traj_smoothing.cpp
@@ -37,10 +37,11 @@
 #include <moveit/trajectory_processing/ruckig_traj_smoothing.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/utils/robot_model_test_utils.h>
+#include <rclcpp/duration.hpp>
 
 namespace
 {
-constexpr double DEFAULT_TIMESTEP = 0.1;  // sec
+const auto DEFAULT_TIMESTEP = rclcpp::Duration::from_seconds(0.1);
 constexpr char JOINT_GROUP[] = "panda_arm";
 
 class RuckigTests : public testing::Test
@@ -114,7 +115,7 @@ TEST_F(RuckigTests, trajectory_duration)
   // Zero velocities and accelerations at the endpoints
   robot_state.setVariablePosition("panda_joint1", 0.0);
   robot_state.update();
-  trajectory_->addSuffixWayPoint(robot_state, 0.0);
+  trajectory_->addSuffixWayPoint(robot_state, rclcpp::Duration::from_seconds(0.0));
 
   robot_state.setVariablePosition("panda_joint1", 0.1);
   robot_state.update();
@@ -122,8 +123,10 @@ TEST_F(RuckigTests, trajectory_duration)
 
   EXPECT_TRUE(
       smoother_.applySmoothing(*trajectory_, 1.0 /* max vel scaling factor */, 1.0 /* max accel scaling factor */));
-  EXPECT_GT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 0.9999 * ideal_duration);
-  EXPECT_LT(trajectory_->getWayPointDurationFromStart(trajectory_->getWayPointCount() - 1), 1.5 * ideal_duration);
+  EXPECT_GT(trajectory_->getWayPointDurationFromStartAt(trajectory_->getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(0.9999 * ideal_duration));
+  EXPECT_LT(trajectory_->getWayPointDurationFromStartAt(trajectory_->getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(1.5 * ideal_duration));
 }
 
 TEST_F(RuckigTests, single_waypoint)

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -165,7 +165,7 @@ TEST(time_optimal_trajectory_generation, test_custom_limits)
   moveit::core::RobotState waypoint_state(robot_model);
   waypoint_state.setToDefaultValues();
 
-  const double delta_t = 0.1;
+  const auto delta_t = rclcpp::Duration::from_seconds(0.1);
   robot_trajectory::RobotTrajectory trajectory(robot_model, group);
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
   trajectory.addSuffixWayPoint(waypoint_state, delta_t);
@@ -272,7 +272,7 @@ TEST(time_optimal_trajectory_generation, testLastWaypoint)
   robot_trajectory::RobotTrajectory trajectory(robot_model, group);
   auto add_waypoint = [&](const std::vector<double>& waypoint) {
     waypoint_state.setJointGroupPositions(group, waypoint);
-    trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+    trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   };
   add_waypoint({ 0.000000000, 0.000000000 });
   add_waypoint({ 0.000396742, 0.000396742 });
@@ -391,17 +391,17 @@ TEST(time_optimal_trajectory_generation, testPluginAPI)
 
   robot_trajectory::RobotTrajectory trajectory(robot_model, group);
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  trajectory.addSuffixWayPoint(waypoint_state, rclcpp::Duration::from_seconds(0.1));
 
   // Number TOTG iterations
   constexpr size_t totg_iterations = 10;
@@ -412,7 +412,7 @@ TEST(time_optimal_trajectory_generation, testPluginAPI)
     robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
 
     // Test if the trajectory was copied correctly
-    ASSERT_EQ(test_trajectory.getDuration(), trajectory.getDuration());
+    ASSERT_EQ(robot_trajectory::total_duration(test_trajectory), robot_trajectory::total_duration(trajectory));
     moveit::core::JointBoundsVector test_bounds = test_trajectory.getRobotModel()->getActiveJointModelsBounds();
     moveit::core::JointBoundsVector original_bounds = trajectory.getRobotModel()->getActiveJointModelsBounds();
     ASSERT_EQ(test_bounds.size(), original_bounds.size());
@@ -430,7 +430,7 @@ TEST(time_optimal_trajectory_generation, testPluginAPI)
       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).acceleration_bounded_,
                 original_bounds.at(0)->at(bound_idx).acceleration_bounded_);
     }
-    ASSERT_EQ(test_trajectory.getWayPointDurationFromPrevious(1), trajectory.getWayPointDurationFromPrevious(1));
+    ASSERT_EQ(test_trajectory.getWayPointDurationFromPreviousAt(1), trajectory.getWayPointDurationFromPreviousAt(1));
 
     TimeOptimalTrajectoryGeneration totg;
     ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -71,7 +71,7 @@ int initRepeatedPointTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   for (i = 0; i < num; ++i)
   {
     state.setVariablePosition(idx[0], 1.0);
-    trajectory.addSuffixWayPoint(state, 0.0);
+    trajectory.addSuffixWayPoint(state, rclcpp::Duration::from_seconds(0.0));
   }
 
   return 0;
@@ -98,12 +98,12 @@ int initStraightTrajectory(robot_trajectory::RobotTrajectory& trajectory)
   for (i = 0; i < num; ++i)
   {
     state.setVariablePosition(idx[0], i * max / num);
-    trajectory.addSuffixWayPoint(state, 0.0);
+    trajectory.addSuffixWayPoint(state, rclcpp::Duration::from_seconds(0.0));
   }
 
   // leave final velocity/acceleration unset
   state.setVariablePosition(idx[0], max);
-  trajectory.addSuffixWayPoint(state, 0.0);
+  trajectory.addSuffixWayPoint(state, rclcpp::Duration::from_seconds(0.0));
 
   return 0;
 }
@@ -126,7 +126,8 @@ TEST(TestTimeParameterization, TestIterativeParabolic)
   std::cout << "IterativeParabolicTimeParameterization  took " << (std::chrono::system_clock::now() - wt).count()
             << '\n';
   printTrajectory(TRAJECTORY);
-  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 3.0);
+  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStartAt(TRAJECTORY.getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(3.0));
 }
 
 TEST(TestTimeParameterization, TestIterativeSpline)
@@ -138,7 +139,8 @@ TEST(TestTimeParameterization, TestIterativeSpline)
   EXPECT_TRUE(time_parameterization.computeTimeStamps(TRAJECTORY));
   std::cout << "IterativeSplineParameterization took " << (std::chrono::system_clock::now() - wt).count() << '\n';
   printTrajectory(TRAJECTORY);
-  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 5.0);
+  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStartAt(TRAJECTORY.getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(5.0));
 }
 
 TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
@@ -151,7 +153,8 @@ TEST(TestTimeParameterization, TestIterativeSplineAddPoints)
   std::cout << "IterativeSplineParameterization with added points took "
             << (std::chrono::system_clock::now() - wt).count() << '\n';
   printTrajectory(TRAJECTORY);
-  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 5.0);
+  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStartAt(TRAJECTORY.getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(5.0));
 }
 
 TEST(TestTimeParameterization, TestRepeatedPoint)
@@ -161,7 +164,8 @@ TEST(TestTimeParameterization, TestRepeatedPoint)
 
   EXPECT_TRUE(time_parameterization.computeTimeStamps(TRAJECTORY));
   printTrajectory(TRAJECTORY);
-  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStart(TRAJECTORY.getWayPointCount() - 1), 0.001);
+  ASSERT_LT(TRAJECTORY.getWayPointDurationFromStartAt(TRAJECTORY.getWayPointCount() - 1),
+            rclcpp::Duration::from_seconds(0.001));
 }
 
 int main(int argc, char** argv)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -240,7 +240,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
       assert(jm->getVariableCount() == 1);
       state->setVariablePosition(jm->getFirstVariableIndex(), source[joint_index++]);
     }
-    result->addSuffixWayPoint(state, 0.0);
+    result->addSuffixWayPoint(state, rclcpp::Duration::from_seconds(0.0));
   }
 
   res.trajectory_.resize(1);

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -480,7 +480,7 @@ void ompl_interface::ModelBasedPlanningContext::convertPath(const ompl::geometri
   for (std::size_t i = 0; i < pg.getStateCount(); ++i)
   {
     spec_.state_space_->copyToRobotState(ks, pg.getState(i));
-    traj.addSuffixWayPoint(ks, 0.0);
+    traj.addSuffixWayPoint(ks, rclcpp::Duration::from_seconds(0.0));
   }
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -64,7 +64,7 @@ void PlanComponentsBuilder::appendWithStrictTimeIncrease(robot_trajectory::Robot
 
   for (size_t i = 1; i < source.getWayPointCount(); ++i)
   {
-    result.addSuffixWayPoint(source.getWayPoint(i), source.getWayPointDurationFromPrevious(i));
+    result.addSuffixWayPoint(source.getWayPoint(i), source.getWayPointDurationFromPreviousAt(i));
   }
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -39,6 +39,7 @@
 #include <math.h>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <moveit/planning_interface/planning_interface.h>
+#include <rclcpp/duration.hpp>
 
 namespace
 {
@@ -119,7 +120,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
   for (size_t i = 0; i < first_intersection_index; ++i)
   {
     res.first_trajectory->insertWayPoint(i, req.first_trajectory->getWayPoint(i),
-                                         req.first_trajectory->getWayPointDurationFromPrevious(i));
+                                         req.first_trajectory->getWayPointDurationFromPreviousAt(i));
   }
 
   // append the blend trajectory
@@ -128,11 +129,11 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
   for (size_t i = second_intersection_index + 1; i < req.second_trajectory->getWayPointCount(); ++i)
   {
     res.second_trajectory->insertWayPoint(i - (second_intersection_index + 1), req.second_trajectory->getWayPoint(i),
-                                          req.second_trajectory->getWayPointDurationFromPrevious(i));
+                                          req.second_trajectory->getWayPointDurationFromPreviousAt(i));
   }
 
   // adjust the time from start
-  res.second_trajectory->setWayPointDurationFromPrevious(0, sampling_time);
+  res.second_trajectory->setWayPointDurationFromPrevious(0, rclcpp::Duration::from_seconds(sampling_time));
 
   res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   return true;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -434,18 +434,18 @@ bool pilz_industrial_motion_planner::determineAndCheckSamplingTime(
 
   if (n1 >= 2)
   {
-    sampling_time = first_trajectory->getWayPointDurationFromPrevious(1);
+    sampling_time = first_trajectory->getWayPointDurationFromPreviousAt(1).seconds();
   }
   else
   {
-    sampling_time = second_trajectory->getWayPointDurationFromPrevious(1);
+    sampling_time = second_trajectory->getWayPointDurationFromPreviousAt(1).seconds();
   }
 
   for (std::size_t i = 1; i < std::max(n1, n2); ++i)
   {
     if (i < n1)
     {
-      if (fabs(sampling_time - first_trajectory->getWayPointDurationFromPrevious(i)) > epsilon)
+      if (fabs(sampling_time - first_trajectory->getWayPointDurationFromPreviousAt(i).seconds()) > epsilon)
       {
         RCLCPP_ERROR_STREAM(LOGGER, "First trajectory violates sampline time " << sampling_time << " between points "
                                                                                << (i - 1) << "and " << i
@@ -456,7 +456,7 @@ bool pilz_industrial_motion_planner::determineAndCheckSamplingTime(
 
     if (i < n2)
     {
-      if (fabs(sampling_time - second_trajectory->getWayPointDurationFromPrevious(i)) > epsilon)
+      if (fabs(sampling_time - second_trajectory->getWayPointDurationFromPreviousAt(i).seconds()) > epsilon)
       {
         RCLCPP_ERROR_STREAM(LOGGER, "Second trajectory violates sampline time " << sampling_time << " between points "
                                                                                 << (i - 1) << "and " << i

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
@@ -230,7 +230,8 @@ inline int getWayPointIndex(const robot_trajectory::RobotTrajectoryPtr& trajecto
 {
   int index_before, index_after;
   double blend;
-  trajectory->findWayPointIndicesForDurationAfterStart(time_from_start, index_before, index_after, blend);
+  trajectory->findWayPointIndicesForDurationAfterStart(rclcpp::Duration::from_seconds(time_from_start), index_before,
+                                                       index_after, blend);
   return blend > 0.5 ? index_after : index_before;
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_blender_transition_window.cpp
@@ -357,7 +357,7 @@ TEST_F(TrajectoryBlenderTransitionWindowTest, testNonUniformSamplingTime)
 
   // Modify first time interval
   EXPECT_GT(res[0].trajectory_->getWayPointCount(), 2u);
-  res[0].trajectory_->setWayPointDurationFromPrevious(1, 2 * sampling_time_);
+  res[0].trajectory_->setWayPointDurationFromPrevious(1, rclcpp::Duration::from_seconds(2 * sampling_time_));
 
   pilz_industrial_motion_planner::TrajectoryBlendRequest blend_req;
   pilz_industrial_motion_planner::TrajectoryBlendResponse blend_res;
@@ -632,15 +632,16 @@ TEST_F(TrajectoryBlenderTransitionWindowTest, testNonLinearBlending)
 
     CartesianTrajectory cart_traj;
     trajectory_msgs::msg::JointTrajectory joint_traj;
-    const double duration{ lin_traj->getWayPointDurationFromStart(lin_traj->getWayPointCount()) };
+    const double duration{ lin_traj->getWayPointDurationFromStartAt(lin_traj->getWayPointCount()).seconds() };
     // time from start zero does not work
-    const double time_from_start_offset{ time_scaling_factor * lin_traj->getWayPointDurations().back() };
+    const double time_from_start_offset{ time_scaling_factor *
+                                         lin_traj->getDurationFromPreviousDeque().back().seconds() };
 
     // generate modified cartesian trajectory
     for (size_t i = 0; i < lin_traj->getWayPointCount(); ++i)
     {
       // transform time to interval [0, 4*pi]
-      const double sine_arg{ 4 * M_PI * lin_traj->getWayPointDurationFromStart(i) / duration };
+      const double sine_arg{ 4 * M_PI * lin_traj->getWayPointDurationFromStartAt(i).seconds() / duration };
 
       // get pose
       CartesianTrajectoryPoint waypoint;
@@ -655,7 +656,7 @@ TEST_F(TrajectoryBlenderTransitionWindowTest, testNonLinearBlending)
       // add to trajectory
       waypoint.pose = waypoint_pose;
       waypoint.time_from_start = rclcpp::Duration::from_seconds(
-          time_from_start_offset + time_scaling_factor * lin_traj->getWayPointDurationFromStart(i));
+          time_from_start_offset + time_scaling_factor * lin_traj->getWayPointDurationFromStartAt(i).seconds());
       cart_traj.points.push_back(waypoint);
     }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -738,8 +738,8 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
   double sampling_time{ 0.0 };
 
   moveit::core::RobotState rstate(robot_model_);
-  first_trajectory->insertWayPoint(0, rstate, 0.1);
-  second_trajectory->insertWayPoint(0, rstate, 0.1);
+  first_trajectory->insertWayPoint(0, rstate, rclcpp::Duration::from_seconds(0.1));
+  second_trajectory->insertWayPoint(0, rstate, rclcpp::Duration::from_seconds(0.1));
 
   EXPECT_FALSE(pilz_industrial_motion_planner::determineAndCheckSamplingTime(first_trajectory, second_trajectory,
                                                                              epsilon, sampling_time));
@@ -764,7 +764,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
       std::make_shared<robot_trajectory::RobotTrajectory>(robot_model_, planning_group_);
   double epsilon{ 0.0001 };
   double sampling_time{ 0.0 };
-  double expected_sampling_time{ 0.1 };
+  auto const expected_sampling_time = rclcpp::Duration::from_seconds(0.1);
 
   moveit::core::RobotState rstate(robot_model_);
   first_trajectory->insertWayPoint(0, rstate, expected_sampling_time);
@@ -776,7 +776,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
 
   EXPECT_TRUE(pilz_industrial_motion_planner::determineAndCheckSamplingTime(first_trajectory, second_trajectory,
                                                                             epsilon, sampling_time));
-  EXPECT_EQ(expected_sampling_time, sampling_time);
+  EXPECT_EQ(expected_sampling_time.seconds(), sampling_time);
 }
 
 /**
@@ -798,14 +798,14 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
       std::make_shared<robot_trajectory::RobotTrajectory>(robot_model_, planning_group_);
   double epsilon{ 0.0001 };
   double sampling_time{ 0.0 };
-  double expected_sampling_time{ 0.1 };
+  auto const expected_sampling_time = rclcpp::Duration::from_seconds(0.1);
 
   moveit::core::RobotState rstate(robot_model_);
   first_trajectory->insertWayPoint(0, rstate, expected_sampling_time);
   first_trajectory->insertWayPoint(1, rstate, expected_sampling_time);
   first_trajectory->insertWayPoint(2, rstate, expected_sampling_time);
   // Violate sampling time
-  first_trajectory->insertWayPoint(2, rstate, expected_sampling_time + 1.0);
+  first_trajectory->insertWayPoint(2, rstate, expected_sampling_time + rclcpp::Duration::from_seconds(1.0));
   first_trajectory->insertWayPoint(3, rstate, expected_sampling_time);
 
   second_trajectory->insertWayPoint(0, rstate, expected_sampling_time);
@@ -815,7 +815,7 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
 
   EXPECT_FALSE(pilz_industrial_motion_planner::determineAndCheckSamplingTime(first_trajectory, second_trajectory,
                                                                              epsilon, sampling_time));
-  EXPECT_EQ(expected_sampling_time, sampling_time);
+  EXPECT_EQ(expected_sampling_time.seconds(), sampling_time);
 }
 
 /**

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
@@ -196,7 +196,7 @@ TEST_F(TrajectoryGeneratorPTPTest, emptyRequest)
   robot_trajectory::RobotTrajectoryPtr trajectory(
       new robot_trajectory::RobotTrajectory(this->robot_model_, planning_group_));
   moveit::core::RobotState state(this->robot_model_);
-  trajectory->addPrefixWayPoint(state, 0);
+  trajectory->addPrefixWayPoint(state, rclcpp::Duration::from_seconds(0));
   res.trajectory_ = trajectory;
 
   EXPECT_FALSE(res.trajectory_->empty());
@@ -554,7 +554,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testScalingFactor)
   EXPECT_TRUE(checkTrajectory(res_msg.trajectory.joint_trajectory, req, planner_limits_.getJointLimitContainer()));
 
   // trajectory duration
-  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStart(res.trajectory_->getWayPointCount()),
+  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStartAt(res.trajectory_->getWayPointCount()).seconds(),
               joint_acceleration_tolerance_);
 
   // way point at 1s
@@ -681,7 +681,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testJointGoalAndAlmostZeroStartVelocity)
   EXPECT_TRUE(checkTrajectory(res_msg.trajectory.joint_trajectory, req, planner_limits_.getJointLimitContainer()));
 
   // trajectory duration
-  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStart(res.trajectory_->getWayPointCount()),
+  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStartAt(res.trajectory_->getWayPointCount()).seconds(),
               joint_acceleration_tolerance_);
 
   // way point at 1s
@@ -823,7 +823,7 @@ TEST_F(TrajectoryGeneratorPTPTest, testJointGoalNoStartVel)
   EXPECT_TRUE(checkTrajectory(res_msg.trajectory.joint_trajectory, req, planner_limits_.getJointLimitContainer()));
 
   // trajectory duration
-  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStart(res.trajectory_->getWayPointCount()),
+  EXPECT_NEAR(4.5, res.trajectory_->getWayPointDurationFromStartAt(res.trajectory_->getWayPointCount()).seconds(),
               joint_position_tolerance_);
 
   // way point at 0s

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -88,7 +88,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
   // If this flag is set, ignore collisions
   if (!stop_before_collision_)
   {
-    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), 0.0);
+    robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), rclcpp::Duration::from_seconds(0.0));
   }
   else
   {
@@ -112,7 +112,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         path_invalidation_event_send_ = false;  // Reset flag
       }
       // Forward next waypoint to the robot controller
-      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), 0.0);
+      robot_command.addSuffixWayPoint(local_trajectory.getWayPoint(0), rclcpp::Duration::from_seconds(0.0));
     }
     else
     {
@@ -133,7 +133,7 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
         current_state_command.zeroAccelerations();
       }
       robot_command.empty();
-      robot_command.addSuffixWayPoint(*current_state, local_trajectory.getWayPointDurationFromPrevious(0));
+      robot_command.addSuffixWayPoint(*current_state, local_trajectory.getWayPointDurationFromPreviousAt(0));
     }
 
     // Detect if the local solver is stuck

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/src/simple_sampler.cpp
@@ -101,7 +101,7 @@ SimpleSampler::getLocalTrajectory(const moveit::core::RobotState& current_state,
 
   // Construct local trajectory containing the next global trajectory waypoint
   local_trajectory.addSuffixWayPoint(reference_trajectory_->getWayPoint(next_waypoint_index_),
-                                     reference_trajectory_->getWayPointDurationFromPrevious(next_waypoint_index_));
+                                     reference_trajectory_->getWayPointDurationFromPreviousAt(next_waypoint_index_));
 
   // Return empty feedback
   return feedback_;

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -171,7 +171,7 @@ bool MoveGroupCartesianPathService::computeService(const std::shared_ptr<rmw_req
 
           robot_trajectory::RobotTrajectory rt(context_->planning_scene_monitor_->getRobotModel(), req->group_name);
           for (const moveit::core::RobotStatePtr& traj_state : traj)
-            rt.addSuffixWayPoint(traj_state, 0.0);
+            rt.addSuffixWayPoint(traj_state, rclcpp::Duration::from_seconds(0.0));
 
           // time trajectory
           // \todo optionally compute timing to move the eef with constant speed

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -181,9 +181,10 @@ public:
     {
       // heuristically decide a duration offset for the trajectory (induced by the additional point added as a prefix to
       // the computed trajectory)
-      res.trajectory_->setWayPointDurationFromPrevious(0, std::min(max_dt_offset_,
-                                                                   res.trajectory_->getAverageSegmentDuration()));
-      res.trajectory_->addPrefixWayPoint(prefix_state, 0.0);
+      auto const avg_duration = robot_trajectory::average_segment_duration(*res.trajectory_).seconds();
+      auto const waypoint_duration = rclcpp::Duration::from_seconds(std::min(max_dt_offset_, avg_duration));
+      res.trajectory_->setWayPointDurationFromPrevious(0, waypoint_duration);
+      res.trajectory_->addPrefixWayPoint(prefix_state, rclcpp::Duration::from_seconds(0.0));
       // we add a prefix point, so we need to bump any previously added index positions
       for (std::size_t& added_index : added_path_index)
         added_index++;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -137,9 +137,10 @@ public:
         {
           // heuristically decide a duration offset for the trajectory (induced by the additional point added as a
           // prefix to the computed trajectory)
-          res.trajectory_->setWayPointDurationFromPrevious(0, std::min(max_dt_offset_,
-                                                                       res.trajectory_->getAverageSegmentDuration()));
-          res.trajectory_->addPrefixWayPoint(prefix_state, 0.0);
+          auto const avg_duration = robot_trajectory::average_segment_duration(*res.trajectory_).seconds();
+          auto const waypoint_duration = rclcpp::Duration::from_seconds(std::min(max_dt_offset_, avg_duration));
+          res.trajectory_->setWayPointDurationFromPrevious(0, waypoint_duration);
+          res.trajectory_->addPrefixWayPoint(prefix_state, rclcpp::Duration::from_seconds(0.0));
           // we add a prefix point, so we need to bump any previously added index positions
           for (std::size_t& added_index : added_path_index)
             added_index++;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -114,7 +114,7 @@ public:
             added_path_index.push_back(i);
 
           // we need to append the solution paths.
-          res2.trajectory_->append(*res.trajectory_, 0.0);
+          res2.trajectory_->append(*res.trajectory_, rclcpp::Duration::from_seconds(0.0));
           res2.trajectory_->swap(*res.trajectory_);
           return true;
         }

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -125,13 +125,13 @@ void planning_scene_monitor::TrajectoryMonitor::recordStates()
     std::pair<moveit::core::RobotStatePtr, rclcpp::Time> state = current_state_monitor_->getCurrentStateAndTime();
     if (trajectory_.empty())
     {
-      trajectory_.addSuffixWayPoint(state.first, 0.0);
+      trajectory_.addSuffixWayPoint(state.first, rclcpp::Duration::from_seconds(0.0));
       trajectory_start_time_ = state.second;
       last_recorded_state_time_ = state.second;
     }
     else
     {
-      trajectory_.addSuffixWayPoint(state.first, (state.second - last_recorded_state_time_).seconds());
+      trajectory_.addSuffixWayPoint(state.first, state.second - last_recorded_state_time_);
       last_recorded_state_time_ = state.second;
     }
     if (state_add_callback_)


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <maybe@tylerjw.dev>

### Description

Use the strong type `rclcpp::Duration` in `RobotTrajectory` and opportunistically convert member functions to free functions.
