### PR TITLE
Fix clang-tidy issues

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -351,7 +351,7 @@ public:
   virtual bool
   searchPositionIK(const std::vector<geometry_msgs::msg::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                    double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
-                   const IKCallbackFn& solution_callback, IKCostFn cost_function,
+                   const IKCallbackFn& solution_callback, const IKCostFn& cost_function,
                    moveit_msgs::msg::MoveItErrorCodes& error_code,
                    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
                    const moveit::core::RobotState* context_state = nullptr) const

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -40,6 +40,8 @@
 
 #include <moveit/robot_state/robot_state.h>
 
+#include <utility>
+
 namespace moveit
 {
 namespace core
@@ -193,7 +195,7 @@ public:
                        kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn())
   {
     return computeCartesianPath(start_state, group, traj, link, distance * direction, global_reference_frame, max_step,
-                                jump_threshold, validCallback, options, cost_function);
+                                jump_threshold, validCallback, options, std::move(cost_function));
   }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular frame.
@@ -203,15 +205,14 @@ public:
      The target frame is assumed to be specified either w.r.t. to the global reference frame or the virtual link frame
      (\e global_reference_frame is false). This function returns the percentage (0..1) of the path that was achieved.
      All other comments from the previous function apply. */
-  static Percentage
-  computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
-                       std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
-                       const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
-                       const JumpThreshold& jump_threshold,
-                       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn(),
-                       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
+  static Percentage computeCartesianPath(
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      const LinkModel* link, const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
+      const JumpThreshold& jump_threshold,
+      const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+      const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn(),
+      const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
@@ -219,15 +220,14 @@ public:
      reached by the virtual frame attached to the robot \e link. The waypoints are transforms given either w.r.t. the global
      reference frame or the virtual frame at the immediately preceding waypoint. The virtual frame needs
      to move in a straight line between two consecutive waypoints. All other comments apply. */
-  static Percentage
-  computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
-                       std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
-                       const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame,
-                       const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
-                       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn(),
-                       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
+  static Percentage computeCartesianPath(
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      const LinkModel* link, const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame,
+      const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
+      const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+      const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn(),
+      const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
   /** \brief Tests joint space jumps of a trajectory.
 

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -40,8 +40,6 @@
 
 #include <moveit/robot_state/robot_state.h>
 
-#include <utility>
-
 namespace moveit
 {
 namespace core
@@ -172,30 +170,28 @@ public:
      the returned path is truncated up to just before the jump.
 
      Kinematics solvers may use cost functions to prioritize certain solutions, which may be specified with \e cost_function. */
-  static Distance
-  computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
-                       std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
-                       const Eigen::Vector3d& translation, bool global_reference_frame, const MaxEEFStep& max_step,
-                       const JumpThreshold& jump_threshold,
-                       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+  static Distance computeCartesianPath(
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      const LinkModel* link, const Eigen::Vector3d& translation, bool global_reference_frame,
+      const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
+      const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+      const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular link.
 
      In contrast to the previous function, the translation vector is specified as a (unit) direction vector and
      a distance. */
-  static Distance
-  computeCartesianPath(RobotState* start_state, const JointModelGroup* group,
-                       std::vector<std::shared_ptr<RobotState>>& traj, const LinkModel* link,
-                       const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
-                       const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
-                       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
-                       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                       kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn())
+  static Distance computeCartesianPath(
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      const LinkModel* link, const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
+      const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
+      const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+      const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn())
   {
     return computeCartesianPath(start_state, group, traj, link, distance * direction, global_reference_frame, max_step,
-                                jump_threshold, validCallback, options, std::move(cost_function));
+                                jump_threshold, validCallback, options, cost_function);
   }
 
   /** \brief Compute the sequence of joint values that correspond to a straight Cartesian path, for a particular frame.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -952,7 +952,7 @@ public:
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::msg::Pose& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -964,7 +964,7 @@ public:
   bool setFromIK(const JointModelGroup* group, const geometry_msgs::msg::Pose& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -975,7 +975,7 @@ public:
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -986,7 +986,7 @@ public:
   bool setFromIK(const JointModelGroup* group, const Eigen::Isometry3d& pose, const std::string& tip,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief If the group this state corresponds to is a chain and a solver is available, then the joint values can be
      set by computing inverse kinematics.
@@ -1000,7 +1000,7 @@ public:
                  const std::vector<double>& consistency_limits, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief  Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1015,7 +1015,7 @@ public:
                  const std::vector<std::string>& tips, double timeout = 0.0,
                  const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /** \brief Warning: This function inefficiently copies all transforms around.
       If the group consists of a set of sub-groups that are each a chain and a solver
@@ -1031,7 +1031,7 @@ public:
                  const std::vector<std::string>& tips, const std::vector<std::vector<double>>& consistency_limits,
                  double timeout = 0.0, const GroupStateValidityCallbackFn& constraint = GroupStateValidityCallbackFn(),
                  const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                 kinematics::KinematicsBase::IKCostFn cost_function = kinematics::KinematicsBase::IKCostFn());
+                 const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn());
 
   /**
       \brief setFromIK for multiple poses and tips (end effectors) when no solver exists for the jmg that can solver for

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -41,7 +41,6 @@
 #include <geometric_shapes/check_isometry.h>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
-#include <utility>
 
 namespace moveit
 {
@@ -59,7 +58,7 @@ CartesianInterpolator::Distance CartesianInterpolator::computeCartesianPath(
     RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
     const Eigen::Vector3d& translation, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
-    const kinematics::KinematicsQueryOptions& options, kinematics::KinematicsBase::IKCostFn cost_function)
+    const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   const double distance = translation.norm();
   // The target pose is obtained by adding the translation vector to the link's current pose
@@ -71,7 +70,7 @@ CartesianInterpolator::Distance CartesianInterpolator::computeCartesianPath(
   // call computeCartesianPath for the computed target pose in the global reference frame
   return CartesianInterpolator::Distance(distance) * computeCartesianPath(start_state, group, traj, link, pose, true,
                                                                           max_step, jump_threshold, validCallback,
-                                                                          options, std::move(cost_function));
+                                                                          options, cost_function);
 }
 
 CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -41,6 +41,7 @@
 #include <geometric_shapes/check_isometry.h>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
+#include <utility>
 
 namespace moveit
 {
@@ -70,14 +71,14 @@ CartesianInterpolator::Distance CartesianInterpolator::computeCartesianPath(
   // call computeCartesianPath for the computed target pose in the global reference frame
   return CartesianInterpolator::Distance(distance) * computeCartesianPath(start_state, group, traj, link, pose, true,
                                                                           max_step, jump_threshold, validCallback,
-                                                                          options, cost_function);
+                                                                          options, std::move(cost_function));
 }
 
 CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
     const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
-    const kinematics::KinematicsQueryOptions& options, kinematics::KinematicsBase::IKCostFn cost_function,
+    const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function,
     const Eigen::Isometry3d& link_offset)
 {
   // check unsanitized inputs for non-isometry
@@ -177,7 +178,7 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
     const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
-    const kinematics::KinematicsQueryOptions& options, kinematics::KinematicsBase::IKCostFn cost_function,
+    const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function,
     const Eigen::Isometry3d& link_offset)
 {
   double percentage_solved = 0.0;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -47,6 +47,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <cassert>
 #include <functional>
+#include <utility>
 #include <moveit/macros/console_colors.h>
 #include <moveit/robot_model/aabb.h>
 
@@ -1469,7 +1470,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg:
     RCLCPP_ERROR(LOGGER, "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
-  return setFromIK(jmg, pose, solver->getTipFrame(), timeout, constraint, options, cost_function);
+  return setFromIK(jmg, pose, solver->getTipFrame(), timeout, constraint, options, std::move(cost_function));
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg::Pose& pose, const std::string& tip,
@@ -1480,7 +1481,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg:
   Eigen::Isometry3d mat;
   tf2::fromMsg(pose, mat);
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, mat, tip, consistency_limits, timeout, constraint, options, cost_function);
+  return setFromIK(jmg, mat, tip, consistency_limits, timeout, constraint, options, std::move(cost_function));
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose, double timeout,
@@ -1495,7 +1496,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
     return false;
   }
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, timeout, constraint, options, cost_function);
+  return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, timeout, constraint, options,
+                   std::move(cost_function));
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose_in, const std::string& tip_in,
@@ -1504,7 +1506,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
                            kinematics::KinematicsBase::IKCostFn cost_function)
 {
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, pose_in, tip_in, consistency_limits, timeout, constraint, options, cost_function);
+  return setFromIK(jmg, pose_in, tip_in, consistency_limits, timeout, constraint, options, std::move(cost_function));
 }
 
 namespace
@@ -1563,7 +1565,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
   std::vector<std::vector<double> > consistency_limits;
   consistency_limits.push_back(consistency_limits_in);
 
-  return setFromIK(jmg, poses, tips, consistency_limits, timeout, constraint, options, cost_function);
+  return setFromIK(jmg, poses, tips, consistency_limits, timeout, constraint, options, std::move(cost_function));
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
@@ -1573,7 +1575,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
                            kinematics::KinematicsBase::IKCostFn cost_function)
 {
   const std::vector<std::vector<double> > consistency_limits;
-  return setFromIK(jmg, poses_in, tips_in, consistency_limits, timeout, constraint, options, cost_function);
+  return setFromIK(jmg, poses_in, tips_in, consistency_limits, timeout, constraint, options, std::move(cost_function));
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
@@ -1799,8 +1801,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   std::vector<double> ik_sol;
   moveit_msgs::msg::MoveItErrorCodes error;
 
-  if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, cost_function,
-                               error, options, this))
+  if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn,
+                               std::move(cost_function), error, options, this))
   {
     std::vector<double> solution(bij.size());
     for (std::size_t i = 0; i < bij.size(); ++i)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -47,7 +47,6 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <cassert>
 #include <functional>
-#include <utility>
 #include <moveit/macros/console_colors.h>
 #include <moveit/robot_model/aabb.h>
 
@@ -1462,7 +1461,7 @@ bool RobotState::integrateVariableVelocity(const JointModelGroup* jmg, const Eig
 bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg::Pose& pose, double timeout,
                            const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
@@ -1470,24 +1469,24 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg:
     RCLCPP_ERROR(LOGGER, "No kinematics solver instantiated for group '%s'", jmg->getName().c_str());
     return false;
   }
-  return setFromIK(jmg, pose, solver->getTipFrame(), timeout, constraint, options, std::move(cost_function));
+  return setFromIK(jmg, pose, solver->getTipFrame(), timeout, constraint, options, cost_function);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const geometry_msgs::msg::Pose& pose, const std::string& tip,
                            double timeout, const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   Eigen::Isometry3d mat;
   tf2::fromMsg(pose, mat);
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, mat, tip, consistency_limits, timeout, constraint, options, std::move(cost_function));
+  return setFromIK(jmg, mat, tip, consistency_limits, timeout, constraint, options, cost_function);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose, double timeout,
                            const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   const kinematics::KinematicsBaseConstPtr& solver = jmg->getSolverInstance();
   if (!solver)
@@ -1496,8 +1495,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
     return false;
   }
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, timeout, constraint, options,
-                   std::move(cost_function));
+  return setFromIK(jmg, pose, solver->getTipFrame(), consistency_limits, timeout, constraint, options, cost_function);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose_in, const std::string& tip_in,
@@ -1506,7 +1504,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
                            kinematics::KinematicsBase::IKCostFn cost_function)
 {
   static std::vector<double> consistency_limits;
-  return setFromIK(jmg, pose_in, tip_in, consistency_limits, timeout, constraint, options, std::move(cost_function));
+  return setFromIK(jmg, pose_in, tip_in, consistency_limits, timeout, constraint, options, cost_function);
 }
 
 namespace
@@ -1565,7 +1563,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
   std::vector<std::vector<double> > consistency_limits;
   consistency_limits.push_back(consistency_limits_in);
 
-  return setFromIK(jmg, poses, tips, consistency_limits, timeout, constraint, options, std::move(cost_function));
+  return setFromIK(jmg, poses, tips, consistency_limits, timeout, constraint, options, cost_function);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
@@ -1575,7 +1573,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
                            kinematics::KinematicsBase::IKCostFn cost_function)
 {
   const std::vector<std::vector<double> > consistency_limits;
-  return setFromIK(jmg, poses_in, tips_in, consistency_limits, timeout, constraint, options, std::move(cost_function));
+  return setFromIK(jmg, poses_in, tips_in, consistency_limits, timeout, constraint, options, cost_function);
 }
 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Isometry3d& poses_in,
@@ -1801,8 +1799,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   std::vector<double> ik_sol;
   moveit_msgs::msg::MoveItErrorCodes error;
 
-  if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn,
-                               std::move(cost_function), error, options, this))
+  if (solver->searchPositionIK(ik_queries, seed, timeout, consistency_limits, ik_sol, ik_callback_fn, cost_function,
+                               error, options, this))
   {
     std::vector<double> solution(bij.size());
     for (std::size_t i = 0; i < bij.size(); ++i)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1501,7 +1501,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
 bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& pose_in, const std::string& tip_in,
                            double timeout, const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   static std::vector<double> consistency_limits;
   return setFromIK(jmg, pose_in, tip_in, consistency_limits, timeout, constraint, options, cost_function);
@@ -1551,7 +1551,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const Eigen::Isometry3d& 
                            const std::vector<double>& consistency_limits_in, double timeout,
                            const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   // Convert from single pose and tip to vectors
   EigenSTL::vector_Isometry3d poses;
@@ -1570,7 +1570,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
                            const std::vector<std::string>& tips_in, double timeout,
                            const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   const std::vector<std::vector<double> > consistency_limits;
   return setFromIK(jmg, poses_in, tips_in, consistency_limits, timeout, constraint, options, cost_function);
@@ -1581,7 +1581,7 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
                            const std::vector<std::vector<double> >& consistency_limit_sets, double timeout,
                            const GroupStateValidityCallbackFn& constraint,
                            const kinematics::KinematicsQueryOptions& options,
-                           kinematics::KinematicsBase::IKCostFn cost_function)
+                           const kinematics::KinematicsBase::IKCostFn& cost_function)
 {
   // Error check
   if (poses_in.size() != tips_in.size())

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -43,7 +43,6 @@
 #include <deque>
 #include <memory>
 #include <optional>
-#include <utility>
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
@@ -335,10 +334,9 @@ public:
     {
       return ((waypoint_iterator == other.waypoint_iterator) && (duration_iterator == other.duration_iterator));
     }
-    bool operator!=(
-        const const It& /*erator*/ /*o*/* /*o*/* /*o*/* /*o*/* /*o*/* /* /* /* / /*oth /*oth /*other*/ /*other*/) const
+    bool operator!=(const Iterator& other) const
     {
-      return !(*ter);
+      return !(*this == other);
     }
     std::pair<moveit::core::RobotStatePtr, double> operator*() const
     {

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -43,6 +43,7 @@
 #include <deque>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
@@ -313,8 +314,8 @@ public:
     std::deque<double>::iterator duration_iterator;
 
   public:
-    explicit Iterator(std::deque<moveit::core::RobotStatePtr>::iterator _waypoint_iterator,
-                      std::deque<double>::iterator _duration_iterator)
+    explicit Iterator(const std::deque<moveit::core::RobotStatePtr>::iterator& _waypoint_iterator,
+                      const std::deque<double>::iterator& _duration_iterator)
       : waypoint_iterator(_waypoint_iterator), duration_iterator(_duration_iterator)
     {
     }
@@ -330,13 +331,14 @@ public:
       ++(*this);
       return retval;
     }
-    bool operator==(Iterator other) const
+    bool operator==(const Iterator& other) const
     {
       return ((waypoint_iterator == other.waypoint_iterator) && (duration_iterator == other.duration_iterator));
     }
-    bool operator!=(Iterator other) const
+    bool operator!=(
+        const const It& /*erator*/ /*o*/* /*o*/* /*o*/* /*o*/* /*o*/* /* /* /* / /*oth /*oth /*other*/ /*other*/) const
     {
-      return !(*this == other);
+      return !(*ter);
     }
     std::pair<moveit::core::RobotStatePtr, double> operator*() const
     {

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_interface.h
@@ -48,7 +48,7 @@ MOVEIT_CLASS_FORWARD(CHOMPInterface);  // Defines CHOMPInterfacePtr, ConstPtr, W
 class CHOMPInterface : public chomp::ChompPlanner
 {
 public:
-  CHOMPInterface(const rclcpp::Node::SharedPtr node);
+  CHOMPInterface(const rclcpp::Node::SharedPtr& node);
 
   const chomp::ChompParameters& getParams() const
   {

--- a/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
+++ b/moveit_planners/chomp/chomp_interface/include/chomp_interface/chomp_planning_context.h
@@ -55,7 +55,7 @@ public:
   bool terminate() override;
 
   CHOMPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model,
-                       rclcpp::Node::SharedPtr node);
+                       const rclcpp::Node::SharedPtr& node);
 
   ~CHOMPPlanningContext() override = default;
 

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -36,11 +36,13 @@
 
 #include <chomp_interface/chomp_interface.h>
 
+#include <utility>
+
 namespace chomp_interface
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
 
-CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr node) : ChompPlanner(), node_(node)
+CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr node) : ChompPlanner(), node_(std::move(node))
 {
   loadParams();
 }

--- a/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_interface.cpp
@@ -36,13 +36,11 @@
 
 #include <chomp_interface/chomp_interface.h>
 
-#include <utility>
-
 namespace chomp_interface
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
 
-CHOMPInterface::CHOMPInterface(rclcpp::Node::SharedPtr node) : ChompPlanner(), node_(std::move(node))
+CHOMPInterface::CHOMPInterface(const rclcpp::Node::SharedPtr& node) : ChompPlanner(), node_(node)
 {
   loadParams();
 }

--- a/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
+++ b/moveit_planners/chomp/chomp_interface/src/chomp_planning_context.cpp
@@ -40,7 +40,8 @@
 namespace chomp_interface
 {
 CHOMPPlanningContext::CHOMPPlanningContext(const std::string& name, const std::string& group,
-                                           const moveit::core::RobotModelConstPtr& model, rclcpp::Node::SharedPtr node)
+                                           const moveit::core::RobotModelConstPtr& model,
+                                           const rclcpp::Node::SharedPtr& node)
   : planning_interface::PlanningContext(name, group), robot_model_(model)
 {
   chomp_interface_ = std::make_shared<CHOMPInterface>(node);

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -388,7 +388,7 @@ protected:
   void unregisterTerminationCondition();
 
   /** \brief Convert OMPL PlannerStatus to moveit_msgs::msg::MoveItErrorCode */
-  int32_t logPlannerStatus(og::SimpleSetupPtr ompl_simple_setup);
+  int32_t logPlannerStatus(const og::SimpleSetupPtr& ompl_simple_setup);
 
   ModelBasedPlanningContextSpecification spec_;
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -968,7 +968,7 @@ void ompl_interface::ModelBasedPlanningContext::unregisterTerminationCondition()
   ptc_ = nullptr;
 }
 
-int32_t ompl_interface::ModelBasedPlanningContext::logPlannerStatus(og::SimpleSetupPtr ompl_simple_setup)
+int32_t ompl_interface::ModelBasedPlanningContext::logPlannerStatus(const og::SimpleSetupPtr& ompl_simple_setup)
 {
   auto result = moveit_msgs::msg::MoveItErrorCodes::PLANNING_FAILED;
   ompl::base::PlannerStatus ompl_status = ompl_simple_setup->getLastPlannerStatus();

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_action.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_action.h
@@ -65,7 +65,7 @@ private:
   using PlannedTrajMsgs = moveit_msgs::msg::MotionSequenceResponse::_planned_trajectories_type;
 
 private:
-  void executeSequenceCallback(const std::shared_ptr<MoveGroupSequenceGoalHandle> goal_handle);
+  void executeSequenceCallback(const std::shared_ptr<MoveGroupSequenceGoalHandle>& goal_handle);
   void
   executeSequenceCallbackPlanAndExecute(const moveit_msgs::action::MoveGroupSequence::Goal::ConstSharedPtr& goal,
                                         const moveit_msgs::action::MoveGroupSequence::Result::SharedPtr& action_res);

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_service.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/move_group_sequence_service.h
@@ -58,8 +58,8 @@ public:
   void initialize() override;
 
 private:
-  bool plan(const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr req,
-            moveit_msgs::srv::GetMotionSequence::Response::SharedPtr res);
+  bool plan(const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr& req,
+            const moveit_msgs::srv::GetMotionSequence::Response::SharedPtr& res);
 
 private:
   rclcpp::Service<moveit_msgs::srv::GetMotionSequence>::SharedPtr sequence_service_;

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -69,16 +69,16 @@ void MoveGroupSequenceAction::initialize()
   move_action_server_ = rclcpp_action::create_server<moveit_msgs::action::MoveGroupSequence>(
       context_->moveit_cpp_->getNode(), "sequence_move_group",
       [](const rclcpp_action::GoalUUID& /* unused */,
-         std::shared_ptr<const moveit_msgs::action::MoveGroupSequence::Goal> /* unused */) {
+         const std::shared_ptr<const moveit_msgs::action::MoveGroupSequence::Goal>& /* unused */) {
         RCLCPP_DEBUG(LOGGER, "Received action goal");
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
-      [this](const std::shared_ptr<MoveGroupSequenceGoalHandle> /* unused goal_handle */) {
+      [this](const std::shared_ptr<MoveGroupSequenceGoalHandle>& /* unused goal_handle */) {
         RCLCPP_DEBUG(LOGGER, "Canceling action goal");
         preemptMoveCallback();
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](const std::shared_ptr<MoveGroupSequenceGoalHandle> goal_handle) {
+      [this](const std::shared_ptr<MoveGroupSequenceGoalHandle>& goal_handle) {
         RCLCPP_DEBUG(LOGGER, "Accepting new action goal");
         executeSequenceCallback(goal_handle);
       },
@@ -88,7 +88,7 @@ void MoveGroupSequenceAction::initialize()
       context_->moveit_cpp_->getNode(), context_->planning_scene_monitor_->getRobotModel());
 }
 
-void MoveGroupSequenceAction::executeSequenceCallback(const std::shared_ptr<MoveGroupSequenceGoalHandle> goal_handle)
+void MoveGroupSequenceAction::executeSequenceCallback(const std::shared_ptr<MoveGroupSequenceGoalHandle>& goal_handle)
 {
   // Notify that goal is being executed
   goal_handle_ = goal_handle;

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -62,8 +62,8 @@ void MoveGroupSequenceService::initialize()
 
   sequence_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetMotionSequence>(
       SEQUENCE_SERVICE_NAME,
-      [this](const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr req,
-             moveit_msgs::srv::GetMotionSequence::Response::SharedPtr res) { return plan(req, std::move(res)); });
+      [this](const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr& req,
+             const moveit_msgs::srv::GetMotionSequence::Response::SharedPtr& res) { return plan(req, res); });
 }
 
 bool MoveGroupSequenceService::plan(const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr& req,
@@ -127,5 +127,4 @@ bool MoveGroupSequenceService::plan(const moveit_msgs::srv::GetMotionSequence::R
 }  // namespace pilz_industrial_motion_planner
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 PLUGINLIB_EXPORT_CLASS(pilz_industrial_motion_planner::MoveGroupSequenceService, move_group::MoveGroupCapability)

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -63,11 +63,11 @@ void MoveGroupSequenceService::initialize()
   sequence_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetMotionSequence>(
       SEQUENCE_SERVICE_NAME,
       [this](const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr req,
-             moveit_msgs::srv::GetMotionSequence::Response::SharedPtr res) { return plan(req, res); });
+             moveit_msgs::srv::GetMotionSequence::Response::SharedPtr res) { return plan(req, std::move(res)); });
 }
 
-bool MoveGroupSequenceService::plan(const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr req,
-                                    moveit_msgs::srv::GetMotionSequence::Response::SharedPtr res)
+bool MoveGroupSequenceService::plan(const moveit_msgs::srv::GetMotionSequence::Request::SharedPtr& req,
+                                    const moveit_msgs::srv::GetMotionSequence::Response::SharedPtr& res)
 {
   // Handle empty requests
   if (req->request.items.empty())
@@ -127,4 +127,5 @@ bool MoveGroupSequenceService::plan(const moveit_msgs::srv::GetMotionSequence::R
 }  // namespace pilz_industrial_motion_planner
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 PLUGINLIB_EXPORT_CLASS(pilz_industrial_motion_planner::MoveGroupSequenceService, move_group::MoveGroupCapability)

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -150,7 +150,7 @@ public:
     rclcpp_action::Client<control_msgs::action::GripperCommand>::SendGoalOptions send_goal_options;
     // Active callback
     send_goal_options.goal_response_callback =
-        [this](rclcpp_action::Client<control_msgs::action::GripperCommand>::GoalHandle::SharedPtr
+        [this](const rclcpp_action::Client<control_msgs::action::GripperCommand>::GoalHandle::SharedPtr&
                /* unused-arg */) { RCLCPP_DEBUG_STREAM(LOGGER, name_ << " started execution"); };
     // Send goal
     auto current_goal_future = controller_action_client_->async_send_goal(goal, send_goal_options);

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -66,7 +66,8 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::ms
   rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SendGoalOptions send_goal_options;
   // Active callback
   send_goal_options.goal_response_callback =
-      [this](rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle::SharedPtr goal_handle) {
+      [this](
+          const rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle::SharedPtr& goal_handle) {
         RCLCPP_INFO_STREAM(LOGGER, name_ << " started execution");
         if (!goal_handle)
           RCLCPP_WARN(LOGGER, "Goal request rejected");

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/include/moveit/global_planner/global_planner_component.h
@@ -95,7 +95,7 @@ private:
 
   // Goal callback for global planning request action server
   void globalPlanningRequestCallback(
-      std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>> goal_handle);
+      const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>>& goal_handle);
 
   // Initialize planning scene monitor and load pipelines
   bool initializeGlobalPlanner();

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -76,7 +76,7 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
       node_, global_planning_action_name,
       // Goal callback
       [this](const rclcpp_action::GoalUUID& /*unused*/,
-             std::shared_ptr<const moveit_msgs::action::GlobalPlanner::Goal> /*unused*/) {
+             const std::shared_ptr<const moveit_msgs::action::GlobalPlanner::Goal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received global planning goal request");
         // If another goal is active, cancel it and reject this goal
         if (long_callback_thread_.joinable())
@@ -156,7 +156,7 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
 }
 
 void GlobalPlannerComponent::globalPlanningRequestCallback(
-    std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>> goal_handle)
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>>& goal_handle)
 {
   // Plan global trajectory
   moveit_msgs::msg::MotionPlanResponse planning_solution = global_planner_instance_->plan(goal_handle);

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -150,12 +150,12 @@ bool HybridPlanningManager::initialize()
       this->get_node_waitables_interface(), hybrid_planning_action_name,
       // Goal callback
       [](const rclcpp_action::GoalUUID& /*unused*/,
-         std::shared_ptr<const moveit_msgs::action::HybridPlanner::Goal> /*unused*/) {
+         const std::shared_ptr<const moveit_msgs::action::HybridPlanner::Goal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received goal request");
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       // Cancel callback
-      [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>> /*unused*/) {
+      [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>>& /*unused*/) {
         cancelHybridManagerGoals();
         RCLCPP_INFO(LOGGER, "Received request to cancel goal");
         return rclcpp_action::CancelResponse::ACCEPT;
@@ -231,7 +231,7 @@ bool HybridPlanningManager::sendGlobalPlannerAction()
 
   // Add goal response callback
   global_goal_options.goal_response_callback =
-      [this](rclcpp_action::ClientGoalHandle<moveit_msgs::action::GlobalPlanner>::SharedPtr goal_handle) {
+      [this](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::GlobalPlanner>::SharedPtr& goal_handle) {
         auto planning_progress = std::make_shared<moveit_msgs::action::HybridPlanner::Feedback>();
         auto& feedback = planning_progress->feedback;
         if (!goal_handle)
@@ -301,7 +301,7 @@ bool HybridPlanningManager::sendLocalPlannerAction()
 
   // Add goal response callback
   local_goal_options.goal_response_callback =
-      [this](rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr goal_handle) {
+      [this](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr& goal_handle) {
         auto planning_progress = std::make_shared<moveit_msgs::action::HybridPlanner::Feedback>();
         auto& feedback = planning_progress->feedback;
         if (!goal_handle)
@@ -317,8 +317,8 @@ bool HybridPlanningManager::sendLocalPlannerAction()
 
   // Add feedback callback
   local_goal_options.feedback_callback =
-      [this](rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr /*unused*/,
-             const std::shared_ptr<const moveit_msgs::action::LocalPlanner::Feedback> local_planner_feedback) {
+      [this](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::LocalPlanner>::SharedPtr& /*unused*/,
+             const std::shared_ptr<const moveit_msgs::action::LocalPlanner::Feedback>& local_planner_feedback) {
         // react is defined in a hybrid_planning_manager plugin
         ReactionResult reaction_result = planner_logic_instance_->react(local_planner_feedback->feedback);
         if (reaction_result.error_code.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -174,7 +174,7 @@ bool HybridPlanningManager::initialize()
   // Initialize global solution subscriber
   global_solution_sub_ = create_subscription<moveit_msgs::msg::MotionPlanResponse>(
       "global_trajectory", rclcpp::SystemDefaultsQoS(),
-      [this](const moveit_msgs::msg::MotionPlanResponse::SharedPtr /* unused */) {
+      [this](const moveit_msgs::msg::MotionPlanResponse::ConstSharedPtr& /* unused */) {
         // react is defined in a hybrid_planning_manager plugin
         ReactionResult reaction_result = planner_logic_instance_->react(HybridPlanningEvent::GLOBAL_SOLUTION_AVAILABLE);
         if (reaction_result.error_code.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -201,7 +201,7 @@ bool LocalPlannerComponent::initialize()
 
   // Initialize global trajectory listener
   global_solution_subscriber_ = node_->create_subscription<moveit_msgs::msg::MotionPlanResponse>(
-      config_.global_solution_topic, 1, [this](const moveit_msgs::msg::MotionPlanResponse::SharedPtr msg) {
+      config_.global_solution_topic, 1, [this](const moveit_msgs::msg::MotionPlanResponse::ConstSharedPtr& msg) {
         // Add received trajectory to internal reference trajectory
         robot_trajectory::RobotTrajectory new_trajectory(planning_scene_monitor_->getRobotModel(), msg->group_name);
         moveit::core::RobotState start_state(planning_scene_monitor_->getRobotModel());

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -156,7 +156,7 @@ bool LocalPlannerComponent::initialize()
       node_, config_.local_planning_action_name,
       // Goal callback
       [this](const rclcpp_action::GoalUUID& /*unused*/,
-             std::shared_ptr<const moveit_msgs::action::LocalPlanner::Goal> /*unused*/) {
+             const std::shared_ptr<const moveit_msgs::action::LocalPlanner::Goal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received local planning goal request");
         // If another goal is active, cancel it and reject this goal
         if (long_callback_thread_.joinable())

--- a/moveit_ros/hybrid_planning/test/hybrid_planning_demo_node.cpp
+++ b/moveit_ros/hybrid_planning/test/hybrid_planning_demo_node.cpp
@@ -107,7 +107,7 @@ public:
     // Add new collision object as soon as global trajectory is available.
     global_solution_subscriber_ = node_->create_subscription<moveit_msgs::msg::MotionPlanResponse>(
         "global_trajectory", rclcpp::SystemDefaultsQoS(),
-        [this](const moveit_msgs::msg::MotionPlanResponse::SharedPtr /* unused */) {
+        [this](const moveit_msgs::msg::MotionPlanResponse::ConstSharedPtr& /* unused */) {
           // Remove old collision objects
           collision_object_1_.operation = collision_object_1_.REMOVE;
 

--- a/moveit_ros/hybrid_planning/test/hybrid_planning_demo_node.cpp
+++ b/moveit_ros/hybrid_planning/test/hybrid_planning_demo_node.cpp
@@ -263,8 +263,8 @@ public:
           }
         };
     send_goal_options.feedback_callback =
-        [](rclcpp_action::ClientGoalHandle<moveit_msgs::action::HybridPlanner>::SharedPtr /*unused*/,
-           const std::shared_ptr<const moveit_msgs::action::HybridPlanner::Feedback> feedback) {
+        [](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::HybridPlanner>::SharedPtr& /*unused*/,
+           const std::shared_ptr<const moveit_msgs::action::HybridPlanner::Feedback>& feedback) {
           RCLCPP_INFO(LOGGER, feedback->feedback.c_str());
         };
 

--- a/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -57,13 +57,13 @@ void ApplyPlanningSceneService::initialize()
       APPLY_PLANNING_SCENE_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                                 const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request> req,
                                                 std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response> res) {
-        return applyScene(request_header, req, res);
+        return applyScene(request_header, req, std::move(res));
       });
 }
 
-bool ApplyPlanningSceneService::applyScene(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                           const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request> req,
-                                           std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response> res)
+bool ApplyPlanningSceneService::applyScene(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                           const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request>& req,
+                                           const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response>& res)
 {
   if (!context_->planning_scene_monitor_)
   {
@@ -77,5 +77,6 @@ bool ApplyPlanningSceneService::applyScene(const std::shared_ptr<rmw_request_id_
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::ApplyPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -54,10 +54,11 @@ void ApplyPlanningSceneService::initialize()
   using std::placeholders::_3;
 
   service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::ApplyPlanningScene>(
-      APPLY_PLANNING_SCENE_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                                const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request> req,
-                                                std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response> res) {
-        return applyScene(request_header, req, std::move(res));
+      APPLY_PLANNING_SCENE_SERVICE_NAME,
+      [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+             const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request>& req,
+             const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response>& res) {
+        return applyScene(request_header, req, res);
       });
 }
 
@@ -77,6 +78,5 @@ bool ApplyPlanningSceneService::applyScene(const std::shared_ptr<rmw_request_id_
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::ApplyPlanningSceneService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/apply_planning_scene_service_capability.h
@@ -53,9 +53,9 @@ public:
   void initialize() override;
 
 private:
-  bool applyScene(const std::shared_ptr<rmw_request_id_t> request_header,
-                  const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request> req,
-                  std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response> res);
+  bool applyScene(const std::shared_ptr<rmw_request_id_t>& request_header,
+                  const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Request>& req,
+                  const std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene::Response>& res);
 
   rclcpp::Service<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr service_;
 };

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -78,10 +78,10 @@ void MoveGroupCartesianPathService::initialize()
   cartesian_path_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetCartesianPath>(
 
       CARTESIAN_PATH_SERVICE_NAME,
-      [this](const std::shared_ptr<rmw_request_id_t> req_id,
-             const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request> req,
-             std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response> res) -> bool {
-        return computeService(req_id, req, std::move(res));
+      [this](const std::shared_ptr<rmw_request_id_t>& req_id,
+             const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request>& req,
+             const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response>& res) -> bool {
+        return computeService(req_id, req, res);
       });
 }
 
@@ -206,6 +206,5 @@ bool MoveGroupCartesianPathService::computeService(
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupCartesianPathService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -81,13 +81,14 @@ void MoveGroupCartesianPathService::initialize()
       [this](const std::shared_ptr<rmw_request_id_t> req_id,
              const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request> req,
              std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response> res) -> bool {
-        return computeService(req_id, req, res);
+        return computeService(req_id, req, std::move(res));
       });
 }
 
-bool MoveGroupCartesianPathService::computeService(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                                   const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request> req,
-                                                   std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response> res)
+bool MoveGroupCartesianPathService::computeService(
+    const std::shared_ptr<rmw_request_id_t>& /* unused */,
+    const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request>& req,
+    const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response>& res)
 {
   RCLCPP_INFO(LOGGER, "Received request to compute Cartesian path");
   context_->planning_scene_monitor_->updateFrameTransforms();
@@ -205,5 +206,6 @@ bool MoveGroupCartesianPathService::computeService(const std::shared_ptr<rmw_req
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupCartesianPathService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.h
@@ -50,9 +50,9 @@ public:
   void initialize() override;
 
 private:
-  bool computeService(const std::shared_ptr<rmw_request_id_t> request_header,
-                      const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request> req,
-                      std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response> res);
+  bool computeService(const std::shared_ptr<rmw_request_id_t>& request_header,
+                      const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Request>& req,
+                      const std::shared_ptr<moveit_msgs::srv::GetCartesianPath::Response>& res);
 
   rclcpp::Service<moveit_msgs::srv::GetCartesianPath>::SharedPtr cartesian_path_service_;
   rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory>::SharedPtr display_path_;

--- a/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
@@ -50,11 +50,11 @@ void move_group::ClearOctomapService::initialize()
   service_ = context_->moveit_cpp_->getNode()->create_service<std_srvs::srv::Empty>(
       CLEAR_OCTOMAP_SERVICE_NAME,
       [this](const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-             std::shared_ptr<std_srvs::srv::Empty::Response> res) { return clearOctomap(req, res); });
+             std::shared_ptr<std_srvs::srv::Empty::Response> res) { return clearOctomap(req, std::move(res)); });
 }
 
-void move_group::ClearOctomapService::clearOctomap(const std::shared_ptr<std_srvs::srv::Empty::Request> /*req*/,
-                                                   std::shared_ptr<std_srvs::srv::Empty::Response> /*res*/)
+void move_group::ClearOctomapService::clearOctomap(const std::shared_ptr<std_srvs::srv::Empty::Request>& /*req*/,
+                                                   const std::shared_ptr<std_srvs::srv::Empty::Response>& /*res*/)
 {
   if (!context_->planning_scene_monitor_)
     RCLCPP_ERROR(LOGGER, "Cannot clear octomap since planning_scene_monitor_ does not exist.");
@@ -65,5 +65,6 @@ void move_group::ClearOctomapService::clearOctomap(const std::shared_ptr<std_srv
 }
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::ClearOctomapService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
@@ -49,8 +49,8 @@ void move_group::ClearOctomapService::initialize()
 {
   service_ = context_->moveit_cpp_->getNode()->create_service<std_srvs::srv::Empty>(
       CLEAR_OCTOMAP_SERVICE_NAME,
-      [this](const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-             std::shared_ptr<std_srvs::srv::Empty::Response> res) { return clearOctomap(req, std::move(res)); });
+      [this](const std::shared_ptr<std_srvs::srv::Empty::Request>& req,
+             const std::shared_ptr<std_srvs::srv::Empty::Response>& res) { return clearOctomap(req, res); });
 }
 
 void move_group::ClearOctomapService::clearOctomap(const std::shared_ptr<std_srvs::srv::Empty::Request>& /*req*/,
@@ -65,6 +65,5 @@ void move_group::ClearOctomapService::clearOctomap(const std::shared_ptr<std_srv
 }
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::ClearOctomapService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/clear_octomap_service_capability.h
@@ -49,8 +49,8 @@ public:
   void initialize() override;
 
 private:
-  void clearOctomap(const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-                    std::shared_ptr<std_srvs::srv::Empty::Response> res);
+  void clearOctomap(const std::shared_ptr<std_srvs::srv::Empty::Request>& req,
+                    const std::shared_ptr<std_srvs::srv::Empty::Response>& res);
 
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr service_;
 };

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -61,7 +61,7 @@ void MoveGroupExecuteTrajectoryAction::initialize()
   execute_action_server_ = rclcpp_action::create_server<ExecTrajectory>(
       node->get_node_base_interface(), node->get_node_clock_interface(), node->get_node_logging_interface(),
       node->get_node_waitables_interface(), EXECUTE_ACTION_NAME,
-      [](const rclcpp_action::GoalUUID& /*unused*/, std::shared_ptr<const ExecTrajectory::Goal> /*unused*/) {
+      [](const rclcpp_action::GoalUUID& /*unused*/, const std::shared_ptr<const ExecTrajectory::Goal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received goal request");
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
@@ -72,7 +72,7 @@ void MoveGroupExecuteTrajectoryAction::initialize()
       [this](const auto& goal) { executePathCallback(goal); });
 }
 
-void MoveGroupExecuteTrajectoryAction::executePathCallback(std::shared_ptr<ExecTrajectoryGoal> goal)
+void MoveGroupExecuteTrajectoryAction::executePathCallback(const std::shared_ptr<ExecTrajectoryGoal>& goal)
 {
   auto action_res = std::make_shared<ExecTrajectory::Result>();
   if (!context_->trajectory_execution_manager_)

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -59,7 +59,7 @@ public:
   void initialize() override;
 
 private:
-  void executePathCallback(std::shared_ptr<ExecTrajectoryGoal> goal);
+  void executePathCallback(const std::shared_ptr<ExecTrajectoryGoal>& goal);
   void executePath(const std::shared_ptr<ExecTrajectoryGoal>& goal, std::shared_ptr<ExecTrajectory::Result>& action_res);
 
   void preemptExecuteTrajectoryCallback();

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -53,16 +53,16 @@ MoveGroupKinematicsService::MoveGroupKinematicsService() : MoveGroupCapability("
 void MoveGroupKinematicsService::initialize()
 {
   fk_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPositionFK>(
-      FK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> req_header,
-                              const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request> req,
+      FK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& req_header,
+                              const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request>& req,
                               std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response> res) {
-        return computeFKService(req_header, req, std::move(res));
+        return computeFKService(req_header, req, res);
       });
   ik_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPositionIK>(
-      IK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> req_header,
-                              const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request> req,
+      IK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& req_header,
+                              const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request>& req,
                               std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res) {
-        return computeIKService(req_header, req, std::move(res));
+        return computeIKService(req_header, req, res);
       });
 }
 
@@ -237,6 +237,5 @@ bool MoveGroupKinematicsService::computeFKService(const std::shared_ptr<rmw_requ
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupKinematicsService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -55,13 +55,13 @@ void MoveGroupKinematicsService::initialize()
   fk_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPositionFK>(
       FK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& req_header,
                               const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request>& req,
-                              std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response> res) {
+                              const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response>& res) {
         return computeFKService(req_header, req, res);
       });
   ik_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPositionIK>(
       IK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& req_header,
                               const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request>& req,
-                              std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res) {
+                              const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response>& res) {
         return computeIKService(req_header, req, res);
       });
 }

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -56,13 +56,13 @@ void MoveGroupKinematicsService::initialize()
       FK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> req_header,
                               const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request> req,
                               std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response> res) {
-        return computeFKService(req_header, req, res);
+        return computeFKService(req_header, req, std::move(res));
       });
   ik_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPositionIK>(
       IK_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> req_header,
                               const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request> req,
                               std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res) {
-        return computeIKService(req_header, req, res);
+        return computeIKService(req_header, req, std::move(res));
       });
 }
 
@@ -158,9 +158,9 @@ void MoveGroupKinematicsService::computeIK(moveit_msgs::msg::PositionIKRequest& 
     error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_GROUP_NAME;
 }
 
-bool MoveGroupKinematicsService::computeIKService(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request> req,
-                                                  std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res)
+bool MoveGroupKinematicsService::computeIKService(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request>& req,
+                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response>& res)
 {
   context_->planning_scene_monitor_->updateFrameTransforms();
 
@@ -192,9 +192,9 @@ bool MoveGroupKinematicsService::computeIKService(const std::shared_ptr<rmw_requ
   return true;
 }
 
-bool MoveGroupKinematicsService::computeFKService(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request> req,
-                                                  std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response> res)
+bool MoveGroupKinematicsService::computeFKService(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request>& req,
+                                                  const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response>& res)
 {
   if (req->fk_link_names.empty())
   {
@@ -237,5 +237,6 @@ bool MoveGroupKinematicsService::computeFKService(const std::shared_ptr<rmw_requ
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupKinematicsService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.h
@@ -50,12 +50,12 @@ public:
   void initialize() override;
 
 private:
-  bool computeIKService(const std::shared_ptr<rmw_request_id_t> request_header,
-                        const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request> req,
-                        std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response> res);
-  bool computeFKService(const std::shared_ptr<rmw_request_id_t> request_header,
-                        const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request> req,
-                        std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response> res);
+  bool computeIKService(const std::shared_ptr<rmw_request_id_t>& request_header,
+                        const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Request>& req,
+                        const std::shared_ptr<moveit_msgs::srv::GetPositionIK::Response>& res);
+  bool computeFKService(const std::shared_ptr<rmw_request_id_t>& request_header,
+                        const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Request>& req,
+                        const std::shared_ptr<moveit_msgs::srv::GetPositionFK::Response>& res);
 
   void computeIK(moveit_msgs::msg::PositionIKRequest& req, moveit_msgs::msg::RobotState& solution,
                  moveit_msgs::msg::MoveItErrorCodes& error_code, moveit::core::RobotState& rs,

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -68,7 +68,7 @@ void MoveGroupMoveAction::initialize()
         RCLCPP_INFO(LOGGER, "Received request to cancel goal");
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](std::shared_ptr<MGActionGoal> goal) { return executeMoveCallback(std::move(goal)); });
+      [this](const std::shared_ptr<MGActionGoal>& goal) { return executeMoveCallback(goal); });
 }
 
 void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal)
@@ -276,6 +276,5 @@ void MoveGroupMoveAction::setMoveState(MoveGroupState state, const std::shared_p
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupMoveAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -60,7 +60,7 @@ void MoveGroupMoveAction::initialize()
   auto node = context_->moveit_cpp_->getNode();
   execute_action_server_ = rclcpp_action::create_server<MGAction>(
       node, MOVE_ACTION,
-      [](const rclcpp_action::GoalUUID& /*unused*/, std::shared_ptr<const MGAction::Goal> /*unused*/) {
+      [](const rclcpp_action::GoalUUID& /*unused*/, const std::shared_ptr<const MGAction::Goal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received request");
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
@@ -68,10 +68,10 @@ void MoveGroupMoveAction::initialize()
         RCLCPP_INFO(LOGGER, "Received request to cancel goal");
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](std::shared_ptr<MGActionGoal> goal) { return executeMoveCallback(goal); });
+      [this](std::shared_ptr<MGActionGoal> goal) { return executeMoveCallback(std::move(goal)); });
 }
 
-void MoveGroupMoveAction::executeMoveCallback(std::shared_ptr<MGActionGoal> goal)
+void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal)
 {
   RCLCPP_INFO(LOGGER, "executing..");
   setMoveState(PLANNING, goal);
@@ -276,5 +276,6 @@ void MoveGroupMoveAction::setMoveState(MoveGroupState state, const std::shared_p
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupMoveAction, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -54,7 +54,7 @@ public:
   void initialize() override;
 
 private:
-  void executeMoveCallback(std::shared_ptr<MGActionGoal> goal);
+  void executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal);
   void executeMoveCallbackPlanAndExecute(const std::shared_ptr<MGActionGoal>& goal,
                                          std::shared_ptr<MGAction::Result>& action_res);
   void executeMoveCallbackPlanOnly(const std::shared_ptr<MGActionGoal>& goal,

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -55,13 +55,13 @@ void MoveGroupPlanService::initialize()
       PLANNER_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                    const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request> req,
                                    std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response> res) {
-        return computePlanService(request_header, req, res);
+        return computePlanService(request_header, req, std::move(res));
       });
 }
 
-bool MoveGroupPlanService::computePlanService(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                              const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request> req,
-                                              std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response> res)
+bool MoveGroupPlanService::computePlanService(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                              const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request>& req,
+                                              const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response>& res)
 {
   RCLCPP_INFO(LOGGER, "Received new planning service request...");
   // before we start planning, ensure that we have the latest robot state received...
@@ -96,5 +96,6 @@ bool MoveGroupPlanService::computePlanService(const std::shared_ptr<rmw_request_
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupPlanService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -52,10 +52,10 @@ MoveGroupPlanService::MoveGroupPlanService() : MoveGroupCapability("MotionPlanSe
 void MoveGroupPlanService::initialize()
 {
   plan_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetMotionPlan>(
-      PLANNER_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                   const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request> req,
-                                   std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response> res) {
-        return computePlanService(request_header, req, std::move(res));
+      PLANNER_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                   const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request>& req,
+                                   const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response>& res) {
+        return computePlanService(request_header, req, res);
       });
 }
 
@@ -96,6 +96,5 @@ bool MoveGroupPlanService::computePlanService(const std::shared_ptr<rmw_request_
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupPlanService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/plan_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/plan_service_capability.h
@@ -49,9 +49,9 @@ public:
   void initialize() override;
 
 private:
-  bool computePlanService(const std::shared_ptr<rmw_request_id_t> request_header,
-                          const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request> req,
-                          std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response> res);
+  bool computePlanService(const std::shared_ptr<rmw_request_id_t>& request_header,
+                          const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Request>& req,
+                          const std::shared_ptr<moveit_msgs::srv::GetMotionPlan::Response>& res);
 
   rclcpp::Service<moveit_msgs::srv::GetMotionPlan>::SharedPtr plan_service_;
 };

--- a/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
@@ -51,28 +51,28 @@ void MoveGroupQueryPlannersService::initialize()
       QUERY_PLANNERS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                           const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request> req,
                                           std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response> res) {
-        return queryInterface(request_header, req, res);
+        return queryInterface(request_header, req, std::move(res));
       });
 
   get_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPlannerParams>(
       GET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                               const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request> req,
                                               std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response> res) {
-        return getParams(request_header, req, res);
+        return getParams(request_header, req, std::move(res));
       });
 
   set_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::SetPlannerParams>(
       SET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                               const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request> req,
                                               std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response> res) {
-        return setParams(request_header, req, res);
+        return setParams(request_header, req, std::move(res));
       });
 }
 
 bool MoveGroupQueryPlannersService::queryInterface(
-    const std::shared_ptr<rmw_request_id_t> /* unused */,
-    const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request> /*req*/,
-    std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response> res)
+    const std::shared_ptr<rmw_request_id_t>& /* unused */,
+    const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request>& /*req*/,
+    const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response>& res)
 {
   for (const auto& planning_pipelines : context_->moveit_cpp_->getPlanningPipelines())
   {
@@ -93,9 +93,9 @@ bool MoveGroupQueryPlannersService::queryInterface(
   return true;
 }
 
-bool MoveGroupQueryPlannersService::getParams(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request> req,
-                                              std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response> res)
+bool MoveGroupQueryPlannersService::getParams(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request>& req,
+                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response>& res)
 {
   const planning_pipeline::PlanningPipelinePtr planning_pipeline = resolvePlanningPipeline(req->pipeline_id);
   if (!planning_pipeline)
@@ -129,9 +129,10 @@ bool MoveGroupQueryPlannersService::getParams(const std::shared_ptr<rmw_request_
   return true;
 }
 
-bool MoveGroupQueryPlannersService::setParams(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                              const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request> req,
-                                              std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response> /*res*/)
+bool MoveGroupQueryPlannersService::setParams(
+    const std::shared_ptr<rmw_request_id_t>& /* unused */,
+    const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request>& req,
+    const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response>& /*res*/)
 {
   if (req->params.keys.size() != req->params.values.size())
     return false;
@@ -163,5 +164,6 @@ bool MoveGroupQueryPlannersService::setParams(const std::shared_ptr<rmw_request_
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupQueryPlannersService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.cpp
@@ -48,24 +48,25 @@ MoveGroupQueryPlannersService::MoveGroupQueryPlannersService() : MoveGroupCapabi
 void MoveGroupQueryPlannersService::initialize()
 {
   query_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::QueryPlannerInterfaces>(
-      QUERY_PLANNERS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                          const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request> req,
-                                          std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response> res) {
-        return queryInterface(request_header, req, std::move(res));
+      QUERY_PLANNERS_SERVICE_NAME,
+      [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+             const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request>& req,
+             const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response>& res) {
+        return queryInterface(request_header, req, res);
       });
 
   get_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetPlannerParams>(
-      GET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request> req,
-                                              std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response> res) {
-        return getParams(request_header, req, std::move(res));
+      GET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request>& req,
+                                              const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response>& res) {
+        return getParams(request_header, req, res);
       });
 
   set_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::SetPlannerParams>(
-      SET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                              const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request> req,
-                                              std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response> res) {
-        return setParams(request_header, req, std::move(res));
+      SET_PLANNER_PARAMS_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                              const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request>& req,
+                                              const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response>& res) {
+        return setParams(request_header, req, res);
       });
 }
 
@@ -164,6 +165,5 @@ bool MoveGroupQueryPlannersService::setParams(
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupQueryPlannersService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/query_planners_service_capability.h
@@ -51,16 +51,16 @@ public:
   void initialize() override;
 
 private:
-  bool queryInterface(const std::shared_ptr<rmw_request_id_t> request_header,
-                      const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request> /*req*/,
-                      std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response> res);
+  bool queryInterface(const std::shared_ptr<rmw_request_id_t>& request_header,
+                      const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Request>& /*req*/,
+                      const std::shared_ptr<moveit_msgs::srv::QueryPlannerInterfaces::Response>& res);
 
-  bool getParams(const std::shared_ptr<rmw_request_id_t> request_header,
-                 const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request> req,
-                 std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response> res);
-  bool setParams(const std::shared_ptr<rmw_request_id_t> request_header,
-                 const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request> req,
-                 std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response> /*res*/);
+  bool getParams(const std::shared_ptr<rmw_request_id_t>& request_header,
+                 const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Request>& req,
+                 const std::shared_ptr<moveit_msgs::srv::GetPlannerParams::Response>& res);
+  bool setParams(const std::shared_ptr<rmw_request_id_t>& request_header,
+                 const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Request>& req,
+                 const std::shared_ptr<moveit_msgs::srv::SetPlannerParams::Response>& /*res*/);
 
   rclcpp::Service<moveit_msgs::srv::QueryPlannerInterfaces>::SharedPtr query_service_;
   rclcpp::Service<moveit_msgs::srv::GetPlannerParams>::SharedPtr get_service_;

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -50,10 +50,10 @@ MoveGroupStateValidationService::MoveGroupStateValidationService() : MoveGroupCa
 void MoveGroupStateValidationService::initialize()
 {
   validity_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetStateValidity>(
-      STATE_VALIDITY_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                          const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request> req,
-                                          std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response> res) {
-        return computeService(request_header, req, std::move(res));
+      STATE_VALIDITY_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request>& req,
+                                          const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response>& res) {
+        return computeService(request_header, req, res);
       });
 }
 
@@ -130,6 +130,5 @@ bool MoveGroupStateValidationService::computeService(
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
-#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupStateValidationService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.cpp
@@ -53,14 +53,14 @@ void MoveGroupStateValidationService::initialize()
       STATE_VALIDITY_SERVICE_NAME, [this](const std::shared_ptr<rmw_request_id_t> request_header,
                                           const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request> req,
                                           std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response> res) {
-        return computeService(request_header, req, res);
+        return computeService(request_header, req, std::move(res));
       });
 }
 
 bool MoveGroupStateValidationService::computeService(
-    const std::shared_ptr<rmw_request_id_t> /* unused */,
-    const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request> req,
-    std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response> res)
+    const std::shared_ptr<rmw_request_id_t>& /* unused */,
+    const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request>& req,
+    const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response>& res)
 {
   planning_scene_monitor::LockedPlanningSceneRO ls(context_->planning_scene_monitor_);
   moveit::core::RobotState rs = ls->getCurrentState();
@@ -130,5 +130,6 @@ bool MoveGroupStateValidationService::computeService(
 }  // namespace move_group
 
 #include <pluginlib/class_list_macros.hpp>
+#include <utility>
 
 PLUGINLIB_EXPORT_CLASS(move_group::MoveGroupStateValidationService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/state_validation_service_capability.h
@@ -49,9 +49,9 @@ public:
   void initialize() override;
 
 private:
-  bool computeService(const std::shared_ptr<rmw_request_id_t> request_header,
-                      const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request> req,
-                      std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response> res);
+  bool computeService(const std::shared_ptr<rmw_request_id_t>& request_header,
+                      const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Request>& req,
+                      const std::shared_ptr<moveit_msgs::srv::GetStateValidity::Response>& res);
 
   rclcpp::Service<moveit_msgs::srv::GetStateValidity>::SharedPtr validity_service_;
 };

--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -59,7 +59,7 @@ public:
    *  \param planning_scene_monitor: PSM should have scene monitor and state monitor
    *                                 already started when passed into this class
    */
-  CollisionCheck(rclcpp::Node::SharedPtr node, const ServoParameters::SharedConstPtr& parameters,
+  CollisionCheck(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
                  const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   ~CollisionCheck()

--- a/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/parameter_descriptor_builder.hpp
@@ -74,7 +74,7 @@ public:
    *
    * @return     Reference to this object
    */
-  ParameterDescriptorBuilder& description(std::string description);
+  ParameterDescriptorBuilder& description(const std::string& description);
 
   /**
    * @brief      Set the additional constraints string (a description of any additional constraints which cannot be
@@ -84,7 +84,7 @@ public:
    *
    * @return     Reference to this object
    */
-  ParameterDescriptorBuilder& additionalConstraints(std::string additional_constraints);
+  ParameterDescriptorBuilder& additionalConstraints(const std::string& additional_constraints);
 
   /**
    * @brief      Sets the read only flag

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -137,7 +137,7 @@ private:
   bool satisfiesPoseTolerance(const Eigen::Vector3d& positional_tolerance, const double angular_tolerance);
 
   /** \brief Subscribe to the target pose on this topic */
-  void targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg);
+  void targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr& msg);
 
   /** \brief Update PID controller target positions & orientations */
   void updateControllerSetpoints();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -55,7 +55,7 @@ class Servo
 {
 public:
   Servo(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
-        planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor);
+        const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   ~Servo();
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.h
@@ -54,7 +54,7 @@ namespace moveit_servo
 class Servo
 {
 public:
-  Servo(const rclcpp::Node::SharedPtr& node, ServoParameters::SharedConstPtr parameters,
+  Servo(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
         planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor);
 
   ~Servo();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -229,9 +229,9 @@ protected:
   void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr msg);
 
   /* \brief Command callbacks */
-  void twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
-  void jointCmdCB(const control_msgs::msg::JointJog::SharedPtr msg);
-  void collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr msg);
+  void twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr& msg);
+  void jointCmdCB(const control_msgs::msg::JointJog::SharedPtr& msg);
+  void collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr& msg);
 
   /**
    * Allow drift in certain dimensions. For example, may allow the wrist to rotate freely.
@@ -241,17 +241,17 @@ protected:
    * @param response the service response
    * @return true if the adjustment was made
    */
-  void changeDriftDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Request> req,
-                             std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Response> res);
+  void changeDriftDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Request>& req,
+                             const std::shared_ptr<moveit_msgs::srv::ChangeDriftDimensions::Response>& res);
 
   /** \brief Start the main calculation timer */
   // Service callback for changing servoing dimensions
-  void changeControlDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Request> req,
-                               std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Response> res);
+  void changeControlDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Request>& req,
+                               const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Response>& res);
 
   /** \brief Service callback to reset Servo status, e.g. so the arm can move again after a collision */
-  bool resetServoStatus(const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-                        std::shared_ptr<std_srvs::srv::Empty::Response> res);
+  bool resetServoStatus(const std::shared_ptr<std_srvs::srv::Empty::Request>& req,
+                        const std::shared_ptr<std_srvs::srv::Empty::Response>& res);
 
   // Pointer to the ROS node
   std::shared_ptr<rclcpp::Node> node_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -227,12 +227,12 @@ protected:
   void enforceControlDimensions(geometry_msgs::msg::TwistStamped& command);
 
   /* \brief Callback for joint subsription */
-  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr msg);
+  void jointStateCB(const sensor_msgs::msg::JointState::ConstSharedPtr& msg);
 
   /* \brief Command callbacks */
-  void twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr& msg);
-  void jointCmdCB(const control_msgs::msg::JointJog::SharedPtr& msg);
-  void collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr& msg);
+  void twistStampedCB(const geometry_msgs::msg::TwistStamped::ConstSharedPtr& msg);
+  void jointCmdCB(const control_msgs::msg::JointJog::ConstSharedPtr& msg);
+  void collisionVelocityScaleCB(const std_msgs::msg::Float64::ConstSharedPtr& msg);
 
   /**
    * Allow drift in certain dimensions. For example, may allow the wrist to rotate freely.

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -79,7 +79,8 @@ enum class ServoType
 class ServoCalcs
 {
 public:
-  ServoCalcs(rclcpp::Node::SharedPtr node, const std::shared_ptr<const moveit_servo::ServoParameters>& parameters,
+  ServoCalcs(const rclcpp::Node::SharedPtr& node,
+             const std::shared_ptr<const moveit_servo::ServoParameters>& parameters,
              const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   ~ServoCalcs();

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.h
@@ -63,25 +63,25 @@ private:
   std::shared_ptr<planning_scene_monitor::PlanningSceneMonitor> planning_scene_monitor_;
 
   /** \brief Start the servo loop. Must be called once to begin Servoing. */
-  void startCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-               std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void startCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+               const std::shared_ptr<std_srvs::srv::Trigger::Response>& response);
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_servo_service_;
 
   /** \brief Stop the servo loop. This involves more overhead than pauseCB, e.g. it clears the planning scene monitor.
    * We recommend using pauseCB/unpauseCB if you will resume the Servo loop soon.
    */
-  void stopCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-              std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void stopCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+              const std::shared_ptr<std_srvs::srv::Trigger::Response>& response);
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_servo_service_;
 
   /** \brief Pause the servo loop but continue monitoring joint state so we can resume easily. */
-  void pauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-               std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void pauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+               const std::shared_ptr<std_srvs::srv::Trigger::Response>& response);
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr pause_servo_service_;
 
   /** \brief Resume the servo loop after pauseCB has been called. */
-  void unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                 std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+                 const std::shared_ptr<std_srvs::srv::Trigger::Response>& response);
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr unpause_servo_service_;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -118,7 +118,7 @@ struct ServoParameters
    * @param dynamic_parameters Enable dynamic parameter handling. (default: true)
    * @return std::shared_ptr<ServoParameters> if all parameters were loaded and verified successfully, nullptr otherwise
    */
-  static SharedConstPtr makeServoParameters(const rclcpp::Node::SharedPtr& node, std::string ns = "moveit_servo",
+  static SharedConstPtr makeServoParameters(const rclcpp::Node::SharedPtr& node, const std::string& ns = "moveit_servo",
                                             bool dynamic_parameters = true);
 
   /**
@@ -128,7 +128,8 @@ struct ServoParameters
    * @param name Name of parameter (key used for callback in map)
    * @param callback function to call when parameter is changed
    */
-  [[nodiscard]] bool registerSetParameterCallback(const std::string name, SetParameterCallbackType callback) const
+  [[nodiscard]] bool registerSetParameterCallback(const std /*unused*/ /*unused*/:&:stringconst & name,
+                &                                  const SetParameterCallbackType& callback) const
   {
     if (callback_handler_)
     {

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -128,8 +128,8 @@ struct ServoParameters
    * @param name Name of parameter (key used for callback in map)
    * @param callback function to call when parameter is changed
    */
-  [[nodiscard]] bool registerSetParameterCallback(const std /*unused*/ /*unused*/:&:stringconst & name,
-                &                                  const SetParameterCallbackType& callback) const
+  [[nodiscard]] bool registerSetParameterCallback(const std::string& name,
+                                                  const SetParameterCallbackType& callback) const
   {
     if (callback_handler_)
     {

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -76,6 +76,6 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
                                            const double hard_stop_singularity_threshold,
                                            const double lower_singularity_threshold,
                                            const double leaving_singularity_threshold_multiplier, rclcpp::Clock& clock,
-                                           moveit::core::RobotStatePtr current_state, StatusCode& status);
+                                           const moveit::core::RobotStatePtr& current_state, StatusCode& status);
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <std_msgs/msg/float64.hpp>
+#include <utility>
 
 #include <moveit_servo/collision_check.h>
 // #include <moveit_servo/make_shared_from_pool.h>
@@ -51,7 +52,7 @@ namespace moveit_servo
 // Constructor for the class that handles collision checking
 CollisionCheck::CollisionCheck(rclcpp::Node::SharedPtr node, const ServoParameters::SharedConstPtr& parameters,
                                const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
-  : node_(node)
+  : node_(std::move(node))
   , parameters_(parameters)
   , planning_scene_monitor_(planning_scene_monitor)
   , self_velocity_scale_coefficient_(-log(0.001) / parameters->self_collision_proximity_threshold)

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -38,7 +38,6 @@
  */
 
 #include <std_msgs/msg/float64.hpp>
-#include <utility>
 
 #include <moveit_servo/collision_check.h>
 // #include <moveit_servo/make_shared_from_pool.h>
@@ -50,9 +49,9 @@ constexpr size_t ROS_LOG_THROTTLE_PERIOD = 30 * 1000;  // Milliseconds to thrott
 namespace moveit_servo
 {
 // Constructor for the class that handles collision checking
-CollisionCheck::CollisionCheck(rclcpp::Node::SharedPtr node, const ServoParameters::SharedConstPtr& parameters,
+CollisionCheck::CollisionCheck(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
                                const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
-  : node_(std::move(node))
+  : node_(node)
   , parameters_(parameters)
   , planning_scene_monitor_(planning_scene_monitor)
   , self_velocity_scale_coefficient_(-log(0.001) / parameters->self_collision_proximity_threshold)

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -62,7 +62,7 @@ public:
   }
 
 private:
-  void statusCB(const std_msgs::msg::Int8::ConstSharedPtr msg)
+  void statusCB(const std_msgs::msg::Int8::ConstSharedPtr& msg)
   {
     moveit_servo::StatusCode latest_status = static_cast<moveit_servo::StatusCode>(msg->data);
     if (latest_status != status_)

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -56,7 +56,7 @@ public:
   StatusMonitor(const rclcpp::Node::SharedPtr& node, const std::string& topic)
   {
     sub_ = node->create_subscription<std_msgs::msg::Int8>(topic, rclcpp::SystemDefaultsQoS(),
-                                                          [this](const std_msgs::msg::Int8::ConstSharedPtr msg) {
+                                                          [this](const std_msgs::msg::Int8::ConstSharedPtr& msg) {
                                                             return statusCB(msg);
                                                           });
   }

--- a/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
+++ b/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
@@ -32,6 +32,8 @@
    Project   : moveit_servo
 */
 
+#include <utility>
+
 #include "moveit_servo/parameter_descriptor_builder.hpp"
 
 namespace moveit_servo
@@ -44,13 +46,13 @@ ParameterDescriptorBuilder& ParameterDescriptorBuilder::type(uint8_t type)
 
 ParameterDescriptorBuilder& ParameterDescriptorBuilder::description(std::string description)
 {
-  msg_.description = description;
+  msg_.description = std::move(description);
   return *this;
 }
 
 ParameterDescriptorBuilder& ParameterDescriptorBuilder::additionalConstraints(std::string additional_constraints)
 {
-  msg_.additional_constraints = additional_constraints;
+  msg_.additional_constraints = std::move(additional_constraints);
   return *this;
 }
 

--- a/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
+++ b/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
@@ -32,8 +32,6 @@
    Project   : moveit_servo
 */
 
-#include <utility>
-
 #include "moveit_servo/parameter_descriptor_builder.hpp"
 
 namespace moveit_servo
@@ -44,15 +42,15 @@ ParameterDescriptorBuilder& ParameterDescriptorBuilder::type(uint8_t type)
   return *this;
 }
 
-ParameterDescriptorBuilder& ParameterDescriptorBuilder::description(std::string description)
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::description(const std::string& description)
 {
-  msg_.description = std::move(description);
+  msg_.description = description;
   return *this;
 }
 
-ParameterDescriptorBuilder& ParameterDescriptorBuilder::additionalConstraints(std::string additional_constraints)
+ParameterDescriptorBuilder& ParameterDescriptorBuilder::additionalConstraints(const std::string& additional_constraints)
 {
-  msg_.additional_constraints = std::move(additional_constraints);
+  msg_.additional_constraints = additional_constraints;
   return *this;
 }
 

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -253,7 +253,7 @@ bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tole
           (std::abs(z_error) < positional_tolerance(2)) && (std::abs(*angular_error_) < angular_tolerance));
 }
 
-void PoseTracking::targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
+void PoseTracking::targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr& msg)
 {
   std::lock_guard<std::mutex> lock(target_pose_mtx_);
   target_pose_ = *msg;

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -99,7 +99,7 @@ PoseTracking::PoseTracking(const rclcpp::Node::SharedPtr& node, const ServoParam
   // Connect to Servo ROS interfaces
   target_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
       "target_pose", rclcpp::SystemDefaultsQoS(),
-      [this](const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg) { return targetPoseCallback(msg); });
+      [this](const geometry_msgs::msg::PoseStamped::ConstSharedPtr& msg) { return targetPoseCallback(msg); });
 
   // Publish outgoing twist commands to the Servo object
   twist_stamped_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -40,6 +40,8 @@
 #include <moveit_servo/make_shared_from_pool.h>
 #include <moveit_servo/servo.h>
 
+#include <utility>
+
 namespace moveit_servo
 {
 namespace
@@ -48,9 +50,9 @@ const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.servo");
 constexpr double ROBOT_STATE_WAIT_TIME = 10.0;  // seconds
 }  // namespace
 
-Servo::Servo(const rclcpp::Node::SharedPtr& node, ServoParameters::SharedConstPtr parameters,
+Servo::Servo(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
              planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor)
-  : planning_scene_monitor_{ planning_scene_monitor }
+  : planning_scene_monitor_{ std::move(planning_scene_monitor) }
   , parameters_{ parameters }
   , servo_calcs_{ node, parameters, planning_scene_monitor_ }
   , collision_checker_{ node, parameters, planning_scene_monitor_ }

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -40,8 +40,6 @@
 #include <moveit_servo/make_shared_from_pool.h>
 #include <moveit_servo/servo.h>
 
-#include <utility>
-
 namespace moveit_servo
 {
 namespace
@@ -51,8 +49,8 @@ constexpr double ROBOT_STATE_WAIT_TIME = 10.0;  // seconds
 }  // namespace
 
 Servo::Servo(const rclcpp::Node::SharedPtr& node, const ServoParameters::SharedConstPtr& parameters,
-             planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor)
-  : planning_scene_monitor_{ std::move(planning_scene_monitor) }
+             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : planning_scene_monitor_{ planning_scene_monitor }
   , parameters_{ parameters }
   , servo_calcs_{ node, parameters, planning_scene_monitor_ }
   , collision_checker_{ node, parameters, planning_scene_monitor_ }

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -104,11 +104,11 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   // Subscribe to command topics
   twist_stamped_sub_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(
       parameters_->cartesian_command_in_topic, rclcpp::SystemDefaultsQoS(),
-      [this](const geometry_msgs::msg::TwistStamped::SharedPtr msg) { return twistStampedCB(msg); });
+      [this](const geometry_msgs::msg::TwistStamped::ConstSharedPtr& msg) { return twistStampedCB(msg); });
 
   joint_cmd_sub_ = node_->create_subscription<control_msgs::msg::JointJog>(
       parameters_->joint_command_in_topic, rclcpp::SystemDefaultsQoS(),
-      [this](const control_msgs::msg::JointJog::SharedPtr msg) { return jointCmdCB(msg); });
+      [this](const control_msgs::msg::JointJog::ConstSharedPtr& msg) { return jointCmdCB(msg); });
 
   // ROS Server for allowing drift in some dimensions
   drift_dimensions_server_ = node_->create_service<moveit_msgs::srv::ChangeDriftDimensions>(
@@ -135,7 +135,7 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   // Subscribe to the collision_check topic
   collision_velocity_scale_sub_ = node_->create_subscription<std_msgs::msg::Float64>(
       "~/collision_velocity_scale", rclcpp::SystemDefaultsQoS(),
-      [this](const std_msgs::msg::Float64::SharedPtr& msg) { return collisionVelocityScaleCB(msg); });
+      [this](const std_msgs::msg::Float64::ConstSharedPtr& msg) { return collisionVelocityScaleCB(msg); });
 
   // Publish freshly-calculated joints to the robot.
   // Put the outgoing msg in the right format (trajectory_msgs/JointTrajectory or std_msgs/Float64MultiArray).
@@ -1173,7 +1173,7 @@ bool ServoCalcs::getEEFrameTransform(geometry_msgs::msg::TransformStamped& trans
   return true;
 }
 
-void ServoCalcs::twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPtr& msg)
+void ServoCalcs::twistStampedCB(const geometry_msgs::msg::TwistStamped::ConstSharedPtr& msg)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   latest_twist_stamped_ = msg;
@@ -1187,7 +1187,7 @@ void ServoCalcs::twistStampedCB(const geometry_msgs::msg::TwistStamped::SharedPt
   input_cv_.notify_all();
 }
 
-void ServoCalcs::jointCmdCB(const control_msgs::msg::JointJog::SharedPtr& msg)
+void ServoCalcs::jointCmdCB(const control_msgs::msg::JointJog::ConstSharedPtr& msg)
 {
   const std::lock_guard<std::mutex> lock(main_loop_mutex_);
   latest_joint_cmd_ = msg;
@@ -1201,7 +1201,7 @@ void ServoCalcs::jointCmdCB(const control_msgs::msg::JointJog::SharedPtr& msg)
   input_cv_.notify_all();
 }
 
-void ServoCalcs::collisionVelocityScaleCB(const std_msgs::msg::Float64::SharedPtr& msg)
+void ServoCalcs::collisionVelocityScaleCB(const std_msgs::msg::Float64::ConstSharedPtr& msg)
 {
   collision_velocity_scale_ = msg.get()->data;
 }

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -56,24 +56,21 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
 
   // Set up services for interacting with Servo
   start_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/start_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-        return startCB(request, std::move(response));
-      });
+      "~/start_servo",
+      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+             const std::shared_ptr<std_srvs::srv::Trigger::Response>& response) { return startCB(request, response); });
   stop_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/stop_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                             std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-        return stopCB(request, std::move(response));
-      });
+      "~/stop_servo",
+      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+             const std::shared_ptr<std_srvs::srv::Trigger::Response>& response) { return stopCB(request, response); });
   pause_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/pause_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-        return pauseCB(request, std::move(response));
-      });
+      "~/pause_servo",
+      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+             const std::shared_ptr<std_srvs::srv::Trigger::Response>& response) { return pauseCB(request, response); });
   unpause_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/unpause_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                                std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-        return unpauseCB(request, std::move(response));
+      "~/unpause_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>& request,
+                                const std::shared_ptr<std_srvs::srv::Trigger::Response>& response) {
+        return unpauseCB(request, response);
       });
 
   // Can set robot_description name from parameters
@@ -142,5 +139,4 @@ void ServoNode::unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>
 
 // Register the component with class_loader
 #include <rclcpp_components/register_node_macro.hpp>
-#include <utility>
 RCLCPP_COMPONENTS_REGISTER_NODE(moveit_servo::ServoNode)

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -56,21 +56,25 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
 
   // Set up services for interacting with Servo
   start_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/start_servo",
-      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-             std::shared_ptr<std_srvs::srv::Trigger::Response> response) { return startCB(request, response); });
+      "~/start_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        return startCB(request, std::move(response));
+      });
   stop_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/stop_servo",
-      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-             std::shared_ptr<std_srvs::srv::Trigger::Response> response) { return stopCB(request, response); });
+      "~/stop_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        return stopCB(request, std::move(response));
+      });
   pause_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/pause_servo",
-      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-             std::shared_ptr<std_srvs::srv::Trigger::Response> response) { return pauseCB(request, response); });
+      "~/pause_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        return pauseCB(request, std::move(response));
+      });
   unpause_servo_service_ = node_->create_service<std_srvs::srv::Trigger>(
-      "~/unpause_servo",
-      [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-             std::shared_ptr<std_srvs::srv::Trigger::Response> response) { return unpauseCB(request, response); });
+      "~/unpause_servo", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                                std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+        return unpauseCB(request, std::move(response));
+      });
 
   // Can set robot_description name from parameters
   std::string robot_description_name = "robot_description";
@@ -106,29 +110,29 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
   servo_ = std::make_unique<moveit_servo::Servo>(node_, servo_parameters, planning_scene_monitor_);
 }
 
-void ServoNode::startCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /* unused */,
-                        std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void ServoNode::startCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& /* unused */,
+                        const std::shared_ptr<std_srvs::srv::Trigger::Response>& response)
 {
   servo_->start();
   response->success = true;
 }
 
-void ServoNode::stopCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /* unused */,
-                       std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void ServoNode::stopCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& /* unused */,
+                       const std::shared_ptr<std_srvs::srv::Trigger::Response>& response)
 {
   servo_->setPaused(true);
   response->success = true;
 }
 
-void ServoNode::pauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /* unused */,
-                        std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void ServoNode::pauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& /* unused */,
+                        const std::shared_ptr<std_srvs::srv::Trigger::Response>& response)
 {
   servo_->setPaused(true);
   response->success = true;
 }
 
-void ServoNode::unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request> /* unused */,
-                          std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void ServoNode::unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>& /* unused */,
+                          const std::shared_ptr<std_srvs::srv::Trigger::Response>& response)
 {
   servo_->setPaused(false);
   response->success = true;
@@ -138,4 +142,5 @@ void ServoNode::unpauseCB(const std::shared_ptr<std_srvs::srv::Trigger::Request>
 
 // Register the component with class_loader
 #include <rclcpp_components/register_node_macro.hpp>
+#include <utility>
 RCLCPP_COMPONENTS_REGISTER_NODE(moveit_servo::ServoNode)

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -454,7 +454,7 @@ std::optional<ServoParameters> ServoParameters::validate(ServoParameters paramet
 }
 
 ServoParameters::SharedConstPtr ServoParameters::makeServoParameters(const rclcpp::Node::SharedPtr& node,
-                                                                     std::string ns, /* = "moveit_servo"*/
+                                                                     const std::string& ns, /* = "moveit_servo"*/
                                                                      bool dynamic_parameters /* = true */)
 {
   auto node_parameters = node->get_node_parameters_interface();

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -227,7 +227,7 @@ public:
       collision_pub_thread_.join();
   }
 
-  void joyCB(const sensor_msgs::msg::Joy::SharedPtr msg)
+  void joyCB(const sensor_msgs::msg::Joy::SharedPtr& msg)
   {
     // Create the messages we might publish
     auto twist_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -164,10 +164,9 @@ public:
     : Node("joy_to_twist_publisher", options), frame_to_publish_(BASE_FRAME_ID)
   {
     // Setup pub/sub
-    joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(JOY_TOPIC, rclcpp::SystemDefaultsQoS(),
-                                                                [this](const sensor_msgs::msg::Joy::SharedPtr msg) {
-                                                                  return joyCB(msg);
-                                                                });
+    joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
+        JOY_TOPIC, rclcpp::SystemDefaultsQoS(),
+        [this](const sensor_msgs::msg::Joy::ConstSharedPtr& msg) { return joyCB(msg); });
 
     twist_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(TWIST_TOPIC, rclcpp::SystemDefaultsQoS());
     joint_pub_ = this->create_publisher<control_msgs::msg::JointJog>(JOINT_TOPIC, rclcpp::SystemDefaultsQoS());
@@ -227,7 +226,7 @@ public:
       collision_pub_thread_.join();
   }
 
-  void joyCB(const sensor_msgs::msg::Joy::SharedPtr& msg)
+  void joyCB(const sensor_msgs::msg::Joy::ConstSharedPtr& msg)
   {
     // Create the messages we might publish
     auto twist_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -92,7 +92,7 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
                                            const double hard_stop_singularity_threshold,
                                            const double lower_singularity_threshold,
                                            const double leaving_singularity_threshold_multiplier, rclcpp::Clock& clock,
-                                           moveit::core::RobotStatePtr current_state, StatusCode& status)
+                                           const moveit::core::RobotStatePtr& current_state, StatusCode& status)
 {
   double velocity_scale = 1;
   std::size_t num_dimensions = commanded_twist.size();

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -159,7 +159,7 @@ TEST_F(PoseTrackingFixture, OutgoingMsgTest)
   // and test some conditions
   trajectory_msgs::msg::JointTrajectory last_received_msg;
   std::function<void(const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr)> traj_callback =
-      [&/* this */](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr msg) {
+      [&/* this */](const trajectory_msgs::msg::JointTrajectory::ConstSharedPtr& msg) {
         EXPECT_EQ(msg->header.frame_id, "panda_link0");
 
         // Exact joint positions may vary based on IK solver

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -238,7 +238,7 @@ public:
     return true;
   }
 
-  bool setupCommandSub(std::string command_type)
+  bool setupCommandSub(const std::string& command_type)
   {
     if (command_type == "trajectory_msgs/JointTrajectory")
     {
@@ -269,7 +269,7 @@ public:
     return true;
   }
 
-  void statusCB(const std_msgs::msg::Int8::SharedPtr msg)
+  void statusCB(const std_msgs::msg::Int8::SharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_status_;
@@ -278,28 +278,28 @@ public:
       status_seen_ = true;
   }
 
-  void collisionScaleCB(const std_msgs::msg::Float64::SharedPtr msg)
+  void collisionScaleCB(const std_msgs::msg::Float64::SharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_collision_scale_;
     latest_collision_scale_ = msg.get()->data;
   }
 
-  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr msg)
+  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_joint_state_;
     latest_joint_state_ = msg;
   }
 
-  void trajectoryCommandCB(const trajectory_msgs::msg::JointTrajectory::SharedPtr msg)
+  void trajectoryCommandCB(const trajectory_msgs::msg::JointTrajectory::SharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_commands_;
     latest_traj_cmd_ = msg;
   }
 
-  void arrayCommandCB(const std_msgs::msg::Float64MultiArray::SharedPtr msg)
+  void arrayCommandCB(const std_msgs::msg::Float64MultiArray::SharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_commands_;

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -265,7 +265,7 @@ public:
   {
     sub_joint_state_ = node_->create_subscription<sensor_msgs::msg::JointState>(
         resolveServoTopicName(servo_parameters_->joint_topic), rclcpp::SystemDefaultsQoS(),
-        [this](const sensor_msgs::msg::JointState::SharedPtr msg) { return jointStateCB(msg); });
+        [this](const sensor_msgs::msg::JointState::ConstSharedPtr& msg) { return jointStateCB(msg); });
     return true;
   }
 
@@ -285,7 +285,7 @@ public:
     latest_collision_scale_ = msg.get()->data;
   }
 
-  void jointStateCB(const sensor_msgs::msg::JointState::SharedPtr& msg)
+  void jointStateCB(const sensor_msgs::msg::JointState::ConstSharedPtr& msg)
   {
     const std::lock_guard<std::mutex> lock(latest_state_mutex_);
     ++num_joint_state_;

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -283,9 +283,9 @@ private:
    *
    * @return     True on success, False otherwise.
    */
-  bool saveMapCallback(const std::shared_ptr<rmw_request_id_t> request_header,
-                       const std::shared_ptr<moveit_msgs::srv::SaveMap::Request> request,
-                       std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response);
+  bool saveMapCallback(const std::shared_ptr<rmw_request_id_t>& request_header,
+                       const std::shared_ptr<moveit_msgs::srv::SaveMap::Request>& request,
+                       const std::shared_ptr<moveit_msgs::srv::SaveMap::Response>& response);
 
   /**
    * @brief      Load octree from a binary file (gets rid of current octree data)
@@ -296,9 +296,9 @@ private:
    *
    * @return     True on success, False otherwise.
    */
-  bool loadMapCallback(const std::shared_ptr<rmw_request_id_t> request_header,
-                       const std::shared_ptr<moveit_msgs::srv::LoadMap::Request> request,
-                       std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response);
+  bool loadMapCallback(const std::shared_ptr<rmw_request_id_t>& request_header,
+                       const std::shared_ptr<moveit_msgs::srv::LoadMap::Request>& request,
+                       const std::shared_ptr<moveit_msgs::srv::LoadMap::Response>& response);
 
   /**
    * @brief      Gets the shape transform cache.

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -131,14 +131,14 @@ OccupancyMapMonitor::OccupancyMapMonitor(std::unique_ptr<MiddlewareHandle> middl
   /* advertise a service for loading octomaps from disk */
   auto save_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t>& request_header,
                                           const std::shared_ptr<moveit_msgs::srv::SaveMap::Request>& request,
-                                          std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response) -> bool {
-    return saveMapCallback(request_header, request, std::move(response));
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Response>& response) -> bool {
+    return saveMapCallback(request_header, request, response);
   };
 
   auto load_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t>& request_header,
                                           const std::shared_ptr<moveit_msgs::srv::LoadMap::Request>& request,
-                                          std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response) -> bool {
-    return loadMapCallback(request_header, request, std::move(response));
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Response>& response) -> bool {
+    return loadMapCallback(request_header, request, response);
   };
 
   middleware_handle_->createSaveMapService(save_map_service_callback);

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -129,16 +129,16 @@ OccupancyMapMonitor::OccupancyMapMonitor(std::unique_ptr<MiddlewareHandle> middl
   }
 
   /* advertise a service for loading octomaps from disk */
-  auto save_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request> request,
+  auto save_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request>& request,
                                           std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response) -> bool {
-    return saveMapCallback(request_header, request, response);
+    return saveMapCallback(request_header, request, std::move(response));
   };
 
-  auto load_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t> request_header,
-                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request> request,
+  auto load_map_service_callback = [this](const std::shared_ptr<rmw_request_id_t>& request_header,
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request>& request,
                                           std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response) -> bool {
-    return loadMapCallback(request_header, request, response);
+    return loadMapCallback(request_header, request, std::move(response));
   };
 
   middleware_handle_->createSaveMapService(save_map_service_callback);
@@ -269,9 +269,9 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
     return false;
 }
 
-bool OccupancyMapMonitor::saveMapCallback(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request> request,
-                                          std::shared_ptr<moveit_msgs::srv::SaveMap::Response> response)
+bool OccupancyMapMonitor::saveMapCallback(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Request>& request,
+                                          const std::shared_ptr<moveit_msgs::srv::SaveMap::Response>& response)
 {
   RCLCPP_INFO(LOGGER, "Writing map to %s", request->filename.c_str());
   tree_->lockRead();
@@ -287,9 +287,9 @@ bool OccupancyMapMonitor::saveMapCallback(const std::shared_ptr<rmw_request_id_t
   return true;
 }
 
-bool OccupancyMapMonitor::loadMapCallback(const std::shared_ptr<rmw_request_id_t> /* unused */,
-                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request> request,
-                                          std::shared_ptr<moveit_msgs::srv::LoadMap::Response> response)
+bool OccupancyMapMonitor::loadMapCallback(const std::shared_ptr<rmw_request_id_t>& /* unused */,
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Request>& request,
+                                          const std::shared_ptr<moveit_msgs::srv::LoadMap::Response>& response)
 {
   RCLCPP_INFO(LOGGER, "Reading map from %s", request->filename.c_str());
 

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -67,7 +67,7 @@ public:
    * @brief A (simple) semantic world representation for pick and place and other tasks.
    * Currently this is used only to represent tables.
    */
-  SemanticWorld(const rclcpp::Node::SharedPtr node, const planning_scene::PlanningSceneConstPtr& planning_scene);
+  SemanticWorld(const rclcpp::Node::SharedPtr& node, const planning_scene::PlanningSceneConstPtr& planning_scene);
 
   /**
    * @brief Get all the tables within a region of interest
@@ -136,7 +136,7 @@ private:
 
   shapes::Mesh* orientPlanarPolygon(const shapes::Mesh& polygon) const;
 
-  void tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr msg);
+  void tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr& msg);
 
   void transformTableArray(object_recognition_msgs::msg::TableArray& table_array) const;
 

--- a/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
+++ b/moveit_ros/perception/semantic_world/include/moveit/semantic_world/semantic_world.h
@@ -136,7 +136,7 @@ private:
 
   shapes::Mesh* orientPlanarPolygon(const shapes::Mesh& polygon) const;
 
-  void tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr& msg);
+  void tableCallback(const object_recognition_msgs::msg::TableArray::ConstSharedPtr& msg);
 
   void transformTableArray(object_recognition_msgs::msg::TableArray& table_array) const;
 

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -60,7 +60,7 @@ namespace semantic_world
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.perception.semantic_world");
 
-SemanticWorld::SemanticWorld(const rclcpp::Node::SharedPtr node,
+SemanticWorld::SemanticWorld(const rclcpp::Node::SharedPtr& node,
                              const planning_scene::PlanningSceneConstPtr& planning_scene)
   : planning_scene_(planning_scene), node_handle_(node)
 
@@ -473,7 +473,7 @@ std::string SemanticWorld::findObjectTable(const geometry_msgs::msg::Pose& pose,
   return std::string();
 }
 
-void SemanticWorld::tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr msg)
+void SemanticWorld::tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr& msg)
 {
   table_array_ = *msg;
   RCLCPP_INFO(LOGGER, "Table callback with %d tables", static_cast<int>(table_array_.tables.size()));

--- a/moveit_ros/perception/semantic_world/src/semantic_world.cpp
+++ b/moveit_ros/perception/semantic_world/src/semantic_world.cpp
@@ -67,7 +67,7 @@ SemanticWorld::SemanticWorld(const rclcpp::Node::SharedPtr& node,
 {
   table_subscriber_ = node_handle_->create_subscription<object_recognition_msgs::msg::TableArray>(
       "table_array", 1,
-      [this](const object_recognition_msgs::msg::TableArray::SharedPtr msg) { return tableCallback(msg); });
+      [this](const object_recognition_msgs::msg::TableArray::ConstSharedPtr& msg) { return tableCallback(msg); });
   visualization_publisher_ =
       node_handle_->create_publisher<visualization_msgs::msg::MarkerArray>("visualize_place", 20);
   collision_object_publisher_ =
@@ -473,7 +473,7 @@ std::string SemanticWorld::findObjectTable(const geometry_msgs::msg::Pose& pose,
   return std::string();
 }
 
-void SemanticWorld::tableCallback(const object_recognition_msgs::msg::TableArray::SharedPtr& msg)
+void SemanticWorld::tableCallback(const object_recognition_msgs::msg::TableArray::ConstSharedPtr& msg)
 {
   table_array_ = *msg;
   RCLCPP_INFO(LOGGER, "Table callback with %d tables", static_cast<int>(table_array_.tables.size()));

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
@@ -59,7 +59,7 @@ public:
    * insert method similar to https://github.com/ompl/ompl/blob/main/src/ompl/base/src/ProblemDefinition.cpp#L54-L161.
    * This way, it is possible to create a sorted container e.g. according to a user specified criteria
    */
-  void pushBack(planning_interface::MotionPlanResponse plan_solution)
+  void pushBack(const planning_interface::MotionPlanResponse& plan_solution)
   {
     std::lock_guard<std::mutex> lock_guard(solutions_mutex_);
     solutions_.push_back(plan_solution);

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -197,7 +197,7 @@ public:
    * provided PlanRequestParameters. */
   planning_interface::MotionPlanResponse
   plan(const MultiPipelinePlanRequestParameters& parameters,
-       SolutionCallbackFunction solution_selection_callback = &getShortestSolution,
+       const SolutionCallbackFunction& solution_selection_callback = &getShortestSolution,
        StoppingCriterionFunction stopping_criterion_callback = nullptr);
 
   /** \brief Execute the latest computed solution trajectory computed by plan(). By default this function terminates

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -227,9 +227,10 @@ planning_interface::MotionPlanResponse PlanningComponent::plan(const PlanRequest
   return plan_solution;
 }
 
-planning_interface::MotionPlanResponse PlanningComponent::plan(const MultiPipelinePlanRequestParameters& parameters,
-                                                               SolutionCallbackFunction solution_selection_callback,
-                                                               StoppingCriterionFunction stopping_criterion_callback)
+planning_interface::MotionPlanResponse
+PlanningComponent::plan(const MultiPipelinePlanRequestParameters& parameters,
+                        const SolutionCallbackFunction& solution_selection_callback,
+                        StoppingCriterionFunction stopping_criterion_callback)
 {
   // Create solutions container
   PlanSolutions planning_solutions{ parameters.multi_plan_request_parameters.size() };

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -315,9 +315,9 @@ private:
   bool haveCompleteStateHelper(const rclcpp::Time& oldest_allowed_update_time,
                                std::vector<std::string>* missing_joints) const;
 
-  void jointStateCallback(sensor_msgs::msg::JointState::ConstSharedPtr joint_state);
+  void jointStateCallback(const sensor_msgs::msg::JointState::ConstSharedPtr& joint_state);
   void updateMultiDofJoints();
-  void transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static);
+  void transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr& msg, const bool is_static);
 
   std::unique_ptr<MiddlewareHandle> middleware_handle_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -445,16 +445,16 @@ protected:
   void configureDefaultPadding();
 
   /** @brief Callback for a new collision object msg*/
-  void collisionObjectCallback(moveit_msgs::msg::CollisionObject::SharedPtr obj);
+  void collisionObjectCallback(const moveit_msgs::msg::CollisionObject::SharedPtr& obj);
 
   /** @brief Callback for a new planning scene world*/
-  void newPlanningSceneWorldCallback(moveit_msgs::msg::PlanningSceneWorld::SharedPtr world);
+  void newPlanningSceneWorldCallback(const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world);
 
   /** @brief Callback for octomap updates */
   void octomapUpdateCallback();
 
   /** @brief Callback for a new attached object msg*/
-  void attachObjectCallback(moveit_msgs::msg::AttachedCollisionObject::SharedPtr obj);
+  void attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj);
 
   /** @brief Callback for a change for an attached object of the current state of the planning scene */
   void currentStateAttachedBodyUpdateCallback(moveit::core::AttachedBody* attached_body, bool just_attached);
@@ -572,11 +572,11 @@ private:
   void stateUpdateTimerCallback();
 
   // Callback for a new planning scene msg
-  void newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr scene);
+  void newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr& scene);
 
   // Callback for requesting the full planning scene via service
-  void getPlanningSceneServiceCallback(moveit_msgs::srv::GetPlanningScene::Request::SharedPtr req,
-                                       moveit_msgs::srv::GetPlanningScene::Response::SharedPtr res);
+  void getPlanningSceneServiceCallback(const moveit_msgs::srv::GetPlanningScene::Request::SharedPtr& req,
+                                       const moveit_msgs::srv::GetPlanningScene::Response::SharedPtr& res);
 
   void updatePublishSettings(bool publish_geom_updates, bool publish_state_updates, bool publish_transform_updates,
                              bool publish_planning_scene, double publish_planning_scene_hz);

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -445,16 +445,16 @@ protected:
   void configureDefaultPadding();
 
   /** @brief Callback for a new collision object msg*/
-  void collisionObjectCallback(const moveit_msgs::msg::CollisionObject::SharedPtr& obj);
+  void collisionObjectCallback(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& obj);
 
   /** @brief Callback for a new planning scene world*/
-  void newPlanningSceneWorldCallback(const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world);
+  void newPlanningSceneWorldCallback(const moveit_msgs::msg::PlanningSceneWorld::ConstSharedPtr& world);
 
   /** @brief Callback for octomap updates */
   void octomapUpdateCallback();
 
   /** @brief Callback for a new attached object msg*/
-  void attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj);
+  void attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::ConstSharedPtr& obj);
 
   /** @brief Callback for a change for an attached object of the current state of the planning scene */
   void currentStateAttachedBodyUpdateCallback(moveit::core::AttachedBody* attached_body, bool just_attached);
@@ -572,7 +572,7 @@ private:
   void stateUpdateTimerCallback();
 
   // Callback for a new planning scene msg
-  void newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr& scene);
+  void newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::ConstSharedPtr& scene);
 
   // Callback for requesting the full planning scene via service
   void getPlanningSceneServiceCallback(const moveit_msgs::srv::GetPlanningScene::Request::SharedPtr& req,

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -43,6 +43,7 @@
 #include <chrono>
 #include <limits>
 #include <memory>
+#include <utility>
 
 namespace planning_scene_monitor
 {
@@ -160,8 +161,9 @@ void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topi
     else
     {
       middleware_handle_->createJointStateSubscription(
-          joint_states_topic,
-          [this](sensor_msgs::msg::JointState::ConstSharedPtr joint_state) { return jointStateCallback(joint_state); });
+          joint_states_topic, [this](sensor_msgs::msg::JointState::ConstSharedPtr joint_state) {
+            return jointStateCallback(std::move(joint_state));
+          });
     }
     if (tf_buffer_ && !robot_model_->getMultiDOFJointModels().empty())
     {
@@ -309,7 +311,7 @@ bool CurrentStateMonitor::waitForCompleteState(const std::string& group, double 
   return ok;
 }
 
-void CurrentStateMonitor::jointStateCallback(sensor_msgs::msg::JointState::ConstSharedPtr joint_state)
+void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState::ConstSharedPtr& joint_state)
 {
   if (joint_state->name.size() != joint_state->position.size())
   {
@@ -465,7 +467,7 @@ void CurrentStateMonitor::updateMultiDofJoints()
 }
 
 // Copied from https://github.com/ros2/geometry2/blob/ros2/tf2_ros/src/transform_listener.cpp
-void CurrentStateMonitor::transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg, const bool is_static)
+void CurrentStateMonitor::transformCallback(const tf2_msgs::msg::TFMessage::ConstSharedPtr& msg, const bool is_static)
 {
   for (const auto& transform : msg->transforms)
   {

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -43,7 +43,6 @@
 #include <chrono>
 #include <limits>
 #include <memory>
-#include <utility>
 
 namespace planning_scene_monitor
 {
@@ -161,8 +160,8 @@ void CurrentStateMonitor::startStateMonitor(const std::string& joint_states_topi
     else
     {
       middleware_handle_->createJointStateSubscription(
-          joint_states_topic, [this](sensor_msgs::msg::JointState::ConstSharedPtr joint_state) {
-            return jointStateCallback(std::move(joint_state));
+          joint_states_topic, [this](const sensor_msgs::msg::JointState::ConstSharedPtr& joint_state) {
+            return jointStateCallback(joint_state);
           });
     }
     if (tf_buffer_ && !robot_model_->getMultiDOFJointModels().empty())

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -619,7 +619,7 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
     stopPublishingPlanningScene();
 }
 
-void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr& scene)
+void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::ConstSharedPtr& scene)
 {
   newPlanningSceneMessage(*scene);
 }
@@ -729,7 +729,8 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
   return result;
 }
 
-void PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world)
+void PlanningSceneMonitor::newPlanningSceneWorldCallback(
+    const moveit_msgs::msg::PlanningSceneWorld::ConstSharedPtr& world)
 {
   if (scene_)
   {
@@ -753,7 +754,7 @@ void PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::msg:
   }
 }
 
-void PlanningSceneMonitor::collisionObjectCallback(const moveit_msgs::msg::CollisionObject::SharedPtr& obj)
+void PlanningSceneMonitor::collisionObjectCallback(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& obj)
 {
   if (!scene_)
     return;
@@ -768,7 +769,7 @@ void PlanningSceneMonitor::collisionObjectCallback(const moveit_msgs::msg::Colli
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
-void PlanningSceneMonitor::attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj)
+void PlanningSceneMonitor::attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::ConstSharedPtr& obj)
 {
   if (scene_)
   {
@@ -1089,8 +1090,9 @@ void PlanningSceneMonitor::startSceneMonitor(const std::string& scene_topic)
   if (!scene_topic.empty())
   {
     planning_scene_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::PlanningScene>(
-        scene_topic, 100,
-        [this](const moveit_msgs::msg::PlanningScene::SharedPtr& scene) { return newPlanningSceneCallback(scene); });
+        scene_topic, 100, [this](const moveit_msgs::msg::PlanningScene::ConstSharedPtr& scene) {
+          return newPlanningSceneCallback(scene);
+        });
     RCLCPP_INFO(LOGGER, "Listening to '%s'", planning_scene_subscriber_->get_topic_name());
   }
 }
@@ -1177,14 +1179,14 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
   {
     collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::CollisionObject>(
         collision_objects_topic, 1024,
-        [this](const moveit_msgs::msg::CollisionObject::SharedPtr& obj) { return collisionObjectCallback(obj); });
+        [this](const moveit_msgs::msg::CollisionObject::ConstSharedPtr& obj) { return collisionObjectCallback(obj); });
     RCLCPP_INFO(LOGGER, "Listening to '%s'", collision_objects_topic.c_str());
   }
 
   if (!planning_scene_world_topic.empty())
   {
     planning_scene_world_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::PlanningSceneWorld>(
-        planning_scene_world_topic, 1, [this](const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world) {
+        planning_scene_world_topic, 1, [this](const moveit_msgs::msg::PlanningSceneWorld::ConstSharedPtr& world) {
           return newPlanningSceneWorldCallback(world);
         });
     RCLCPP_INFO(LOGGER, "Listening to '%s' for planning scene world geometry", planning_scene_world_topic.c_str());
@@ -1255,7 +1257,7 @@ void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_top
     {
       // using regular message filter as there's no header
       attached_collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::AttachedCollisionObject>(
-          attached_objects_topic, 1024, [this](const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj) {
+          attached_objects_topic, 1024, [this](const moveit_msgs::msg::AttachedCollisionObject::ConstSharedPtr& obj) {
             return attachObjectCallback(obj);
           });
       RCLCPP_INFO(LOGGER, "Listening to '%s' for attached collision objects",

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -51,6 +51,7 @@
 #include <std_msgs/msg/string.hpp>
 
 #include <chrono>
+#include <utility>
 using namespace std::chrono_literals;
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_monitor.planning_scene_monitor");
@@ -252,7 +253,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     return;
   }
 
-  auto psm_parameter_set_callback = [this](std::vector<rclcpp::Parameter> parameters) -> auto
+  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto
   {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
@@ -578,12 +579,13 @@ void PlanningSceneMonitor::providePlanningSceneService(const std::string& servic
   get_scene_service_ = pnode_->create_service<moveit_msgs::srv::GetPlanningScene>(
       service_name, [this](moveit_msgs::srv::GetPlanningScene::Request::SharedPtr req,
                            moveit_msgs::srv::GetPlanningScene::Response::SharedPtr res) {
-        return getPlanningSceneServiceCallback(req, res);
+        return getPlanningSceneServiceCallback(std::move(req), std::move(res));
       });
 }
 
-void PlanningSceneMonitor::getPlanningSceneServiceCallback(moveit_msgs::srv::GetPlanningScene::Request::SharedPtr req,
-                                                           moveit_msgs::srv::GetPlanningScene::Response::SharedPtr res)
+void PlanningSceneMonitor::getPlanningSceneServiceCallback(
+    const moveit_msgs::srv::GetPlanningScene::Request::SharedPtr& req,
+    const moveit_msgs::srv::GetPlanningScene::Response::SharedPtr& res)
 {
   if (req->components.components & moveit_msgs::msg::PlanningSceneComponents::TRANSFORMS)
     updateFrameTransforms();
@@ -618,7 +620,7 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
     stopPublishingPlanningScene();
 }
 
-void PlanningSceneMonitor::newPlanningSceneCallback(moveit_msgs::msg::PlanningScene::SharedPtr scene)
+void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::SharedPtr& scene)
 {
   newPlanningSceneMessage(*scene);
 }
@@ -728,7 +730,7 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
   return result;
 }
 
-void PlanningSceneMonitor::newPlanningSceneWorldCallback(moveit_msgs::msg::PlanningSceneWorld::SharedPtr world)
+void PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world)
 {
   if (scene_)
   {
@@ -752,7 +754,7 @@ void PlanningSceneMonitor::newPlanningSceneWorldCallback(moveit_msgs::msg::Plann
   }
 }
 
-void PlanningSceneMonitor::collisionObjectCallback(moveit_msgs::msg::CollisionObject::SharedPtr obj)
+void PlanningSceneMonitor::collisionObjectCallback(const moveit_msgs::msg::CollisionObject::SharedPtr& obj)
 {
   if (!scene_)
     return;
@@ -767,7 +769,7 @@ void PlanningSceneMonitor::collisionObjectCallback(moveit_msgs::msg::CollisionOb
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);
 }
 
-void PlanningSceneMonitor::attachObjectCallback(moveit_msgs::msg::AttachedCollisionObject::SharedPtr obj)
+void PlanningSceneMonitor::attachObjectCallback(const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj)
 {
   if (scene_)
   {
@@ -1176,15 +1178,16 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
   {
     collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::CollisionObject>(
         collision_objects_topic, 1024,
-        [this](moveit_msgs::msg::CollisionObject::SharedPtr obj) { return collisionObjectCallback(obj); });
+        [this](moveit_msgs::msg::CollisionObject::SharedPtr obj) { return collisionObjectCallback(std::move(obj)); });
     RCLCPP_INFO(LOGGER, "Listening to '%s'", collision_objects_topic.c_str());
   }
 
   if (!planning_scene_world_topic.empty())
   {
     planning_scene_world_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::PlanningSceneWorld>(
-        planning_scene_world_topic, 1,
-        [this](moveit_msgs::msg::PlanningSceneWorld::SharedPtr world) { return newPlanningSceneWorldCallback(world); });
+        planning_scene_world_topic, 1, [this](moveit_msgs::msg::PlanningSceneWorld::SharedPtr world) {
+          return newPlanningSceneWorldCallback(std::move(world));
+        });
     RCLCPP_INFO(LOGGER, "Listening to '%s' for planning scene world geometry", planning_scene_world_topic.c_str());
   }
 
@@ -1253,8 +1256,9 @@ void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_top
     {
       // using regular message filter as there's no header
       attached_collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::AttachedCollisionObject>(
-          attached_objects_topic, 1024,
-          [this](moveit_msgs::msg::AttachedCollisionObject::SharedPtr obj) { return attachObjectCallback(obj); });
+          attached_objects_topic, 1024, [this](moveit_msgs::msg::AttachedCollisionObject::SharedPtr obj) {
+            return attachObjectCallback(std::move(obj));
+          });
       RCLCPP_INFO(LOGGER, "Listening to '%s' for attached collision objects",
                   attached_collision_object_subscriber_->get_topic_name());
     }

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -51,7 +51,6 @@
 #include <std_msgs/msg/string.hpp>
 
 #include <chrono>
-#include <utility>
 using namespace std::chrono_literals;
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.planning_scene_monitor.planning_scene_monitor");
@@ -577,9 +576,9 @@ void PlanningSceneMonitor::providePlanningSceneService(const std::string& servic
 {
   // Load the service
   get_scene_service_ = pnode_->create_service<moveit_msgs::srv::GetPlanningScene>(
-      service_name, [this](moveit_msgs::srv::GetPlanningScene::Request::SharedPtr req,
-                           moveit_msgs::srv::GetPlanningScene::Response::SharedPtr res) {
-        return getPlanningSceneServiceCallback(std::move(req), std::move(res));
+      service_name, [this](const moveit_msgs::srv::GetPlanningScene::Request::SharedPtr& req,
+                           const moveit_msgs::srv::GetPlanningScene::Response::SharedPtr& res) {
+        return getPlanningSceneServiceCallback(req, res);
       });
 }
 
@@ -1091,7 +1090,7 @@ void PlanningSceneMonitor::startSceneMonitor(const std::string& scene_topic)
   {
     planning_scene_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::PlanningScene>(
         scene_topic, 100,
-        [this](const moveit_msgs::msg::PlanningScene::SharedPtr scene) { return newPlanningSceneCallback(scene); });
+        [this](const moveit_msgs::msg::PlanningScene::SharedPtr& scene) { return newPlanningSceneCallback(scene); });
     RCLCPP_INFO(LOGGER, "Listening to '%s'", planning_scene_subscriber_->get_topic_name());
   }
 }
@@ -1178,15 +1177,15 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
   {
     collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::CollisionObject>(
         collision_objects_topic, 1024,
-        [this](moveit_msgs::msg::CollisionObject::SharedPtr obj) { return collisionObjectCallback(std::move(obj)); });
+        [this](const moveit_msgs::msg::CollisionObject::SharedPtr& obj) { return collisionObjectCallback(obj); });
     RCLCPP_INFO(LOGGER, "Listening to '%s'", collision_objects_topic.c_str());
   }
 
   if (!planning_scene_world_topic.empty())
   {
     planning_scene_world_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::PlanningSceneWorld>(
-        planning_scene_world_topic, 1, [this](moveit_msgs::msg::PlanningSceneWorld::SharedPtr world) {
-          return newPlanningSceneWorldCallback(std::move(world));
+        planning_scene_world_topic, 1, [this](const moveit_msgs::msg::PlanningSceneWorld::SharedPtr& world) {
+          return newPlanningSceneWorldCallback(world);
         });
     RCLCPP_INFO(LOGGER, "Listening to '%s' for planning scene world geometry", planning_scene_world_topic.c_str());
   }
@@ -1256,8 +1255,8 @@ void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_top
     {
       // using regular message filter as there's no header
       attached_collision_object_subscriber_ = pnode_->create_subscription<moveit_msgs::msg::AttachedCollisionObject>(
-          attached_objects_topic, 1024, [this](moveit_msgs::msg::AttachedCollisionObject::SharedPtr obj) {
-            return attachObjectCallback(std::move(obj));
+          attached_objects_topic, 1024, [this](const moveit_msgs::msg::AttachedCollisionObject::SharedPtr& obj) {
+            return attachObjectCallback(obj);
           });
       RCLCPP_INFO(LOGGER, "Listening to '%s' for attached collision objects",
                   attached_collision_object_subscriber_->get_topic_name());

--- a/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
@@ -69,7 +69,7 @@ struct MockCurrentStateMonitorMiddlewareHandle : public planning_scene_monitor::
   MOCK_METHOD(void, resetTfSubscriptions, (), (override));
 };
 
-void waitFor(std::chrono::seconds timeout, std::function<bool()> done)
+void waitFor(std::chrono::seconds timeout, const std::function<bool()>& done)
 {
   const auto start = std::chrono::steady_clock::now();
   while ((std::chrono::steady_clock::now() - start) < timeout)

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -41,6 +41,8 @@
 #include <urdf/model.h>
 #include <srdfdom/model.h>
 #include <rclcpp/rclcpp.hpp>
+#include <utility>
+#include <utility>
 
 namespace rdf_loader
 {
@@ -95,7 +97,8 @@ public:
 
   void setNewModelCallback(NewModelCallback cb)
   {
-    new_model_cb_ = cb;
+    std::move();
+    new_model_cb_ = std::move(cb);
   }
 
   /** @brief determine if given path points to a xacro file */

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -41,8 +41,6 @@
 #include <urdf/model.h>
 #include <srdfdom/model.h>
 #include <rclcpp/rclcpp.hpp>
-#include <utility>
-#include <utility>
 
 namespace rdf_loader
 {
@@ -95,10 +93,9 @@ public:
     return srdf_;
   }
 
-  void setNewModelCallback(NewModelCallback cb)
+  void setNewModelCallback(const NewModelCallback& cb)
   {
-    std::move();
-    new_model_cb_ = std::move(cb);
+    new_model_cb_ = cb;
   }
 
   /** @brief determine if given path points to a xacro file */

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
@@ -68,9 +68,9 @@ protected:
 
   bool shouldPublish();
 
-  bool waitForMessage(const rclcpp::Duration timeout);
+  bool waitForMessage(const rclcpp::Duration& timeout);
 
-  void stringCallback(const std_msgs::msg::String::SharedPtr msg);
+  void stringCallback(const std_msgs::msg::String::SharedPtr& msg);
 
   std::shared_ptr<rclcpp::Node> node_;
   std::string name_;

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
@@ -60,7 +60,7 @@ class SynchronizedStringParameter
 {
 public:
   std::string loadInitialValue(const std::shared_ptr<rclcpp::Node>& node, const std::string& name,
-                               StringCallback parent_callback = {}, bool default_continuous_value = false,
+                               const StringCallback& parent_callback = {}, bool default_continuous_value = false,
                                double default_timeout = 10.0);
 
 protected:

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/synchronized_string_parameter.h
@@ -70,7 +70,7 @@ protected:
 
   bool waitForMessage(const rclcpp::Duration& timeout);
 
-  void stringCallback(const std_msgs::msg::String::SharedPtr& msg);
+  void stringCallback(const std_msgs::msg::String::ConstSharedPtr& msg);
 
   std::shared_ptr<rclcpp::Node> node_;
   std::string name_;

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -36,17 +36,16 @@
 
 #include <moveit/rdf_loader/synchronized_string_parameter.h>
 
-#include <utility>
-
 namespace rdf_loader
 {
 std::string SynchronizedStringParameter::loadInitialValue(const std::shared_ptr<rclcpp::Node>& node,
-                                                          const std::string& name, StringCallback parent_callback,
+                                                          const std::string& name,
+                                                          const StringCallback& parent_callback,
                                                           bool default_continuous_value, double default_timeout)
 {
   node_ = node;
   name_ = name;
-  parent_callback_ = std::move(parent_callback);
+  parent_callback_ = parent_callback;
 
   if (getMainParameter())
   {

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -124,7 +124,7 @@ bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration& timeout
   auto const temp_node = std::make_shared<rclcpp::Node>(nd_name);
   string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_, rclcpp::QoS(1).transient_local().reliable(),
-      [this](const std_msgs::msg::String::SharedPtr msg) { return stringCallback(msg); });
+      [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return stringCallback(msg); });
 
   rclcpp::WaitSet wait_set;
   wait_set.add_subscription(string_subscriber_);
@@ -143,7 +143,7 @@ bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration& timeout
   return false;
 }
 
-void SynchronizedStringParameter::stringCallback(const std_msgs::msg::String::SharedPtr& msg)
+void SynchronizedStringParameter::stringCallback(const std_msgs::msg::String::ConstSharedPtr& msg)
 {
   if (msg->data == content_)
   {

--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -36,6 +36,8 @@
 
 #include <moveit/rdf_loader/synchronized_string_parameter.h>
 
+#include <utility>
+
 namespace rdf_loader
 {
 std::string SynchronizedStringParameter::loadInitialValue(const std::shared_ptr<rclcpp::Node>& node,
@@ -44,7 +46,7 @@ std::string SynchronizedStringParameter::loadInitialValue(const std::shared_ptr<
 {
   node_ = node;
   name_ = name;
-  parent_callback_ = parent_callback;
+  parent_callback_ = std::move(parent_callback);
 
   if (getMainParameter())
   {
@@ -117,7 +119,7 @@ bool SynchronizedStringParameter::shouldPublish()
   return publish_string;
 }
 
-bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
+bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration& timeout)
 {
   auto const nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
   auto const temp_node = std::make_shared<rclcpp::Node>(nd_name);
@@ -142,7 +144,7 @@ bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration timeout)
   return false;
 }
 
-void SynchronizedStringParameter::stringCallback(const std_msgs::msg::String::SharedPtr msg)
+void SynchronizedStringParameter::stringCallback(const std_msgs::msg::String::SharedPtr& msg)
 {
   if (msg->data == content_)
   {

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -270,7 +270,7 @@ private:
 
   void stopExecutionInternal();
 
-  void receiveEvent(const std_msgs::msg::String::SharedPtr& event);
+  void receiveEvent(const std_msgs::msg::String::ConstSharedPtr& event);
 
   void loadControllerParams();
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -270,7 +270,7 @@ private:
 
   void stopExecutionInternal();
 
-  void receiveEvent(const std_msgs::msg::String::SharedPtr event);
+  void receiveEvent(const std_msgs::msg::String::SharedPtr& event);
 
   void loadControllerParams();
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -183,8 +183,8 @@ void TrajectoryExecutionManager::initialize()
   auto options = rclcpp::SubscriptionOptions();
   options.callback_group = callback_group;
   event_topic_subscriber_ = node_->create_subscription<std_msgs::msg::String>(
-      EXECUTION_EVENT_TOPIC, 100, [this](const std_msgs::msg::String::SharedPtr event) { return receiveEvent(event); },
-      options);
+      EXECUTION_EVENT_TOPIC, 100,
+      [this](const std_msgs::msg::String::ConstSharedPtr& event) { return receiveEvent(event); }, options);
 
   controller_mgr_node_->get_parameter("trajectory_execution.execution_duration_monitoring",
                                       execution_duration_monitoring_);
@@ -273,7 +273,7 @@ void TrajectoryExecutionManager::processEvent(const std::string& event)
     RCLCPP_WARN_STREAM(LOGGER, "Unknown event type: '" << event << "'");
 }
 
-void TrajectoryExecutionManager::receiveEvent(const std_msgs::msg::String::SharedPtr& event)
+void TrajectoryExecutionManager::receiveEvent(const std_msgs::msg::String::ConstSharedPtr& event)
 {
   RCLCPP_INFO_STREAM(LOGGER, "Received event '" << event->data << "'");
   processEvent(event->data);

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -199,7 +199,7 @@ void TrajectoryExecutionManager::initialize()
   else
     RCLCPP_INFO(LOGGER, "Trajectory execution is not managing controllers");
 
-  auto controller_mgr_parameter_set_callback = [this](std::vector<rclcpp::Parameter> parameters) {
+  auto controller_mgr_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
     for (const auto& parameter : parameters)
@@ -273,7 +273,7 @@ void TrajectoryExecutionManager::processEvent(const std::string& event)
     RCLCPP_WARN_STREAM(LOGGER, "Unknown event type: '" << event << "'");
 }
 
-void TrajectoryExecutionManager::receiveEvent(const std_msgs::msg::String::SharedPtr event)
+void TrajectoryExecutionManager::receiveEvent(const std_msgs::msg::String::SharedPtr& event)
 {
   RCLCPP_INFO_STREAM(LOGGER, "Received event '" << event->data << "'");
   processEvent(event->data);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -771,7 +771,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr goal_handle) {
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr& goal_handle) {
           if (!goal_handle)
           {
             done = true;
@@ -848,7 +848,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::MoveGroup>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr goal_handle) {
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::MoveGroup>::SharedPtr& goal_handle) {
           if (!goal_handle)
           {
             done = true;
@@ -910,7 +910,7 @@ public:
     auto send_goal_opts = rclcpp_action::Client<moveit_msgs::action::ExecuteTrajectory>::SendGoalOptions();
 
     send_goal_opts.goal_response_callback =
-        [&](rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::SharedPtr goal_handle) {
+        [&](const rclcpp_action::ClientGoalHandle<moveit_msgs::action::ExecuteTrajectory>::SharedPtr& goal_handle) {
           if (!goal_handle)
           {
             done = true;

--- a/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
+++ b/moveit_ros/planning_interface/planning_scene_interface/src/planning_scene_interface.cpp
@@ -271,7 +271,7 @@ public:
   }
 
 private:
-  void waitForService(std::shared_ptr<rclcpp::ClientBase> srv)
+  void waitForService(const std::shared_ptr<rclcpp::ClientBase>& srv)
   {
     // rclcpp::Duration time_before_warning(5.0);
     // srv.waitForExistence(time_before_warning);

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -571,7 +571,7 @@ void RobotInteraction::toggleMoveInteractiveMarkerTopic(bool enable)
         std::string topic_name = int_marker_move_topics_[i];
         std::string marker_name = int_marker_names_[i];
         std::function<void(const geometry_msgs::msg::PoseStamped::SharedPtr)> subscription_callback =
-            [this, marker_name](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+            [this, marker_name](const geometry_msgs::msg::PoseStamped::SharedPtr& msg) {
               moveInteractiveMarker(marker_name, *msg);
             };
         auto subscription =

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/interactive_marker_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/interactive_marker_display.h
@@ -114,10 +114,10 @@ private:
   void unsubscribe();
 
   /// Called by InteractiveMarkerClient when successfully initialized.
-  void initializeCallback(visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr /*msg*/);
+  void initializeCallback(const visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr& /*msg*/);
 
   /// Called by InteractiveMarkerClient when an update from a server is received.
-  void updateCallback(visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg);
+  void updateCallback(const visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr& msg);
 
   /// Called by InteractiveMarkerClient when it resets.
   void resetCallback();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -246,7 +246,7 @@ protected:
   void setQueryStateHelper(bool use_start_state, const std::string& v);
   void populateMenuHandler(std::shared_ptr<interactive_markers::MenuHandler>& mh);
 
-  void selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg);
+  void selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr& msg);
 
   // overrides from Display
   void onInitialize() override;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -297,7 +297,7 @@ private:
   std::string selected_support_surface_name_;
 
   rclcpp_action::Client<object_recognition_msgs::action::ObjectRecognition>::SharedPtr object_recognition_client_;
-  void listenDetectedObjects(const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr msg);
+  void listenDetectedObjects(const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr& msg);
   rclcpp::Subscription<object_recognition_msgs::msg::RecognizedObjectArray>::SharedPtr object_recognition_subscriber_;
 
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr plan_subscriber_;
@@ -313,13 +313,13 @@ private:
   shapes::ShapePtr loadMeshResource(const std::string& url);
   void loadStoredStates(const std::string& pattern);
 
-  void remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr msg);
-  void remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg);
-  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg);
+  void remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr& msg);
+  void remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr& msg);
+  void remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr& msg);
+  void remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr& msg);
+  void remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr& msg);
+  void remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr& msg);
+  void remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr& msg);
 
   /* Selects or unselects a item in a list by the item name */
   void setItemSelectionInList(const std::string& item_name, bool selection, QListWidget* list);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
@@ -114,10 +114,12 @@ void InteractiveMarkerDisplay::onInitialize()
 
   interactive_marker_client_->setInitializeCallback(
       [this](visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr msg) {
-        return initializeCallback(msg);
+        return initializeCallback(std::move(msg));
       });
   interactive_marker_client_->setUpdateCallback(
-      [this](visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg) { return updateCallback(msg); });
+      [this](visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg) {
+        return updateCallback(std::move(msg));
+      });
   interactive_marker_client_->setResetCallback([this]() { return resetCallback(); });
   interactive_marker_client_->setStatusCallback(
       [this](interactive_markers::InteractiveMarkerClient::Status status, const std::string& message) {
@@ -278,13 +280,14 @@ void InteractiveMarkerDisplay::updatePoses(
   }
 }
 
-void InteractiveMarkerDisplay::initializeCallback(visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr msg)
+void InteractiveMarkerDisplay::initializeCallback(
+    const visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr& msg)
 {
   eraseAllMarkers();
   updateMarkers(msg->markers);
 }
 
-void InteractiveMarkerDisplay::updateCallback(visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg)
+void InteractiveMarkerDisplay::updateCallback(const visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr& msg)
 {
   updateMarkers(msg->markers);
   updatePoses(msg->poses);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
@@ -113,12 +113,12 @@ void InteractiveMarkerDisplay::onInitialize()
       pnode_, frame_transformer, fixed_frame_.toStdString());
 
   interactive_marker_client_->setInitializeCallback(
-      [this](visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr msg) {
-        return initializeCallback(std::move(msg));
+      [this](const visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr& msg) {
+        return initializeCallback(msg);
       });
   interactive_marker_client_->setUpdateCallback(
-      [this](visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg) {
-        return updateCallback(std::move(msg));
+      [this](const visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr& msg) {
+        return updateCallback(msg);
       });
   interactive_marker_client_->setResetCallback([this]() { return resetCallback(); });
   interactive_marker_client_->setStatusCallback(

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -293,7 +293,7 @@ void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)
   }
 }
 
-void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr msg)
+void MotionPlanningDisplay::selectPlanningGroupCallback(const std_msgs::msg::String::ConstSharedPtr& msg)
 {
   // synchronize ROS callback with main loop
   addMainLoopJob([this, group = msg->data] { changePlanningGroup(group); });

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -285,7 +285,7 @@ void MotionPlanningDisplay::toggleSelectPlanningGroupSubscription(bool enable)
   {
     planning_group_sub_ = node_->create_subscription<std_msgs::msg::String>(
         "/rviz/moveit/select_planning_group", 1,
-        [this](const std_msgs::msg::String::ConstSharedPtr msg) { return selectPlanningGroupCallback(msg); });
+        [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return selectPlanningGroupCallback(msg); });
   }
   else
   {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -268,25 +268,25 @@ void MotionPlanningFrame::allowExternalProgramCommunication(bool enable)
     using std::placeholders::_1;
     plan_subscriber_ = node_->create_subscription<std_msgs::msg::Empty>(
         "/rviz/moveit/plan", 1,
-        [this](const std_msgs::msg::Empty::ConstSharedPtr msg) { return remotePlanCallback(msg); });
+        [this](const std_msgs::msg::Empty::ConstSharedPtr& msg) { return remotePlanCallback(msg); });
     execute_subscriber_ = node_->create_subscription<std_msgs::msg::Empty>(
         "/rviz/moveit/execute", 1,
-        [this](const std_msgs::msg::Empty::ConstSharedPtr msg) { return remoteExecuteCallback(msg); });
+        [this](const std_msgs::msg::Empty::ConstSharedPtr& msg) { return remoteExecuteCallback(msg); });
     stop_subscriber_ = node_->create_subscription<std_msgs::msg::Empty>(
         "/rviz/moveit/stop", 1,
-        [this](const std_msgs::msg::Empty::ConstSharedPtr msg) { return remoteStopCallback(msg); });
+        [this](const std_msgs::msg::Empty::ConstSharedPtr& msg) { return remoteStopCallback(msg); });
     update_start_state_subscriber_ = node_->create_subscription<std_msgs::msg::Empty>(
         "/rviz/moveit/update_start_state", 1,
-        [this](const std_msgs::msg::Empty::ConstSharedPtr msg) { return remoteUpdateStartStateCallback(msg); });
+        [this](const std_msgs::msg::Empty::ConstSharedPtr& msg) { return remoteUpdateStartStateCallback(msg); });
     update_goal_state_subscriber_ = node_->create_subscription<std_msgs::msg::Empty>(
         "/rviz/moveit/update_goal_state", 1,
-        [this](const std_msgs::msg::Empty::ConstSharedPtr msg) { return remoteUpdateGoalStateCallback(msg); });
+        [this](const std_msgs::msg::Empty::ConstSharedPtr& msg) { return remoteUpdateGoalStateCallback(msg); });
     update_custom_start_state_subscriber_ = node_->create_subscription<moveit_msgs::msg::RobotState>(
-        "/rviz/moveit/update_custom_start_state", 1, [this](const moveit_msgs::msg::RobotState::ConstSharedPtr msg) {
+        "/rviz/moveit/update_custom_start_state", 1, [this](const moveit_msgs::msg::RobotState::ConstSharedPtr& msg) {
           return remoteUpdateCustomStartStateCallback(msg);
         });
     update_custom_goal_state_subscriber_ = node_->create_subscription<moveit_msgs::msg::RobotState>(
-        "/rviz/moveit/update_custom_goal_state", 1, [this](const moveit_msgs::msg::RobotState::ConstSharedPtr msg) {
+        "/rviz/moveit/update_custom_goal_state", 1, [this](const moveit_msgs::msg::RobotState::ConstSharedPtr& msg) {
           return remoteUpdateCustomGoalStateCallback(msg);
         });
   }
@@ -611,7 +611,7 @@ void MotionPlanningFrame::initFromMoveGroupNS()
 
   object_recognition_subscriber_ = node_->create_subscription<object_recognition_msgs::msg::RecognizedObjectArray>(
       "recognized_object_array", 1,
-      [this](const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr msg) {
+      [this](const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr& msg) {
         return listenDetectedObjects(msg);
       });
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_manipulation.cpp
@@ -160,7 +160,7 @@ void MotionPlanningFrame::triggerObjectDetection()
 }
 
 void MotionPlanningFrame::listenDetectedObjects(
-    const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr /*msg*/)
+    const object_recognition_msgs::msg::RecognizedObjectArray::ConstSharedPtr& /*msg*/)
 {
   rclcpp::sleep_for(std::chrono::seconds(1));
   planning_display_->addMainLoopJob([this] { processDetectedObjects(); });

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -551,22 +551,22 @@ void MotionPlanningFrame::configureForPlanning()
     planning_display_->dropVisualizedTrajectory();
 }
 
-void MotionPlanningFrame::remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
   planButtonClicked();
 }
 
-void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
   executeButtonClicked();
 }
 
-void MotionPlanningFrame::remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
   stopButtonClicked();
 }
 
-void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -580,7 +580,7 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Em
   }
 }
 
-void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr /*msg*/)
+void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
   if (move_group_ && planning_display_)
   {
@@ -594,7 +594,7 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::msg::Emp
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
+void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr& msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();
@@ -612,7 +612,7 @@ void MotionPlanningFrame::remoteUpdateCustomStartStateCallback(const moveit_msgs
   }
 }
 
-void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr msg)
+void MotionPlanningFrame::remoteUpdateCustomGoalStateCallback(const moveit_msgs::msg::RobotState::ConstSharedPtr& msg)
 {
   moveit_msgs::msg::RobotState msg_no_attached(*msg);
   msg_no_attached.attached_collision_objects.clear();

--- a/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/include/moveit/robot_state_rviz_plugin/robot_state_display.h
@@ -112,7 +112,7 @@ protected:
   void setLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name, const QColor& color);
   void unsetLinkColor(rviz_default_plugins::robot::Robot* robot, const std::string& link_name);
 
-  void newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state);
+  void newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr& state);
 
   void setRobotHighlights(const moveit_msgs::msg::DisplayRobotState::_highlight_links_type& highlight_links);
   void setHighlight(const std::string& link_name, const std_msgs::msg::ColorRGBA& color);

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -305,7 +305,7 @@ void RobotStateDisplay::changedRobotStateTopic()
 
   robot_state_subscriber_ = node_->create_subscription<moveit_msgs::msg::DisplayRobotState>(
       robot_state_topic_property_->getStdString(), 10,
-      [this](const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state) { return newRobotStateCallback(state); });
+      [this](const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr& state) { return newRobotStateCallback(state); });
 }
 
 void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr& state_msg)

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -308,7 +308,7 @@ void RobotStateDisplay::changedRobotStateTopic()
       [this](const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state) { return newRobotStateCallback(state); });
 }
 
-void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr state_msg)
+void RobotStateDisplay::newRobotStateCallback(const moveit_msgs::msg::DisplayRobotState::ConstSharedPtr& state_msg)
 {
   if (!robot_model_)
     return;

--- a/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -125,7 +125,7 @@ protected:
   /**
    * \brief ROS callback for an incoming path message
    */
-  void incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg);
+  void incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr& msg);
 
   /**
    * \brief get time to show each single robot state

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -185,7 +185,7 @@ void TrajectoryVisualization::onInitialize(const rclcpp::Node::SharedPtr& node, 
 
   trajectory_topic_sub_ = node_->create_subscription<moveit_msgs::msg::DisplayTrajectory>(
       trajectory_topic_property_->getStdString(), 2,
-      [this](const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg) { return incomingDisplayTrajectory(msg); });
+      [this](const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr& msg) { return incomingDisplayTrajectory(msg); });
 }
 
 void TrajectoryVisualization::setName(const QString& name)
@@ -294,7 +294,7 @@ void TrajectoryVisualization::changedTrajectoryTopic()
   {
     trajectory_topic_sub_ = node_->create_subscription<moveit_msgs::msg::DisplayTrajectory>(
         trajectory_topic_property_->getStdString(), 2,
-        [this](const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg) {
+        [this](const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr& msg) {
           return incomingDisplayTrajectory(msg);
         });
   }

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -536,7 +536,7 @@ void TrajectoryVisualization::update(float wall_dt, float sim_dt)
                                    (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible())));
 }
 
-void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr msg)
+void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr& msg)
 {
   // Error check
   if (!robot_state_ || !robot_model_)

--- a/moveit_ros/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/src/save_to_warehouse.cpp
@@ -196,13 +196,13 @@ int main(int argc, char** argv)
 
   psm.addUpdateCallback([&](auto&&) { return onSceneUpdate(psm, pss); });
 
-  auto callback1 = [&](moveit_msgs::msg::MotionPlanRequest msg) -> void { return onMotionPlanRequest(msg, psm, pss); };
-  auto mplan_req_sub =
-      node->create_subscription<moveit_msgs::msg::MotionPlanRequest>("motion_plan_request", 100, callback1);
-  auto callback2 = [&](moveit_msgs::msg::Constraints msg) -> void { return onConstraints(msg, cs); };
-  auto constr_sub = node->create_subscription<moveit_msgs::msg::Constraints>("constraints", 100, callback2);
-  auto callback3 = [&](moveit_msgs::msg::RobotState msg) -> void { return onRobotState(msg, rs); };
-  auto state_sub = node->create_subscription<moveit_msgs::msg::RobotState>("robot_state", 100, callback3);
+  auto mplan_req_sub = node->create_subscription<moveit_msgs::msg::MotionPlanRequest>(
+      "motion_plan_request", 100,
+      [&](const moveit_msgs::msg::MotionPlanRequest& msg) { onMotionPlanRequest(msg, psm, pss); });
+  auto constr_sub = node->create_subscription<moveit_msgs::msg::Constraints>(
+      "constraints", 100, [&](const moveit_msgs::msg::Constraints& msg) { onConstraints(msg, cs); });
+  auto state_sub = node->create_subscription<moveit_msgs::msg::RobotState>(
+      "robot_state", 100, [&](const moveit_msgs::msg::RobotState& msg) { onRobotState(msg, rs); });
 
   std::vector<std::string> topics;
   psm.getMonitoredTopics(topics);

--- a/moveit_ros/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/src/warehouse_services.cpp
@@ -48,13 +48,14 @@
 #include <rclcpp/node_options.hpp>
 #include <rclcpp/parameter_value.hpp>
 #include <rclcpp/utilities.hpp>
+#include <utility>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.ros.warehouse.warehouse_services");
 
-bool storeState(const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request> request,
-                std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response> response,
+bool storeState(const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request>& request,
+                const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response>& response,
                 moveit_warehouse::RobotStateStorage& rs)
 {
   if (request->name.empty())
@@ -66,8 +67,8 @@ bool storeState(const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehous
   return (response->success = true);
 }
 
-bool listStates(const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Request> request,
-                std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Response> response,
+bool listStates(const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Request>& request,
+                const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Response>& response,
                 moveit_warehouse::RobotStateStorage& rs)
 {
   if (request->regex.empty())
@@ -81,16 +82,16 @@ bool listStates(const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehou
   return true;
 }
 
-bool hasState(const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request> request,
-              std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response> response,
+bool hasState(const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request>& request,
+              const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response>& response,
               moveit_warehouse::RobotStateStorage& rs)
 {
   response->exists = rs.hasRobotState(request->name, request->robot);
   return true;
 }
 
-bool getState(const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Request> request,
-              std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Response> response,
+bool getState(const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Request>& request,
+              const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Response>& response,
               moveit_warehouse::RobotStateStorage& rs)
 {
   if (!rs.hasRobotState(request->name, request->robot))
@@ -106,8 +107,8 @@ bool getState(const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse
   return true;
 }
 
-bool renameState(const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Request> request,
-                 std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Response> /*response*/,
+bool renameState(const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Request>& request,
+                 const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Response>& /*response*/,
                  moveit_warehouse::RobotStateStorage& rs)
 {
   if (!rs.hasRobotState(request->old_name, request->robot))
@@ -119,8 +120,8 @@ bool renameState(const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWareh
   return true;
 }
 
-bool deleteState(const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request> request,
-                 std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response> /*response*/,
+bool deleteState(const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request>& request,
+                 const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response>& /*response*/,
                  moveit_warehouse::RobotStateStorage& rs)
 {
   if (!rs.hasRobotState(request->name, request->robot))
@@ -193,32 +194,32 @@ int main(int argc, char** argv)
 
   auto save_cb = [&](const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request> request,
                      std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response> response) -> bool {
-    return storeState(request, response, rs);
+    return storeState(request, std::move(response), rs);
   };
 
   auto list_cb = [&](const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Request> request,
                      std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Response> response) -> bool {
-    return listStates(request, response, rs);
+    return listStates(request, std::move(response), rs);
   };
 
   auto get_cb = [&](const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Request> request,
                     std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Response> response) -> bool {
-    return getState(request, response, rs);
+    return getState(request, std::move(response), rs);
   };
 
   auto has_cb = [&](const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request> request,
                     std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response> response) -> bool {
-    return hasState(request, response, rs);
+    return hasState(request, std::move(response), rs);
   };
 
   auto rename_cb = [&](const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Request> request,
                        std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Response> response) -> bool {
-    return renameState(request, response, rs);
+    return renameState(request, std::move(response), rs);
   };
 
   auto delete_cb = [&](const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request> request,
                        std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response> response) -> bool {
-    return deleteState(request, response, rs);
+    return deleteState(request, std::move(response), rs);
   };
 
   auto save_state_server =

--- a/moveit_ros/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/src/warehouse_services.cpp
@@ -48,7 +48,6 @@
 #include <rclcpp/node_options.hpp>
 #include <rclcpp/parameter_value.hpp>
 #include <rclcpp/utilities.hpp>
-#include <utility>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
@@ -192,34 +191,37 @@ int main(int argc, char** argv)
       RCLCPP_INFO(LOGGER, " * %s", name.c_str());
   }
 
-  auto save_cb = [&](const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request> request,
-                     std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response> response) -> bool {
-    return storeState(request, std::move(response), rs);
+  auto save_cb = [&](const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Request>& request,
+                     const std::shared_ptr<moveit_msgs::srv::SaveRobotStateToWarehouse::Response>& response) -> bool {
+    return storeState(request, response, rs);
   };
 
-  auto list_cb = [&](const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Request> request,
-                     std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Response> response) -> bool {
-    return listStates(request, std::move(response), rs);
+  auto list_cb = [&](const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Request>& request,
+                     const std::shared_ptr<moveit_msgs::srv::ListRobotStatesInWarehouse::Response>& response) -> bool {
+    return listStates(request, response, rs);
   };
 
-  auto get_cb = [&](const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Request> request,
-                    std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Response> response) -> bool {
-    return getState(request, std::move(response), rs);
+  auto get_cb = [&](const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Request>& request,
+                    const std::shared_ptr<moveit_msgs::srv::GetRobotStateFromWarehouse::Response>& response) -> bool {
+    return getState(request, response, rs);
   };
 
-  auto has_cb = [&](const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request> request,
-                    std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response> response) -> bool {
-    return hasState(request, std::move(response), rs);
+  auto has_cb =
+      [&](const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Request>& request,
+          const std::shared_ptr<moveit_msgs::srv::CheckIfRobotStateExistsInWarehouse::Response>& response) -> bool {
+    return hasState(request, response, rs);
   };
 
-  auto rename_cb = [&](const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Request> request,
-                       std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Response> response) -> bool {
-    return renameState(request, std::move(response), rs);
+  auto rename_cb =
+      [&](const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Request>& request,
+          const std::shared_ptr<moveit_msgs::srv::RenameRobotStateInWarehouse::Response>& response) -> bool {
+    return renameState(request, response, rs);
   };
 
-  auto delete_cb = [&](const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request> request,
-                       std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response> response) -> bool {
-    return deleteState(request, std::move(response), rs);
+  auto delete_cb =
+      [&](const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Request>& request,
+          const std::shared_ptr<moveit_msgs::srv::DeleteRobotStateFromWarehouse::Response>& response) -> bool {
+    return deleteState(request, response, rs);
   };
 
   auto save_state_server =

--- a/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/setup_assistant_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/setup_assistant_widget.hpp
@@ -75,7 +75,7 @@ public:
    * @param parent - used by Qt for destructing all elements
    * @return
    */
-  SetupAssistantWidget(rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr node, QWidget* parent,
+  SetupAssistantWidget(const rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr& node, QWidget* parent,
                        const boost::program_options::variables_map& args);
 
   /**

--- a/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
@@ -47,7 +47,6 @@
 #include <QStackedWidget>
 #include <QString>
 #include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
-#include <utility>
 
 namespace moveit_setup
 {
@@ -56,10 +55,10 @@ namespace assistant
 // ******************************************************************************************
 // Outer User Interface for MoveIt Configuration Assistant
 // ******************************************************************************************
-SetupAssistantWidget::SetupAssistantWidget(rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr node,
+SetupAssistantWidget::SetupAssistantWidget(const rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr& node,
                                            QWidget* parent, const boost::program_options::variables_map& args)
   : QWidget(parent)
-  , node_abstraction_(std::move(node))
+  , node_abstraction_(node)
   , node_(node_abstraction_.lock()->get_raw_node())
   , widget_loader_("moveit_setup_framework", "moveit_setup::SetupStepWidget")
 {

--- a/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
@@ -47,6 +47,7 @@
 #include <QStackedWidget>
 #include <QString>
 #include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
+#include <utility>
 
 namespace moveit_setup
 {
@@ -58,7 +59,7 @@ namespace assistant
 SetupAssistantWidget::SetupAssistantWidget(rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr node,
                                            QWidget* parent, const boost::program_options::variables_map& args)
   : QWidget(parent)
-  , node_abstraction_(node)
+  , node_abstraction_(std::move(node))
   , node_(node_abstraction_.lock()->get_raw_node())
   , widget_loader_("moveit_setup_framework", "moveit_setup::SetupStepWidget")
 {

--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/moveit_controllers.hpp
@@ -114,7 +114,7 @@ public:
     }
   };
 
-  virtual FieldPointers getAdditionalControllerFields() const
+  FieldPointers getAdditionalControllerFields() const override
   {
     FieldPointers fields;
     fields.push_back(std::make_shared<ActionNamespaceField>());

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/config.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/config.hpp
@@ -43,6 +43,8 @@
 #include <yaml-cpp/yaml.h>
 
 #include <set>
+#include <utility>
+#include <utility>
 
 namespace moveit_setup
 {
@@ -63,10 +65,11 @@ public:
    * @param parent_node Shared pointer to the parent node
    * @param name
    */
-  void initialize(std::shared_ptr<DataWarehouse> config_data, const rclcpp::Node::SharedPtr& parent_node,
+  void initialize(const std::shared_ptr<DataWarehouse>& config_data, const rclcpp::Node::SharedPtr& parent_node,
                   const std::string& name)
   {
-    config_data_ = config_data;
+    std::move(config_);
+    data_ = std::move(config_data);
     parent_node_ = parent_node;
     name_ = name;
     logger_ = std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child(name));

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/config.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/config.hpp
@@ -43,8 +43,6 @@
 #include <yaml-cpp/yaml.h>
 
 #include <set>
-#include <utility>
-#include <utility>
 
 namespace moveit_setup
 {
@@ -68,8 +66,7 @@ public:
   void initialize(const std::shared_ptr<DataWarehouse>& config_data, const rclcpp::Node::SharedPtr& parent_node,
                   const std::string& name)
   {
-    std::move(config_);
-    data_ = std::move(config_data);
+    config_data_ = config_data;
     parent_node_ = parent_node;
     name_ = name;
     logger_ = std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child(name));

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/qt/rviz_panel.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/qt/rviz_panel.hpp
@@ -58,8 +58,8 @@ class RVizPanel : public QWidget, public rviz_common::WindowManagerInterface
 {
   Q_OBJECT
 public:
-  RVizPanel(QWidget* parent, rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr node_abstraction,
-            DataWarehousePtr config_data);
+  RVizPanel(QWidget* parent, const rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr& node_abstraction,
+            const DataWarehousePtr& config_data);
   ~RVizPanel() override;
 
   bool isReadyForInitialization() const

--- a/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
@@ -37,6 +37,7 @@
 #include <moveit_setup_framework/data/urdf_config.hpp>
 #include <moveit_setup_framework/data/srdf_config.hpp>
 #include <QApplication>
+#include <utility>
 #include "rviz_rendering/render_window.hpp"
 
 namespace moveit_setup
@@ -45,9 +46,9 @@ RVizPanel::RVizPanel(QWidget* parent, rviz_common::ros_integration::RosNodeAbstr
                      DataWarehousePtr config_data)
   : QWidget(parent)
   , parent_(parent)
-  , node_abstraction_(node_abstraction)
+  , node_abstraction_(std::move(node_abstraction))
   , node_(node_abstraction_.lock()->get_raw_node())
-  , config_data_(config_data)
+  , config_data_(std::move(config_data))
 {
   logger_ = std::make_shared<rclcpp::Logger>(node_->get_logger().get_child("RVizPanel"));
 

--- a/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
@@ -37,18 +37,18 @@
 #include <moveit_setup_framework/data/urdf_config.hpp>
 #include <moveit_setup_framework/data/srdf_config.hpp>
 #include <QApplication>
-#include <utility>
 #include "rviz_rendering/render_window.hpp"
 
 namespace moveit_setup
 {
-RVizPanel::RVizPanel(QWidget* parent, rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr node_abstraction,
-                     DataWarehousePtr config_data)
+RVizPanel::RVizPanel(QWidget* parent,
+                     const rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr& node_abstraction,
+                     const DataWarehousePtr& config_data)
   : QWidget(parent)
   , parent_(parent)
-  , node_abstraction_(std::move(node_abstraction))
+  , node_abstraction_(node_abstraction)
   , node_(node_abstraction_.lock()->get_raw_node())
-  , config_data_(std::move(config_data))
+  , config_data_(config_data)
 {
   logger_ = std::make_shared<rclcpp::Logger>(node_->get_logger().get_child("RVizPanel"));
 


### PR DESCRIPTION
Having the clang-tidy check `performance-unnecessary-value-param` disabled for a few years, lead to the [introduction of several shortcomings in the code](https://github.com/ros-planning/moveit2/actions/runs/3427540403), which should be fixed asap.
Applying all automatic fixes from clang-tidy is not a good idea as you can see from [second commit, trying to cleanup a few of them](https://github.com/ros-planning/moveit2/pull/1706/commits/25c798e9e3726ca76b672ec04a828ef358d15a75). Somebody from the MoveIt2 team should take over and clean up the remaining ones. @henningkayser, can you please coordinate this work?