### PR TITLE
Replace C array with std::array in std::vector template argument

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp
@@ -152,7 +152,7 @@ void ChompTrajectory::fillInMinJerk()
 
   // calculate the spline coefficients for each joint:
   // (these are for the special case of zero start and end vel and acc)
-  std::vector<double[6]> coeff(num_joints_);
+  std::vector<std::array<double, 6>> coeff(num_joints_);
   for (size_t i = 0; i < num_joints_; ++i)
   {
     double x0 = (*this)(start_index, i);


### PR DESCRIPTION
### Description

When compiling on macOS, Apple clang (version 13.1.6) throws the same compilation error as the one reported https://github.com/ros-planning/moveit/issues/3157 in MoveIt for ROS1 with the cause being invalid destructor call for C array type. So I made a simple change from C array to `std::array` to make the code more compatible with different C++ STL implementations.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
