### PR TITLE
Backport to Humble

### DIFF
--- a/moveit_commander/src/moveit_commander/planning_scene_interface.py
+++ b/moveit_commander/src/moveit_commander/planning_scene_interface.py
@@ -268,11 +268,11 @@ class PlanningSceneInterface(object):
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
+        co.pose = pose.pose
         box = SolidPrimitive()
         box.type = SolidPrimitive.BOX
         box.dimensions = list(size)
         co.primitives = [box]
-        co.primitive_poses = [pose.pose]
         return co
 
     @staticmethod
@@ -290,6 +290,7 @@ class PlanningSceneInterface(object):
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
+        co.pose = pose.pose
 
         mesh = Mesh()
         first_face = scene.meshes[0].faces[0]
@@ -320,7 +321,6 @@ class PlanningSceneInterface(object):
             point.z = vertex[2] * scale[2]
             mesh.vertices.append(point)
         co.meshes = [mesh]
-        co.mesh_poses = [pose.pose]
         pyassimp.release(scene)
         return co
 
@@ -330,11 +330,11 @@ class PlanningSceneInterface(object):
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
+        co.pose = pose.pose
         sphere = SolidPrimitive()
         sphere.type = SolidPrimitive.SPHERE
         sphere.dimensions = [radius]
         co.primitives = [sphere]
-        co.primitive_poses = [pose.pose]
         return co
 
     @staticmethod
@@ -343,11 +343,11 @@ class PlanningSceneInterface(object):
         co.operation = CollisionObject.ADD
         co.id = name
         co.header = pose.header
+        co.pose = pose.pose
         cylinder = SolidPrimitive()
         cylinder.type = SolidPrimitive.CYLINDER
         cylinder.dimensions = [height, radius]
         co.primitives = [cylinder]
-        co.primitive_poses = [pose.pose]
         return co
 
     @staticmethod

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
@@ -87,23 +87,26 @@ function cleanup {
 function run_quiet {
    # When running in quiet mode, save stdout as 3, then redirect stdout to $TMP_DIR/ikfast.log
    if [ "$QUIET" == "1" ] ; then
-      local STDOUT=3;
-      local STDERR=4;
-      exec 3>&1 1>$TMP_DIR/ifast.log
-      exec 4>&2 2>$TMP_DIR/ifast.log
+      local STDOUT=3
+      local STDERR=4
+      exec 3>&1 1>"$TMP_DIR/ikfast.log"
+      exec 4>&2 2>&1
    fi
 
    set +e
    "$@"
    ret=$?
    set -e
-   if [ $ret != 0 ] ; then
-      echo "$@\nfailed with exec code $ret:"
-      cat $TMP_DIR/ifast.log
-   fi
 
    # Restore stdout + stderr
    exec 1>&${STDOUT:-1}  # restore stdout
+   exec 2>&${STDERR:-2}  # restore stderr
+
+   if [ $ret != 0 ] ; then
+      echo "'$*' failed with exec code $ret:"
+      test "$QUIET" == "1" && cat "$TMP_DIR/ikfast.log"
+   fi
+
    return $ret
 }
 

--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
@@ -207,6 +207,11 @@ while true ; do
    filename=$(basename -- "$INPUT")
    extension=$(echo "${filename##*.}" | tr '[:upper:]' '[:lower:]')
    case "$extension" in
+      xacro)
+         URDF="$TMP_DIR/${filename%.*}.urdf"
+         xacro "$INPUT" > "$URDF"
+         INPUT="$URDF"
+         ;;
       urdf)  # create .dae from .urdf
          extract_robot_name "$INPUT"
          create_dae_file

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/path_circle_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/path_circle_generator.h
@@ -39,6 +39,8 @@
 #include <kdl/rotational_interpolation_sa.hpp>
 #include <kdl/utilities/error.h>
 
+#include <memory>
+
 namespace pilz_industrial_motion_planner
 {
 /**

--- a/moveit_ros/planning/launch/collision_checker_compare.launch
+++ b/moveit_ros/planning/launch/collision_checker_compare.launch
@@ -1,10 +1,9 @@
 <launch>
   <arg name="visualization" default="false" doc="turns on and off visualization with rviz"/>
 
-  <!-- send Panda urdf to parameter server -->
-  <param name="robot_description" textfile="$(find moveit_resources_panda_description)/urdf/panda.urdf" />
-
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch"/>
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
 
   <node name="compare_collision_checking_speed" pkg="moveit_ros_planning" type="moveit_compare_collision_checking_speed_fcl_bullet" respawn="false" output="screen">
     <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/kinematics.yaml"/>


### PR DESCRIPTION
- Load robot_description via planning_context.launch
- auto_create_ikfast_moveit_plugin.sh: allow xacro input
- Fix run_quiet()
- Adjust python PSI to new CollisionObject.pose interface (#3176)
- Add missing header for std::unique_ptr (#3180)

### Description

These are changes that do not have a moveit2 PR associated with them as they were forward ports from moveit1.