### PR TITLE
Use generate_parameter_library to load LMA kinematics parameters

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -32,6 +32,7 @@ set(THIS_PACKAGE_LIBRARIES
   moveit_cached_ik_kinematics_base
   moveit_cached_ik_kinematics_plugin
   moveit_kdl_kinematics_plugin
+  lma_kinematics_parameters
   moveit_lma_kinematics_plugin
   moveit_srv_kinematics_plugin
 )

--- a/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/lma_kinematics_plugin/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(MOVEIT_LIB_NAME moveit_lma_kinematics_plugin)
 
+generate_parameter_library(
+  lma_kinematics_parameters # cmake target name for the parameter library
+  src/lma_kinematics_parameters.yaml # path to input yaml file
+)
+
 add_library(${MOVEIT_LIB_NAME} SHARED src/lma_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
@@ -8,6 +13,10 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_core
   moveit_msgs
   tf2_kdl
+)
+
+target_link_libraries(${MOVEIT_LIB_NAME}
+  lma_kinematics_parameters
 )
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
+++ b/moveit_kinematics/lma_kinematics_plugin/include/moveit/lma_kinematics_plugin/lma_kinematics_plugin.h
@@ -39,6 +39,7 @@
 // ROS2
 #include <rclcpp/rclcpp.hpp>
 #include <random_numbers/random_numbers.h>
+#include <lma_kinematics_parameters.hpp>
 
 // ROS msgs
 #include <geometry_msgs/msg/pose.hpp>
@@ -155,13 +156,7 @@ private:
   std::vector<std::string> joint_names_;
   rclcpp::Node::SharedPtr node_;
 
-  int max_solver_iterations_;
-  double epsilon_;
-  /** weight of orientation error vs position error
-   *
-   * < 1.0: orientation has less importance than position
-   * > 1.0: orientation has more importance than position
-   * = 0.0: perform position-only IK */
-  double orientation_vs_position_weight_;
+  std::shared_ptr<lma_kinematics::ParamListener> param_listener_;
+  lma_kinematics::Params params_;
 };
 }  // namespace lma_kinematics_plugin

--- a/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_parameters.yaml
+++ b/moveit_kinematics/lma_kinematics_plugin/src/lma_kinematics_parameters.yaml
@@ -1,0 +1,37 @@
+lma_kinematics:
+
+  max_solver_iterations: {
+    type: int,
+    default_value: 500,
+    description: "Maximum solver iterations",
+    validation: {
+      gt_eq<>: [ 0.0 ]
+    }
+  }
+
+  epsilon: {
+    type: double,
+    default_value: 0.00001,
+    description: "Epsilon. Default is 1e-5",
+    validation: {
+      gt<>: [ 0.0 ]
+    }
+  }
+
+  orientation_vs_position: {
+    type: double,
+    default_value: 1.0,
+    description: "Weight of orientation error vs position error
+                  * < 1.0: orientation has less importance than position
+                  * > 1.0: orientation has more importance than position
+                  * = 0.0: perform position-only IK",
+    validation: {
+      gt_eq<>: [ 0.0 ]
+    }
+  }
+
+  position_only_ik: {
+    type: bool,
+    default_value: false,
+    description: "position_only_ik overrules orientation_vs_position. If true, sets orientation_vs_position weight to 0.0",
+  }


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load LMA kinematics parameters

TODO:
- [ ] Any changes to the parameter list?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
