### PR TITLE
Delete ineffective setting of the ACM.

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -328,9 +328,6 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
     }
   }
 
-  if (acm_)
-    scene->getAllowedCollisionMatrixNonConst() = *acm_;
-
   collision_detection::CollisionEnvPtr active_cenv = scene->getCollisionEnvNonConst();
   active_cenv->setLinkPadding(collision_detector_->cenv_->getLinkPadding());
   active_cenv->setLinkScale(collision_detector_->cenv_->getLinkScale());


### PR DESCRIPTION
### Description

It looks to me like this bit of code did nothing:

```
  if (acm_)
    scene->getAllowedCollisionMatrixNonConst() = *acm_;
```

```
collision_detection::AllowedCollisionMatrix& PlanningScene::getAllowedCollisionMatrixNonConst()
{
  if (!acm_)
    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(parent_->getAllowedCollisionMatrix());
  return *acm_;
}
```