### PR TITLE
Fix dead tutorial link

### DIFF
--- a/moveit_ros/moveit_servo/README.md
+++ b/moveit_ros/moveit_servo/README.md
@@ -1,3 +1,3 @@
 # Moveit Servo
 
-See the [Realtime Arm Servoing Tutorial](https://moveit.picknik.ai/main/doc/realtime_servo/realtime_servo_tutorial.html) for installation instructions, quick-start guide, an overview about `moveit_servo`, and to learn how to set it up on your robot.
+See the [Realtime Arm Servoing Tutorial](https://moveit.picknik.ai/main/doc/examples/realtime_servo/realtime_servo_tutorial.html) for installation instructions, quick-start guide, an overview about `moveit_servo`, and to learn how to set it up on your robot.


### PR DESCRIPTION
When we refactored the tutorials site it looks like we killed some links. Do we not have a CI job to catch dead links?

### Description

The link was dead. Not it is not. :pray:
