### PR TITLE
Require CMake 3.22 everywhere

### DIFF
--- a/moveit_commander/CMakeLists.txt
+++ b/moveit_commander/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.22)
 project(moveit_commander)
 
 find_package(catkin REQUIRED)

--- a/moveit_experimental/collision_distance_field_ros/CMakeLists.txt
+++ b/moveit_experimental/collision_distance_field_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.22)
 include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 
 # Set the build type.  Options are:

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/CMakeLists.txt
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.22)
 include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 
 # Set the build type.  Options are:

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/CMakeLists.txt
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.22)
 include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 
 # Set the build type.  Options are:

--- a/moveit_planners/trajopt/CMakeLists.txt
+++ b/moveit_planners/trajopt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.22)
 project(moveit_planners_trajopt)
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
### Description

Most of MoveIt already requires CMake 3.22 but there were a few projects that seemingly missed getting updated. `main` includes 42 instances of `cmake_minimum_required(VERSION 3.22)` and this PR only adds 5 more.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
