### PR TITLE
Use adjustable waypoint batch sizes for Ruckig

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -98,8 +98,13 @@ private:
                                     ruckig::OutputParameter<ruckig::DynamicDOFs>& ruckig_output);
 
   /**
-   * \brief Break the `trajectory` parameter into batches of reasonable size, run Ruckig on each of them, then
+   * \brief Break the `trajectory` parameter into batches of reasonable size (~100), run Ruckig on each of them, then
    * re-combine into a single trajectory again.
+   * runRuckig() stretches all input waypoints in time until all kinematic limits are obeyed. This works but it can
+   * slow the trajectory more than necessary. It's better to feed in just a few waypoints at once, so that only the
+   * waypoints needing it get stretched.
+   * Here, break the trajectory waypoints into batches so the output is closer to time-optimal.
+   * There is a trade-off between time-optimality of the output trajectory and runtime of the smoothing algorithm.
    * \param[in, out] trajectory      Trajectory to smooth.
    * \param[in, out] ruckig_input    Necessary input for Ruckig smoothing. Contains kinematic limits (vel, accel, jerk)
    */

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -103,8 +103,9 @@ private:
    * \param[in, out] trajectory      Trajectory to smooth.
    * \param[in, out] ruckig_input    Necessary input for Ruckig smoothing. Contains kinematic limits (vel, accel, jerk)
    */
-  static bool runRuckigInBatches(const size_t num_waypoints, robot_trajectory::RobotTrajectory& trajectory,
-                                 ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input);
+  static std::optional<robot_trajectory::RobotTrajectory>
+  runRuckigInBatches(const size_t num_waypoints, const robot_trajectory::RobotTrajectory& trajectory,
+                     ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input);
 
   /**
    * \brief A utility function to instantiate and run Ruckig for a series of waypoints.

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -110,7 +110,7 @@ private:
    */
   static std::optional<robot_trajectory::RobotTrajectory>
   runRuckigInBatches(const size_t num_waypoints, const robot_trajectory::RobotTrajectory& trajectory,
-                     ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input);
+                     ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input, size_t batch_size = 100);
 
   /**
    * \brief A utility function to instantiate and run Ruckig for a series of waypoints.

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -98,6 +98,15 @@ private:
                                     ruckig::OutputParameter<ruckig::DynamicDOFs>& ruckig_output);
 
   /**
+   * \brief Break the `trajectory` parameter into batches of reasonable size, run Ruckig on each of them, then
+   * re-combine into a single trajectory again.
+   * \param[in, out] trajectory      Trajectory to smooth.
+   * \param[in, out] ruckig_input    Necessary input for Ruckig smoothing. Contains kinematic limits (vel, accel, jerk)
+   */
+  static bool runRuckigInBatches(const size_t num_waypoints, robot_trajectory::RobotTrajectory& trajectory,
+                                 ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input);
+
+  /**
    * \brief A utility function to instantiate and run Ruckig for a series of waypoints.
    * \param[in, out] trajectory      Trajectory to smooth.
    * \param[in, out] ruckig_input    Necessary input for Ruckig smoothing. Contains kinematic limits (vel, accel, jerk)

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -200,11 +200,8 @@ RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_traj
     size_t first_new_waypoint = first_point_previously_smoothed ? 1 : 0;
 
     // Add smoothed waypoints to the output
-    for (size_t waypoint_idx = first_new_waypoint; waypoint_idx < sub_trajectory.getWayPointCount(); ++waypoint_idx)
-    {
-      output_trajectory.addSuffixWayPoint(sub_trajectory.getWayPoint(waypoint_idx),
-                                          sub_trajectory.getWayPointDurationFromPrevious(waypoint_idx));
-    }
+    double initial_dt = sub_trajectory.getWayPointDurationFromPrevious(first_new_waypoint);
+    output_trajectory.append(sub_trajectory, initial_dt, first_new_waypoint, sub_trajectory.getWayPointCount() - 1);
 
     batch_start_idx += batch_size;
     batch_end_idx += batch_size;

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -150,16 +150,13 @@ std::optional<robot_trajectory::RobotTrajectory>
 RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_trajectory::RobotTrajectory& trajectory,
                                     ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input)
 {
-  // runRuckig() stretches all input waypoints in time until all kinematic limits are obeyed. This works but it can
-  // slow the trajectory more than necessary. It's better to feed in just a few waypoints at once, so that only the
-  // waypoints needing it get stretched.
-  // Here, break the trajectory waypoints into batches so the output is closer to time-optimal.
-  // There is a trade-off between time-optimality of the output trajectory and runtime of the smoothing algorithm.
   // We take the batch size as the lesser of 0.1*num_waypoints or 100, to keep a balance between run time and
   // time-optimality.
-  size_t temp_batch_size = std::min(size_t(0.1 * num_waypoints), size_t(100));
-  // But we need at least 2 waypoints
-  size_t waypoint_batch_size = std::max(size_t(2), temp_batch_size);
+  const size_t waypoint_batch_size = [num_waypoints]() {
+    const size_t temp_batch_size = std::min(size_t(0.1 * num_waypoints), size_t(100));
+    // We need at least 2 waypoints
+    return std::max(size_t(2), temp_batch_size);
+  }();
   size_t batch_start_idx = 0;
   size_t batch_end_idx = waypoint_batch_size - 1;
   const size_t full_traj_final_idx = num_waypoints - 1;

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -82,8 +82,11 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   }
 
   auto ruckig_result = runRuckigInBatches(num_waypoints, trajectory, ruckig_input);
-  trajectory = ruckig_result.value();
-  return ruckig_result.has_value();
+  if (ruckig_result.has_value())
+  {
+    trajectory = ruckig_result.value();
+  }
+  return ruckig_result.has_value();  // Ruckig failed to smooth the trajectory
 }
 
 bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
@@ -142,8 +145,11 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   }
 
   auto ruckig_result = runRuckigInBatches(num_waypoints, trajectory, ruckig_input);
-  trajectory = ruckig_result.value();
-  return ruckig_result.has_value();
+  if (ruckig_result.has_value())
+  {
+    trajectory = ruckig_result.value();
+  }
+  return ruckig_result.has_value();  // Ruckig failed to smooth the trajectory
 }
 
 std::optional<robot_trajectory::RobotTrajectory>

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -200,8 +200,11 @@ RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_traj
     size_t first_new_waypoint = first_point_previously_smoothed ? 1 : 0;
 
     // Add smoothed waypoints to the output
-    double initial_dt = sub_trajectory.getWayPointDurationFromPrevious(first_new_waypoint);
-    output_trajectory.append(sub_trajectory, initial_dt, first_new_waypoint, sub_trajectory.getWayPointCount() - 1);
+    for (size_t waypoint_idx = first_new_waypoint; waypoint_idx < sub_trajectory.getWayPointCount(); ++waypoint_idx)
+    {
+      output_trajectory.addSuffixWayPoint(sub_trajectory.getWayPoint(waypoint_idx),
+                                          sub_trajectory.getWayPointDurationFromPrevious(waypoint_idx));
+    }
 
     batch_start_idx += batch_size;
     batch_end_idx += batch_size;

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -154,18 +154,17 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
 
 std::optional<robot_trajectory::RobotTrajectory>
 RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_trajectory::RobotTrajectory& trajectory,
-                                    ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input)
+                                    ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input, size_t batch_size)
 {
-  // We take the batch size as the lesser of 0.1*num_waypoints or 100, to keep a balance between run time and
+  // We take the batch size as the lesser of 0.1*num_waypoints or batch_size, to keep a balance between run time and
   // time-optimality.
-  // TODO(andyz): parameterize as MIN_BATCH_SIZE and BATCH_SCALING_FACTOR or something like that
-  const size_t waypoint_batch_size = [num_waypoints]() {
-    const size_t temp_batch_size = std::min(size_t(0.1 * num_waypoints), size_t(100));
+  batch_size = [num_waypoints, batch_size]() {
+    const size_t temp_batch_size = std::min(size_t(0.1 * num_waypoints), size_t(batch_size));
     // We need at least 2 waypoints
     return std::max(size_t(2), temp_batch_size);
   }();
   size_t batch_start_idx = 0;
-  size_t batch_end_idx = waypoint_batch_size - 1;
+  size_t batch_end_idx = batch_size - 1;
   const size_t full_traj_final_idx = num_waypoints - 1;
   // A deep copy is not needed since the waypoints are cleared immediately
   robot_trajectory::RobotTrajectory sub_trajectory =
@@ -207,8 +206,8 @@ RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_traj
                                           sub_trajectory.getWayPointDurationFromPrevious(waypoint_idx));
     }
 
-    batch_start_idx += waypoint_batch_size;
-    batch_end_idx += waypoint_batch_size;
+    batch_start_idx += batch_size;
+    batch_end_idx += batch_size;
   }
 
   return std::make_optional<robot_trajectory::RobotTrajectory>(output_trajectory, true /* deep copy */);

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -152,6 +152,7 @@ RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_traj
 {
   // We take the batch size as the lesser of 0.1*num_waypoints or 100, to keep a balance between run time and
   // time-optimality.
+  // TODO(andyz): parameterize as MIN_BATCH_SIZE and BATCH_SCALING_FACTOR or something like that
   const size_t waypoint_batch_size = [num_waypoints]() {
     const size_t temp_batch_size = std::min(size_t(0.1 * num_waypoints), size_t(100));
     // We need at least 2 waypoints


### PR DESCRIPTION
Addresses #1439.

This feeds waypoints into Ruckig in batches of min(100 waypoints, 10% of waypoints).

- If you feed in too many waypoints at once, the output trajectory will have a longer duration than it needs to.
- If you feed in too few waypoints at once, and the trajectory is very long (like 100,000 waypoints), the runtime will be very slow.

Hopefully this is a happy medium. @swiz23 are you able to test this?

This can be tested easily by adding [this line](https://moveit.picknik.ai/main/doc/examples/time_parameterization/time_parameterization_tutorial.html?highlight=ruckig#jerk-limited-trajectory-smoothing) to [moveit_resources/panda/ompl_planning.yaml](https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/config/ompl_planning.yaml), then run any of the motion planning MoveIt2 tutorials:

> request_adapters: >-
>   default_planner_request_adapters/AddRuckigTrajectorySmoothing
>   default_planner_request_adapters/AddTimeOptimalParameterization
>   ...
