### PR TITLE
updated comment formatting for correct doxygen generation

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_parameters.h
@@ -64,40 +64,36 @@ public:
   bool setTrajectoryInitializationMethod(std::string method);
 
 public:
-  double planning_time_limit_;  /// maximum time the optimizer can take to find a solution before terminating
-  int max_iterations_;          /// maximum number of iterations that the planner can take to find a good solution while
-                                /// optimization
-  int max_iterations_after_collision_free_;  /// maximum iterations to be performed after a collision free path is
-                                             /// found.
-  double smoothness_cost_weight_;  /// smoothness_cost_weight parameters controls its weight in the final cost that
-                                   /// CHOMP is actually optimizing over
-  double obstacle_cost_weight_;  /// controls the weight to be given to obstacles towards the final cost CHOMP optimizes
-                                 /// over
-  double learning_rate_;  /// learning rate used by the optimizer to find the local / global minima while reducing the
-                          /// total cost
+  double planning_time_limit_; /*!< maximum time the optimizer can take to find a solution before terminating */
+  int max_iterations_; /*!< maximum number of iterations that the planner can take to find a good solution while optimization */
+  int max_iterations_after_collision_free_; /*!< maximum iterations to be performed after a collision free path is found. */
+  double smoothness_cost_weight_; /*!< smoothness_cost_weight parameters controls its weight in the final cost that
+                                     CHOMP is actually optimizing over */
+  double
+      obstacle_cost_weight_; /*!< controls the weight to be given to obstacles towards the final cost CHOMP optimizes over */
+  double learning_rate_; /*!< learning rate used by the optimizer to find the local / global minima while reducing the total cost */
+  double smoothness_cost_velocity_;     /*!< variables associated with the cost in velocity */
+  double smoothness_cost_acceleration_; /*!< variables associated with the cost in acceleration */
+  double smoothness_cost_jerk_;         /*!< variables associated with the cost in jerk */
+  bool use_stochastic_descent_; /*!< set this to true/false if you want to use stochastic descent while optimizing the cost. */
 
-  double smoothness_cost_velocity_;      /// variables associated with the cost in velocity
-  double smoothness_cost_acceleration_;  /// variables associated with the cost in acceleration
-  double smoothness_cost_jerk_;          /// variables associated with the cost in jerk
-  bool use_stochastic_descent_;  /// set this to true/false if you want to use stochastic descent while optimizing the
-                                 /// cost.
+  double
+      ridge_factor_; /*!< the noise added to the diagnal of the total quadratic cost matrix in the objective function */
+  bool use_pseudo_inverse_;            /*!< enable pseudo inverse calculations or not. */
+  double pseudo_inverse_ridge_factor_; /*!< set the ridge factor if pseudo inverse is enabled */
 
-  double ridge_factor_;  /// the noise added to the diagnal of the total quadratic cost matrix in the objective function
-  bool use_pseudo_inverse_;             /// enable pseudo inverse calculations or not.
-  double pseudo_inverse_ridge_factor_;  /// set the ridge factor if pseudo inverse is enabled
-
-  double joint_update_limit_;   /// set the update limit for the robot joints
-  double min_clearance_;        /// the minimum distance that needs to be maintained to avoid obstacles
-  double collision_threshold_;  /// the collision threshold cost that needs to be mainted to avoid collisions
+  double joint_update_limit_;  /*!< set the update limit for the robot joints */
+  double min_clearance_;       /*!< the minimum distance that needs to be maintained to avoid obstacles */
+  double collision_threshold_; /*!< the collision threshold cost that needs to be maintained to avoid collisions */
   bool filter_mode_;
 
   static const std::vector<std::string> VALID_INITIALIZATION_METHODS;
-  std::string trajectory_initialization_method_;  /// trajectory initialization method to be specified
+  std::string trajectory_initialization_method_; /*!< trajectory initialization method to be specified */
 
-  bool enable_failure_recovery_;  /// if set to true, CHOMP tries to vary certain parameters to try and find a path if
-                                  /// an initial path is not found with the specified chomp parameters
-  int max_recovery_attempts_;     /// this the maximum recovery attempts to find a collision free path after an initial
-                                  /// failure to find a solution
+  bool enable_failure_recovery_; /*!< if set to true, CHOMP tries to vary certain parameters to try and find a path if
+                                    an initial path is not found with the specified chomp parameters */
+  int max_recovery_attempts_;    /*!< this the maximum recovery attempts to find a collision free path after an initial
+                                    failure to find a solution */
 };
 
 }  // namespace chomp


### PR DESCRIPTION
### Description

The Doxygen documentation is generated incorrectly due to incorrect comment syntax. This PR corrects the issue

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
