### PR TITLE
MSA: write the default controller namespace

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -190,12 +190,7 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
           if (controller.type_ == "FollowJointTrajectory")
           {
             emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
-          }
-          else
-          {
-            RCLCPP_ERROR_STREAM(*logger_, "Only a FollowJointTrajectory type of controller is supported, for now. "
-                                          "Update moveit_controllers.yaml.");
-            return false;
+            emitter << YAML::Key << "default" << YAML::Value << "true";
           }
 
           // Write joints

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -187,6 +187,7 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
         emitter << YAML::BeginMap;
         {
           emitter << YAML::Key << "type" << YAML::Value << controller.type_;
+          emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
           // Write joints
           emitter << YAML::Key << "joints";
           emitter << YAML::Value;

--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -187,7 +187,17 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
         emitter << YAML::BeginMap;
         {
           emitter << YAML::Key << "type" << YAML::Value << controller.type_;
-          emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
+          if (controller.type_ == "FollowJointTrajectory")
+          {
+            emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
+          }
+          else
+          {
+            RCLCPP_ERROR_STREAM(*logger_, "Only a FollowJointTrajectory type of controller is supported, for now. "
+                                          "Update moveit_controllers.yaml.");
+            return false;
+          }
+
           // Write joints
           emitter << YAML::Key << "joints";
           emitter << YAML::Value;


### PR DESCRIPTION
### Description

MoveIt Setup Assistant should write the controller namespace to the yaml file, like this:

```
  arm_controller:
    type: FollowJointTrajectory
    action_ns: follow_joint_trajectory
    joints:
      - J1
...
      - J6
```

Fixes #1514 