### PR TITLE
Use pragma once as header include guard

### DIFF
--- a/moveit_core/version/version.h.in
+++ b/moveit_core/version/version.h.in
@@ -32,8 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef MOVEIT_VERSION_
-#define MOVEIT_VERSION_
+#pragma once
 
 #define MOVEIT_VERSION_STR "@MOVEIT_VERSION@"
 
@@ -47,5 +46,3 @@
 
 /// Use like: #if MOVEIT_VERSION >= MOVEIT_VERSION_CHECK(1, 0, 0)
 #define MOVEIT_VERSION_CHECK(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
-
-#endif

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast.h
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast.h
@@ -39,8 +39,7 @@
 #include <list>
 #include <stdexcept>
 
-#ifndef IKFAST_HEADER_COMMON
-#define IKFAST_HEADER_COMMON
+#pragma once
 
 /// should be the same as ikfast.__version__
 #define IKFAST_VERSION 61
@@ -308,8 +307,6 @@ protected:
   std::list<IkSolution<T> > _listsolutions;
 };
 }  // namespace ikfast
-
-#endif  // OPENRAVE_IKFAST_HEADER
 
 // The following code is dependent on the C++ library linking with.
 #ifdef IKFAST_HAS_LIBRARY

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits.hpp
@@ -14,8 +14,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS__JOINT_LIMITS_HPP_
-#define JOINT_LIMITS__JOINT_LIMITS_HPP_
+#pragma once
 
 // TODO(henning): This file is copied from the DRAFT PR https://github.com/ros-controls/ros2_control/pull/462 since the
 // current ros2_control implementation does not offer the desired joint limits API, yet. Remove when ros2_control has an
@@ -130,5 +129,3 @@ struct SoftJointLimits
 };
 
 }  // namespace joint_limits
-
-#endif  // JOINT_LIMITS__JOINT_LIMITS_HPP_

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
@@ -14,8 +14,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS__JOINT_LIMITS_ROSPARAM_HPP_
-#define JOINT_LIMITS__JOINT_LIMITS_ROSPARAM_HPP_
+#pragma once
 
 // TODO(henning): This file is copied from the DRAFT PR https://github.com/ros-controls/ros2_control/pull/462 since the
 // current ros2_control implementation does not offer the desired joint limits API, yet. Remove when ros2_control has an
@@ -301,5 +300,3 @@ inline bool get_joint_limits(const std::string& joint_name, const rclcpp::Node::
 }
 
 }  // namespace joint_limits
-
-#endif  // JOINT_LIMITS__JOINT_LIMITS_ROSPARAM_HPP_

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/include/ikfast.h
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/include/ikfast.h
@@ -36,8 +36,7 @@
 #include <list>
 #include <stdexcept>
 
-#ifndef IKFAST_HEADER_COMMON
-#define IKFAST_HEADER_COMMON
+#pragma once
 
 /// should be the same as ikfast.__version__
 #define IKFAST_VERSION 61
@@ -305,8 +304,6 @@ protected:
   std::list<IkSolution<T> > _listsolutions;
 };
 }
-
-#endif  // OPENRAVE_IKFAST_HEADER
 
 // The following code is dependent on the C++ library linking with.
 #ifdef IKFAST_HAS_LIBRARY

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/ogre_helpers/mesh_shape.hpp
@@ -27,8 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OGRE_TOOLS_MESH_SHAPE_H
-#define OGRE_TOOLS_MESH_SHAPE_H
+#pragma once
 
 #include <rviz_rendering/objects/shape.hpp>
 
@@ -137,5 +136,3 @@ private:
 };
 
 }  // namespace rviz_rendering
-
-#endif


### PR DESCRIPTION
### Description

The changes replace ifndef header include guards with pragma once.
See #882 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
