### PR TITLE
Migrate to Ogre.h

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
@@ -36,7 +36,6 @@
 
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
 #include <Ogre.h>
-#include <OgreQuaternion.h>
 
 bool moveit_rviz_plugin::PlanningLinkUpdater::getLinkTransforms(const std::string& link_name,
                                                                 Ogre::Vector3& visual_position,

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp
@@ -35,7 +35,7 @@
 /* Author: Ioan Sucan */
 
 #include <moveit/rviz_plugin_render_tools/planning_link_updater.h>
-#include <OgreVector3.h>
+#include <Ogre.h>
 #include <OgreQuaternion.h>
 
 bool moveit_rviz_plugin::PlanningLinkUpdater::getLinkTransforms(const std::string& link_name,


### PR DESCRIPTION
### Description

When building, I get the following message:
```
In file included from /workspaces/ros2-rolling-ws/src/moveit2/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_link_updater.cpp:38:
/opt/ros/rolling/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h:2:62: note: ‘#pragma message: /opt/ros/rolling/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h is deprecated, migrate to Ogre.h’
    2 | #pragma message( __FILE__ " is deprecated, migrate to Ogre.h")
```

This PR uses Ogre.h instead of the deprecated OgreVector3.h as per the message suggests.