### PR TITLE
size_t bijection index type

### DIFF
--- a/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
+++ b/moveit_core/constraint_samplers/src/default_constraint_samplers.cpp
@@ -530,7 +530,7 @@ void samplingIkCallbackFnAdapter(moveit::core::RobotState* state, const moveit::
                                  const moveit::core::GroupStateValidityCallbackFn& constraint,
                                  const std::vector<double>& ik_sol, moveit_msgs::msg::MoveItErrorCodes& error_code)
 {
-  const std::vector<unsigned int>& bij = jmg->getKinematicsSolverJointBijection();
+  const std::vector<size_t>& bij = jmg->getKinematicsSolverJointBijection();
   std::vector<double> solution(bij.size());
   for (std::size_t i = 0; i < bij.size(); ++i)
     solution[i] = ik_sol[bij[i]];
@@ -625,7 +625,7 @@ bool IKConstraintSampler::callIK(const geometry_msgs::msg::Pose& ik_query,
                                  const kinematics::KinematicsBase::IKCallbackFn& adapted_ik_validity_callback,
                                  double timeout, moveit::core::RobotState& state, bool use_as_seed)
 {
-  const std::vector<unsigned int>& ik_joint_bijection = jmg_->getKinematicsSolverJointBijection();
+  const std::vector<size_t>& ik_joint_bijection = jmg_->getKinematicsSolverJointBijection();
   std::vector<double> seed(ik_joint_bijection.size(), 0.0);
   std::vector<double> vals;
 

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -95,7 +95,7 @@ public:
         An element bijection[i] at index \e i in this array, maps the variable at index bijection[i] in this group to
        the variable at index
         i in the kinematic solver. */
-    std::vector<unsigned int> bijection_;
+    std::vector<size_t> bijection_;
 
     kinematics::KinematicsBasePtr solver_instance_;
 
@@ -566,7 +566,7 @@ public:
      kinematics solver.
       An element bijection[i] at index \e i in this array, maps the variable at index bijection[i] in this group to
       the variable at index i in the kinematic solver. */
-  const std::vector<unsigned int>& getKinematicsSolverJointBijection() const
+  const std::vector<size_t>& getKinematicsSolverJointBijection() const
   {
     return group_kinematics_.first.bijection_;
   }
@@ -583,8 +583,7 @@ public:
                            double dt) const;
 
 protected:
-  bool computeIKIndexBijection(const std::vector<std::string>& ik_jnames,
-                               std::vector<unsigned int>& joint_bijection) const;
+  bool computeIKIndexBijection(const std::vector<std::string>& ik_jnames, std::vector<size_t>& joint_bijection) const;
 
   /** \brief Update the variable values for the state of a group with respect to the mimic joints. This only updates
       mimic joints that have the parent in this group. If there is a joint mimicking one that is outside the group,

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -566,7 +566,7 @@ void JointModelGroup::setDefaultIKTimeout(double ik_timeout)
 }
 
 bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik_jnames,
-                                              std::vector<unsigned int>& joint_bijection) const
+                                              std::vector<size_t>& joint_bijection) const
 {
   joint_bijection.clear();
   for (const std::string& ik_jname : ik_jnames)
@@ -584,7 +584,7 @@ bool JointModelGroup::computeIKIndexBijection(const std::vector<std::string>& ik
       return false;
     }
     const JointModel* jm = getJointModel(ik_jname);
-    for (unsigned int k = 0; k < jm->getVariableCount(); ++k)
+    for (size_t k = 0; k < jm->getVariableCount(); ++k)
       joint_bijection.push_back(it->second + k);
   }
   return true;
@@ -742,7 +742,7 @@ bool JointModelGroup::isValidVelocityMove(const double* from_joint_pose, const d
                                           std::size_t array_size, double dt) const
 {
   const std::vector<const JointModel::Bounds*>& bounds = getActiveJointModelsBounds();
-  const std::vector<unsigned int>& bij = getKinematicsSolverJointBijection();
+  const std::vector<size_t>& bij = getKinematicsSolverJointBijection();
 
   for (std::size_t i = 0; i < array_size; ++i)
   {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1513,7 +1513,7 @@ bool ikCallbackFnAdapter(RobotState* state, const JointModelGroup* group,
                          const GroupStateValidityCallbackFn& constraint, const geometry_msgs::msg::Pose& /*unused*/,
                          const std::vector<double>& ik_sol, moveit_msgs::msg::MoveItErrorCodes& error_code)
 {
-  const std::vector<unsigned int>& bij = group->getKinematicsSolverJointBijection();
+  const std::vector<size_t>& bij = group->getKinematicsSolverJointBijection();
   std::vector<double> solution(bij.size());
   for (std::size_t i = 0; i < bij.size(); ++i)
     solution[bij[i]] = ik_sol[i];
@@ -1787,7 +1787,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
     };
 
   // Bijection
-  const std::vector<unsigned int>& bij = jmg->getKinematicsSolverJointBijection();
+  const std::vector<size_t>& bij = jmg->getKinematicsSolverJointBijection();
 
   std::vector<double> initial_values;
   copyJointGroupPositions(jmg, initial_values);
@@ -1961,7 +1961,7 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
     bool found_solution = true;
     for (std::size_t sg = 0; sg < sub_groups.size(); ++sg)
     {
-      const std::vector<unsigned int>& bij = sub_groups[sg]->getKinematicsSolverJointBijection();
+      const std::vector<size_t>& bij = sub_groups[sg]->getKinematicsSolverJointBijection();
       std::vector<double> seed(bij.size());
       // the first seed is the initial state
       if (first_seed)

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -131,7 +131,7 @@ private:
 
     const moveit::core::JointModelGroup* subgroup_;
     kinematics::KinematicsBasePtr kinematics_solver_;
-    std::vector<unsigned int> bijection_;
+    std::vector<size_t> bijection_;
     ompl::base::StateSpacePtr state_space_;
     std::vector<std::string> fk_link_;
   };


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <maybe@tylerjw.dev>

### Description

Use size_t for the index type used by bijection. https://en.cppreference.com/w/cpp/types/size_t is the type returned by `size` methods in the stl and is the standard type for use when indexing.