### PR TITLE
Add moveit_core dependency to robot_interaction

### DIFF
--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -5,6 +5,7 @@ project(moveit_ros_robot_interaction)
 find_package(moveit_common REQUIRED)
 moveit_package()
 
+find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(tf2 REQUIRED)
@@ -17,6 +18,7 @@ find_package(rclcpp REQUIRED)
 set(MOVEIT_LIB_NAME moveit_robot_interaction)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  moveit_core
   moveit_ros_planning
   interactive_markers
   tf2_geometry_msgs

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -18,8 +18,9 @@
   <author email="isucan@google.com">Ioan Sucan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>moveit_common</depend>
 
+  <depend>moveit_common</depend>
+  <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
### Description

This PR addresses the core issue in https://github.com/ros-planning/moveit2/issues/1594, which is a missing dependency that makes moveit2's `robot_interaction` package build successfully if building with a single worker, but fail at linking time otherwise against some functions available in `moveit_core`.
