### PR TITLE
[Servo] Use a WallRate so the clock is monotonically increasing

### DIFF
--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -114,7 +114,6 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
   // Wait a bit for a target pose message to arrive.
   // The target pose may get updated by new messages as the robot moves (in a callback function).
   const rclcpp::Time start_time = node_->now();
-  rclcpp::Clock clock;
 
   while ((!haveRecentTargetPose(target_pose_timeout) || !haveRecentEndEffectorPose(target_pose_timeout)) &&
          ((node_->now() - start_time).seconds() < target_pose_timeout))
@@ -170,7 +169,7 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
     if (!loop_rate_.sleep())
     {
-      RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, LOG_THROTTLE_PERIOD, "Target control rate was missed");
+      RCLCPP_WARN_STREAM_THROTTLE(LOGGER, *node_->get_clock(), LOG_THROTTLE_PERIOD, "Target control rate was missed");
     }
   }
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -327,7 +327,7 @@ void ServoCalcs::stop()
 
 void ServoCalcs::mainCalcLoop()
 {
-  rclcpp::Rate rate(1.0 / parameters_->publish_period);
+  rclcpp::WallRate rate(1.0 / parameters_->publish_period);
 
   while (rclcpp::ok() && !stop_requested_)
   {


### PR DESCRIPTION
### Description

The default `rclcpp::Rate` uses a `[std::chrono::system_clock](http://en.cppreference.com/w/cpp/chrono/system_clock.html)`. Better to use a `rclcpp::WallRate` here since we only care about the change in time.

Hat tip for @ChrisThrasher for bringing this type of issue to my attention.

If we're really lucky, this will fix the Servo tests.