### PR TITLE
[Servo] Remove the option for "stop distance"-based collision checking

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -67,6 +67,5 @@ command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing com
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-# Collision checking begins slowing down when nearer than a specified distance.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -60,13 +60,7 @@ command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing com
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-# Two collision check algorithms are available:
-# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
-# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
 collision_check_type: threshold_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
-# Parameters for "stop_distance"-type collision checking
-collision_distance_safety_factor: 1000.0 # Must be >= 1. A large safety factor is recommended to account for latency
-min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -60,7 +60,5 @@ command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing com
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-collision_check_type: threshold_distance
-# Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -83,9 +83,6 @@ private:
   /** \brief Get a read-only copy of the planning scene */
   planning_scene_monitor::LockedPlanningSceneRO getLockedPlanningSceneRO() const;
 
-  /** \brief Callback for collision stopping time, from the thread that is aware of velocity and acceleration */
-  void worstCaseStopTimeCB(const std_msgs::msg::Float64::SharedPtr msg);
-
   // Pointer to the ROS node
   const std::shared_ptr<rclcpp::Node> node_;
 
@@ -107,9 +104,6 @@ private:
   bool collision_detected_ = false;
   bool paused_ = false;
 
-  // Variables for stop-distance-based collision checking
-  double worst_case_stop_time_ = std::numeric_limits<double>::max();
-
   const double self_velocity_scale_coefficient_;
   const double scene_velocity_scale_coefficient_;
 
@@ -121,7 +115,6 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   double period_;  // The loop period, in seconds
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr collision_velocity_scale_pub_;
-  rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr worst_case_stop_time_sub_;
 
   mutable std::mutex joint_state_mutex_;
   sensor_msgs::msg::JointState latest_joint_state_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -311,7 +311,6 @@ protected:
   rclcpp::Subscription<control_msgs::msg::JointJog>::SharedPtr joint_cmd_sub_;
   rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr collision_velocity_scale_sub_;
   rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr status_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr worst_case_stop_time_pub_;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_outgoing_cmd_pub_;
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr multiarray_outgoing_cmd_pub_;
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr condition_pub_;

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -74,10 +74,6 @@ CollisionCheck::CollisionCheck(rclcpp::Node::SharedPtr node, const ServoParamete
   collision_velocity_scale_pub_ =
       node_->create_publisher<std_msgs::msg::Float64>("~/collision_velocity_scale", rclcpp::SystemDefaultsQoS());
 
-  worst_case_stop_time_sub_ = node_->create_subscription<std_msgs::msg::Float64>(
-      "~/worst_case_stop_time", rclcpp::SystemDefaultsQoS(),
-      [this](const std_msgs::msg::Float64::SharedPtr msg) { return worstCaseStopTimeCB(msg); });
-
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
 }
 
@@ -155,11 +151,6 @@ void CollisionCheck::run()
     msg->data = velocity_scale_;
     collision_velocity_scale_pub_->publish(std::move(msg));
   }
-}
-
-void CollisionCheck::worstCaseStopTimeCB(const std_msgs::msg::Float64::SharedPtr msg)
-{
-  worst_case_stop_time_ = msg.get()->data;
 }
 
 void CollisionCheck::setPaused(bool paused)

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -58,7 +58,5 @@ command_out_topic: servo_node/command # Publish outgoing commands here
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 5.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-collision_check_type: threshold_distance
-# Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]

--- a/moveit_ros/moveit_servo/test/config/servo_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings.yaml
@@ -58,13 +58,7 @@ command_out_topic: servo_node/command # Publish outgoing commands here
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 5.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-# Two collision check algorithms are available:
-# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
-# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
-collision_check_type: stop_distance
+collision_check_type: threshold_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
-# Parameters for "stop_distance"-type collision checking
-collision_distance_safety_factor: 1000.0 # Must be >= 1. A large safety factor is recommended to account for latency
-min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
@@ -58,7 +58,5 @@ command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing com
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 5.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-collision_check_type: threshold_distance
-# Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]

--- a/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
+++ b/moveit_ros/moveit_servo/test/config/servo_settings_low_latency.yaml
@@ -58,13 +58,7 @@ command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing com
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
 collision_check_rate: 5.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-# Two collision check algorithms are available:
-# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
-# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
-collision_check_type: stop_distance
+collision_check_type: threshold_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a collision is this far [m]
 scene_collision_proximity_threshold: 0.03 # Start decelerating when a collision is this far [m]
-# Parameters for "stop_distance"-type collision checking
-collision_distance_safety_factor: 1000.0 # Must be >= 1. A large safety factor is recommended to account for latency
-min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]


### PR DESCRIPTION
### Description

This was an experimental method for collision checking that was added back in MoveIt1 [here](https://github.com/ros-planning/moveit/pull/2100).

It didn't work very well in practice and I thought it had already been removed. It definitely isn't functional at this point (you can verify this by `grep -r worst_case_stop_time_pub_` -- you'll see that the publisher is never actually initialized.

or `grep -r collision_check_type` and you'll see that the parameter isn't actually read.


