### PR TITLE
Fix logic with enforcing constrained planning state space

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -536,11 +536,10 @@ ModelBasedPlanningContextPtr PlanningContextManager::getPlanningContext(
   auto constrained_planning_iterator = pc->second.config.find("enforce_constrained_state_space");
   auto joint_space_planning_iterator = pc->second.config.find("enforce_joint_model_state_space");
 
-  // Use ConstrainedPlanningStateSpace if there is exactly one position constraint or one orientation constraint
-  // Mixed constraints are not supported
+  // Use ConstrainedPlanningStateSpace if there is exactly one position constraint and/or one orientation constraint
   if (constrained_planning_iterator != pc->second.config.end() &&
       boost::lexical_cast<bool>(constrained_planning_iterator->second) &&
-      ((req.path_constraints.position_constraints.size() == 1) !=
+      ((req.path_constraints.position_constraints.size() == 1) ||
        (req.path_constraints.orientation_constraints.size() == 1)))
   {
     factory = getStateSpaceFactory(ConstrainedPlanningStateSpace::PARAMETERIZATION_TYPE);


### PR DESCRIPTION
### Description

Fixes #1552, change to logic when enforcing constrained planning state space in the mixed constraint case.

When running the constrained planning tutorial with:
`ros2 launch moveit2_tutorials ompl_constrained_planning.launch.py`

You should see the following log for the last example (required debug log level):
`[moveit.ompl_planning.planning_context_manager]: planning_context_manager: Using OMPL's constrained state space for planning.`
