### PR TITLE
 Use generate_parameter_library to load prbt ikfast kinematics parameters

### DIFF
--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -26,8 +26,14 @@ find_package(tf2_kdl REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_eigen_kdl REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 
 include_directories(include)
+
+generate_parameter_library(
+  prbt_ikfast_kinematics_parameters # cmake target name for the parameter library
+  src/prbt_ikfast_kinematics_parameters.yaml # path to input yaml file
+)
 
 add_library(prbt_manipulator_moveit_ikfast_plugin SHARED
   src/prbt_manipulator_ikfast_moveit_plugin.cpp)
@@ -46,10 +52,12 @@ ament_target_dependencies(prbt_manipulator_moveit_ikfast_plugin
   tf2_geometry_msgs
 )
 
+target_link_libraries(prbt_manipulator_moveit_ikfast_plugin prbt_ikfast_kinematics_parameters)
+
 pluginlib_export_plugin_description_file(moveit_core prbt_manipulator_moveit_ikfast_plugin_description.xml)
 
 install(
-  TARGETS prbt_manipulator_moveit_ikfast_plugin
+  TARGETS prbt_manipulator_moveit_ikfast_plugin prbt_ikfast_kinematics_parameters
   EXPORT ${PROJECT_NAME}Targets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -58,6 +66,6 @@ install(
 )
 
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} generate_parameter_library)
 
 ament_package()

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_ikfast_kinematics_parameters.yaml
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_ikfast_kinematics_parameters.yaml
@@ -1,0 +1,6 @@
+prbt_ikfast_kinematics:
+  link_prefix: {
+    type: string,
+    default_value: "",
+    description: "prefix added to tip- and baseframe to allow different namespaces or multi-robot setups",
+  }

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -52,7 +52,7 @@
 #include <tf2_kdl/tf2_kdl.hpp>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/robot_state/robot_state.h>
-
+#include <prbt_ikfast_kinematics_parameters.hpp>
 
 using namespace moveit::core;
 
@@ -169,13 +169,13 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   const size_t num_joints_;
   std::vector<int> free_params_;
 
+  std::shared_ptr<prbt_ikfast_kinematics::ParamListener> param_listener_;
+  prbt_ikfast_kinematics::Params params_;
+
   // The ikfast and base frame are the start and end of the kinematic chain for which the
   // IKFast analytic solution was generated.
   const std::string IKFAST_TIP_FRAME_ = "flange";
   const std::string IKFAST_BASE_FRAME_ = "base_link";
-
-  // prefix added to tip- and baseframe to allow different namespaces or multi-robot setups
-  std::string link_prefix_;
 
   // The transform tip and base bool are set to true if this solver is used with a kinematic
   // chain that extends beyond the ikfast tip and base frame. The solution will be valid so
@@ -414,14 +414,8 @@ bool IKFastKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, con
   }
 
   storeValues(robot_model, group_name, base_frame, tip_frames, search_discretization);
-  if (!lookupParam(node, "link_prefix", link_prefix_, std::string("")))
-  {
-    RCLCPP_INFO(LOGGER, "Using empty link_prefix.");
-  }
-  else
-  {
-    RCLCPP_INFO_STREAM(LOGGER, "Using link_prefix: '" << link_prefix_ << "'");
-  }
+
+  RCLCPP_INFO_STREAM(LOGGER, "Using link_prefix: '" << params_.link_prefix << "'");
 
   // verbose error output. subsequent checks in computeRelativeTransform return false then
   if (!robot_model.hasLinkModel(tip_frames_[0]))
@@ -429,12 +423,12 @@ bool IKFastKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, con
   if (!robot_model.hasLinkModel(base_frame_))
     RCLCPP_ERROR_STREAM(LOGGER, "base_frame '" << base_frame_ << "' does not exist.");
 
-  if (!robot_model.hasLinkModel(link_prefix_ + IKFAST_TIP_FRAME_))
-    RCLCPP_ERROR_STREAM(LOGGER, "prefixed tip frame '" << link_prefix_ + IKFAST_TIP_FRAME_
+  if (!robot_model.hasLinkModel(params_.link_prefix + IKFAST_TIP_FRAME_))
+    RCLCPP_ERROR_STREAM(LOGGER, "prefixed tip frame '" << params_.link_prefix + IKFAST_TIP_FRAME_
                                                        << "' does not exist. "
                                                           "Please check your link_prefix parameter.");
-  if (!robot_model.hasLinkModel(link_prefix_ + IKFAST_BASE_FRAME_))
-    RCLCPP_ERROR_STREAM(LOGGER, "prefixed base frame '" << link_prefix_ + IKFAST_BASE_FRAME_
+  if (!robot_model.hasLinkModel(params_.link_prefix + IKFAST_BASE_FRAME_))
+    RCLCPP_ERROR_STREAM(LOGGER, "prefixed base frame '" << params_.link_prefix + IKFAST_BASE_FRAME_
                                                         << "' does not exist. "
                                                            "Please check your link_prefix parameter.");
   // This IKFast solution was generated with IKFAST_TIP_FRAME_ and IKFAST_BASE_FRAME_.
@@ -442,9 +436,9 @@ bool IKFastKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, con
   // a robot mounted on a table or a robot with an end effector attached to the last link.
   // To support these use cases, we store the transform from the IKFAST_BASE_FRAME_ to the
   // base_frame_ and IKFAST_TIP_FRAME_ the tip_frame_ and transform to the input pose accordingly
-  if (!computeRelativeTransform(tip_frames_[0], link_prefix_ + IKFAST_TIP_FRAME_, group_tip_to_chain_tip_,
+  if (!computeRelativeTransform(tip_frames_[0], params_.link_prefix + IKFAST_TIP_FRAME_, group_tip_to_chain_tip_,
                                 tip_transform_required_) ||
-      !computeRelativeTransform(link_prefix_ + IKFAST_BASE_FRAME_, base_frame_, chain_base_to_group_base_,
+      !computeRelativeTransform(params_.link_prefix + IKFAST_BASE_FRAME_, base_frame_, chain_base_to_group_base_,
                                 base_transform_required_))
   {
     return false;

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -413,6 +413,10 @@ bool IKFastKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, con
     return false;
   }
 
+  std::string kinematics_param_prefix = "robot_description_kinematics." + group_name;
+  param_listener_ = std::make_shared<prbt_ikfast_kinematics::ParamListener>(node, kinematics_param_prefix);
+  params_ = param_listener_->get_params();
+
   storeValues(robot_model, group_name, base_frame, tip_frames, search_discretization);
 
   RCLCPP_INFO_STREAM(LOGGER, "Using link_prefix: '" << params_.link_prefix << "'");


### PR DESCRIPTION
### Description

Use `generate_parameter_library` to load prbt ikfast kinematics parameters

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
