### PR TITLE
Log when named target does not exist

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -1679,7 +1679,10 @@ std::map<std::string, double> MoveGroupInterface::getNamedTargetValues(const std
   }
   else
   {
-    impl_->getJointModelGroup()->getVariableDefaultPositions(name, positions);
+    if (!impl_->getJointModelGroup()->getVariableDefaultPositions(name, positions))
+    {
+      RCLCPP_ERROR(LOGGER, "The requested named target '%s' does not exist, returning empty positions.", name.c_str());
+    }
   }
   return positions;
 }


### PR DESCRIPTION
### Description

This avoids hiding the (likely) bug where an incorrect state name is given

Replaces https://github.com/ros-planning/moveit2/pull/1579

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
