### PR TITLE
Fix moveit_core building

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -208,14 +208,14 @@ add_subdirectory(collision_detection_fcl)
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
 
 # Plugin exports

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -21,6 +21,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   urdf
   urdfdom
   urdfdom_headers
+  srdfdom
   visualization_msgs
   tf2_eigen
   geometric_shapes

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -13,8 +13,7 @@ add_library(${MOVEIT_LIB_NAME} SHARED
 )
 include(GenerateExportHeader)
 generate_export_header(${MOVEIT_LIB_NAME})
-target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<TARGET_PROPERTY:moveit_planning_scene,INCLUDE_DIRECTORIES>)
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+
 ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   rmw_implementation
@@ -27,6 +26,10 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   geometric_shapes
   OCTOMAP
 )
+target_include_directories(${MOVEIT_LIB_NAME} BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+target_include_directories(${MOVEIT_LIB_NAME} PUBLIC $<TARGET_PROPERTY:moveit_planning_scene,INCLUDE_DIRECTORIES>)
+
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   moveit_robot_state

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -59,14 +59,14 @@ add_subdirectory(test)
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
 
 if(BUILD_TESTING)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -31,14 +31,14 @@ ament_target_dependencies(${IKFAST_LIBRARY_NAME}
 target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable -Wno-unused-parameter)
 
 install(TARGETS ${IKFAST_LIBRARY_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)
 
 pluginlib_export_plugin_description_file(moveit_core _ROBOT_NAME___GROUP_NAME__moveit_ikfast_plugin_description.xml)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(moveit_core)
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(rclcpp)

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -27,13 +27,13 @@ include_directories(SYSTEM
 add_subdirectory(ompl_interface)
 
 install(TARGETS moveit_ompl_interface moveit_ompl_planner_plugin
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(moveit_core ompl)
 
 pluginlib_export_plugin_description_file(moveit_core ompl_interface_plugin_description.xml)

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
@@ -48,7 +48,7 @@ ament_target_dependencies(${PROJECT_NAME}
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -57,7 +57,7 @@ install(
 
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp moveit_core moveit_msgs tf2_eigen)
 
 if(BUILD_TESTING)

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -50,14 +50,14 @@ pluginlib_export_plugin_description_file(moveit_core prbt_manipulator_moveit_ikf
 
 install(
   TARGETS prbt_manipulator_moveit_ikfast_plugin
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 ament_package()

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -81,11 +81,11 @@ endif()
 
 ## Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin ${PROJECT_NAME}_gripper_plugin ${PROJECT_NAME}_empty_plugin
-EXPORT export_${PROJECT_NAME}
-ARCHIVE DESTINATION lib
-LIBRARY DESTINATION lib
-RUNTIME DESTINATION bin
-INCLUDES DESTINATION include
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
 ## Mark cpp header files for installation
@@ -96,7 +96,7 @@ install(DIRECTORY include/
 pluginlib_export_plugin_description_file(moveit_core moveit_core_plugins.xml)
 pluginlib_export_plugin_description_file(moveit_ros_control_interface moveit_ros_control_interface_plugins.xml)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(
     ${THIS_PACKAGE_INCLUDE_DEPENDS}
     Boost

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -41,7 +41,7 @@ ament_target_dependencies(${PROJECT_NAME}
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -49,7 +49,7 @@ install(
 )
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
   Boost

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -57,14 +57,14 @@ target_link_libraries(moveit_combine_predefined_poses_benchmark ${MOVEIT_LIB_NAM
 
 install(
   TARGETS ${MOVEIT_LIB_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(

--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -69,7 +69,7 @@ rclcpp_components_register_nodes(moveit_global_planner_component "moveit::hybrid
 rclcpp_components_register_nodes(moveit_local_planner_component "moveit::hybrid_planning::LocalPlannerComponent")
 
 install(TARGETS ${LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -95,6 +95,6 @@ pluginlib_export_plugin_description_file(moveit_hybrid_planning forward_trajecto
 ament_export_include_directories(include)
 ament_export_libraries(${LIBRARIES})
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 
 ament_package()

--- a/moveit_ros/hybrid_planning/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/CMakeLists.txt
@@ -92,8 +92,6 @@ pluginlib_export_plugin_description_file(moveit_hybrid_planning simple_sampler_p
 pluginlib_export_plugin_description_file(moveit_hybrid_planning replan_invalidated_trajectory_plugin.xml)
 pluginlib_export_plugin_description_file(moveit_hybrid_planning forward_trajectory_plugin.xml)
 
-ament_export_include_directories(include)
-ament_export_libraries(${LIBRARIES})
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -83,7 +83,7 @@ install(
   TARGETS
     moveit_move_group_default_capabilities
     moveit_move_group_capabilities_base
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -92,7 +92,7 @@ install(
 
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -135,7 +135,7 @@ install(
     ${POSE_TRACKING}
     ${SERVO_COMPONENT_NODE}
     ${SERVO_CONTROLLER_INPUT}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -159,7 +159,7 @@ install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 #############

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(moveit_ros_occupancy_map_server ${MOVEIT_LIB_NAME})
 
 install(
   TARGETS ${MOVEIT_LIB_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -65,7 +65,7 @@ install(TARGETS moveit_ros_occupancy_map_server
 )
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} eigen3_cmake_module)
 
 if(BUILD_TESTING)

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -112,14 +112,14 @@ add_subdirectory(semantic_world)
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 pluginlib_export_plugin_description_file(moveit_ros_occupancy_map_monitor "pointcloud_octomap_updater_plugin_description.xml")

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -90,14 +90,14 @@ add_subdirectory(moveit_cpp)
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 pluginlib_export_plugin_description_file(moveit_core "planning_request_adapters_plugin_description.xml")

--- a/moveit_ros/planning_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/CMakeLists.txt
@@ -93,14 +93,14 @@ endif()
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -185,8 +185,7 @@ public:
     if (constraints_init_thread_)
       constraints_init_thread_->join();
 
-    if (callback_executor_.is_spinning())
-      callback_executor_.cancel();
+    callback_executor_.cancel();
 
     if (callback_thread_.joinable())
       callback_thread_.join();

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 install(
   TARGETS ${MOVEIT_LIB_NAME}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -58,7 +58,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MOVEIT_LIB_NAME}_export.h DESTINATIO
 
 install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)

--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -114,14 +114,14 @@ pluginlib_export_plugin_description_file(rviz_common robot_state_rviz_plugin_des
 
 install(
   TARGETS ${THIS_PACKAGE_LIBRARIES}
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -22,14 +22,14 @@ add_subdirectory(warehouse)
 
 install(
   TARGETS moveit_warehouse
-  EXPORT export_${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(moveit_core)

--- a/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 install(DIRECTORY templates DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -69,7 +69,7 @@ install(DIRECTORY include/
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(export_${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}Targets)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
@@ -59,6 +59,7 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
 )
 install(FILES moveit_setup_framework_plugins.xml
         DESTINATION share/${PROJECT_NAME}
@@ -66,10 +67,8 @@ install(FILES moveit_setup_framework_plugins.xml
 install(DIRECTORY include/
         DESTINATION include
 )
-ament_export_include_directories(include)
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}Targets)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
@@ -64,6 +64,7 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
 )
 install(FILES moveit_setup_framework_plugins.xml
         DESTINATION share/${PROJECT_NAME}
@@ -71,14 +72,11 @@ install(FILES moveit_setup_framework_plugins.xml
 install(DIRECTORY include/
         DESTINATION include
 )
-
 install(DIRECTORY launch
         DESTINATION share/${PROJECT_NAME}
 )
-ament_export_include_directories(include)
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}Targets)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 install(DIRECTORY templates DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -78,7 +78,7 @@ install(DIRECTORY launch
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(export_${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}Targets)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_TESTING)
 endif()
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -68,7 +68,7 @@ install(DIRECTORY include/
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(export_${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}Targets)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
@@ -58,6 +58,7 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
 )
 install(FILES moveit_setup_framework_plugins.xml
         DESTINATION share/${PROJECT_NAME}
@@ -65,10 +66,8 @@ install(FILES moveit_setup_framework_plugins.xml
 install(DIRECTORY include/
         DESTINATION include
 )
-ament_export_include_directories(include)
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}Targets)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
@@ -74,9 +74,9 @@ install(FILES moveit_setup_framework_plugins.xml
 
 install(DIRECTORY templates DESTINATION share/${PROJECT_NAME})
 
-ament_export_targets(export_moveit_setup_framework HAS_LIBRARY_TARGET)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_moveit_setup_framework
+        EXPORT ${PROJECT_NAME}Targets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin

--- a/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
@@ -82,7 +82,7 @@ install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin
         INCLUDES DESTINATION include
 )
-ament_export_include_directories(include)
+
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(Qt5Core)
 ament_export_dependencies(Qt5Widgets)

--- a/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
@@ -48,6 +48,7 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
 )
 install(FILES moveit_setup_framework_plugins.xml
         DESTINATION share/${PROJECT_NAME}
@@ -55,10 +56,8 @@ install(FILES moveit_setup_framework_plugins.xml
 install(DIRECTORY include/
         DESTINATION include
 )
-ament_export_include_directories(include)
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}Targets)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 install(DIRECTORY templates DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -58,7 +58,7 @@ install(DIRECTORY include/
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(export_${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}Targets)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
@@ -69,6 +69,7 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
 )
 install(FILES moveit_setup_framework_plugins.xml
         DESTINATION share/${PROJECT_NAME}
@@ -76,10 +77,8 @@ install(FILES moveit_setup_framework_plugins.xml
 install(DIRECTORY include/
         DESTINATION include
 )
-ament_export_include_directories(include)
 
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}Targets)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
@@ -65,7 +65,7 @@ if(BUILD_TESTING)
 endif()
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -79,7 +79,7 @@ install(DIRECTORY include/
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(export_${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}Targets)
 pluginlib_export_plugin_description_file(moveit_setup_framework moveit_setup_framework_plugins.xml)
 
 ament_package()


### PR DESCRIPTION
Trying to build branch `main` on `Galactic`, I ran into the following compiler error:
```
collision_matrix.cpp: In constructor ‘collision_detection::AllowedCollisionMatrix::AllowedCollisionMatrix(const srdf::Model&)’:
collision_matrix.cpp:62:39: error: ‘const class srdf::Model’ has no member named ‘getNoDefaultCollisionLinks’
```
There were actually two issues (having srdfdom part of the current workspace):
- `srdfdom` was missing as an explicit dependency. Its includes were only found accidentally in /opt/ros
- The include order was screwed because moveit_planning_scene's include directories (not comprising srdfdom but /opt/ros) were included before all other includes. The latter are pulled in via `ament_target_dependencies()`, which handles correct ordering for the overlay. Thus srdfdom was found in /opt/ros instead of the local overlay.

Skimming through the cmake files, I noticed inconsistent naming of export targets: Most packages used `export_${PROJECT_NAME}`, while some also used the [standard (by convention)](https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#building-a-library) `${PROJECT_NAME}Targets`. I changed all to the latter.