### PR TITLE
Small optimization in constructGoalConstraints()

### DIFF
--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -182,7 +182,7 @@ moveit_msgs::msg::Constraints constructGoalConstraints(const std::string& link_n
   pcm.header = pose.header;
   pcm.constraint_region.primitive_poses.resize(1);
   // orientation of constraint region does not affect anything, since it is a sphere
-  pcm.constraint_region.primitive_poses[0] = pose.pose;
+  pcm.constraint_region.primitive_poses[0].position = pose.pose.position;
   pcm.weight = 1.0;
 
   goal.orientation_constraints.resize(1);

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -181,13 +181,8 @@ moveit_msgs::msg::Constraints constructGoalConstraints(const std::string& link_n
 
   pcm.header = pose.header;
   pcm.constraint_region.primitive_poses.resize(1);
-  pcm.constraint_region.primitive_poses[0].position = pose.pose.position;
-
   // orientation of constraint region does not affect anything, since it is a sphere
-  pcm.constraint_region.primitive_poses[0].orientation.x = 0.0;
-  pcm.constraint_region.primitive_poses[0].orientation.y = 0.0;
-  pcm.constraint_region.primitive_poses[0].orientation.z = 0.0;
-  pcm.constraint_region.primitive_poses[0].orientation.w = 1.0;
+  pcm.constraint_region.primitive_poses[0] = pose.pose;
   pcm.weight = 1.0;
 
   goal.orientation_constraints.resize(1);


### PR DESCRIPTION
We can use the input orientation here since, as the comment says:

> // orientation of constraint region does not affect anything, since it is a sphere
