### PR TITLE
 Use generate_parameter_library to load ikfast kinematics parameters

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 from __future__ import print_function
 
+from symbol import parameters
+
 """
 IKFast Plugin Generator for MoveIt
 
@@ -180,6 +182,19 @@ def xmlElement(name, text=None, **attributes):
     return e
 
 
+def create_parameter_dict():
+    parameter_dict = {
+        "ikfast_kinematics": {
+            "link_prefix": {
+                "default_value": "",
+                "type": "string",
+                "description": "prefix added to tip- and baseframe to allow different namespaces or multi-robot setups",
+            }
+        }
+    }
+    return parameter_dict
+
+
 def create_ikfast_package(args):
     try:
         setattr(
@@ -223,6 +238,13 @@ def create_ikfast_package(args):
             pkg_xml_path, xml_declaration=True, pretty_print=True, encoding="UTF-8"
         )
         print("Created package.xml at: '%s'" % pkg_xml_path)
+
+    # Create parameter YAML in src folder
+    parameters_yaml_path = src_path + "ikfast_kinematics_parameters.yaml"
+    if not os.path.exists(parameters_yaml_path):
+        print("Create parameters.yaml at: '%s'" % parameters_yaml_path)
+        with open(parameters_yaml_path, "w") as file:
+            documents = yaml.dump(create_parameter_dict(), file)
 
 
 def find_template_dir():

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -17,6 +17,11 @@ find_package(LAPACK REQUIRED)
 
 include_directories(include)
 
+generate_parameter_library(
+  ikfast_kinematics_parameters # cmake target name for the parameter library
+  ikfast_kinematics_parameters.yaml # path to input yaml file
+)
+
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)
 add_library(${IKFAST_LIBRARY_NAME} SHARED src/_ROBOT_NAME___GROUP_NAME__ikfast_moveit_plugin.cpp)
 ament_target_dependencies(${IKFAST_LIBRARY_NAME}
@@ -30,7 +35,11 @@ ament_target_dependencies(${IKFAST_LIBRARY_NAME}
 # suppress warnings about unused variables in OpenRave's solver code
 target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable -Wno-unused-parameter)
 
-install(TARGETS ${IKFAST_LIBRARY_NAME}
+target_link_libraries(${MOVEIT_LIB_NAME}
+  ikfast_kinematics_parameters
+)
+
+install(TARGETS ${IKFAST_LIBRARY_NAME} ikfast_kinematics_parameters
   EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(rclcpp REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(LAPACK REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 
 include_directories(include)
 
@@ -53,4 +54,5 @@ ament_export_dependencies(pluginlib)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(tf2_kdl)
 ament_export_dependencies(tf2_eigen)
+ament_export_dependencies(generate_parameter_library)
 ament_package()

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(include)
 
 generate_parameter_library(
   ikfast_kinematics_parameters # cmake target name for the parameter library
-  ikfast_kinematics_parameters.yaml # path to input yaml file
+  src/ikfast_kinematics_parameters.yaml # path to input yaml file
 )
 
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -36,7 +36,7 @@ ament_target_dependencies(${IKFAST_LIBRARY_NAME}
 # suppress warnings about unused variables in OpenRave's solver code
 target_compile_options(${IKFAST_LIBRARY_NAME} PRIVATE -Wno-unused-variable -Wno-unused-parameter)
 
-target_link_libraries(${MOVEIT_LIB_NAME}
+target_link_libraries(${IKFAST_LIBRARY_NAME}
   ikfast_kinematics_parameters
 )
 

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast_kinematics_parameters.yaml
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast_kinematics_parameters.yaml
@@ -1,5 +1,6 @@
 ikfast_kinematics:
   link_prefix: {
     type: string,
+    default_value: "",
     description: "prefix added to tip- and baseframe to allow different namespaces or multi-robot setups",
   }

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast_kinematics_parameters.yaml
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast_kinematics_parameters.yaml
@@ -1,0 +1,5 @@
+ikfast_kinematics:
+  link_prefix: {
+    type: string,
+    description: "prefix added to tip- and baseframe to allow different namespaces or multi-robot setups",
+  }


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load ikfast kinematics parameters

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
