### PR TITLE
Do not add Pilz parameters to MoveIt Configs Utils if Pilz is not used

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -125,9 +125,10 @@ class MoveItConfigs:
         parameters.update(self.joint_limits)
         parameters.update(self.moveit_cpp)
         # Update robot_description_planning with pilz cartesian limits
-        parameters["robot_description_planning"].update(
-            self.pilz_cartesian_limits["robot_description_planning"]
-        )
+        if self.pilz_cartesian_limits:
+            parameters["robot_description_planning"].update(
+                self.pilz_cartesian_limits["robot_description_planning"]
+            )
         return parameters
 
 


### PR DESCRIPTION
### Description
After #1571, if MoveIt Configs Utils is used and `self.pilz_cartesian_limits` is not set (which can happen if not using Pilz), I get this error when  launching

`[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: 'robot_description_planning'`

This can be seen in https://github.com/ros-planning/moveit2_tutorials/pull/492.

This PR adds a condition checking if `self.pilz_cartesian_limits` is populated before adding parameters.