### PR TITLE
Express Humble/Rolling differences in #if

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(MOVEIT_LIB_NAME moveit_move_group_interface)
 
-# TODO(#1608): Enable deprecated declarations warning as error once humble support is removed from main branch
-add_compile_options(-Wno-deprecated-declarations)
-
 add_library(${MOVEIT_LIB_NAME} SHARED src/move_group_interface.cpp)
 include(GenerateExportHeader)
 generate_export_header(${MOVEIT_LIB_NAME})

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -86,7 +86,25 @@ enum ActiveTargetType
   POSITION,
   ORIENTATION
 };
+
+// Function to support both Rolling and Humble on the main branch
+// Rolling has deprecated the version of the create_client method that takes
+// rmw_qos_profile_services_default for the QoS argument
+template <typename ServiceT>
+typename rclcpp::Client<ServiceT>::SharedPtr create_client_default_qos(const rclcpp::Node::SharedPtr& node,
+                                                                       const std::string& name,
+                                                                       rclcpp::CallbackGroup::SharedPtr group)
+{
+#if RCLCPP_VERSION_GTE(17, 0, 0)
+  // Rolling
+  return node->create_client<ServiceT>(name, rclcpp::SystemDefaultsQoS(), group);
+#else
+  // Humble
+  return node->create_client<ServiceT>(name, rmw_qos_profile_services_default, group);
+#endif
 }
+
+}  // namespace
 
 class MoveGroupInterface::MoveGroupInterfaceImpl
 {
@@ -163,38 +181,18 @@ public:
         node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::EXECUTE_ACTION_NAME), callback_group_);
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
 
-    // Support both Rolling and Humble on the Main branch
-    // Rolling has deprecated the version of the create_client method that takes
-    // rmw_qos_profile_services_default for the QoS argument
-#if RCLCPP_VERSION_GTE(17, 0, 0)
-    // Rolling
-    query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
-    get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
-    set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
-    cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
-        rclcpp::SystemDefaultsQoS(), callback_group_);
-#else
-    // Humble
-    query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
-    get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
-    set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
-    cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
-        rmw_qos_profile_services_default, callback_group_);
-#endif
+    query_service_ = create_client_default_qos<moveit_msgs::srv::QueryPlannerInterfaces>(
+        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
+        callback_group_);
+    get_params_service_ = create_client_default_qos<moveit_msgs::srv::GetPlannerParams>(
+        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
+        callback_group_);
+    set_params_service_ = create_client_default_qos<moveit_msgs::srv::SetPlannerParams>(
+        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
+        callback_group_);
+    cartesian_path_service_ = create_client_default_qos<moveit_msgs::srv::GetCartesianPath>(
+        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
+        callback_group_);
 
     RCLCPP_INFO_STREAM(LOGGER, "Ready to take commands for planning group " << opt.group_name_ << ".");
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -195,7 +195,6 @@ public:
         rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
 #endif
-    // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 
     RCLCPP_INFO_STREAM(LOGGER, "Ready to take commands for planning group " << opt.group_name_ << ".");
   }


### PR DESCRIPTION
- Express Humble/Rolling differences in #if
- Remove commented out line of code

### Description

Instead of disabling the warning for deprecations in CMake, I looked into a way to support both Humble and Rolling in main so we can continue to get the warnings that will help us stay up to date with Rolling.

I found this ROS Answers post about how to write an #if pre-processor statement for detecting the ROS version: https://answers.ros.org/question/9562/how-do-i-test-the-ros-version-in-c-code/

That lead me to this ament package that is used by rclcpp to create a variable based on its version here: https://github.com/ament/ament_cmake/tree/rolling/ament_cmake_gen_version_h/cmake

The code in that generated file has changed over time and isn't exactly what is in the first ROS Answers post and on my machine is this:

```cpp
/// \def RCLCPP_VERSION_MAJOR
/// Defines RCLCPP major version number
#define RCLCPP_VERSION_MAJOR (17)

/// \def RCLCPP_VERSION_MINOR
/// Defines RCLCPP minor version number
#define RCLCPP_VERSION_MINOR (0)

/// \def RCLCPP_VERSION_PATCH
/// Defines RCLCPP version patch number
#define RCLCPP_VERSION_PATCH (0)

/// \def RCLCPP_VERSION_STR
/// Defines RCLCPP version string
#define RCLCPP_VERSION_STR "17.0.0"

/// \def RCLCPP_VERSION_GTE
/// Defines a macro to check whether the version of RCLCPP is greater than or equal to
/// the given version triple.
#define RCLCPP_VERSION_GTE(major, minor, patch) ( \
     (major < RCLCPP_VERSION_MAJOR) ? true \
     : (major > RCLCPP_VERSION_MAJOR) ? false \
     : (minor < RCLCPP_VERSION_MINOR) ? true \
     : (minor > RCLCPP_VERSION_MINOR) ? false \
     : (patch < RCLCPP_VERSION_PATCH) ? true \
     : (patch > RCLCPP_VERSION_PATCH) ? false \
     : true)
```

From this, I was able to update the code to support both Rolling and Humble by detecting the version of the function calls.