### PR TITLE
[Servo] Update the `thread_priority` library location

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -33,7 +33,6 @@ moveit_package()
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   control_msgs
   control_toolbox
-  controller_manager
   geometry_msgs
   moveit_core
   moveit_msgs
@@ -41,6 +40,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
   rclcpp
   rclcpp_components
+  realtime_tools
   sensor_msgs
   std_msgs
   std_srvs

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -25,12 +25,12 @@
 
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
-  <depend>controller_manager</depend>
   <depend>geometry_msgs</depend>
   <depend>moveit_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>pluginlib</depend>
+  <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -42,7 +42,7 @@
 #include <chrono>
 #include <mutex>
 
-#include <controller_manager/realtime.hpp>
+#include <realtime_tools/thread_priority.hpp>
 #include <std_msgs/msg/bool.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -277,9 +277,9 @@ void ServoCalcs::start()
   stop_requested_ = false;
   thread_ = std::thread([this] {
     // Check if a realtime kernel is installed. Set a higher thread priority, if so
-    if (controller_manager::has_realtime_kernel())
+    if (realtime_tools::has_realtime_kernel())
     {
-      if (!controller_manager::configure_sched_fifo(THREAD_PRIORITY))
+      if (!realtime_tools::configure_sched_fifo(THREAD_PRIORITY))
       {
         RCLCPP_WARN(LOGGER, "Could not enable FIFO RT scheduling policy");
       }


### PR DESCRIPTION
### Description

Update the `thread_priority` library location since it moved to the `realtime_tools` package in [this PR](https://github.com/ros-controls/realtime_tools/pull/83).

To link it properly will require merging this additional `realtime_tools` PR first:  https://github.com/ros-controls/realtime_tools/pull/91