### PR TITLE
Use generate_parameter_library to load KDL kinematics parameters

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -32,6 +32,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 set(THIS_PACKAGE_LIBRARIES
   moveit_cached_ik_kinematics_base
   moveit_cached_ik_kinematics_plugin
+  kdl_kinematics_parameters
   moveit_kdl_kinematics_plugin
   lma_kinematics_parameters
   moveit_lma_kinematics_plugin

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(pluginlib REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_msgs REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 
 # Finds Boost Components
 include(ConfigExtras.cmake)
@@ -42,6 +43,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   moveit_ros_planning
   Boost
+  generate_parameter_library
 )
 
 pluginlib_export_plugin_description_file(moveit_core kdl_kinematics_plugin_description.xml)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_core
   moveit_msgs
 )
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_cached_ik_kinematics_plugin)
 
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
@@ -23,7 +24,6 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_msgs
 )
 target_link_libraries(${MOVEIT_LIB_NAME}
-    moveit_cached_ik_kinematics_base
     moveit_kdl_kinematics_plugin
     moveit_srv_kinematics_plugin)
 if(trac_ik_kinematics_plugin_FOUND)

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -32,11 +32,3 @@ target_compile_definitions(${MOVEIT_LIB_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_F
 target_compile_definitions(${MOVEIT_LIB_NAME} PRIVATE "MOVEIT_KDL_KINEMATICS_PLUGIN_BUILDING_DLL")
 
 install(DIRECTORY include/ DESTINATION include)
-
-install(
-  TARGETS kdl_kinematics_parameters
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(MOVEIT_LIB_NAME moveit_kdl_kinematics_plugin)
 
+generate_parameter_library(
+  kdl_kinematics_parameters # cmake target name for the parameter library
+  src/kdl_kinematics_parameters.yaml # path to input yaml file
+)
+
 add_library(${MOVEIT_LIB_NAME} SHARED
   src/kdl_kinematics_plugin.cpp
   src/chainiksolver_vel_mimic_svd.cpp)
@@ -16,6 +21,10 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   EIGEN3
 )
 
+target_link_libraries(${MOVEIT_LIB_NAME}
+  kdl_kinematics_parameters
+)
+
 # prevent pluginlib from using boost
 target_compile_definitions(${MOVEIT_LIB_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -23,3 +32,11 @@ target_compile_definitions(${MOVEIT_LIB_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_F
 target_compile_definitions(${MOVEIT_LIB_NAME} PRIVATE "MOVEIT_KDL_KINEMATICS_PLUGIN_BUILDING_DLL")
 
 install(DIRECTORY include/ DESTINATION include)
+
+install(
+  TARGETS kdl_kinematics_parameters
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -39,6 +39,7 @@
 // ROS
 #include <rclcpp/rclcpp.hpp>
 #include <random_numbers/random_numbers.h>
+#include <kdl_kinematics_parameters.hpp>
 
 // ROS msgs
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -182,5 +183,8 @@ private:
    * > 1.0: orientation has more importance than position
    * = 0.0: perform position-only IK */
   double orientation_vs_position_weight_;
+
+  // std::shared_ptr<kdl_kinematics::ParamListener> param_listener_;
+  // kdl_kinematics::Params params_;
 };
 }  // namespace kdl_kinematics_plugin

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -184,7 +184,7 @@ private:
    * = 0.0: perform position-only IK */
   double orientation_vs_position_weight_;
 
-  // std::shared_ptr<kdl_kinematics::ParamListener> param_listener_;
-  // kdl_kinematics::Params params_;
+  std::shared_ptr<kdl_kinematics::ParamListener> param_listener_;
+  kdl_kinematics::Params params_;
 };
 }  // namespace kdl_kinematics_plugin

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -175,15 +175,6 @@ private:
   std::vector<double> joint_weights_;
   Eigen::VectorXd joint_min_, joint_max_;  ///< joint limits
 
-  int max_solver_iterations_;
-  double epsilon_;
-  /** weight of orientation error vs position error
-   *
-   * < 1.0: orientation has less importance than position
-   * > 1.0: orientation has more importance than position
-   * = 0.0: perform position-only IK */
-  double orientation_vs_position_weight_;
-
   std::shared_ptr<kdl_kinematics::ParamListener> param_listener_;
   kdl_kinematics::Params params_;
 };

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -19,14 +19,18 @@ kdl_kinematics:
     type: int,
     default_value: 500,
     description: "Maximum solver iterations",
-    # validation:
+    validation: {
+      gt_eq<>: [ 0.0 ]
+    }
   }
 
   epsilon: {
     type: double,
     default_value: 0.00001,
     description: "Epsilon. Default is 1e-5",
-    # validation:
+    validation: {
+      gt<>: [ 0.0 ]
+    }
   }
 
   orientation_vs_position: {
@@ -36,12 +40,13 @@ kdl_kinematics:
                   * < 1.0: orientation has less importance than position
                   * > 1.0: orientation has more importance than position
                   * = 0.0: perform position-only IK",
-    # validation:
+    validation: {
+      gt_eq<>: [ 0.0 ]
+    }
   }
 
   position_only_ik: {
     type: bool,
     default_value: false,
     description: "position_only_ik overrules orientation_vs_position. If true, sets orientation_vs_position weight to 0.0",
-    # validation:
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -1,0 +1,41 @@
+kdl_kinematics:
+  joints: {
+    type: string_array,
+    default_value: ["joint1", "joint2", "joint3"],
+    description: "Joints names to assign weights",
+  }
+
+  __map_joints:
+    weight: {
+      type: double,
+      default_value: 1.0,
+      description: "Joint weight",
+    }
+
+  max_solver_iterations: {
+    type: int,
+    default_value: 500,
+    description: "Maximum solver iterations",
+    # validation:
+  }
+
+  epsilon: {
+    type: double,
+    default_value: 0.00001,
+    description: "Epsilon. Default is 1e-5",
+    # validation:
+  }
+
+  orientation_vs_position: {
+    type: double,
+    default_value: 1.0,
+    description: "orientation vs position weight",
+    # validation:
+  }
+
+  position_only_ik: {
+    type: bool,
+    default_value: false,
+    description: "position_only_ik overrules orientation_vs_position. Sets orientation_vs_position to 0.0",
+    # validation:
+  }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -39,6 +39,6 @@ kdl_kinematics:
   position_only_ik: {
     type: bool,
     default_value: false,
-    description: "position_only_ik overrules orientation_vs_position. Sets orientation_vs_position to 0.0",
+    description: "position_only_ik overrules orientation_vs_position. If true, sets orientation_vs_position weight to 0.0",
     # validation:
   }

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -29,7 +29,10 @@ kdl_kinematics:
   orientation_vs_position: {
     type: double,
     default_value: 1.0,
-    description: "orientation vs position weight",
+    description: "Weight of orientation error vs position error
+                  * < 1.0: orientation has less importance than position
+                  * > 1.0: orientation has more importance than position
+                  * = 0.0: perform position-only IK",
     # validation:
   }
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -1,6 +1,7 @@
 kdl_kinematics:
   joints: {
     type: string_array,
+    default_value: [],
     description: "Joints names to assign weights",
   }
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -1,7 +1,6 @@
 kdl_kinematics:
   joints: {
     type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
     description: "Joints names to assign weights",
   }
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -10,6 +10,9 @@ kdl_kinematics:
       type: double,
       default_value: 1.0,
       description: "Joint weight",
+      validation: {
+        gt<>: [ 0.0 ]
+      }
     }
 
   max_solver_iterations: {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -37,6 +37,8 @@
 #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
 #include <moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp>
 
+#include "kdl_kinematics_parameters.hpp"
+
 #include <tf2_kdl/tf2_kdl.hpp>
 #include <tf2/transform_datatypes.h>
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -37,8 +37,6 @@
 #include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
 #include <moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp>
 
-#include "kdl_kinematics_parameters.hpp"
-
 #include <tf2_kdl/tf2_kdl.hpp>
 #include <tf2/transform_datatypes.h>
 

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -27,6 +27,7 @@
   <depend>moveit_core</depend>
   <depend>class_loader</depend>
   <depend>pluginlib</depend>
+  <depend>generate_parameter_library</depend>
   <depend>eigen</depend>
   <depend>tf2</depend>
   <depend>tf2_kdl</depend>


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load KDL kinematics parameters

How to assign the KDL parameters in `kinematics.yaml` file
```
panda_arm:
  kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
  kinematics_solver_search_resolution: 0.005
  kinematics_solver_timeout: 0.05

  joints: ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]
  # Default weight for joints is 1.0 
  joint1:
    weight: 2.0
  joint5:
    weight: 1.5

  max_solver_iterations: 200
  epsilon: 0.0001
  orientation_vs_position: 0.2
  position_only_ik: false
```
TODO:
- [x] Figure out if any parameters can be removed - Retain all
- [x] Is there a better way to assign joint weights? - The above method works fine
### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
