### PR TITLE
PR about potential missing *2 in FloatingjointModel::distanceRotation

### DIFF
--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -126,7 +126,7 @@ double FloatingJointModel::distanceRotation(const double* values1, const double*
   if (dq + std::numeric_limits<double>::epsilon() >= 1.0)
     return 0.0;
   else
-    return acos(dq);
+    return 2.0 * acos(dq);
 }
 
 void FloatingJointModel::interpolate(const double* from, const double* to, const double t, double* state) const

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -172,51 +172,49 @@ TEST(FloatingJointTest, interpolation_test)
   }
 }
 
-TEST(FloatingJointTest, distance_rotation_test) {
+TEST(FloatingJointTest, distance_rotation_test)
+{
+  // Create a simple floating joint model with some dummy parameters (these are not used by the test)
+  moveit::core::FloatingJointModel fjm("joint", 0, 0);
 
-    // Create a simple floating joint model with some dummy parameters (these are not used by the test)
-    moveit::core::FloatingJointModel fjm("joint", 0, 0);
+  // We set some bounds where the joint position's translation component is bounded between -1 and 1 in all
+  // dimensions. This is necessary, otherwise we just get (0,0,0) translations.
+  moveit::core::JointModel::Bounds bounds;
+  bounds = fjm.getVariableBounds();
+  bounds[0].min_position_ = -1.0;
+  bounds[0].max_position_ = 1.0;
+  bounds[1].min_position_ = -1.0;
+  bounds[1].max_position_ = 1.0;
+  bounds[2].min_position_ = -1.0;
+  bounds[2].max_position_ = 1.0;
 
-    // We set some bounds where the joint position's translation component is bounded between -1 and 1 in all
-    // dimensions. This is necessary, otherwise we just get (0,0,0) translations.
-    moveit::core::JointModel::Bounds bounds;
-    bounds = fjm.getVariableBounds();
-    bounds[0].min_position_ = -1.0;
-    bounds[0].max_position_ = 1.0;
-    bounds[1].min_position_ = -1.0;
-    bounds[1].max_position_ = 1.0;
-    bounds[2].min_position_ = -1.0;
-    bounds[2].max_position_ = 1.0;
+  double jv1[7];
+  double jv2[7];
 
-    double jv1[7];
-    double jv2[7];
-    
-    random_numbers::RandomNumberGenerator rng;
+  random_numbers::RandomNumberGenerator rng;
 
-    for (size_t i = 0; i < 1000; ++i)
-    {
-        // Randomize the joint settings.
-        fjm.getVariableRandomPositions(rng, jv1, bounds);
-        
-        Eigen::Isometry3d tf1;
-        fjm.computeTransform(jv1, tf1);
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    // Randomize the joint settings.
+    fjm.getVariableRandomPositions(rng, jv1, bounds);
 
-        double angle = rng.uniformReal(-M_PI, M_PI);
-        Eigen::AngleAxisd random_rotation(angle, Eigen::Vector3d::Random().normalized());
+    Eigen::Isometry3d tf1;
+    fjm.computeTransform(jv1, tf1);
 
-        Eigen::Quaterniond q2(tf1.rotation() * random_rotation);
-        jv2[3] = q2.x();
-        jv2[4] = q2.y();
-        jv2[5] = q2.z();
-        jv2[6] = q2.w();
-        
-        // Get the distances between the two joint configurations
-        double d1 = fjm.distanceRotation(jv1, jv2);
+    double angle = rng.uniformReal(-M_PI, M_PI);
+    Eigen::AngleAxisd random_rotation(angle, Eigen::Vector3d::Random().normalized());
 
-        EXPECT_NEAR(abs(angle), d1, 1e-6);
+    Eigen::Quaterniond q2(tf1.rotation() * random_rotation);
+    jv2[3] = q2.x();
+    jv2[4] = q2.y();
+    jv2[5] = q2.z();
+    jv2[6] = q2.w();
 
-    }
-    
+    // Get the distances between the two joint configurations
+    double d1 = fjm.distanceRotation(jv1, jv2);
+
+    EXPECT_NEAR(abs(angle), d1, 1e-6);
+  }
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -172,6 +172,53 @@ TEST(FloatingJointTest, interpolation_test)
   }
 }
 
+TEST(FloatingJointTest, distance_rotation_test) {
+
+    // Create a simple floating joint model with some dummy parameters (these are not used by the test)
+    moveit::core::FloatingJointModel fjm("joint", 0, 0);
+
+    // We set some bounds where the joint position's translation component is bounded between -1 and 1 in all
+    // dimensions. This is necessary, otherwise we just get (0,0,0) translations.
+    moveit::core::JointModel::Bounds bounds;
+    bounds = fjm.getVariableBounds();
+    bounds[0].min_position_ = -1.0;
+    bounds[0].max_position_ = 1.0;
+    bounds[1].min_position_ = -1.0;
+    bounds[1].max_position_ = 1.0;
+    bounds[2].min_position_ = -1.0;
+    bounds[2].max_position_ = 1.0;
+
+    double jv1[7];
+    double jv2[7];
+    
+    random_numbers::RandomNumberGenerator rng;
+
+    for (size_t i = 0; i < 1000; ++i)
+    {
+        // Randomize the joint settings.
+        fjm.getVariableRandomPositions(rng, jv1, bounds);
+        
+        Eigen::Isometry3d tf1;
+        fjm.computeTransform(jv1, tf1);
+
+        double angle = rng.uniformReal(-M_PI, M_PI);
+        Eigen::AngleAxisd random_rotation(angle, Eigen::Vector3d::Random().normalized());
+
+        Eigen::Quaterniond q2(tf1.rotation() * random_rotation);
+        jv2[3] = q2.x();
+        jv2[4] = q2.y();
+        jv2[5] = q2.z();
+        jv2[6] = q2.w();
+        
+        // Get the distances between the two joint configurations
+        double d1 = fjm.distanceRotation(jv1, jv2);
+
+        EXPECT_NEAR(abs(angle), d1, 1e-6);
+
+    }
+    
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description
See Issue [#1528](https://github.com/ros-planning/moveit2/issues/1528)

I have only added a failing test case corresponding to the issue and created this PR to add any possible fixes, do not merge yet.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
