### PR TITLE
Add planner configurations to CHOMP and PILZ

### DIFF
--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -194,7 +194,7 @@ public:
   virtual bool canServiceRequest(const MotionPlanRequest& req) const = 0;
 
   /// \brief Specify the settings to be used for specific algorithms
-  virtual void setPlannerConfigurations(const PlannerConfigurationMap& pcs);
+  virtual void setPlannerConfigurations(const PlannerConfigurationMap& pcs) = 0;
 
   /// \brief Get the settings for a specific algorithm
   const PlannerConfigurationMap& getPlannerConfigurations() const

--- a/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_plugin.cpp
@@ -55,10 +55,17 @@ public:
   bool initialize(const moveit::core::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
                   const std::string& /* unused */) override
   {
+    planning_interface::PlannerConfigurationMap pconfig;
     for (const std::string& group : model->getJointModelGroupNames())
     {
       planning_contexts_[group] = std::make_shared<CHOMPPlanningContext>("chomp_planning_context", group, model, node);
+      const planning_interface::PlannerConfigurationSettings planner_config_settings{
+        group, group, std::map<std::string, std::string>()
+      };
+      pconfig[planner_config_settings.name] = planner_config_settings;
     }
+
+    setPlannerConfigurations(pconfig);
     return true;
   }
 
@@ -111,6 +118,11 @@ public:
   {
     algs.resize(1);
     algs[0] = "CHOMP";
+  }
+
+  void setPlannerConfigurations(const planning_interface::PlannerConfigurationMap& pcs) override
+  {
+    config_settings_ = pcs;
   }
 
 protected:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -115,6 +115,12 @@ public:
    */
   void registerContextLoader(const pilz_industrial_motion_planner::PlanningContextLoaderPtr& planning_context_loader);
 
+  /**
+   * @brief Specify the settings to be used for an algorithms
+   * @param pcs Map of planner configurations
+   */
+  void setPlannerConfigurations(const planning_interface::PlannerConfigurationMap& pcs) override;
+
 private:
   /// Plugin loader
   std::unique_ptr<pluginlib::ClassLoader<PlanningContextLoader>> planner_context_loader;

--- a/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
@@ -102,6 +102,19 @@ bool CommandPlanner::initialize(const moveit::core::RobotModelConstPtr& model, c
     registerContextLoader(loader_pointer);
   }
 
+  // Specify for which joint model groups this planner is usable
+  planning_interface::PlannerConfigurationMap pconfig;
+
+  for (const auto& group : model_->getJointModelGroupNames())
+  {
+    const planning_interface::PlannerConfigurationSettings planner_config_settings{
+      group, group, std::map<std::string, std::string>()
+    };
+    pconfig[planner_config_settings.name] = planner_config_settings;
+  }
+
+  setPlannerConfigurations(pconfig);
+
   return true;
 }
 
@@ -172,6 +185,11 @@ void CommandPlanner::registerContextLoader(
     throw ContextLoaderRegistrationException("The command [" + planning_context_loader->getAlgorithm() +
                                              "] is already registered");
   }
+}
+
+void CommandPlanner::setPlannerConfigurations(const planning_interface::PlannerConfigurationMap& pcs)
+{
+  config_settings_ = pcs;
 }
 
 }  // namespace pilz_industrial_motion_planner


### PR DESCRIPTION
### Description

Right now it is not possible to use planners other than OMPL with the moveit_cpp interface. The reason for this is the following:

When the plan() method of the planning component gets called, all available planning pipelines are searched based on their name [[1]](https://github.com/ros-planning/moveit2/blob/e89526de24d88fb05eb646a7925de69ba480bfe8/moveit_ros/planning/moveit_cpp/src/planning_component.cpp#L163). These names are provided by moveit_cpp [[2]](https://github.com/ros-planning/moveit2/blob/e89526de24d88fb05eb646a7925de69ba480bfe8/moveit_ros/planning/moveit_cpp/src/planning_component.cpp#L81). The moveit_cpp function that provides the planning pipeline names reads them from an internal map [[3]](https://github.com/ros-planning/moveit2/blob/e89526de24d88fb05eb646a7925de69ba480bfe8/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp#L216). A planning pipelines needs to have a planner plugin that has a PlannerConfiguration in order to be added to this map [[4]](https://github.com/ros-planning/moveit2/blob/e89526de24d88fb05eb646a7925de69ba480bfe8/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp#L167). This PR adds the missing configuations to CHOMP and PILZ to make them usable in moveit_cpp and in addition to that it makes the PlannerManager's `setPlannerConfigurations` function pure virtual to remind futur planning plugin implementations  to add a planner configuation
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
