### PR TITLE
fix compilation under debian bullseye

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -7,4 +7,56 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: 2.12.0
+    version: 2.14.0
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: galactic-devel
+  ros-planning/geometric_shapes:
+    type: git
+    url: https://github.com/ros-planning/geometric_shapes.git
+    version: ros2
+  ros-planning/random_numbers:
+    type: git
+    url: https://github.com/ros-planning/random_numbers.git
+    version: ros2
+  ros-controls/realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master
+  ros-planning/moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: ros2
+  wg-perception/object_recognition_msgs:
+    type: git
+    url: https://github.com/wg-perception/object_recognition_msgs.git
+    version: ros2
+  OctoMap/octomap_msgs:
+    type: git
+    url: https://github.com/OctoMap/octomap_msgs.git
+    version: ros2
+  pantor/ruckig:
+    type: git
+    url: https://github.com/pantor/ruckig.git
+    version: master
+  ros-planning/srdfdom:
+    type: git
+    url: https://github.com/ros-planning/srdfdom.git
+    version: ros2
+  ros-perception/vision_opencv:
+    type: git
+    url: https://github.com/ros-perception/vision_opencv.git
+    version: humble
+  ros-planning/warehouse_ros:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros.git
+    version: ros2
+  ompl/ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: main
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -28,6 +28,8 @@ find_package(tf2_ros REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(Boost REQUIRED COMPONENTS)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++11")
+
 # TODO(henning): Remove/Port
 # if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
 #   find_package(code_coverage REQUIRED)

--- a/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <memory>
 #include "pilz_industrial_motion_planner/path_circle_generator.h"
 
 namespace pilz_industrial_motion_planner


### PR DESCRIPTION
### Description
these commits were needed to build moveit2 on debian bullseye.
In particular:
# A missing library has been added and the C ++ 11 standard has been enabled.
#The moveit2.repos file has been modified to include the missing code.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
