### PR TITLE
Re-enable clang-tidy check `performance-unnecessary-value-param`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,6 @@
 ---
-# TODO(henningkayser): Re-enable performance-unnecessary-value-param once #214 is resolved
 Checks:          '-*,
                   performance-*,
-                  -performance-unnecessary-value-param,
                   llvm-namespace-comment,
                   modernize-redundant-void-arg,
                   modernize-use-nullptr,


### PR DESCRIPTION
... after #214 was fixed in rclcpp.
