### PR TITLE
Convert OMPL status to MoveItErrorCode in the OMPL interface

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
       UPSTREAM_WORKSPACE: moveit2.repos $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
+      # Uninstall binaries that are duplicated in the .repos file
+      # TODO(andyz): remove this once a sync containing 35b93c8 happens
+      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs -y
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       # Clear the ccache stats before and log the stats after the build
       AFTER_SETUP_CCACHE: ccache --zero-stats --max-size=10.0G

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -1,4 +1,9 @@
 repositories:
+  # TODO(andyz): remove this once a sync containing 35b93c8 happens
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: ros2
   # https://github.com/ros-planning/moveit_resources/pull/147
   moveit_resources:
     type: git

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -388,7 +388,7 @@ protected:
   void unregisterTerminationCondition();
 
   /** \brief Convert OMPL PlannerStatus to moveit_msgs::msg::MoveItErrorCode */
-  void omplPlannerStatusToMoveItErrorCode(og::SimpleSetupPtr ompl_simple_setup, moveit_msgs::msg::MoveItErrorCodes& res);
+  int32_t logPlannerStatus(og::SimpleSetupPtr ompl_simple_setup);
 
   ModelBasedPlanningContextSpecification spec_;
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -293,7 +293,7 @@ public:
      @param timeout The time to spend on solving
      @param count The number of runs to combine the paths of, in an attempt to generate better quality paths
   */
-  bool solve(double timeout, unsigned int count);
+  const moveit_msgs::msg::MoveItErrorCodes solve(double timeout, unsigned int count);
 
   /* @brief Benchmark the planning problem. Return true on successful saving of benchmark results
      @param timeout The time to spend on solving
@@ -386,6 +386,9 @@ protected:
 
   void registerTerminationCondition(const ob::PlannerTerminationCondition& ptc);
   void unregisterTerminationCondition();
+
+  /** \brief Convert OMPL PlannerStatus to moveit_msgs::msg::MoveItErrorCode */
+  void omplPlannerStatusToMoveItErrorCode(og::SimpleSetupPtr ompl_simple_setup, moveit_msgs::msg::MoveItErrorCodes& res);
 
   ModelBasedPlanningContextSpecification spec_;
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -980,15 +980,15 @@ void ompl_interface::ModelBasedPlanningContext::omplPlannerStatusToMoveItErrorCo
       break;
     case ompl::base::PlannerStatus::INVALID_START:
       RCLCPP_WARN(LOGGER, "Invalid start state");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      res.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_INVALID;
       break;
     case ompl::base::PlannerStatus::INVALID_GOAL:
       RCLCPP_WARN(LOGGER, "Invalid goal state");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      res.val = moveit_msgs::msg::MoveItErrorCodes::GOAL_STATE_INVALID;
       break;
     case ompl::base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE:
       RCLCPP_WARN(LOGGER, "Unrecognized goal type");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      res.val = moveit_msgs::msg::MoveItErrorCodes::UNRECOGNIZED_GOAL_TYPE;
       break;
     case ompl::base::PlannerStatus::TIMEOUT:
       RCLCPP_WARN(LOGGER, "Timed out");
@@ -1003,11 +1003,11 @@ void ompl_interface::ModelBasedPlanningContext::omplPlannerStatusToMoveItErrorCo
       break;
     case ompl::base::PlannerStatus::CRASH:
       RCLCPP_WARN(LOGGER, "OMPL crashed!");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      res.val = moveit_msgs::msg::MoveItErrorCodes::CRASH;
       break;
     case ompl::base::PlannerStatus::ABORT:
       RCLCPP_WARN(LOGGER, "OMPL was aborted");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      res.val = moveit_msgs::msg::MoveItErrorCodes::ABORT;
       break;
     default:
       // This should never happen

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -861,7 +861,7 @@ const moveit_msgs::msg::MoveItErrorCodes ompl_interface::ModelBasedPlanningConte
     last_plan_time_ = ompl_simple_setup_->getLastPlanComputationTime();
     unregisterTerminationCondition();
     // fill the result status code
-    omplPlannerStatusToMoveItErrorCode(ompl_simple_setup_, result);
+    result.val = logPlannerStatus(ompl_simple_setup_);
   }
   else
   {
@@ -968,52 +968,53 @@ void ompl_interface::ModelBasedPlanningContext::unregisterTerminationCondition()
   ptc_ = nullptr;
 }
 
-void ompl_interface::ModelBasedPlanningContext::omplPlannerStatusToMoveItErrorCode(
-    og::SimpleSetupPtr ompl_simple_setup, moveit_msgs::msg::MoveItErrorCodes& res)
+int32_t ompl_interface::ModelBasedPlanningContext::logPlannerStatus(og::SimpleSetupPtr ompl_simple_setup)
 {
+  auto result = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
   ompl::base::PlannerStatus ompl_status = ompl_simple_setup->getLastPlannerStatus();
   switch (ompl::base::PlannerStatus::StatusType(ompl_status))
   {
     case ompl::base::PlannerStatus::UNKNOWN:
       RCLCPP_WARN(LOGGER, "Motion planning failed for an unknown reason");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      result = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
       break;
     case ompl::base::PlannerStatus::INVALID_START:
       RCLCPP_WARN(LOGGER, "Invalid start state");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_INVALID;
+      result = moveit_msgs::msg::MoveItErrorCodes::START_STATE_INVALID;
       break;
     case ompl::base::PlannerStatus::INVALID_GOAL:
       RCLCPP_WARN(LOGGER, "Invalid goal state");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::GOAL_STATE_INVALID;
+      result = moveit_msgs::msg::MoveItErrorCodes::GOAL_STATE_INVALID;
       break;
     case ompl::base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE:
       RCLCPP_WARN(LOGGER, "Unrecognized goal type");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::UNRECOGNIZED_GOAL_TYPE;
+      result = moveit_msgs::msg::MoveItErrorCodes::UNRECOGNIZED_GOAL_TYPE;
       break;
     case ompl::base::PlannerStatus::TIMEOUT:
       RCLCPP_WARN(LOGGER, "Timed out");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::TIMED_OUT;
+      result = moveit_msgs::msg::MoveItErrorCodes::TIMED_OUT;
       break;
     case ompl::base::PlannerStatus::APPROXIMATE_SOLUTION:
       RCLCPP_WARN(LOGGER, "Solution is approximate");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      result = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
       break;
     case ompl::base::PlannerStatus::EXACT_SOLUTION:
-      res.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      result = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
       break;
     case ompl::base::PlannerStatus::CRASH:
       RCLCPP_WARN(LOGGER, "OMPL crashed!");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::CRASH;
+      result = moveit_msgs::msg::MoveItErrorCodes::CRASH;
       break;
     case ompl::base::PlannerStatus::ABORT:
       RCLCPP_WARN(LOGGER, "OMPL was aborted");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::ABORT;
+      result = moveit_msgs::msg::MoveItErrorCodes::ABORT;
       break;
     default:
       // This should never happen
       RCLCPP_WARN(LOGGER, "Unexpected PlannerStatus code from OMPL.");
-      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      result = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
   }
+  return result;
 }
 
 bool ompl_interface::ModelBasedPlanningContext::terminate()

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -754,11 +754,6 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
   int iv = ompl_simple_setup_->getSpaceInformation()->getMotionValidator()->getInvalidMotionCount();
   RCLCPP_DEBUG(LOGGER, "There were %d valid motions and %d invalid motions.", v, iv);
 
-  if (ompl_simple_setup_->getProblemDefinition()->hasApproximateSolution())
-  {
-    RCLCPP_WARN(LOGGER, "Computed solution is approximate");
-  }
-
   // Debug OMPL setup and solution
   std::stringstream debug_out;
   ompl_simple_setup_->print(debug_out);
@@ -767,7 +762,8 @@ void ompl_interface::ModelBasedPlanningContext::postSolve()
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 {
-  if (solve(request_.allowed_planning_time, request_.num_planning_attempts))
+  res.error_code_ = solve(request_.allowed_planning_time, request_.num_planning_attempts);
+  if (res.error_code_.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
   {
     double ptime = getLastPlanTime();
     if (simplify_solutions_)
@@ -793,14 +789,15 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   else
   {
     RCLCPP_INFO(LOGGER, "Unable to solve the planning problem");
-    res.error_code_.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
 }
 
 bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
-  if (solve(request_.allowed_planning_time, request_.num_planning_attempts))
+  moveit_msgs::msg::MoveItErrorCodes moveit_result =
+      solve(request_.allowed_planning_time, request_.num_planning_attempts);
+  if (moveit_result.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
   {
     res.trajectory_.reserve(3);
 
@@ -834,9 +831,9 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
       getSolutionPath(*res.trajectory_.back());
     }
 
-    // fill the response
     RCLCPP_DEBUG(LOGGER, "%s: Returning successful solution with %lu states", getName().c_str(),
                  getOMPLSimpleSetup()->getSolutionPath().getStateCount());
+    res.error_code_.val = moveit_result.val;
     return true;
   }
   else
@@ -847,20 +844,24 @@ bool ompl_interface::ModelBasedPlanningContext::solve(planning_interface::Motion
   }
 }
 
-bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned int count)
+const moveit_msgs::msg::MoveItErrorCodes ompl_interface::ModelBasedPlanningContext::solve(double timeout,
+                                                                                          unsigned int count)
 {
   ompl::time::point start = ompl::time::now();
   preSolve();
 
-  bool result = false;
+  moveit_msgs::msg::MoveItErrorCodes result;
+  result.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
   if (count <= 1 || multi_query_planning_enabled_)  // multi-query planners should always run in single instances
   {
     RCLCPP_DEBUG(LOGGER, "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
     registerTerminationCondition(ptc);
-    result = ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION;
+    result.val = ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION;
     last_plan_time_ = ompl_simple_setup_->getLastPlanComputationTime();
     unregisterTerminationCondition();
+    // fill the result status code
+    omplPlannerStatusToMoveItErrorCode(ompl_simple_setup_, result);
   }
   else
   {
@@ -884,7 +885,10 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
 
       ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
       registerTerminationCondition(ptc);
-      result = ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION;
+      if (ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION)
+      {
+        result.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      }
       last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
       unregisterTerminationCondition();
     }
@@ -893,7 +897,7 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
       ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
       registerTerminationCondition(ptc);
       int n = count / max_planning_threads_;
-      result = true;
+      result.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
       for (int i = 0; i < n && !ptc(); ++i)
       {
         ompl_parallel_plan_.clearPlanners();
@@ -913,7 +917,10 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
         }
 
         bool r = ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION;
-        result = result && r;
+        // Was this latest call successful too?
+        result.val = (result.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS && r) ?
+                         moveit_msgs::msg::MoveItErrorCodes::SUCCESS :
+                         moveit_msgs::msg::MoveItErrorCodes::FAILURE;
       }
       n = count % max_planning_threads_;
       if (n && !ptc())
@@ -935,7 +942,10 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
         }
 
         bool r = ompl_parallel_plan_.solve(ptc, 1, count, hybridize_) == ompl::base::PlannerStatus::EXACT_SOLUTION;
-        result = result && r;
+        // Was this latest call successful too?
+        result.val = (result.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS && r) ?
+                         moveit_msgs::msg::MoveItErrorCodes::SUCCESS :
+                         moveit_msgs::msg::MoveItErrorCodes::FAILURE;
       }
       last_plan_time_ = ompl::time::seconds(ompl::time::now() - start);
       unregisterTerminationCondition();
@@ -943,7 +953,6 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
   }
 
   postSolve();
-
   return result;
 }
 
@@ -957,6 +966,54 @@ void ompl_interface::ModelBasedPlanningContext::unregisterTerminationCondition()
 {
   std::unique_lock<std::mutex> slock(ptc_lock_);
   ptc_ = nullptr;
+}
+
+void ompl_interface::ModelBasedPlanningContext::omplPlannerStatusToMoveItErrorCode(
+    og::SimpleSetupPtr ompl_simple_setup, moveit_msgs::msg::MoveItErrorCodes& res)
+{
+  ompl::base::PlannerStatus ompl_status = ompl_simple_setup->getLastPlannerStatus();
+  switch (ompl::base::PlannerStatus::StatusType(ompl_status))
+  {
+    case ompl::base::PlannerStatus::UNKNOWN:
+      RCLCPP_WARN(LOGGER, "Motion planning failed for an unknown reason");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      break;
+    case ompl::base::PlannerStatus::INVALID_START:
+      RCLCPP_WARN(LOGGER, "Invalid start state");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      break;
+    case ompl::base::PlannerStatus::INVALID_GOAL:
+      RCLCPP_WARN(LOGGER, "Invalid goal state");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      break;
+    case ompl::base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE:
+      RCLCPP_WARN(LOGGER, "Unrecognized goal type");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+      break;
+    case ompl::base::PlannerStatus::TIMEOUT:
+      RCLCPP_WARN(LOGGER, "Timed out");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::TIMED_OUT;
+      break;
+    case ompl::base::PlannerStatus::APPROXIMATE_SOLUTION:
+      RCLCPP_WARN(LOGGER, "Solution is approximate");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      break;
+    case ompl::base::PlannerStatus::EXACT_SOLUTION:
+      res.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+      break;
+    case ompl::base::PlannerStatus::CRASH:
+      RCLCPP_WARN(LOGGER, "OMPL crashed!");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      break;
+    case ompl::base::PlannerStatus::ABORT:
+      RCLCPP_WARN(LOGGER, "OMPL was aborted");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      break;
+    default:
+      // This should never happen
+      RCLCPP_WARN(LOGGER, "Unexpected PlannerStatus code from OMPL.");
+      res.val = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
+  }
 }
 
 bool ompl_interface::ModelBasedPlanningContext::terminate()


### PR DESCRIPTION
### Description

Get better detail from planning errors by converting OMPL codes to MoveItErrorCode and returning them.

OMPL code documentation:  https://github.com/ompl/ompl/blob/main/src/ompl/base/PlannerStatus.h
MoveItErrorCode documentation:  https://github.com/ros-planning/moveit_msgs/blob/master/msg/MoveItErrorCodes.msg