### PR TITLE
Add `-Wunused-function`

### DIFF
--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -45,7 +45,7 @@ macro(moveit_package)
     # Enable warnings
     add_compile_options(-Wall -Wextra
       -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
-      -Wno-unused-parameter -Wno-unused-function)
+      -Wno-unused-parameter)
   else()
     # Defaults for Microsoft C++ compiler
     add_compile_options(/W3 /wd4251 /wd4068 /wd4275)

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/ros_bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/ros_bullet_utils.h
@@ -37,8 +37,8 @@ namespace collision_detection_bullet
  *   \param active_links Stores the active links
  *   \param urdf_link The current urdf link representation
  *   \param active Indicates if link is considered active */
-static void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
-                                        const urdf::LinkConstSharedPtr& urdf_link, bool active);
+void getActiveLinkNamesRecursive(std::vector<std::string>& active_links, const urdf::LinkConstSharedPtr& urdf_link,
+                                 bool active);
 
 shapes::ShapePtr constructShape(const urdf::Geometry* geom);
 

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/ros_bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/ros_bullet_utils.cpp
@@ -40,8 +40,8 @@ const rclcpp::Logger BULLET_LOGGER = rclcpp::get_logger("collision_detection.bul
 
 namespace collision_detection_bullet
 {
-static void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
-                                        const urdf::LinkConstSharedPtr& urdf_link, bool active)
+void getActiveLinkNamesRecursive(std::vector<std::string>& active_links, const urdf::LinkConstSharedPtr& urdf_link,
+                                 bool active)
 {
   if (active)
   {


### PR DESCRIPTION
### Description

This function is regarded as unused in some translation units because it's marked `static` but not used in every single TU where it's included. `static` free functions are typically only used within a single TU as a way to tell the compiler that no other TUs will link to this function.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
