### PR TITLE
Use <> for non-local headers

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/allvalid/collision_detector_allocator_allvalid.h
@@ -39,7 +39,7 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection/allvalid/collision_env_allvalid.h>
 
-#include "moveit_collision_detection_export.h"
+#include <moveit_collision_detection_export.h>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_tools.h
@@ -41,10 +41,10 @@
 #include <moveit_msgs/msg/contact_information.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rcl/time.h"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/time.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rcl/time.h>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/time.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bullet.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/collision_detector_allocator_bullet.h
@@ -39,7 +39,7 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection_bullet/collision_env_bullet.h>
 
-#include "moveit_collision_detection_bullet_export.h"
+#include <moveit_collision_detection_bullet_export.h>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_cast_bvh_manager.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_cast_bvh_manager.cpp
@@ -31,7 +31,7 @@
 
 /* Author: Levi Armstrong, Jens Petit */
 
-#include "moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h"
+#include <moveit/collision_detection_bullet/bullet_integration/bullet_cast_bvh_manager.h>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_discrete_bvh_manager.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_discrete_bvh_manager.cpp
@@ -31,7 +31,7 @@
 
 /* Author: Levi Armstrong, Jens Petit */
 
-#include "moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h"
+#include <moveit/collision_detection_bullet/bullet_integration/bullet_discrete_bvh_manager.h>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
@@ -32,7 +32,7 @@
 
 /* Authors: John Schulman, Levi Armstrong */
 
-#include "moveit/collision_detection_bullet/bullet_integration/bullet_utils.h"
+#include <moveit/collision_detection_bullet/bullet_integration/bullet_utils.h>
 
 #include <BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h>
 #include <BulletCollision/CollisionShapes/btShapeHull.h>

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/contact_checker_common.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/contact_checker_common.cpp
@@ -33,7 +33,7 @@
  * Author: Levi Armstrong
  */
 
-#include "moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h"
+#include <moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/ros_bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/ros_bullet_utils.cpp
@@ -31,7 +31,7 @@
 
 /* Author: Jorge Nicho*/
 
-#include "moveit/collision_detection_bullet/bullet_integration/ros_bullet_utils.h"
+#include <moveit/collision_detection_bullet/bullet_integration/ros_bullet_utils.h>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_detector_allocator_fcl.h
@@ -39,7 +39,7 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_detection_fcl/collision_env_fcl.h>
 
-#include "moveit_collision_detection_fcl_export.h"
+#include <moveit_collision_detection_fcl_export.h>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_detector_allocator_hybrid.h
@@ -39,7 +39,7 @@
 #include <moveit/collision_detection/collision_detector_allocator.h>
 #include <moveit/collision_distance_field/collision_env_hybrid.h>
 
-#include "moveit_collision_distance_field_export.h"
+#include <moveit_collision_distance_field_export.h>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_distance_field_types.h
@@ -52,10 +52,10 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
-#include "rclcpp/clock.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/utilities.hpp"
+#include <rclcpp/clock.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/utilities.hpp>
 
 namespace collision_detection
 {

--- a/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
+++ b/moveit_core/collision_distance_field/include/moveit/collision_distance_field/collision_env_distance_field.h
@@ -41,7 +41,7 @@
 #include <moveit/collision_distance_field/collision_common_distance_field.h>
 #include <moveit/collision_detection/collision_env.h>
 #include <moveit/planning_scene/planning_scene.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <mutex>
 
 namespace collision_detection

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler.h
@@ -39,7 +39,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include <vector>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 /**
  * \brief The constraint samplers namespace contains a number of
  * methods for generating samples based on a constraint or set of

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_allocator.h
@@ -38,7 +38,7 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_manager.h
@@ -38,9 +38,9 @@
 
 #include <moveit/constraint_samplers/constraint_sampler_allocator.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/clock.hpp"
-#include "rclcpp/duration.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/constraint_sampler_tools.h
@@ -38,7 +38,7 @@
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <visualization_msgs/msg/marker_array.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/default_constraint_samplers.h
@@ -39,7 +39,7 @@
 #include <moveit/constraint_samplers/constraint_sampler.h>
 #include <moveit/macros/class_forward.h>
 #include <random_numbers/random_numbers.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <Eigen/Geometry>
 

--- a/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
+++ b/moveit_core/constraint_samplers/include/moveit/constraint_samplers/union_constraint_sampler.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include <moveit/constraint_samplers/constraint_sampler.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace constraint_samplers
 {

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -44,7 +44,7 @@
 #include <moveit_msgs/srv/get_position_fk.hpp>
 #include <moveit_msgs/srv/get_position_ik.hpp>
 #include <moveit_msgs/msg/kinematic_solver_info.hpp>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace pr2_arm_kinematics
 {

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -40,7 +40,7 @@
 #include <string>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 /// Namespace for the base class of a MoveIt controller manager
 namespace moveit_controller_manager

--- a/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/distance_field.h
@@ -44,7 +44,7 @@
 #include <Eigen/Geometry>
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <moveit/macros/class_forward.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace shapes
 {

--- a/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/propagation_distance_field.h
@@ -42,7 +42,7 @@
 #include <Eigen/Core>
 #include <set>
 #include <octomap/octomap.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace EigenSTL
 {

--- a/moveit_core/distance_field/test/test_voxel_grid.cpp
+++ b/moveit_core/distance_field/test/test_voxel_grid.cpp
@@ -37,7 +37,7 @@
 #include <gtest/gtest.h>
 
 #include <moveit/distance_field/voxel_grid.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace distance_field;
 

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -50,8 +50,8 @@
 #include <memory>
 #include <typeinfo>
 
-#include "rclcpp/clock.hpp"
-#include "rclcpp/duration.hpp"
+#include <rclcpp/clock.hpp>
+#include <rclcpp/duration.hpp>
 
 namespace kinematic_constraints
 {

--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -42,7 +42,7 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/parameter_value.hpp>
 
-#include "rclcpp/node.hpp"
+#include <rclcpp/node.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 

--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -44,7 +44,7 @@
 #include <string>
 #include <functional>
 
-#include "moveit_kinematics_base_export.h"
+#include <moveit_kinematics_base_export.h>
 
 namespace moveit
 {

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
@@ -38,10 +38,10 @@
 
 #pragma once
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/macros/class_forward.h>
 
-#include "moveit_smoothing_base_export.h"
+#include <moveit_smoothing_base_export.h>
 
 namespace moveit
 {

--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -42,7 +42,7 @@
 #include <rclcpp/node.hpp>
 #include <string>
 #include <map>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace planning_scene
 {

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -55,9 +55,9 @@
 #include <functional>
 #include <thread>
 #include <variant>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
-#include "moveit_planning_scene_export.h"
+#include <moveit_planning_scene_export.h>
 
 /** \brief This namespace includes the central class for representing planning contexts */
 namespace planning_scene

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -51,7 +51,7 @@
 #endif
 
 #if VISUALIZE_PR2_RVIZ
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <visualization_msgs/msg/marker.h>
 #include <geometric_shapes/shape_operations.h>
 #endif

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -44,11 +44,11 @@
 #include <memory>
 #include <optional>
 
-#include "rcl/error_handling.h"
-#include "rcl/time.h"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/utilities.hpp"
+#include <rcl/error_handling.h>
+#include <rcl/time.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/utilities.hpp>
 
 namespace robot_trajectory
 {

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_spline_parameterization.h
@@ -38,7 +38,7 @@
 #pragma once
 
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/trajectory_processing/time_parameterization.h>
 
 namespace trajectory_processing

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/iterative_time_parameterization.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include <moveit/robot_trajectory/robot_trajectory.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include <moveit/trajectory_processing/time_parameterization.h>
 
 namespace trajectory_processing

--- a/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_parameterization.cpp
@@ -42,7 +42,7 @@
 #include <moveit/trajectory_processing/iterative_spline_parameterization.h>
 #include <moveit/trajectory_processing/iterative_time_parameterization.h>
 #include <moveit/utils/robot_model_test_utils.h>
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // Logger
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_trajectory_processing.test.test_time_parameterization");

--- a/moveit_core/utils/src/lexical_casts.cpp
+++ b/moveit_core/utils/src/lexical_casts.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Simon Schmeisser */
 
-#include "moveit/utils/lexical_casts.h"
+#include <moveit/utils/lexical_casts.h>
 #include <locale>
 #include <sstream>
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -60,11 +60,11 @@
 #include <ompl/base/terminationconditions/IterationTerminationCondition.h>
 #include <ompl/base/terminationconditions/CostConvergenceTerminationCondition.h>
 
-#include "ompl/base/objectives/PathLengthOptimizationObjective.h"
-#include "ompl/base/objectives/MechanicalWorkOptimizationObjective.h"
-#include "ompl/base/objectives/MinimaxObjective.h"
-#include "ompl/base/objectives/StateCostIntegralObjective.h"
-#include "ompl/base/objectives/MaximizeMinClearanceObjective.h"
+#include <ompl/base/objectives/PathLengthOptimizationObjective.h>
+#include <ompl/base/objectives/MechanicalWorkOptimizationObjective.h>
+#include <ompl/base/objectives/MinimaxObjective.h>
+#include <ompl/base/objectives/StateCostIntegralObjective.h>
+#include <ompl/base/objectives/MaximizeMinClearanceObjective.h>
 #include <ompl/geometric/planners/prm/LazyPRM.h>
 
 namespace ompl_interface

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
@@ -23,8 +23,8 @@
 #include <limits>
 #include <string>
 
-#include "joint_limits_copy/joint_limits.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include <joint_limits_copy/joint_limits.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/command_list_manager.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/command_list_manager.h
@@ -44,9 +44,9 @@
 #include <moveit_msgs/msg/motion_plan_response.hpp>
 #include <moveit_msgs/msg/motion_sequence_request.hpp>
 
-#include "pilz_industrial_motion_planner/plan_components_builder.h"
-#include "pilz_industrial_motion_planner/trajectory_blender.h"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/plan_components_builder.h>
+#include <pilz_industrial_motion_planner/trajectory_blender.h>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 #include <cartesian_limits_parameters.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_aggregator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_aggregator.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_container.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 
 #include <map>
 #include <vector>

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 #include <limits>
 
 #include <joint_limits_copy/joint_limits_rosparam.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_validator.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/limits_container.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/limits_container.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
 #include <math.h>
 
 #include "cartesian_limits_parameters.hpp"

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/pilz_industrial_motion_planner.h
@@ -36,8 +36,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/planning_interface/planning_interface.h>

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/plan_components_builder.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/plan_components_builder.h
@@ -41,10 +41,10 @@
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/planning_interface/planning_interface.h>
 
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blender.h"
-#include "pilz_industrial_motion_planner/trajectory_functions.h"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blender.h>
+#include <pilz_industrial_motion_planner/trajectory_functions.h>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_base.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_base.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_circ.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -44,8 +44,8 @@
 #include <atomic>
 #include <thread>
 
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_circ.h"
+#include <pilz_industrial_motion_planner/planning_context_base.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_circ.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_lin.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -42,8 +42,8 @@
 #include <atomic>
 #include <thread>
 
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
+#include <pilz_industrial_motion_planner/planning_context_base.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_lin.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader.h
@@ -34,14 +34,14 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 #include <memory>
 #include <vector>
 
 #include <moveit/planning_interface/planning_interface.h>
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_circ.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 #include <moveit/planning_interface/planning_interface.h>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_lin.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 #include <moveit/planning_interface/planning_interface.h>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_loader_ptp.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 #include <moveit/planning_interface/planning_interface.h>
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/planning_context_ptp.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -44,8 +44,8 @@
 #include <atomic>
 #include <thread>
 
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_ptp.h"
+#include <pilz_industrial_motion_planner/planning_context_base.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_ptp.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/tip_frame_getter.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/tip_frame_getter.h
@@ -39,7 +39,7 @@
 #include <string>
 #include <vector>
 
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender.h
@@ -34,12 +34,12 @@
 
 #pragma once
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/planning_interface/planning_interface.h>
 
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_response.h"
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_response.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender_transition_window.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_blender_transition_window.h
@@ -35,11 +35,11 @@
 #pragma once
 
 #include <moveit/planning_interface/planning_interface.h>
-#include "pilz_industrial_motion_planner/cartesian_trajectory.h"
-#include "pilz_industrial_motion_planner/cartesian_trajectory_point.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blender.h"
-#include "pilz_industrial_motion_planner/trajectory_functions.h"
+#include <pilz_industrial_motion_planner/cartesian_trajectory.h>
+#include <pilz_industrial_motion_planner/cartesian_trajectory_point.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blender.h>
+#include <pilz_industrial_motion_planner/trajectory_functions.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -43,8 +43,8 @@
 #include <trajectory_msgs/msg/multi_dof_joint_trajectory.hpp>
 #include <moveit/planning_scene/planning_scene.h>
 
-#include "pilz_industrial_motion_planner/cartesian_trajectory.h"
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/cartesian_trajectory.h>
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -44,10 +44,10 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/planning_scene/planning_scene.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
-#include "pilz_industrial_motion_planner/limits_container.h"
-#include "pilz_industrial_motion_planner/trajectory_functions.h"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
+#include <pilz_industrial_motion_planner/limits_container.h>
+#include <pilz_industrial_motion_planner/trajectory_functions.h>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
@@ -39,7 +39,7 @@
 #include <kdl/velocityprofile.hpp>
 #include <moveit/planning_scene/planning_scene.h>
 
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
@@ -38,8 +38,8 @@
 #include <kdl/rotational_interpolation_sa.hpp>
 #include <moveit/planning_scene/planning_scene.h>
 
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
-#include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
+#include <pilz_industrial_motion_planner/velocity_profile_atrap.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
@@ -36,10 +36,10 @@
 
 #include <moveit/planning_scene/planning_scene.h>
 
-#include "eigen3/Eigen/Eigen"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
-#include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
+#include <eigen3/Eigen/Eigen>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
+#include <pilz_industrial_motion_planner/velocity_profile_atrap.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/velocity_profile_atrap.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/velocity_profile_atrap.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "kdl/velocityprofile.hpp"
+#include <kdl/velocityprofile.hpp>
 #include <iostream>
 
 namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/command_list_manager.h"
+#include <pilz_industrial_motion_planner/command_list_manager.h>
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
@@ -44,10 +44,10 @@
 #include <moveit/robot_state/conversions.h>
 
 #include "cartesian_limits_parameters.hpp"
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/tip_frame_getter.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blender_transition_window.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/tip_frame_getter.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blender_transition_window.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_aggregator.cpp
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/joint_limits_interface_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/joint_limits_interface_extension.h>
 
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_container.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
 #include <cmath>
 
 #include <rclcpp/logger.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_validator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/joint_limits_validator.cpp
@@ -35,10 +35,10 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
-#include "pilz_industrial_motion_planner/joint_limits_interface_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
+#include <pilz_industrial_motion_planner/joint_limits_interface_extension.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_validator.h"
+#include <pilz_industrial_motion_planner/joint_limits_validator.h>
 
 bool pilz_industrial_motion_planner::JointLimitsValidator::validateAllPositionLimitsEqual(
     const pilz_industrial_motion_planner::JointLimitsContainer& joint_limits)

--- a/moveit_planners/pilz_industrial_motion_planner/src/limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/limits_container.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 #include <rclcpp/logger.hpp>
 
 namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -36,7 +36,7 @@
 
 // Modified by Pilz GmbH & Co. KG
 
-#include "pilz_industrial_motion_planner/move_group_sequence_action.h"
+#include <pilz_industrial_motion_planner/move_group_sequence_action.h>
 
 #include <time.h>
 
@@ -48,8 +48,8 @@
 #include <moveit/utils/message_checks.h>
 #include <moveit/moveit_cpp/moveit_cpp.h>
 
-#include "pilz_industrial_motion_planner/command_list_manager.h"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/command_list_manager.h>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -36,11 +36,11 @@
 
 // Modified by Pilz GmbH & Co. KG
 
-#include "pilz_industrial_motion_planner/move_group_sequence_service.h"
+#include <pilz_industrial_motion_planner/move_group_sequence_service.h>
 
-#include "pilz_industrial_motion_planner/capability_names.h"
-#include "pilz_industrial_motion_planner/command_list_manager.h"
-#include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include <pilz_industrial_motion_planner/capability_names.h>
+#include <pilz_industrial_motion_planner/command_list_manager.h>
+#include <pilz_industrial_motion_planner/trajectory_generation_exceptions.h>
 
 #include <moveit/moveit_cpp/moveit_cpp.h>
 namespace pilz_industrial_motion_planner

--- a/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/path_circle_generator.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/path_circle_generator.h"
+#include <pilz_industrial_motion_planner/path_circle_generator.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
@@ -34,14 +34,14 @@
 
 #include <rclcpp/logging.hpp>
 
-#include "pilz_industrial_motion_planner/pilz_industrial_motion_planner.h"
+#include <pilz_industrial_motion_planner/pilz_industrial_motion_planner.h>
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
-#include "pilz_industrial_motion_planner/planning_context_loader_ptp.h"
-#include "pilz_industrial_motion_planner/planning_exceptions.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
+#include <pilz_industrial_motion_planner/planning_context_loader_ptp.h>
+#include <pilz_industrial_motion_planner/planning_exceptions.h>
 
 #include "cartesian_limits_parameters.hpp"
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -32,11 +32,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/plan_components_builder.h"
+#include <pilz_industrial_motion_planner/plan_components_builder.h>
 
 #include <cassert>
 
-#include "pilz_industrial_motion_planner/tip_frame_getter.h"
+#include <pilz_industrial_motion_planner/tip_frame_getter.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 pilz_industrial_motion_planner::PlanningContextLoader::PlanningContextLoader() : limits_set_(false), model_set_(false)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_circ.cpp
@@ -35,10 +35,10 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
-#include "pilz_industrial_motion_planner/planning_context_loader_circ.h"
-#include "moveit/planning_scene/planning_scene.h"
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/planning_context_circ.h"
+#include <pilz_industrial_motion_planner/planning_context_loader_circ.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <pilz_industrial_motion_planner/planning_context_base.h>
+#include <pilz_industrial_motion_planner/planning_context_circ.h>
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_lin.cpp
@@ -32,10 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/planning_context_loader_lin.h"
-#include "moveit/planning_scene/planning_scene.h"
-#include "pilz_industrial_motion_planner/planning_context_base.h"
-#include "pilz_industrial_motion_planner/planning_context_lin.h"
+#include <pilz_industrial_motion_planner/planning_context_loader_lin.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <pilz_industrial_motion_planner/planning_context_base.h>
+#include <pilz_industrial_motion_planner/planning_context_lin.h>
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/planning_context_loader_ptp.cpp
@@ -32,9 +32,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/planning_context_loader_ptp.h"
-#include "moveit/planning_scene/planning_scene.h"
-#include "pilz_industrial_motion_planner/planning_context_ptp.h"
+#include <pilz_industrial_motion_planner/planning_context_loader_ptp.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <pilz_industrial_motion_planner/planning_context_ptp.h>
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_blender_transition_window.h"
+#include <pilz_industrial_motion_planner/trajectory_blender_transition_window.h>
 
 #include <algorithm>
 #include <memory>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_functions.h"
+#include <pilz_industrial_motion_planner/trajectory_functions.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <tf2/LinearMath/Quaternion.h>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
 
 #include <cassert>
 
@@ -43,7 +43,7 @@
 #include <kdl/velocityprofile_trap.hpp>
 #include <moveit/robot_state/conversions.h>
 
-#include "pilz_industrial_motion_planner/limits_container.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_generator_circ.h"
-#include "pilz_industrial_motion_planner/path_circle_generator.h"
+#include <pilz_industrial_motion_planner/trajectory_generator_circ.h>
+#include <pilz_industrial_motion_planner/path_circle_generator.h>
 
 #include <cassert>
 #include <sstream>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
+#include <pilz_industrial_motion_planner/trajectory_generator_lin.h>
 
 #include <cassert>
 #include <sstream>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/trajectory_generator_ptp.h"
-#include "moveit/robot_state/conversions.h"
+#include <pilz_industrial_motion_planner/trajectory_generator_ptp.h>
+#include <moveit/robot_state/conversions.h>
 
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logger.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
+#include <pilz_industrial_motion_planner/velocity_profile_atrap.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
@@ -56,8 +56,8 @@
 
 #include "test_utils.h"
 
-#include "pilz_industrial_motion_planner/command_list_manager.h"
-#include "pilz_industrial_motion_planner/tip_frame_getter.h"
+#include <pilz_industrial_motion_planner/command_list_manager.h>
+#include <pilz_industrial_motion_planner/tip_frame_getter.h>
 
 const std::string ROBOT_DESCRIPTION_STR{ "robot_description" };
 const std::string EMPTY_VALUE{ "" };

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_get_solver_tip_frame.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_get_solver_tip_frame.cpp
@@ -44,7 +44,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <ros/ros.h>
 
-#include "pilz_industrial_motion_planner/tip_frame_getter.h"
+#include <pilz_industrial_motion_planner/tip_frame_getter.h>
 
 static const std::string ROBOT_DESCRIPTION_PARAM{ "robot_description" };
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_plan_components_builder.cpp
@@ -42,8 +42,8 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 
-#include "pilz_industrial_motion_planner/plan_components_builder.h"
-#include "pilz_industrial_motion_planner/trajectory_blender_transition_window.h"
+#include <pilz_industrial_motion_planner/plan_components_builder.h>
+#include <pilz_industrial_motion_planner/trajectory_blender_transition_window.h>
 
 const std::string PARAM_PLANNING_GROUP_NAME("planning_group");
 const std::string ROBOT_DESCRIPTION_STR{ "robot_description" };

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_action.cpp
@@ -58,7 +58,7 @@
 #include <pilz_industrial_motion_planner_testutils/sequence.h>
 #include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 
-#include "moveit_msgs/MoveGroupSequenceAction.h"
+#include <moveit_msgs/MoveGroupSequenceAction.h>
 
 static constexpr int WAIT_FOR_ACTION_SERVER_TIME_OUT{ 10 };  // seconds
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_action_preemption.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_action_preemption.cpp
@@ -59,7 +59,7 @@
 #include <pilz_industrial_motion_planner_testutils/sequence.h>
 #include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 
-#include "moveit_msgs/MoveGroupSequenceAction.h"
+#include <moveit_msgs/MoveGroupSequenceAction.h>
 
 static constexpr double WAIT_FOR_RESULT_TIME_OUT{ 5. };          // seconds
 static constexpr double TIME_BEFORE_CANCEL_GOAL{ 1.0 };          // seconds

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_service_capability.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_sequence_service_capability.cpp
@@ -52,9 +52,9 @@
 #include <pilz_industrial_motion_planner_testutils/sequence.h>
 #include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 
-#include "moveit_msgs/GetMotionSequence.h"
-#include "moveit_msgs/MotionSequenceRequest.h"
-#include "pilz_industrial_motion_planner/capability_names.h"
+#include <moveit_msgs/GetMotionSequence.h>
+#include <moveit_msgs/MotionSequenceRequest.h>
+#include <pilz_industrial_motion_planner/capability_names.h>
 
 // Parameters from the node
 const std::string TEST_DATA_FILE_NAME("testdata_file_name");

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
@@ -43,10 +43,10 @@
 #endif
 
 #include <moveit_msgs/msg/motion_sequence_request.hpp>
-#include "pilz_industrial_motion_planner/limits_container.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_response.h"
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include <pilz_industrial_motion_planner/limits_container.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_response.h>
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
 #include <boost/core/demangle.hpp>
 #include <math.h>
 #include <moveit/kinematic_constraints/utils.h>

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_get_solver_tip_frame.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_get_solver_tip_frame.cpp
@@ -42,7 +42,7 @@
 
 #include <moveit/robot_model/joint_model_group.h>
 
-#include "pilz_industrial_motion_planner/tip_frame_getter.h"
+#include <pilz_industrial_motion_planner/tip_frame_getter.h>
 
 namespace pilz_industrial_motion_planner
 {

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limit.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limit.cpp
@@ -36,8 +36,8 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
-#include "pilz_industrial_motion_planner/joint_limits_interface_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
+#include <pilz_industrial_motion_planner/joint_limits_interface_extension.h>
 
 using namespace pilz_industrial_motion_planner;
 using namespace pilz_industrial_motion_planner::joint_limits_interface;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_aggregator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_aggregator.cpp
@@ -37,11 +37,11 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
-#include "pilz_industrial_motion_planner/joint_limits_interface_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
+#include <pilz_industrial_motion_planner/joint_limits_interface_extension.h>
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 /**
  * @brief Unittest of the JointLimitsAggregator class

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_container.cpp
@@ -34,8 +34,8 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 
 using namespace pilz_industrial_motion_planner;
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_joint_limits_validator.cpp
@@ -34,9 +34,9 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_extension.h"
+#include <pilz_industrial_motion_planner/joint_limits_extension.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_validator.h"
+#include <pilz_industrial_motion_planner/joint_limits_validator.h>
 
 using namespace pilz_industrial_motion_planner;
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner.cpp
@@ -39,10 +39,10 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
-#include "pilz_industrial_motion_planner/pilz_industrial_motion_planner.h"
+#include <pilz_industrial_motion_planner/pilz_industrial_motion_planner.h>
 #include "test_utils.h"
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("unittest_pilz_industrial_motion_planner");
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
@@ -36,9 +36,9 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/pilz_industrial_motion_planner.h"
-#include "pilz_industrial_motion_planner/planning_context_loader_ptp.h"
-#include "pilz_industrial_motion_planner/planning_exceptions.h"
+#include <pilz_industrial_motion_planner/pilz_industrial_motion_planner.h>
+#include <pilz_industrial_motion_planner/planning_context_loader_ptp.h>
+#include <pilz_industrial_motion_planner/planning_exceptions.h>
 
 using namespace pilz_industrial_motion_planner;
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_planning_context.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_planning_context.cpp
@@ -42,10 +42,10 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/planning_context_circ.h"
-#include "pilz_industrial_motion_planner/planning_context_lin.h"
-#include "pilz_industrial_motion_planner/planning_context_ptp.h"
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/planning_context_circ.h>
+#include <pilz_industrial_motion_planner/planning_context_lin.h>
+#include <pilz_industrial_motion_planner/planning_context_ptp.h>
 
 #include "test_utils.h"
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_planning_context_loaders.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_planning_context_loaders.cpp
@@ -39,11 +39,11 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
-#include "pilz_industrial_motion_planner/planning_context_loader.h"
+#include <pilz_industrial_motion_planner/planning_context_loader.h>
 
 #include "test_utils.h"
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("unittest_planning_context_loader");
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_blender_transition_window.cpp
@@ -47,14 +47,14 @@
 #include <pilz_industrial_motion_planner_testutils/sequence.h>
 #include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_request.h"
-#include "pilz_industrial_motion_planner/trajectory_blend_response.h"
-#include "pilz_industrial_motion_planner/trajectory_blender_transition_window.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_request.h>
+#include <pilz_industrial_motion_planner/trajectory_blend_response.h>
+#include <pilz_industrial_motion_planner/trajectory_blender_transition_window.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_lin.h>
 #include "test_utils.h"
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace pilz_industrial_motion_planner;
 using namespace pilz_industrial_motion_planner_testutils;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -53,10 +53,10 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include "pilz_industrial_motion_planner/cartesian_trajectory.h"
-#include "pilz_industrial_motion_planner/cartesian_trajectory_point.h"
-#include "pilz_industrial_motion_planner/limits_container.h"
-#include "pilz_industrial_motion_planner/trajectory_functions.h"
+#include <pilz_industrial_motion_planner/cartesian_trajectory.h>
+#include <pilz_industrial_motion_planner/cartesian_trajectory_point.h>
+#include <pilz_industrial_motion_planner/limits_container.h>
+#include <pilz_industrial_motion_planner/trajectory_functions.h>
 #include "test_utils.h"
 
 #define _USE_MATH_DEFINES

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator.cpp
@@ -36,7 +36,7 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/trajectory_generator.h"
+#include <pilz_industrial_motion_planner/trajectory_generator.h>
 
 using namespace pilz_industrial_motion_planner;
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
@@ -43,13 +43,13 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_circ.h"
-#include "pilz_industrial_motion_planner_testutils/command_types_typedef.h"
-#include "pilz_industrial_motion_planner_testutils/xml_testdata_loader.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_circ.h>
+#include <pilz_industrial_motion_planner_testutils/command_types_typedef.h>
+#include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 #include "test_utils.h"
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace pilz_industrial_motion_planner;
 using namespace pilz_industrial_motion_planner_testutils;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_common.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_common.cpp
@@ -42,16 +42,16 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_state/robot_state.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/joint_limits_container.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_circ.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_ptp.h"
-#include "pilz_industrial_motion_planner/trajectory_blender_transition_window.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/joint_limits_container.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_circ.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_lin.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_ptp.h>
+#include <pilz_industrial_motion_planner/trajectory_blender_transition_window.h>
 
 #include "test_utils.h"
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 #include "cartesian_limits_parameters.hpp"
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_lin.cpp
@@ -36,10 +36,10 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_lin.h"
-#include "pilz_industrial_motion_planner_testutils/command_types_typedef.h"
-#include "pilz_industrial_motion_planner_testutils/xml_testdata_loader.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_lin.h>
+#include <pilz_industrial_motion_planner_testutils/command_types_typedef.h>
+#include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 #include "test_utils.h"
 
 #include <moveit/kinematic_constraints/utils.h>
@@ -48,7 +48,7 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/robot_state/robot_state.h>
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 using namespace pilz_industrial_motion_planner;
 using namespace pilz_industrial_motion_planner_testutils;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
@@ -36,8 +36,8 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/joint_limits_aggregator.h"
-#include "pilz_industrial_motion_planner/trajectory_generator_ptp.h"
+#include <pilz_industrial_motion_planner/joint_limits_aggregator.h>
+#include <pilz_industrial_motion_planner/trajectory_generator_ptp.h>
 #include "test_utils.h"
 
 #include <moveit/kinematic_constraints/utils.h>
@@ -45,7 +45,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <pluginlib/class_loader.hpp>
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 // parameters from parameter server
 const std::string PARAM_PLANNING_GROUP_NAME("planning_group");

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_velocity_profile_atrap.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_velocity_profile_atrap.cpp
@@ -34,7 +34,7 @@
 
 #include <gtest/gtest.h>
 
-#include "pilz_industrial_motion_planner/velocity_profile_atrap.h"
+#include <pilz_industrial_motion_planner/velocity_profile_atrap.h>
 
 // Modultest Level1 of Class VelocityProfileATrap
 #define EPSILON 1.0e-10

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/xml_testdata_loader.h
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/xml_testdata_loader.h
@@ -42,7 +42,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 
-#include "pilz_industrial_motion_planner_testutils/testdata_loader.h"
+#include <pilz_industrial_motion_planner_testutils/testdata_loader.h>
 
 namespace pt = boost::property_tree;
 namespace pilz_industrial_motion_planner_testutils

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/cartesianconfiguration.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/cartesianconfiguration.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner_testutils/cartesianconfiguration.h"
+#include <pilz_industrial_motion_planner_testutils/cartesianconfiguration.h>
 
 #include <stdexcept>
 #include <tf2_eigen/tf2_eigen.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/jointconfiguration.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/jointconfiguration.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner_testutils/jointconfiguration.h"
+#include <pilz_industrial_motion_planner_testutils/jointconfiguration.h>
 
 #include <moveit/kinematic_constraints/utils.h>
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/robotconfiguration.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/robotconfiguration.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner_testutils/robotconfiguration.h"
+#include <pilz_industrial_motion_planner_testutils/robotconfiguration.h>
 
 #include <stdexcept>
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/sequence.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/sequence.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner_testutils/sequence.h"
+#include <pilz_industrial_motion_planner_testutils/sequence.h>
 
 #include <algorithm>
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/src/xml_testdata_loader.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/src/xml_testdata_loader.cpp
@@ -32,16 +32,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "pilz_industrial_motion_planner_testutils/xml_testdata_loader.h"
+#include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
 
 #include <iostream>
 
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include "pilz_industrial_motion_planner_testutils/default_values.h"
-#include "pilz_industrial_motion_planner_testutils/exception_types.h"
-#include "pilz_industrial_motion_planner_testutils/xml_constants.h"
+#include <pilz_industrial_motion_planner_testutils/default_values.h>
+#include <pilz_industrial_motion_planner_testutils/exception_types.h>
+#include <pilz_industrial_motion_planner_testutils/xml_constants.h>
 
 namespace pt = boost::property_tree;
 namespace pilz_industrial_motion_planner_testutils

--- a/moveit_planners/trajopt/src/kinematic_terms.cpp
+++ b/moveit_planners/trajopt/src/kinematic_terms.cpp
@@ -4,7 +4,7 @@
 #include <trajopt_sco/expr_ops.hpp>
 #include <trajopt_sco/modeling_utils.hpp>
 
-#include "trajopt_interface/kinematic_terms.h"
+#include <trajopt_interface/kinematic_terms.h>
 
 using namespace std;
 using namespace sco;

--- a/moveit_planners/trajopt/src/problem_description.cpp
+++ b/moveit_planners/trajopt/src/problem_description.cpp
@@ -46,8 +46,8 @@
 #include <trajopt_utils/logging.hpp>
 #include <trajopt_utils/vector_ops.hpp>
 
-#include "trajopt_interface/problem_description.h"
-#include "trajopt_interface/kinematic_terms.h"
+#include <trajopt_interface/problem_description.h>
+#include <trajopt_interface/kinematic_terms.h>
 
 /**
  * @brief Checks the size of the parameter given and throws if incorrect

--- a/moveit_planners/trajopt/src/trajopt_interface.cpp
+++ b/moveit_planners/trajopt/src/trajopt_interface.cpp
@@ -53,8 +53,8 @@
 #include <Eigen/Geometry>
 #include <unordered_map>
 
-#include "trajopt_interface/trajopt_interface.h"
-#include "trajopt_interface/problem_description.h"
+#include <trajopt_interface/trajopt_interface.h>
+#include <trajopt_interface/problem_description.h>
 
 namespace trajopt_interface
 {

--- a/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planner_manager.cpp
@@ -38,11 +38,11 @@
 
 #include <moveit/planning_interface/planning_interface.h>
 
-#include "moveit/collision_detection_fcl/collision_detector_allocator_fcl.h"
+#include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.h>
 
 #include <class_loader/class_loader.hpp>
 
-#include "trajopt_interface/trajopt_planning_context.h"
+#include <trajopt_interface/trajopt_planning_context.h>
 
 namespace trajopt_interface
 {

--- a/moveit_planners/trajopt/src/trajopt_planning_context.cpp
+++ b/moveit_planners/trajopt/src/trajopt_planning_context.cpp
@@ -7,8 +7,8 @@
 
 #include <Eigen/Geometry>
 
-#include "trajopt_interface/trajopt_planning_context.h"
-#include "trajopt_interface/trajopt_interface.h"
+#include <trajopt_interface/trajopt_planning_context.h>
+#include <trajopt_interface/trajopt_interface.h>
 
 namespace trajopt_interface
 {

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.h
@@ -51,7 +51,7 @@
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
 
-#include "trajectory_msgs/msg/joint_trajectory.hpp"
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>

--- a/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
+++ b/moveit_ros/moveit_servo/src/parameter_descriptor_builder.cpp
@@ -32,7 +32,7 @@
    Project   : moveit_servo
 */
 
-#include "moveit_servo/parameter_descriptor_builder.hpp"
+#include <moveit_servo/parameter_descriptor_builder.hpp>
 
 namespace moveit_servo
 {

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "moveit_servo/pose_tracking.h"
-#include "moveit_servo/servo_parameters.h"
+#include <moveit_servo/pose_tracking.h>
+#include <moveit_servo/servo_parameters.h>
 
 #include <chrono>
 using namespace std::literals;

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/stereo_camera_model.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/stereo_camera_model.h
@@ -39,7 +39,7 @@
 #include <moveit/mesh_filter/sensor_model.h>
 #include <string>
 
-#include "moveit_mesh_filter_export.h"
+#include <moveit_mesh_filter_export.h>
 
 namespace mesh_filter
 {

--- a/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/moveit_ros/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -47,7 +47,7 @@
 
 #include <memory>
 
-#include "moveit_planning_pipeline_export.h"
+#include <moveit_planning_pipeline_export.h>
 
 /** \brief Planning pipeline */
 namespace planning_pipeline

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -52,7 +52,7 @@
 #include <mutex>
 #include <thread>
 
-#include "moveit_planning_scene_monitor_export.h"
+#include <moveit_planning_scene_monitor_export.h>
 
 namespace planning_scene_monitor
 {

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
@@ -38,12 +38,12 @@
 #include <memory>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "moveit/planning_scene_monitor/current_state_monitor.h"
-#include "moveit/utils/robot_model_test_utils.h"
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_ros/buffer.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <moveit/planning_scene_monitor/current_state_monitor.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
 
 struct MockMiddlewareHandle : public planning_scene_monitor::CurrentStateMonitor::MiddlewareHandle
 {

--- a/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
@@ -38,13 +38,13 @@
 #include <chrono>
 #include <thread>
 #include <atomic>
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "moveit/planning_scene_monitor/trajectory_monitor.h"
-#include "moveit/planning_scene_monitor/current_state_monitor.h"
-#include "moveit/utils/robot_model_test_utils.h"
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_ros/buffer.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <moveit/planning_scene_monitor/trajectory_monitor.h>
+#include <moveit/planning_scene_monitor/current_state_monitor.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
 
 using namespace std::chrono_literals;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -50,7 +50,7 @@
 #include <deque>
 #include <thread>
 
-#include "moveit_trajectory_execution_manager_export.h"
+#include <moveit_trajectory_execution_manager_export.h>
 
 namespace trajectory_execution_manager
 {

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -61,7 +61,7 @@
 #include <utility>
 #include <tf2_ros/buffer.h>
 
-#include "moveit_move_group_interface_export.h"
+#include <moveit_move_group_interface_export.h>
 
 namespace moveit
 {

--- a/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
+++ b/moveit_ros/planning_interface/py_bindings_tools/src/roscpp_initializer.cpp
@@ -34,8 +34,8 @@
 
 /* Author: Ioan Sucan */
 
-#include "moveit/py_bindings_tools/roscpp_initializer.h"
-#include "moveit/py_bindings_tools/py_conversions.h"
+#include <moveit/py_bindings_tools/roscpp_initializer.h>
+#include <moveit/py_bindings_tools/py_conversions.h>
 #include <ros/ros.h>
 #include <memory>
 #include <thread>

--- a/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/moveit_ros/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -40,7 +40,7 @@
 #include <mutex>
 #include <functional>
 
-#include "moveit_robot_interaction_export.h"
+#include <moveit_robot_interaction_export.h>
 
 namespace robot_interaction
 {

--- a/moveit_ros/robot_interaction/src/robot_interaction.cpp
+++ b/moveit_ros/robot_interaction/src/robot_interaction.cpp
@@ -35,7 +35,7 @@
 
 /* Author: Ioan Sucan, Adam Leeper */
 
-#include "moveit/robot_interaction/robot_interaction.h"
+#include <moveit/robot_interaction/robot_interaction.h>
 #include <moveit/robot_interaction/interaction_handler.h>
 #include <moveit/robot_interaction/interactive_marker_helpers.h>
 #include <moveit/robot_interaction/kinematic_options_map.h>

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/interactive_marker_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/interactive_marker_display.h
@@ -40,17 +40,17 @@
 #include <string>
 #include <vector>
 
-#include "visualization_msgs/msg/interactive_marker.hpp"
-#include "visualization_msgs/msg/interactive_marker_update.hpp"
-#include "visualization_msgs/msg/interactive_marker_init.hpp"
+#include <visualization_msgs/msg/interactive_marker.hpp>
+#include <visualization_msgs/msg/interactive_marker_update.hpp>
+#include <visualization_msgs/msg/interactive_marker_init.hpp>
 
 #ifndef Q_MOC_RUN
-#include "interactive_markers/interactive_marker_client.hpp"
+#include <interactive_markers/interactive_marker_client.hpp>
 #endif
 
-#include "rviz_common/display.hpp"
+#include <rviz_common/display.hpp>
 
-#include "rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp"
+#include <rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp>
 
 namespace rviz_common
 {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
@@ -33,13 +33,13 @@
 #include <utility>
 #include <vector>
 
-#include "rviz_common/properties/bool_property.hpp"
-#include "rviz_common/validate_floats.hpp"
-#include "rviz_common/display_context.hpp"
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/validate_floats.hpp>
+#include <rviz_common/display_context.hpp>
 
-#include "rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp"
+#include <rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp>
 
-#include "moveit/motion_planning_rviz_plugin/interactive_marker_display.h"
+#include <moveit/motion_planning_rviz_plugin/interactive_marker_display.h>
 
 namespace rviz_default_plugins
 {

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -47,7 +47,7 @@
 #include <rclcpp/rclcpp.hpp>
 #endif
 
-#include "moveit_planning_scene_rviz_plugin_core_export.h"
+#include <moveit_planning_scene_rviz_plugin_core_export.h>
 
 namespace Ogre
 {

--- a/moveit_ros/warehouse/include/moveit/warehouse/constraints_storage.h
+++ b/moveit_ros/warehouse/include/moveit/warehouse/constraints_storage.h
@@ -36,11 +36,11 @@
 
 #pragma once
 
-#include "moveit/warehouse/moveit_message_storage.h"
+#include <moveit/warehouse/moveit_message_storage.h>
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/msg/constraints.hpp>
 
-#include "moveit_warehouse_export.h"
+#include <moveit_warehouse_export.h>
 
 namespace moveit_warehouse
 {

--- a/moveit_ros/warehouse/include/moveit/warehouse/planning_scene_storage.h
+++ b/moveit_ros/warehouse/include/moveit/warehouse/planning_scene_storage.h
@@ -36,13 +36,13 @@
 
 #pragma once
 
-#include "moveit/warehouse/moveit_message_storage.h"
+#include <moveit/warehouse/moveit_message_storage.h>
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/msg/planning_scene.hpp>
 #include <moveit_msgs/msg/motion_plan_request.hpp>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 
-#include "moveit_warehouse_export.h"
+#include <moveit_warehouse_export.h>
 
 namespace moveit_warehouse
 {

--- a/moveit_ros/warehouse/include/moveit/warehouse/state_storage.h
+++ b/moveit_ros/warehouse/include/moveit/warehouse/state_storage.h
@@ -40,7 +40,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/msg/robot_state.hpp>
 
-#include "moveit_warehouse_export.h"
+#include <moveit_warehouse_export.h>
 
 namespace moveit_warehouse
 {

--- a/moveit_ros/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
+++ b/moveit_ros/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include "moveit/warehouse/moveit_message_storage.h"
+#include <moveit/warehouse/moveit_message_storage.h>
 #include <moveit/macros/class_forward.h>
 #include <moveit_msgs/msg/trajectory_constraints.hpp>
 

--- a/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/setup_assistant_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/setup_assistant_widget.hpp
@@ -47,10 +47,10 @@
 class QSplitter;
 
 // Setup Assistant
-#include "moveit_setup_framework/qt/setup_step_widget.hpp"
-#include "moveit_setup_framework/qt/rviz_panel.hpp"
-#include "moveit_setup_framework/data_warehouse.hpp"
-#include "moveit_setup_assistant/navigation_widget.hpp"
+#include <moveit_setup_framework/qt/setup_step_widget.hpp>
+#include <moveit_setup_framework/qt/rviz_panel.hpp>
+#include <moveit_setup_framework/data_warehouse.hpp>
+#include <moveit_setup_assistant/navigation_widget.hpp>
 
 #ifndef Q_MOC_RUN
 // Other

--- a/moveit_setup_assistant/moveit_setup_assistant/src/main.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/main.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Dave Coleman */
 
-#include "moveit_setup_assistant/setup_assistant_widget.hpp"
+#include <moveit_setup_assistant/setup_assistant_widget.hpp>
 #include <rviz_common/ros_integration/ros_client_abstraction.hpp>
 #include <QApplication>
 #include <QMessageBox>

--- a/moveit_setup_assistant/moveit_setup_assistant/src/navigation_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/navigation_widget.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Dave Coleman */
 
-#include "moveit_setup_assistant/navigation_widget.hpp"
+#include <moveit_setup_assistant/navigation_widget.hpp>
 #include <QApplication>
 #include <QPainter>
 #include <QScrollBar>

--- a/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
@@ -35,7 +35,7 @@
 /* Author: Dave Coleman */
 
 // SA
-#include "moveit_setup_assistant/setup_assistant_widget.hpp"
+#include <moveit_setup_assistant/setup_assistant_widget.hpp>
 
 // Qt
 #include <QApplication>

--- a/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files_widget.hpp
@@ -37,8 +37,8 @@
 #pragma once
 
 #include <moveit_setup_core_plugins/configuration_files.hpp>
-#include "moveit_setup_framework/qt/setup_step_widget.hpp"
-#include "moveit_setup_framework/qt/helper_widgets.hpp"
+#include <moveit_setup_framework/qt/setup_step_widget.hpp>
+#include <moveit_setup_framework/qt/helper_widgets.hpp>
 
 #include <QList>
 #include <QLabel>

--- a/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/start_screen_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/start_screen_widget.hpp
@@ -36,8 +36,8 @@
 
 #pragma once
 
-#include "moveit_setup_framework/qt/setup_step_widget.hpp"
-#include "moveit_setup_framework/qt/helper_widgets.hpp"
+#include <moveit_setup_framework/qt/setup_step_widget.hpp>
+#include <moveit_setup_framework/qt/helper_widgets.hpp>
 #include <rclcpp/node.hpp>
 #include <QWidget>
 #include <QFrame>

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
@@ -48,7 +48,7 @@
 #include <QSplitter>
 #include <QVBoxLayout>
 
-#include "moveit_setup_core_plugins/configuration_files_widget.hpp"
+#include <moveit_setup_core_plugins/configuration_files_widget.hpp>
 
 // Boost
 #include <boost/algorithm/string.hpp>  // string trim

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
@@ -50,7 +50,7 @@
 #include <QVBoxLayout>
 
 // SA
-#include "moveit_setup_core_plugins/start_screen_widget.hpp"
+#include <moveit_setup_core_plugins/start_screen_widget.hpp>
 // C
 #include <fstream>  // for reading in urdf
 #include <streambuf>

--- a/moveit_setup_assistant/moveit_setup_framework/src/helper_widgets.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/helper_widgets.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Dave Coleman */
 
-#include "moveit_setup_framework/qt/helper_widgets.hpp"
+#include <moveit_setup_framework/qt/helper_widgets.hpp>
 #include <QFileDialog>
 #include <QFont>
 #include <QLabel>

--- a/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
@@ -37,7 +37,7 @@
 #include <moveit_setup_framework/data/urdf_config.hpp>
 #include <moveit_setup_framework/data/srdf_config.hpp>
 #include <QApplication>
-#include "rviz_rendering/render_window.hpp"
+#include <rviz_rendering/render_window.hpp>
 
 namespace moveit_setup
 {


### PR DESCRIPTION
### Description

Closes #1724.

Unless a header lives in the same or a child directory of the file including it, it's recommended to use <> for the #include statement.

For more information, see the C++ Core Guidelines item SF.12

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else

I tried to leave quotes around headers that exist in the same directory (or a child directory) of the file including them which his why not all headers are using `<>`.
