### PR TITLE
Add `-Wunused-parameter`

### DIFF
--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -44,8 +44,7 @@ macro(moveit_package)
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Enable warnings
     add_compile_options(-Wall -Wextra
-      -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual
-      -Wno-unused-parameter)
+      -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual)
   else()
     # Defaults for Microsoft C++ compiler
     add_compile_options(/W3 /wd4251 /wd4068 /wd4275)

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT WIN32)
   add_compile_options(-Wall)
   add_compile_options(-Wextra)
-  add_compile_options(-Wno-unused-parameter)
   add_compile_options(-Wno-unused-variable)
 endif()
 


### PR DESCRIPTION
### Description

Turns out there was no code violating this warning so it's trivial to add this warning back. Not using a parameter is often a sign of bugged code so it's a valuable warning to add. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
