### PR TITLE
Install from rosdep in source Docker build

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -22,8 +22,15 @@ RUN --mount=type=cache,target=/root/.ccache/ \
     # Fetch required upstream sources for building
     vcs import src < src/moveit2/moveit2.repos && \
     if [ -r "src/moveit2/moveit2_${ROS_DISTRO}.repos" ] ; then vcs import src < "src/moveit2/moveit2_${ROS_DISTRO}.repos" ; fi && \
-    #
+    # Source ROS install
     . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
+    # Install dependencies from rosdep
+    apt-get -q update && \
+    rosdep update && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Build the workspace
     colcon build \
             --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             --ament-cmake-args -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
### Description

This should fix failing CI for PRs that add dependencies.

CI jobs that trigger the docker builds do not push to docker-hub, they just test building the docker images. This causes a problem when a dependency is added because the step that previously installed all dependencies `ci` is not pushed so the `source` job that attempts to build can use those dependencies.
