### PR TITLE
Add joint acceleration validator methods to Pilz limits container

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -130,7 +130,7 @@ public:
    * @param joint_position
    * @return true if within limits, false otherwise
    */
-  bool verifyPositionLimit(const std::string& joint_name, const double& joint_position) const;
+  bool verifyPositionLimit(const std::string& joint_name, double joint_position) const;
 
   /**
    * @brief verify velocity limit of single joint
@@ -138,7 +138,7 @@ public:
    * @param joint_velocity
    * @return true if within limits, false otherwise
    */
-  bool verifyVelocityLimit(const std::string& joint_name, const double& joint_velocity) const;
+  bool verifyVelocityLimit(const std::string& joint_name, double joint_velocity) const;
 
   /**
    * @brief verify acceleration limit of single joint
@@ -146,7 +146,7 @@ public:
    * @param joint_acceleration
    * @return true if within limits, false otherwise
    */
-  bool verifyAccelerationLimit(const std::string& joint_name, const double& joint_acceleration) const;
+  bool verifyAccelerationLimit(const std::string& joint_name, double joint_acceleration) const;
 
   /**
    * @brief verify deceleration limit of single joint
@@ -154,7 +154,7 @@ public:
    * @param joint_acceleration
    * @return true if within limits, false otherwise
    */
-  bool verifyDecelerationLimit(const std::string& joint_name, const double& joint_acceleration) const;
+  bool verifyDecelerationLimit(const std::string& joint_name, double joint_acceleration) const;
 
 private:
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -128,17 +128,33 @@ public:
    * @brief verify position limit of single joint
    * @param joint_name
    * @param joint_position
-   * @return
+   * @return true if within limits, false otherwise
+   */
+  bool verifyPositionLimit(const std::string& joint_name, const double& joint_position) const;
+
+  /**
+   * @brief verify velocity limit of single joint
+   * @param joint_name
+   * @param joint_velocity
+   * @return true if within limits, false otherwise
    */
   bool verifyVelocityLimit(const std::string& joint_name, const double& joint_velocity) const;
 
   /**
-   * @brief verify position limit of single joint
+   * @brief verify acceleration limit of single joint
    * @param joint_name
-   * @param joint_position
-   * @return
+   * @param joint_acceleration
+   * @return true if within limits, false otherwise
    */
-  bool verifyPositionLimit(const std::string& joint_name, const double& joint_position) const;
+  bool verifyAccelerationLimit(const std::string& joint_name, const double& joint_acceleration) const;
+
+  /**
+   * @brief verify deceleration limit of single joint
+   * @param joint_name
+   * @param joint_acceleration
+   * @return true if within limits, false otherwise
+   */
+  bool verifyDecelerationLimit(const std::string& joint_name, const double& joint_acceleration) const;
 
 private:
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
@@ -109,25 +109,25 @@ std::map<std::string, JointLimit>::const_iterator JointLimitsContainer::end() co
   return container_.end();
 }
 
-bool JointLimitsContainer::verifyPositionLimit(const std::string& joint_name, const double& joint_position) const
+bool JointLimitsContainer::verifyPositionLimit(const std::string& joint_name, double joint_position) const
 {
   return (!(hasLimit(joint_name) && getLimit(joint_name).has_position_limits &&
             (joint_position < getLimit(joint_name).min_position || joint_position > getLimit(joint_name).max_position)));
 }
 
-bool JointLimitsContainer::verifyVelocityLimit(const std::string& joint_name, const double& joint_velocity) const
+bool JointLimitsContainer::verifyVelocityLimit(const std::string& joint_name, double joint_velocity) const
 {
   return (!(hasLimit(joint_name) && getLimit(joint_name).has_velocity_limits &&
             fabs(joint_velocity) > getLimit(joint_name).max_velocity));
 }
 
-bool JointLimitsContainer::verifyAccelerationLimit(const std::string& joint_name, const double& joint_acceleration) const
+bool JointLimitsContainer::verifyAccelerationLimit(const std::string& joint_name, double joint_acceleration) const
 {
   return (!(hasLimit(joint_name) && getLimit(joint_name).has_acceleration_limits &&
             fabs(joint_acceleration) > getLimit(joint_name).max_acceleration));
 }
 
-bool JointLimitsContainer::verifyDecelerationLimit(const std::string& joint_name, const double& joint_acceleration) const
+bool JointLimitsContainer::verifyDecelerationLimit(const std::string& joint_name, double joint_acceleration) const
 {
   return (!(hasLimit(joint_name) && getLimit(joint_name).has_deceleration_limits &&
             fabs(joint_acceleration) > -1.0 * getLimit(joint_name).max_deceleration));

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
@@ -109,16 +109,28 @@ std::map<std::string, JointLimit>::const_iterator JointLimitsContainer::end() co
   return container_.end();
 }
 
+bool JointLimitsContainer::verifyPositionLimit(const std::string& joint_name, const double& joint_position) const
+{
+  return (!(hasLimit(joint_name) && getLimit(joint_name).has_position_limits &&
+            (joint_position < getLimit(joint_name).min_position || joint_position > getLimit(joint_name).max_position)));
+}
+
 bool JointLimitsContainer::verifyVelocityLimit(const std::string& joint_name, const double& joint_velocity) const
 {
   return (!(hasLimit(joint_name) && getLimit(joint_name).has_velocity_limits &&
             fabs(joint_velocity) > getLimit(joint_name).max_velocity));
 }
 
-bool JointLimitsContainer::verifyPositionLimit(const std::string& joint_name, const double& joint_position) const
+bool JointLimitsContainer::verifyAccelerationLimit(const std::string& joint_name, const double& joint_acceleration) const
 {
-  return (!(hasLimit(joint_name) && getLimit(joint_name).has_position_limits &&
-            (joint_position < getLimit(joint_name).min_position || joint_position > getLimit(joint_name).max_position)));
+  return (!(hasLimit(joint_name) && getLimit(joint_name).has_acceleration_limits &&
+            fabs(joint_acceleration) > getLimit(joint_name).max_acceleration));
+}
+
+bool JointLimitsContainer::verifyDecelerationLimit(const std::string& joint_name, const double& joint_acceleration) const
+{
+  return (!(hasLimit(joint_name) && getLimit(joint_name).has_deceleration_limits &&
+            fabs(joint_acceleration) > -1.0 * getLimit(joint_name).max_deceleration));
 }
 
 void JointLimitsContainer::updateCommonLimit(const JointLimit& joint_limit, JointLimit& common_limit)

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -174,8 +174,7 @@ bool pilz_industrial_motion_planner::verifySampleJointLimits(
     // acceleration case
     if (fabs(velocity_last.at(pos.first)) <= fabs(velocity_current))
     {
-      if (joint_limits.getLimit(pos.first).has_acceleration_limits &&
-          fabs(acceleration_current) > fabs(joint_limits.getLimit(pos.first).max_acceleration))
+      if (!joint_limits.verifyAccelerationLimit(pos.first, acceleration_current))
       {
         RCLCPP_ERROR_STREAM(LOGGER, "Joint acceleration limit of "
                                         << pos.first << " violated. Set the acceleration scaling factor lower!"
@@ -188,8 +187,7 @@ bool pilz_industrial_motion_planner::verifySampleJointLimits(
     // deceleration case
     else
     {
-      if (joint_limits.getLimit(pos.first).has_deceleration_limits &&
-          fabs(acceleration_current) > fabs(joint_limits.getLimit(pos.first).max_deceleration))
+      if (!joint_limits.verifyDecelerationLimit(pos.first, acceleration_current))
       {
         RCLCPP_ERROR_STREAM(LOGGER, "Joint deceleration limit of "
                                         << pos.first << " violated. Set the acceleration scaling factor lower!"


### PR DESCRIPTION
### Description

While developing, I found a bug in Pilz where not setting joint acceleration limits causes us to directly access a map with a non-existent key and segfault while validating a trajectory against joint limits.

This had already been handled for the position and velocity limits by first checking the existence of this key using `hasLimit()`, so it just required a little bit of copy-paste for the acceleration / deceleration case.

NOTE: As this work is doing in service of MoveIt Studio, it should be backported to Humble.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
