### PR TITLE
Disable flaky test_servo_singularity + test_rdf_integration

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -209,14 +209,15 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_servo_collision ${THIS_PACKAGE_INCLUDE_DEPENDS})
   add_ros_test(test/launch/test_servo_collision.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
+  # TODO(sjahr): Debug and re-enable this test
   # Servo singularity checking integration test
-  ament_add_gtest_executable(test_servo_singularity
-        test/test_servo_singularity.cpp
-        test/servo_launch_test_common.hpp
-  )
-  target_link_libraries(test_servo_singularity ${SERVO_PARAM_LIB_NAME})
-  ament_target_dependencies(test_servo_singularity ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  add_ros_test(test/launch/test_servo_singularity.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  #ament_add_gtest_executable(test_servo_singularity
+  #      test/test_servo_singularity.cpp
+  #      test/servo_launch_test_common.hpp
+  #)
+  #target_link_libraries(test_servo_singularity ${SERVO_PARAM_LIB_NAME})
+  #ament_target_dependencies(test_servo_singularity ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  #add_ros_test(test/launch/test_servo_singularity.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
   # pose_tracking
   ament_add_gtest_executable(test_servo_pose_tracking

--- a/moveit_ros/planning/rdf_loader/CMakeLists.txt
+++ b/moveit_ros/planning/rdf_loader/CMakeLists.txt
@@ -16,6 +16,7 @@ install(DIRECTORY
         DESTINATION share/${PROJECT_NAME}/rdf_loader/test
 )
 
+# TODO(sjahr) Debug and re-enable
 #if(BUILD_TESTING)
 #  find_package(ament_cmake_gtest REQUIRED)
 #  find_package(ros_testing REQUIRED)

--- a/moveit_ros/planning/rdf_loader/CMakeLists.txt
+++ b/moveit_ros/planning/rdf_loader/CMakeLists.txt
@@ -16,24 +16,24 @@ install(DIRECTORY
         DESTINATION share/${PROJECT_NAME}/rdf_loader/test
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
-  find_package(ros_testing REQUIRED)
-
-  ament_add_gtest_executable(test_rdf_integration
-      test/test_rdf_integration.cpp
-  )
-  target_link_libraries(test_rdf_integration ${MOVEIT_LIB_NAME})
-  add_ros_test(test/launch/test_rdf_integration.test.py TIMEOUT 120)
-
-  add_executable(boring_string_publisher test/boring_string_publisher.cpp)
-  target_link_libraries(boring_string_publisher ${MOVEIT_LIB_NAME})
-
-  install(
-    TARGETS
-      test_rdf_integration boring_string_publisher
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-  )
-endif()
+#if(BUILD_TESTING)
+#  find_package(ament_cmake_gtest REQUIRED)
+#  find_package(ros_testing REQUIRED)
+#
+#  ament_add_gtest_executable(test_rdf_integration
+#      test/test_rdf_integration.cpp
+#  )
+#  target_link_libraries(test_rdf_integration ${MOVEIT_LIB_NAME})
+#  add_ros_test(test/launch/test_rdf_integration.test.py TIMEOUT 120)
+#
+#  add_executable(boring_string_publisher test/boring_string_publisher.cpp)
+#  target_link_libraries(boring_string_publisher ${MOVEIT_LIB_NAME})
+#
+#  install(
+#    TARGETS
+#      test_rdf_integration boring_string_publisher
+#    ARCHIVE DESTINATION lib
+#    LIBRARY DESTINATION lib
+#    RUNTIME DESTINATION lib/${PROJECT_NAME}
+#  )
+#endif()


### PR DESCRIPTION
### Description

`test_servo_singularity` and `test_servo_singularity` are flaky, we should disable them for now. I've created an issue #1531

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
