### PR TITLE
Switch back to the moveit_msgs debian

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,6 @@ jobs:
       UPSTREAM_WORKSPACE: moveit2.repos $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
-      # Uninstall binaries that are duplicated in the .repos file
-      # TODO(andyz): remove this once a sync containing 35b93c8 happens
-      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove -y ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs || true
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       # Clear the ccache stats before and log the stats after the build
       AFTER_SETUP_CCACHE: ccache --zero-stats --max-size=10.0G


### PR DESCRIPTION
This cleans up the TODO [here](https://github.com/ros-planning/moveit2/blob/66a64b4a72b6ddef1af2329f20ed8162554d5bcb/.github/workflows/ci.yaml#L39):  

```
      # Uninstall binaries that are duplicated in the .repos file
      # TODO(andyz): remove this once a sync containing 35b93c8 happens
      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove -y ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs || true
```