### PR TITLE
 Use generate_parameter_library to load srv kinematics parameters

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -34,6 +34,7 @@ set(THIS_PACKAGE_LIBRARIES
   moveit_kdl_kinematics_plugin
   lma_kinematics_parameters
   moveit_lma_kinematics_plugin
+  srv_kinematics_parameters
   moveit_srv_kinematics_plugin
 )
 

--- a/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(MOVEIT_LIB_NAME moveit_srv_kinematics_plugin)
 
+
+generate_parameter_library(
+  srv_kinematics_parameters # cmake target name for the parameter library
+  src/srv_kinematics_parameters.yaml # path to input yaml file
+)
+
 add_library(${MOVEIT_LIB_NAME} SHARED src/srv_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
@@ -7,6 +13,10 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_core
   moveit_msgs
+)
+
+target_link_libraries(${MOVEIT_LIB_NAME}
+  srv_kinematics_parameters
 )
 
 install(DIRECTORY include/ DESTINATION include)

--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -152,5 +152,8 @@ private:
   rclcpp::Client<moveit_msgs::srv::GetPositionIK>::SharedPtr ik_service_client_;
 
   rclcpp::Node::SharedPtr node_;
+
+  std::shared_ptr<srv_kinematics::ParamListener> param_listener_;
+  srv_kinematics::Params params_;
 };
 }  // namespace srv_kinematics_plugin

--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -43,6 +43,7 @@
 
 // ROS2
 #include <rclcpp/rclcpp.hpp>
+#include <srv_kinematics_parameters.hpp>
 
 // System
 #include <memory>

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_parameters.yaml
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_parameters.yaml
@@ -1,0 +1,9 @@
+srv_kinematics:
+  kinematics_solver_service_name: {
+    type: string,
+    default_value: "solve_ik",
+    description: "Kinematics Solver Service Name",
+    validation: {
+      not_empty<>: []
+    }
+  }


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load srv kinematics parameters

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
