### PR TITLE
Planning request adapters: short-circuit if failure, return code rather than bool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       # Uninstall binaries that are duplicated in the .repos file
       # TODO(andyz): remove this once a sync containing 35b93c8 happens
-      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs -y
+      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove -y ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs || true
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       # Clear the ccache stats before and log the stats after the build
       AFTER_SETUP_CCACHE: ccache --zero-stats --max-size=10.0G

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -74,25 +74,27 @@ public:
     return "";
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req,
-                    planning_interface::MotionPlanResponse& res) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const;
 
   /** \brief Adapt the planning request if needed, call the planner
       function \e planner and update the planning response if
       needed. If the response is changed, the index values of the
       states added without planning are added to \e
       added_path_index */
-  virtual bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                            const planning_interface::MotionPlanRequest& req,
-                            planning_interface::MotionPlanResponse& res,
-                            std::vector<std::size_t>& added_path_index) const = 0;
+  virtual moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                                     const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                                     const planning_interface::MotionPlanRequest& req,
+                                                     planning_interface::MotionPlanResponse& res,
+                                                     std::vector<std::size_t>& added_path_index) const = 0;
 
 protected:
   /** \brief Helper param for getting a parameter using a namespace **/
@@ -129,15 +131,16 @@ public:
     adapters_.push_back(adapter);
   }
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req,
-                    planning_interface::MotionPlanResponse& res) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res) const;
 
-  bool adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
-                    const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const;
+  moveit::core::MoveItErrorCode adaptAndPlan(const planning_interface::PlannerManagerPtr& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const;
 
 private:
   std::vector<PlanningRequestAdapterConstPtr> adapters_;

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -52,7 +52,7 @@ class PlanningRequestAdapter
 {
 public:
   using PlannerFn =
-      std::function<bool(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
+      std::function<void(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
                          planning_interface::MotionPlanResponse&)>;
 
   PlanningRequestAdapter()

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -39,6 +39,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/utils/moveit_error_code.h>
 #include <functional>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>
@@ -52,7 +53,7 @@ class PlanningRequestAdapter
 {
 public:
   using PlannerFn =
-      std::function<void(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
+      std::function<moveit::core::MoveItErrorCode(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
                          planning_interface::MotionPlanResponse&)>;
 
   PlanningRequestAdapter()

--- a/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
+++ b/moveit_core/planning_request_adapter/include/moveit/planning_request_adapter/planning_request_adapter.h
@@ -52,9 +52,9 @@ MOVEIT_CLASS_FORWARD(PlanningRequestAdapter);  // Defines PlanningRequestAdapter
 class PlanningRequestAdapter
 {
 public:
-  using PlannerFn =
-      std::function<moveit::core::MoveItErrorCode(const planning_scene::PlanningSceneConstPtr&, const planning_interface::MotionPlanRequest&,
-                         planning_interface::MotionPlanResponse&)>;
+  using PlannerFn = std::function<moveit::core::MoveItErrorCode(const planning_scene::PlanningSceneConstPtr&,
+                                                                const planning_interface::MotionPlanRequest&,
+                                                                planning_interface::MotionPlanResponse&)>;
 
   PlanningRequestAdapter()
   {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -145,7 +145,6 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
                const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
                planning_interface::MotionPlanResponse& res) {
         res = callAdapter(adapter, fn, scene, req, added_path_index);
-        RCLCPP_ERROR_STREAM(LOGGER, "Adapter  result: " << res.error_code_.val);
         // If any adapter fails, return false
         if (res.error_code_.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
         {

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -145,8 +145,7 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
                const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
                planning_interface::MotionPlanResponse& res) {
         res = callAdapter(adapter, fn, scene, req, added_path_index);
-        // If any adapter fails, return false. Otherwise, the pipeline would continue onward anyway and the failure
-        // error code would get lost.
+        // Abort pipeline and return error code in case of failure
         return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
       };
     }

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -145,11 +145,9 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
                const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
                planning_interface::MotionPlanResponse& res) {
         res = callAdapter(adapter, fn, scene, req, added_path_index);
-        // If any adapter fails, return false
-        if (res.error_code_.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
-        {
-          return false;
-        }
+        // If any adapter fails, return false. Otherwise, the pipeline would continue onward anyway and the failure
+        // error code would get lost.
+        return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
       };
     }
 

--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -150,7 +150,7 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
       };
     }
 
-    bool result = fn(planning_scene, req, res);
+    fn(planning_scene, req, res);
     added_path_index.clear();
 
     // merge the index values from each adapter
@@ -163,7 +163,7 @@ bool PlanningRequestAdapterChain::adaptAndPlan(const planning_interface::Planner
         added_path_index.push_back(added_index);
       }
     std::sort(added_path_index.begin(), added_path_index.end());
-    return result;
+    return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   }
 }
 

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -180,8 +180,11 @@ public:
 
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    if (!planner(ps, req, res))
+    planner(ps, req, res);
+    if (res.error_code_.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
+    {
       return false;
+    }
 
     // create a hybrid collision detector to set the collision checker as hybrid
     collision_detection::CollisionDetectorAllocatorPtr hybrid_cd(

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -180,8 +180,8 @@ public:
 
     // following call to planner() calls the OMPL planner and stores the trajectory inside the MotionPlanResponse res
     // variable which is then used by CHOMP for optimization of the computed trajectory
-    planner(ps, req, res);
-    if (res.error_code_.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
+    moveit::core::MoveItErrorCode moveit_code = planner(ps, req, res);
+    if (!bool(moveit_code))
     {
       return false;
     }

--- a/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp
@@ -172,9 +172,10 @@ public:
     return "CHOMP Optimizer";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& ps,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     RCLCPP_DEBUG(LOGGER, "CHOMP: adaptAndPlan ...");
 
@@ -183,7 +184,7 @@ public:
     moveit::core::MoveItErrorCode moveit_code = planner(ps, req, res);
     if (!bool(moveit_code))
     {
-      return false;
+      return moveit_code;
     }
 
     // create a hybrid collision detector to set the collision checker as hybrid
@@ -205,10 +206,15 @@ public:
     {
       res.trajectory_ = res_detailed.trajectory_[0];
       res.planning_time_ += res_detailed.processing_time_[0];
+      moveit_code = moveit::core::MoveItErrorCode::FAILURE;
+    }
+    else
+    {
+      moveit_code = moveit::core::MoveItErrorCode::SUCCESS;
     }
     res.error_code_ = res_detailed.error_code_;
 
-    return planning_success;
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -259,7 +259,6 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     if (adapter_chain_)
     {
       solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index);
-      RCLCPP_ERROR_STREAM(LOGGER, "Res 0: " << res.error_code_.val);
       if (!adapter_added_state_index.empty())
       {
         std::stringstream ss;
@@ -272,9 +271,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     {
       planning_interface::PlanningContextPtr context =
           planner_instance_->getPlanningContext(planning_scene, req, res.error_code_);
-      RCLCPP_ERROR_STREAM(LOGGER, "Res 1: " << res.error_code_.val);
       solved = context ? context->solve(res) : false;
-      RCLCPP_ERROR_STREAM(LOGGER, "Res 1a: " << res.error_code_.val);
     }
   }
   catch (std::exception& ex)
@@ -403,7 +400,6 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
                           "equivalent?");
   }
 
-  RCLCPP_ERROR_STREAM(LOGGER, "Res return: " << res.error_code_.val);
   return solved && valid;
 }
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -259,6 +259,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     if (adapter_chain_)
     {
       solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index);
+      RCLCPP_ERROR_STREAM(LOGGER, "Res 0: " << res.error_code_.val);
       if (!adapter_added_state_index.empty())
       {
         std::stringstream ss;
@@ -271,7 +272,9 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     {
       planning_interface::PlanningContextPtr context =
           planner_instance_->getPlanningContext(planning_scene, req, res.error_code_);
+      RCLCPP_ERROR_STREAM(LOGGER, "Res 1: " << res.error_code_.val);
       solved = context ? context->solve(res) : false;
+      RCLCPP_ERROR_STREAM(LOGGER, "Res 1a: " << res.error_code_.val);
     }
   }
   catch (std::exception& ex)
@@ -400,6 +403,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
                           "equivalent?");
   }
 
+  RCLCPP_ERROR_STREAM(LOGGER, "Res return: " << res.error_code_.val);
   return solved && valid;
 }
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -258,7 +258,8 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
   {
     if (adapter_chain_)
     {
-      solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index);
+      solved =
+          bool(adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index));
       if (!adapter_added_state_index.empty())
       {
         std::stringstream ss;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -63,20 +63,19 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    planner(planning_scene, req, res);
-    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
       {
         RCLCPP_WARN(LOGGER, "Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return bool(moveit_code);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -63,7 +63,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
+    planner(planning_scene, req, res);
+    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     if (result && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -59,9 +59,11 @@ public:
     return "Add Time Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
     if (bool(moveit_code) && res.trajectory_)
@@ -75,7 +77,7 @@ public:
       }
     }
 
-    return bool(moveit_code);
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
@@ -64,7 +64,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
+    planner(planning_scene, req, res);
+    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     if (result && res.trajectory_)
     {
       if (!smoother_.applySmoothing(*res.trajectory_, req.max_velocity_scaling_factor,

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
@@ -60,9 +60,11 @@ public:
     return "Add Ruckig trajectory smoothing.";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
     if (bool(moveit_code) && res.trajectory_)
@@ -74,7 +76,7 @@ public:
       }
     }
 
-    return bool(moveit_code);
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_ruckig_traj_smoothing.cpp
@@ -64,18 +64,17 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    planner(planning_scene, req, res);
-    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       if (!smoother_.applySmoothing(*res.trajectory_, req.max_velocity_scaling_factor,
                                     req.max_acceleration_scaling_factor))
       {
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return bool(moveit_code);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -68,9 +68,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    planner(planning_scene, req, res);
-    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, " Running '%s'", getDescription().c_str());
       TimeOptimalTrajectoryGeneration totg(path_tolerance_, resample_dt_, min_angle_change_);
@@ -78,11 +77,11 @@ public:
                                   req.max_acceleration_scaling_factor))
       {
         RCLCPP_WARN(LOGGER, " Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return bool(moveit_code);
   }
 
 protected:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -64,9 +64,11 @@ public:
     return "Add Time Optimal Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
     if (bool(moveit_code) && res.trajectory_)
@@ -81,7 +83,7 @@ public:
       }
     }
 
-    return bool(moveit_code);
+    return moveit_code;
   }
 
 protected:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -68,7 +68,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
+    planner(planning_scene, req, res);
+    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     if (result && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, " Running '%s'", getDescription().c_str());

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -62,20 +62,19 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    planner(planning_scene, req, res);
-    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-    if (result && res.trajectory_)
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    if (bool(moveit_code) && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
       {
         RCLCPP_WARN(LOGGER, "Time parametrization for the solution path failed.");
-        result = false;
+        moveit_code = moveit::core::MoveItErrorCode::FAILURE;
       }
     }
 
-    return result;
+    return bool(moveit_code);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -62,7 +62,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    bool result = planner(planning_scene, req, res);
+    planner(planning_scene, req, res);
+    bool result = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     if (result && res.trajectory_)
     {
       RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -58,9 +58,11 @@ public:
     return "Add Time Parameterization";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
     if (bool(moveit_code) && res.trajectory_)
@@ -74,7 +76,7 @@ public:
       }
     }
 
-    return bool(moveit_code);
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -51,8 +51,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    planner(planning_scene, req, res);
-    return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    return bool(moveit_code);
   }
 
   void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -51,7 +51,8 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    return planner(planning_scene, req, res);
+    planner(planning_scene, req, res);
+    return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   }
 
   void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -47,12 +47,13 @@ public:
     return "No Op";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
-    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
-    return bool(moveit_code);
+    return planner(planning_scene, req, res);
   }
 
   void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -165,19 +165,18 @@ public:
       }
     }
 
-    bool solved;
+    moveit::core::MoveItErrorCode moveit_code;
     // if we made any changes, use them
     if (change_req)
     {
       planning_interface::MotionPlanRequest req2 = req;
       moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-      planner(planning_scene, req2, res);
+      moveit_code = planner(planning_scene, req2, res);
     }
     else
     {
-      planner(planning_scene, req, res);
+      moveit_code = planner(planning_scene, req, res);
     }
-    solved = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
 
     // re-add the prefix state, if it was constructed
     if (prefix_state && res.trajectory_ && !res.trajectory_->empty())
@@ -193,7 +192,7 @@ public:
       added_path_index.push_back(0);
     }
 
-    return solved;
+    return bool(moveit_code);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -66,9 +66,11 @@ public:
     return "Fix Start State Bounds";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
 
@@ -192,7 +194,7 @@ public:
       added_path_index.push_back(0);
     }
 
-    return bool(moveit_code);
+    return moveit_code;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -171,10 +171,13 @@ public:
     {
       planning_interface::MotionPlanRequest req2 = req;
       moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-      solved = planner(planning_scene, req2, res);
+      planner(planning_scene, req2, res);
     }
     else
-      solved = planner(planning_scene, req, res);
+    {
+      planner(planning_scene, req, res);
+    }
+    solved = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
 
     // re-add the prefix state, if it was constructed
     if (prefix_state && res.trajectory_ && !res.trajectory_->empty())

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -76,7 +76,7 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& added_path_index) const override
   {
-    RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
+    RCLCPP_ERROR(LOGGER, "Running '%s'", getDescription().c_str());
 
     // get the specified start state
     moveit::core::RobotState start_state = planning_scene->getCurrentState();
@@ -151,9 +151,10 @@ public:
       {
         RCLCPP_WARN(LOGGER,
                     "Unable to find a valid state nearby the start state (using jiggle fraction of %lf and %u sampling "
-                    "attempts). Passing the original planning request to the planner.",
+                    "attempts).",
                     jiggle_fraction_, sampling_attempts_);
-        return planner(planning_scene, req, res);
+        res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_IN_COLLISION;
+        return false;
       }
     }
     else

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -132,7 +132,8 @@ public:
       {
         planning_interface::MotionPlanRequest req2 = req;
         moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-        bool solved = planner(planning_scene, req2, res);
+        planner(planning_scene, req, res);
+        bool solved = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
         if (solved && !res.trajectory_->empty())
         {
           // heuristically decide a duration offset for the trajectory (induced by the additional point added as a
@@ -163,7 +164,8 @@ public:
         RCLCPP_DEBUG(LOGGER, "Start state is valid");
       else
         RCLCPP_DEBUG(LOGGER, "Start state is valid with respect to group %s", creq.group_name.c_str());
-      return planner(planning_scene, req, res);
+      planner(planning_scene, req, res);
+      return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
     }
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -76,7 +76,7 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& added_path_index) const override
   {
-    RCLCPP_ERROR(LOGGER, "Running '%s'", getDescription().c_str());
+    RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
 
     // get the specified start state
     moveit::core::RobotState start_state = planning_scene->getCurrentState();

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -132,9 +132,8 @@ public:
       {
         planning_interface::MotionPlanRequest req2 = req;
         moveit::core::robotStateToRobotStateMsg(start_state, req2.start_state);
-        planner(planning_scene, req, res);
-        bool solved = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-        if (solved && !res.trajectory_->empty())
+        moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req2, res);
+        if (bool(moveit_code) && !res.trajectory_->empty())
         {
           // heuristically decide a duration offset for the trajectory (induced by the additional point added as a
           // prefix to the computed trajectory)
@@ -146,7 +145,7 @@ public:
             added_index++;
           added_path_index.push_back(0);
         }
-        return solved;
+        return bool(moveit_code);
       }
       else
       {
@@ -164,8 +163,8 @@ public:
         RCLCPP_DEBUG(LOGGER, "Start state is valid");
       else
         RCLCPP_DEBUG(LOGGER, "Start state is valid with respect to group %s", creq.group_name.c_str());
-      planner(planning_scene, req, res);
-      return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+      return bool(moveit_code);
     }
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -72,9 +72,11 @@ public:
     return "Fix Start State In Collision";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
 
@@ -145,7 +147,7 @@ public:
             added_index++;
           added_path_index.push_back(0);
         }
-        return bool(moveit_code);
+        return moveit_code;
       }
       else
       {
@@ -154,7 +156,8 @@ public:
                     "attempts).",
                     jiggle_fraction_, sampling_attempts_);
         res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_IN_COLLISION;
-        return false;
+        return moveit::core::MoveItErrorCode(moveit_msgs::msg::MoveItErrorCodes::START_STATE_IN_COLLISION);
+        ;
       }
     }
     else
@@ -163,8 +166,7 @@ public:
         RCLCPP_DEBUG(LOGGER, "Start state is valid");
       else
         RCLCPP_DEBUG(LOGGER, "Start state is valid with respect to group %s", creq.group_name.c_str());
-      moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
-      return bool(moveit_code);
+      return planner(planning_scene, req, res);
     }
   }
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -93,6 +93,7 @@ public:
       bool solved1 = planner(planning_scene, req2, res2);
       added_path_index_temp.swap(added_path_index);
 
+      bool solved2 = false;
       if (solved1)
       {
         planning_interface::MotionPlanRequest req3 = req;
@@ -101,7 +102,7 @@ public:
 
         // extract the last state of the computed motion plan and set it as the new start state
         moveit::core::robotStateToRobotStateMsg(res2.trajectory_->getLastWayPoint(), req3.start_state);
-        bool solved2 = planner(planning_scene, req3, res);
+        solved2 = planner(planning_scene, req3, res);
         res.planning_time_ += res2.planning_time_;
 
         if (solved2)
@@ -119,14 +120,9 @@ public:
           res2.trajectory_->swap(*res.trajectory_);
           return true;
         }
-        else
-        {
-          RCLCPP_WARN(LOGGER, "Unable to meet path constraints at the start.");
-          res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;
-          return false;
-        }
       }
-      else
+
+      if (!solved1 || !solved2)
       {
         RCLCPP_WARN(LOGGER, "Unable to meet path constraints at the start.");
         res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -63,9 +63,11 @@ public:
     return "Fix Start State Path Constraints";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& added_path_index) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& added_path_index) const override
   {
     RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
 
@@ -118,21 +120,22 @@ public:
           // we need to append the solution paths.
           res2.trajectory_->append(*res.trajectory_, 0.0);
           res2.trajectory_->swap(*res.trajectory_);
-          return true;
+          return moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
         }
       }
 
       if (!bool(solved1) || !bool(solved2))
       {
         RCLCPP_WARN(LOGGER, "Unable to meet path constraints at the start.");
+        moveit::core::MoveItErrorCode moveit_code(
+            moveit_msgs::msg::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS);
         res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;
-        return false;
+        return moveit_code;
       }
     }
 
     RCLCPP_DEBUG(LOGGER, "Path constraints are OK. Continuing without `fix_start_state_path_constraints`.");
-    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
-    return bool(moveit_code);
+    return planner(planning_scene, req, res);
   }
 };
 }  // namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -90,7 +90,8 @@ public:
       // index information from that call
       std::vector<std::size_t> added_path_index_temp;
       added_path_index_temp.swap(added_path_index);
-      bool solved1 = planner(planning_scene, req2, res2);
+      planner(planning_scene, req2, res2);
+      bool solved1 = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
       added_path_index_temp.swap(added_path_index);
 
       bool solved2 = false;
@@ -102,7 +103,8 @@ public:
 
         // extract the last state of the computed motion plan and set it as the new start state
         moveit::core::robotStateToRobotStateMsg(res2.trajectory_->getLastWayPoint(), req3.start_state);
-        solved2 = planner(planning_scene, req3, res);
+        planner(planning_scene, req3, res);
+        solved2 = (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
         res.planning_time_ += res2.planning_time_;
 
         if (solved2)
@@ -132,7 +134,8 @@ public:
     else
     {
       RCLCPP_DEBUG(LOGGER, "Path constraints are OK. Continuing without `fix_start_state_path_constraints`.");
-      return planner(planning_scene, req, res);
+      planner(planning_scene, req, res);
+      return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
     }
   }
 };

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -67,7 +67,7 @@ public:
                     const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
                     std::vector<std::size_t>& added_path_index) const override
   {
-    RCLCPP_ERROR(LOGGER, "Running '%s'", getDescription().c_str());
+    RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
 
     // get the specified start state
     moveit::core::RobotState start_state = planning_scene->getCurrentState();

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -131,12 +131,10 @@ public:
         return false;
       }
     }
-    else
-    {
-      RCLCPP_DEBUG(LOGGER, "Path constraints are OK. Continuing without `fix_start_state_path_constraints`.");
-      planner(planning_scene, req, res);
-      return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
-    }
+
+    RCLCPP_DEBUG(LOGGER, "Path constraints are OK. Continuing without `fix_start_state_path_constraints`.");
+    planner(planning_scene, req, res);
+    return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
   }
 };
 }  // namespace default_planner_request_adapters

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -77,10 +77,12 @@ public:
       moveit_msgs::msg::WorkspaceParameters& default_wp = req2.workspace_parameters;
       default_wp.min_corner.x = default_wp.min_corner.y = default_wp.min_corner.z = -workspace_extent_;
       default_wp.max_corner.x = default_wp.max_corner.y = default_wp.max_corner.z = workspace_extent_;
-      return planner(planning_scene, req2, res);
+      planner(planning_scene, req2, res);
+      return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
     }
-    else
-      return planner(planning_scene, req, res);
+
+    planner(planning_scene, req, res);
+    return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -62,9 +62,11 @@ public:
     return "Fix Workspace Bounds";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
     const moveit_msgs::msg::WorkspaceParameters& wparams = req.workspace_parameters;
@@ -77,12 +79,10 @@ public:
       moveit_msgs::msg::WorkspaceParameters& default_wp = req2.workspace_parameters;
       default_wp.min_corner.x = default_wp.min_corner.y = default_wp.min_corner.z = -workspace_extent_;
       default_wp.max_corner.x = default_wp.max_corner.y = default_wp.max_corner.z = workspace_extent_;
-      moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req2, res);
-      return bool(moveit_code);
+      return planner(planning_scene, req2, res);
     }
 
-    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
-    return bool(moveit_code);
+    return planner(planning_scene, req, res);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -77,12 +77,12 @@ public:
       moveit_msgs::msg::WorkspaceParameters& default_wp = req2.workspace_parameters;
       default_wp.min_corner.x = default_wp.min_corner.y = default_wp.min_corner.z = -workspace_extent_;
       default_wp.max_corner.x = default_wp.max_corner.y = default_wp.max_corner.z = workspace_extent_;
-      planner(planning_scene, req2, res);
-      return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req2, res);
+      return bool(moveit_code);
     }
 
-    planner(planning_scene, req, res);
-    return res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, req, res);
+    return bool(moveit_code);
   }
 
 private:

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -66,8 +66,11 @@ public:
     planning_interface::MotionPlanRequest modified = req;
     kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), modified.path_constraints);
     for (moveit_msgs::msg::Constraints& constraint : modified.goal_constraints)
+    {
       kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), constraint);
-    return planner(planning_scene, modified, res);
+    }
+    planner(planning_scene, modified, res);
+    return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
   }
 };
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -69,8 +69,8 @@ public:
     {
       kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), constraint);
     }
-    planner(planning_scene, modified, res);
-    return (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, modified, res);
+    return bool(moveit_code);
   }
 };
 

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/resolve_constraint_frames.cpp
@@ -58,9 +58,11 @@ public:
     return "Resolve constraint frames to robot links";
   }
 
-  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
-                    const planning_interface::MotionPlanRequest& req, planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t>& /*added_path_index*/) const override
+  moveit::core::MoveItErrorCode adaptAndPlan(const PlannerFn& planner,
+                                             const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                             const planning_interface::MotionPlanRequest& req,
+                                             planning_interface::MotionPlanResponse& res,
+                                             std::vector<std::size_t>& /*added_path_index*/) const override
   {
     RCLCPP_DEBUG(LOGGER, "Running '%s'", getDescription().c_str());
     planning_interface::MotionPlanRequest modified = req;
@@ -69,8 +71,7 @@ public:
     {
       kinematic_constraints::resolveConstraintFrames(planning_scene->getCurrentState(), constraint);
     }
-    moveit::core::MoveItErrorCode moveit_code = planner(planning_scene, modified, res);
-    return bool(moveit_code);
+    return planner(planning_scene, modified, res);
   }
 };
 


### PR DESCRIPTION
### Description

Previously, if one of the planning request adapters failed, the pipeline would continue onward anyway. Also, only a `bool` was returned, although `moveit_msgs::MoveItErrorCodes.msg` has some enums to report more detail.

This PR short-circuits in case there is an adapter failure and reports the actual error code.

For example, here's the output when there are 6 adapters and `FixStartStateCollision` fails:

```
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588225372] [moveit_ros.fix_start_state_collision]: Running 'Fix Start State In Collision'
[moveit_cpp_tutorial-4] [WARN] [1665063576.588230842] [moveit_ros.fix_start_state_collision]: Unable to find a valid state nearby the start state (using jiggle fraction of 0.020000 and 100 sampling attempts).
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588242808] [moveit.planning_request_adapter]: Adapter  result: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588261618] [moveit.planning_request_adapter]: Adapter  result: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588265353] [moveit.planning_request_adapter]: Adapter  result: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588267620] [moveit.planning_request_adapter]: Adapter  result: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588291731] [moveit.planning_request_adapter]: Adapter  result: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588300902] [moveit.ros_planning.planning_pipeline]: Res return: -10
[moveit_cpp_tutorial-4] [ERROR] [1665063576.588302635] [moveit.ros_planning_interface.planning_component]: Could not compute plan successfully
```

A code of -10 means ["START_STATE_IN_COLLISION"](https://github.com/ros-planning/moveit_msgs/blob/master/msg/MoveItErrorCodes.msg)  :+1:

Prior to this PR, the output would be:

```
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760674407] [moveit.planning_request_adapter]: Adapter result: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760687109] [moveit.planning_request_adapter]: Adapter result: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760691608] [moveit.planning_request_adapter]: Adapter result: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760693864] [moveit.planning_request_adapter]: Adapter result: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760695824] [moveit.planning_request_adapter]: Adapter result: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760701750] [moveit.ros_planning.planning_pipeline]: Res return: 0
[moveit_cpp_tutorial-4] [ERROR] [1665067792.760704577] [moveit.ros_planning_interface.planning_component]: Could not compute plan successfully
```

Which is not very useful for debugging.


### Testing this PR

I've been testing with the [move_group_interface tutorial](https://moveit.picknik.ai/main/doc/examples/move_group_interface/move_group_interface_tutorial.html). You can publish collision objects conveniently from the GUI:

`ros2 launch moveit2_tutorials move_group.launch.py`

`ros2 launch moveit2_tutorials move_group_interface_tutorial.launch.py`

This image shows a START_STATE_IN_COLLISION result code.

![box_collision](https://user-images.githubusercontent.com/11284393/194565147-7b4cb3d2-c6c7-4a30-9c23-55d99c5796e6.png)
