### PR TITLE
Add missing depend in package.xml

### DIFF
--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
@@ -21,6 +21,7 @@
   <build_depend>tf2_eigen</build_depend>
   <build_depend>tf2_kdl</build_depend>
   <build_depend>tf2_eigen_kdl</build_depend>
+  <depend>generate_parameter_library</depend>
   <exec_depend>moveit_core</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>rclcpp</exec_depend>


### PR DESCRIPTION
### Description

This should fix the build error for the `moveit_resources_prbt_ikfast_manipulator_plugin` package

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
