### PR TITLE
Deprecate lookupParam function

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -604,8 +604,8 @@ protected:
    * as the predominant configuration but also allows groupwise specifications.
    */
   template <typename T>
-  inline bool lookupParam(const rclcpp::Node::SharedPtr& node, const std::string& param, T& val,
-                          const T& default_val) const
+  [[deprecated("Use generate_parameter_library instead")]] inline bool
+  lookupParam(const rclcpp::Node::SharedPtr& node, const std::string& param, T& val, const T& default_val) const
   {
     if (node->has_parameter({ group_name_ + "." + param }))
     {


### PR DESCRIPTION
### Description
Remove the function once the following PRs are merged
https://github.com/ros-planning/moveit2/pull/1671
https://github.com/ros-planning/moveit2/pull/1673
https://github.com/ros-planning/moveit2/pull/1674
https://github.com/ros-planning/moveit2/pull/1675
https://github.com/ros-planning/moveit2/pull/1677
https://github.com/ros-planning/moveit2/pull/1680

Update - We have decided to deprecate it instead

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
