### PR TITLE
Fix deprecated declaration usage

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
+# TODO(#1608): Enable deprecated declarations warning as error once humble support is removed from main branch
 add_compile_options(-Wno-deprecated-declarations)
 
 add_library(${MOVEIT_LIB_NAME} SHARED src/move_group_interface.cpp)

--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
+add_compile_options(-Wno-deprecated-declarations)
+
 add_library(${MOVEIT_LIB_NAME} SHARED src/move_group_interface.cpp)
 include(GenerateExportHeader)
 generate_export_header(${MOVEIT_LIB_NAME})

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -163,17 +163,17 @@ public:
 
     query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
+        rclcpp::SystemDefaultsQoS(), callback_group_);
     get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
+        rclcpp::SystemDefaultsQoS(), callback_group_);
     set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
+        rclcpp::SystemDefaultsQoS(), callback_group_);
 
     cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
+        rclcpp::SystemDefaultsQoS(), callback_group_);
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -163,17 +163,17 @@ public:
 
     query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
+        rmw_qos_profile_services_default, callback_group_);
     get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
+        rmw_qos_profile_services_default, callback_group_);
     set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
+        rmw_qos_profile_services_default, callback_group_);
 
     cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
+        rmw_qos_profile_services_default, callback_group_);
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 


### PR DESCRIPTION
### Description
The new rolling update has deprecated the usage of function parameter of type `rmw_qos_profile_t` when calling `create_client` function. 
Related issue - https://github.com/ros2/rclcpp/pull/1964
CI fails due to this warning which GCC will promote to an error and fails the build.
```
rclcpp::CallbackGroup::SharedPtr = std::shared_ptr<rclcpp::CallbackGroup>]’ is deprecated: use rclcpp::QoS instead of rmw_qos_profile_t [-Werror=deprecated-declarations]
    164 |     query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
        |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
    165 |         rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
        |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    166 |         rmw_qos_profile_services_default, callback_group_);
        |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

Here's a fix for it
