### PR TITLE
Const ptr to jmg arg for cost function

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -156,7 +156,7 @@ public:
 
   /** @brief Signature for a cost function used to evaluate IK solutions. */
   using IKCostFn = std::function<double(const geometry_msgs::msg::Pose&, const moveit::core::RobotState&,
-                                        moveit::core::JointModelGroup*, const std::vector<double>&)>;
+                                        moveit::core::JointModelGroup const*, const std::vector<double>&)>;
 
   /**
    * @brief Given a desired pose of the end-effector, compute the joint angles to reach it


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

### Description

This shouldn't break anything and is more consistent with the use of jmg. @wyattrees did you have some reason to make this a non-const ptr?

Also, @wyattrees why does this cost function take a single pose and not a vector of poses?