### PR TITLE
Use hashed version of generate_parameter_library

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -16,4 +16,4 @@ repositories:
   generate_parameter_library:
     type: git
     url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version: main
+    version: 93b8955f7595d022a03477a042c0571ea09a6d01


### PR DESCRIPTION
### Description

The latest main version of generate_parameter_library depends on RSL. The changes in that version are unnecessary for moveit2, so moveit2 should depend on a hash.
