### PR TITLE
Add error_code_to_string function

### DIFF
--- a/moveit_core/utils/include/moveit/utils/moveit_error_code.h
+++ b/moveit_core/utils/include/moveit/utils/moveit_error_code.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <moveit_msgs/msg/move_it_error_codes.h>
+#include <string>
 
 namespace moveit
 {
@@ -71,6 +72,68 @@ public:
     return val != c;
   }
 };
+
+/**
+ * @brief Convenience function to translated error message into string
+   @param error_code Error code to be translated to a string
+   @return Error code string
+ */
+inline std::string error_code_to_string(MoveItErrorCode error_code)
+{
+  switch (error_code.val)
+  {
+    case moveit::core::MoveItErrorCode::SUCCESS:
+      return std::string("SUCCESS");
+    case moveit::core::MoveItErrorCode::FAILURE:
+      return std::string("FAILURE");
+    case moveit::core::MoveItErrorCode::PLANNING_FAILED:
+      return std::string("PLANNING_FAILED");
+    case moveit::core::MoveItErrorCode::INVALID_MOTION_PLAN:
+      return std::string("INVALID_MOTION_PLAN");
+    case moveit::core::MoveItErrorCode::MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE:
+      return std::string("MOTION_PLAN_INVALIDATED_BY_ENVIRONMENT_CHANGE");
+    case moveit::core::MoveItErrorCode::CONTROL_FAILED:
+      return std::string("CONTROL_FAILED");
+    case moveit::core::MoveItErrorCode::UNABLE_TO_AQUIRE_SENSOR_DATA:
+      return std::string("UNABLE_TO_AQUIRE_SENSOR_DATA");
+    case moveit::core::MoveItErrorCode::TIMED_OUT:
+      return std::string("TIMED_OUT");
+    case moveit::core::MoveItErrorCode::PREEMPTED:
+      return std::string("PREEMPTED");
+    case moveit::core::MoveItErrorCode::START_STATE_IN_COLLISION:
+      return std::string("START_STATE_IN_COLLISION");
+    case moveit::core::MoveItErrorCode::START_STATE_VIOLATES_PATH_CONSTRAINTS:
+      return std::string("START_STATE_VIOLATES_PATH_CONSTRAINTS");
+    case moveit::core::MoveItErrorCode::GOAL_IN_COLLISION:
+      return std::string("GOAL_IN_COLLISION");
+    case moveit::core::MoveItErrorCode::GOAL_VIOLATES_PATH_CONSTRAINTS:
+      return std::string("GOAL_VIOLATES_PATH_CONSTRAINTS");
+    case moveit::core::MoveItErrorCode::GOAL_CONSTRAINTS_VIOLATED:
+      return std::string("GOAL_CONSTRAINTS_VIOLATED");
+    case moveit::core::MoveItErrorCode::INVALID_GROUP_NAME:
+      return std::string("INVALID_GROUP_NAME");
+    case moveit::core::MoveItErrorCode::INVALID_GOAL_CONSTRAINTS:
+      return std::string("INVALID_GOAL_CONSTRAINTS");
+    case moveit::core::MoveItErrorCode::INVALID_ROBOT_STATE:
+      return std::string("INVALID_ROBOT_STATE");
+    case moveit::core::MoveItErrorCode::INVALID_LINK_NAME:
+      return std::string("INVALID_LINK_NAME");
+    case moveit::core::MoveItErrorCode::INVALID_OBJECT_NAME:
+      return std::string("INVALID_OBJECT_NAME");
+    case moveit::core::MoveItErrorCode::FRAME_TRANSFORM_FAILURE:
+      return std::string("FRAME_TRANSFORM_FAILURE");
+    case moveit::core::MoveItErrorCode::COLLISION_CHECKING_UNAVAILABLE:
+      return std::string("COLLISION_CHECKING_UNAVAILABLE");
+    case moveit::core::MoveItErrorCode::ROBOT_STATE_STALE:
+      return std::string("ROBOT_STATE_STALE");
+    case moveit::core::MoveItErrorCode::SENSOR_INFO_STALE:
+      return std::string("SENSOR_INFO_STALE");
+    case moveit::core::MoveItErrorCode::COMMUNICATION_FAILURE:
+      return std::string("COMMUNICATION_FAILURE");
+    case moveit::core::MoveItErrorCode::NO_IK_SOLUTION:
+      return std::string("NO_IK_SOLUTION");
+  }
+}
 
 }  // namespace core
 }  // namespace moveit


### PR DESCRIPTION
### Description

Adds convenience function to print a MoveItError code

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
