### PR TITLE
Use generate_parameter_library to load cached IK kinematics parameters

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -29,6 +29,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 )
 
 set(THIS_PACKAGE_LIBRARIES
+  cached_ik_kinematics_parameters
   moveit_cached_ik_kinematics_base
   moveit_cached_ik_kinematics_plugin
   moveit_kdl_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -9,10 +9,16 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_core
   moveit_msgs
 )
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_cached_ik_kinematics_plugin)
 
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
 endif()
+
+generate_parameter_library(
+  cached_ik_kinematics_parameters # cmake target name for the parameter library
+  include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml # path to input yaml file
+)
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)
 add_library(${MOVEIT_LIB_NAME} SHARED src/cached_ik_kinematics_plugin.cpp)
@@ -23,7 +29,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   moveit_msgs
 )
 target_link_libraries(${MOVEIT_LIB_NAME}
-    moveit_cached_ik_kinematics_base
+    cached_ik_kinematics_parameters
     moveit_kdl_kinematics_plugin
     moveit_srv_kinematics_plugin)
 if(trac_ik_kinematics_plugin_FOUND)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml
@@ -3,26 +3,22 @@
       type: int,
       default_value: 5000,
       description: "Maximum cache size",
-      # validation:
     }
 
     min_pose_distance: {
       type: double,
       default_value: 1.0,
       description: "Minimum pose distance",
-      # validation:
     }
 
     min_joint_config_distance: {
       type: double,
       default_value: 1.0,
       description: "Minimum joint config distance",
-      # validation:
     }
 
     cached_ik_path: {
       type: string,
       default_value: "",
       description: "Cached IK path",
-      # validation:
     }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml
@@ -1,0 +1,28 @@
+  cached_ik_kinematics:
+    max_cache_size: {
+      type: int,
+      default_value: 5000,
+      description: "Maximum cache size",
+      # validation:
+    }
+
+    min_pose_distance: {
+      type: double,
+      default_value: 1.0,
+      description: "Minimum pose distance",
+      # validation:
+    }
+
+    min_joint_config_distance: {
+      type: double,
+      default_value: 1.0,
+      description: "Minimum joint config distance",
+      # validation:
+    }
+
+    cached_ik_path: {
+      type: string,
+      default_value: "",
+      description: "Cached IK path",
+      # validation:
+    }

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -54,13 +54,10 @@ void CachedIKKinematicsPlugin<KinematicsPlugin>::initCache(const std::string& ro
                                                            const std::string& cache_name)
 {
   IKCache::Options opts;
-  int max_cache_size;  // rosparam can't handle unsigned int
-  kinematics::KinematicsBase::lookupParam(node_, "max_cache_size", max_cache_size,
-                                          static_cast<int>(opts.max_cache_size));
-  opts.max_cache_size = max_cache_size;
-  kinematics::KinematicsBase::lookupParam(node_, "min_pose_distance", opts.min_pose_distance, 1.0);
-  kinematics::KinematicsBase::lookupParam(node_, "min_joint_config_distance", opts.min_joint_config_distance, 1.0);
-  kinematics::KinematicsBase::lookupParam<std::string>(node_, "cached_ik_path", opts.cached_ik_path, "");
+  opts.max_cache_size = params_.max_cache_size;
+  opts.min_pose_distance = params_.min_pose_distance;
+  opts.min_joint_config_distance = params_.min_joint_config_distance;
+  opts.cached_ik_path = params_.cached_ik_path;
 
   cache_.initializeCache(robot_id, group_name, cache_name, KinematicsPlugin::getJointNames().size(), opts);
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -46,6 +46,7 @@
 #include <unordered_map>
 #include <utility>
 #include <filesystem>
+#include <cached_ik_kinematics_parameters.hpp>
 
 namespace cached_ik_kinematics_plugin
 {
@@ -229,6 +230,11 @@ public:
                   const std::vector<std::string>& tip_frames, double search_discretization) override
   {
     node_ = node;
+
+    std::string kinematics_param_prefix = "robot_description_kinematics." + group_name;
+    param_listener_ = std::make_shared<cached_ik_kinematics::ParamListener>(node, kinematics_param_prefix);
+    params_ = param_listener_->get_params();
+
     return initializeImpl(node, robot_model, group_name, base_frame, tip_frames, search_discretization);
   }
 
@@ -257,6 +263,8 @@ public:
 
 private:
   rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<cached_ik_kinematics::ParamListener> param_listener_;
+  cached_ik_kinematics::Params params_;
 
   IKCache cache_;
 


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load cached ik kinematics parameters

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
