### PR TITLE
Use a stronger source of randomness

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -16,4 +16,8 @@ repositories:
   generate_parameter_library:
     type: git
     url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version: 93b8955f7595d022a03477a042c0571ea09a6d01
+    version: 0.3.0
+  rsl:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version: 0.2.0

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(rsl REQUIRED)
 find_package(trac_ik_kinematics_plugin QUIET)
 find_package(ur_kinematics QUIET)
 
@@ -27,6 +28,7 @@ ament_target_dependencies(${MOVEIT_LIB_NAME}
   rclcpp
   moveit_core
   moveit_msgs
+  rsl
 )
 target_link_libraries(${MOVEIT_LIB_NAME}
     cached_ik_kinematics_parameters

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -91,7 +91,7 @@ public:
     if (((long unsigned int)dists.rows()) < data.size() || ((long unsigned int)dists.cols()) < k)
       dists.resize(std::max(2 * ((long unsigned int)dists.rows()) + 1, data.size()), k);
     // first center is picked randomly
-    centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(generator_));
+    centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(rsl::rng()));
     for (unsigned i = 1; i < k; ++i)
     {
       unsigned ind = 0;
@@ -123,8 +123,5 @@ public:
 protected:
   /** \brief The used distance function */
   DistanceFunction distFun_;
-
-  /** Random number generator used to select first center */
-  std::mt19937 generator_{ std::random_device{}() };
 };
 }  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <moveit/exceptions/exceptions.h>
+#include <rsl/random.hpp>
 #include <algorithm>
 #include <queue>
 #include <unordered_set>
@@ -552,7 +553,7 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::shuffle(permutation.begin(), permutation.end(), rsl::rng());
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)
@@ -606,7 +607,7 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::shuffle(permutation.begin(), permutation.end(), rsl::rng());
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -33,6 +33,7 @@
   <depend>tf2_kdl</depend>
   <depend>orocos_kdl_vendor</depend>
   <depend>moveit_msgs</depend>
+  <depend>rsl</depend>
 
   <!-- some requirements of ikfast scripts -->
   <exec_depend>urdfdom</exec_depend> <!-- provides check_urdf -->

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(moveit_core REQUIRED)
 find_package(chomp_motion_planner REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rsl REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
@@ -18,6 +19,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   pluginlib
   rclcpp
+  rsl
 )
 
 include_directories(

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -9,11 +9,13 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rsl REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   rclcpp
+  rsl
   trajectory_msgs
   visualization_msgs
 )

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/multivariate_gaussian.h
@@ -40,6 +40,7 @@
 #include <cstdlib>
 #include <eigen3/Eigen/Cholesky>
 #include <eigen3/Eigen/Core>
+#include <rsl/random.hpp>
 
 namespace chomp
 {
@@ -61,7 +62,6 @@ private:
   Eigen::MatrixXd covariance_cholesky_; /**< Cholesky decomposition (LL^T) of the covariance */
 
   int size_;
-  std::mt19937 rng_;
   std::normal_distribution<double> gaussian_;
 };
 
@@ -72,7 +72,6 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
                                            const Eigen::MatrixBase<Derived2>& covariance)
   : mean_(mean), covariance_(covariance), covariance_cholesky_(covariance_.llt().matrixL()), gaussian_(0.0, 1.0)
 {
-  rng_ = std::mt19937(std::random_device{}());
   size_ = mean.rows();
 }
 
@@ -80,7 +79,7 @@ template <typename Derived>
 void MultivariateGaussian::sample(Eigen::MatrixBase<Derived>& output)
 {
   for (int i = 0; i < size_; ++i)
-    output(i) = gaussian_(rng_);
+    output(i) = gaussian_(rsl::rng());
   output = mean_ + covariance_cholesky_ * output;
 }
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -19,6 +19,7 @@
 
   <depend>moveit_core</depend>
   <depend>rclcpp</depend>
+  <depend>rsl</depend>
   <depend>trajectory_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -51,13 +51,6 @@ namespace chomp
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("chomp_optimizer");
 
-double getRandomDouble()
-{
-  std::default_random_engine seed;
-  std::uniform_real_distribution<> uniform(0.0, 1.0);
-  return uniform(seed);
-}
-
 ChompOptimizer::ChompOptimizer(ChompTrajectory* trajectory, const planning_scene::PlanningSceneConstPtr& planning_scene,
                                const std::string& planning_group, const ChompParameters* parameters,
                                const moveit::core::RobotState& start_state)
@@ -610,7 +603,7 @@ void ChompOptimizer::calculateCollisionIncrements()
   // This is faster and guaranteed to converge, but it may take more iterations in the worst case.
   if (parameters_->use_stochastic_descent_)
   {
-    start_point = static_cast<int>(getRandomDouble() * (free_vars_end_ - free_vars_start_) + free_vars_start_);
+    start_point = static_cast<int>(rsl::uniform_real(0., 1.) * (free_vars_end_ - free_vars_start_) + free_vars_start_);
     if (start_point < free_vars_start_)
       start_point = free_vars_start_;
     if (start_point > free_vars_end_)
@@ -1069,9 +1062,9 @@ void ChompOptimizer::perturbTrajectory()
 //     int j = 0;
 //     for(map<string, pair<double, double> >::iterator it = bounds.begin(); it != bounds.end(); ++it)
 //     {
-//       double randVal = jointState->getJointStateValues()[j] + (getRandomDouble()
+//       double randVal = jointState->getJointStateValues()[j] + (rsl::uniform_real(0., 1.)
 //                                                                * (parameters_->getRandomJumpAmount()) -
-//                                                                getRandomDouble() *
+//                                                                rsl::uniform_real(0., 1.) *
 //                                                                (parameters_->getRandomJumpAmount()));
 
 //       if(!continuous)

--- a/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/CMakeLists.txt
@@ -10,12 +10,14 @@ find_package(ament_cmake REQUIRED)
 find_package(chomp_motion_planner REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rsl REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   chomp_motion_planner
   moveit_core
   pluginlib
   rclcpp
+  rsl
 )
 
 add_library(${PROJECT_NAME} SHARED src/chomp_optimizer_adapter.cpp)

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -16,6 +16,7 @@
   <depend>moveit_core</depend>
   <depend>chomp_motion_planner</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
+  <depend>rsl</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
### Description

`rsl::rng()` seeds a Mersenne twister to the full extent allowed by the `<random>` API so that we can ensure we're getting the highest quality randomness possible. Using this global random number generator also lets us remove a few member variables that existed for this same purpose.

`std::random_shuffle` has been deprecated and removed from the standard so I also replaced the remaining uses of that function with `std::shuffle`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

