### PR TITLE
Do not allow a mutable ACM to be returned from the planning scene

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -291,8 +291,18 @@ public:
   {
     return acm_ ? *acm_ : parent_->getAllowedCollisionMatrix();
   }
-  /** \brief Get the allowed collision matrix */
-  collision_detection::AllowedCollisionMatrix& getAllowedCollisionMatrixNonConst();
+
+  /** \brief Update the allowed collision matrix */
+  void update(collision_detection::AllowedCollisionMatrix const& new_acm);
+
+  /** \brief Clear the allowed collision matrix */
+  void clearAllowedCollisionMatrix();
+
+  /** \brief Update one entry in the allowed collision matrix */
+  void updateAllowedCollisionMatrixEntry(const std::string& link, bool value);
+  void updateAllowedCollisionMatrixEntry(const std::string& link_1, const std::string& link_2, bool value);
+  void updateAllowedCollisionMatrixEntry(const std::vector<std::string>& link_1, const std::vector<std::string>& link_2,
+                                         bool value);
 
   /**@}*/
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -329,7 +329,9 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
   }
 
   if (acm_)
-    scene->getAllowedCollisionMatrixNonConst() = *acm_;
+  {
+    scene->update(*acm_);
+  }
 
   collision_detection::CollisionEnvPtr active_cenv = scene->getCollisionEnvNonConst();
   active_cenv->setLinkPadding(collision_detector_->cenv_->getLinkPadding());
@@ -532,11 +534,40 @@ void PlanningScene::setCollisionObjectUpdateCallback(const collision_detection::
   current_world_object_update_callback_ = callback;
 }
 
-collision_detection::AllowedCollisionMatrix& PlanningScene::getAllowedCollisionMatrixNonConst()
+void PlanningScene::update(collision_detection::AllowedCollisionMatrix const& new_acm)
 {
-  if (!acm_)
-    acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(parent_->getAllowedCollisionMatrix());
-  return *acm_;
+  acm_ = std::make_shared<collision_detection::AllowedCollisionMatrix>(new_acm);
+}
+
+void PlanningScene::clearAllowedCollisionMatrix()
+{
+  if (acm_)
+    acm_->clear();
+}
+
+void PlanningScene::updateAllowedCollisionMatrixEntry(const std::string& link, bool value)
+{
+  if (acm_)
+  {
+    acm_->setEntry(link, value);
+  }
+}
+
+void PlanningScene::updateAllowedCollisionMatrixEntry(const std::string& link_1, const std::string& link_2, bool value)
+{
+  if (acm_)
+  {
+    acm_->setEntry(link_1, link_2, value);
+  }
+}
+
+void PlanningScene::updateAllowedCollisionMatrixEntry(const std::vector<std::string>& link_1,
+                                                      const std::vector<std::string>& link_2, bool value)
+{
+  if (acm_)
+  {
+    acm_->setEntry(link_1, link_2, value);
+  }
 }
 
 const moveit::core::Transforms& PlanningScene::getTransforms()

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/compute_default_collisions.cpp
@@ -436,7 +436,7 @@ unsigned int disableAdjacentLinks(planning_scene::PlanningScene& scene, LinkGrap
         num_disabled += setLinkPair(link_graph_it->first->getName(), (*adj_it)->getName(), ADJACENT, link_pairs);
 
         // disable link checking in the collision matrix
-        scene.getAllowedCollisionMatrixNonConst().setEntry(link_graph_it->first->getName(), (*adj_it)->getName(), true);
+        scene.updateAllowedCollisionMatrixEntry(link_graph_it->first->getName(), (*adj_it)->getName(), true);
       }
     }
   }
@@ -465,7 +465,7 @@ unsigned int disableDefaultCollisions(planning_scene::PlanningScene& scene, Link
     num_disabled += setLinkPair(it->first.first, it->first.second, DEFAULT, link_pairs);
 
     // disable link checking in the collision matrix
-    scene.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second, true);
+    scene.updateAllowedCollisionMatrixEntry(it->first.first, it->first.second, true);
   }
 
   // RCLCPP_INFO_STREAM(LOGGER, "Disabled %d link pairs that are in collision in default state from collision checking", num_disabled);
@@ -532,7 +532,7 @@ unsigned int disableAlwaysInCollision(planning_scene::PlanningScene& scene, Link
         num_disabled += setLinkPair(it->first.first, it->first.second, ALWAYS, link_pairs);
 
         // disable link checking in the collision matrix
-        scene.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second, true);
+        scene.updateAllowedCollisionMatrixEntry(it->first.first, it->first.second, true);
 
         found++;
       }
@@ -637,8 +637,8 @@ void disableNeverInCollisionThread(ThreadComputation tc)
         std::scoped_lock slock(*tc.lock_);
         tc.links_seen_colliding_->insert(it->first);
 
-        tc.scene_.getAllowedCollisionMatrixNonConst().setEntry(it->first.first, it->first.second,
-                                                               true);  // disable link checking in the collision matrix
+        // disable link checking in the collision matrix
+        tc.scene_.updateAllowedCollisionMatrixEntry(it->first.first, it->first.second, true);
       }
     }
   }

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/default_collisions.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/default_collisions.cpp
@@ -160,7 +160,7 @@ void DefaultCollisions::generateCollisionTable(unsigned int num_trials, double m
   const bool include_never_colliding = true;
 
   // clear previously loaded collision matrix entries
-  srdf_config_->getPlanningScene()->getAllowedCollisionMatrixNonConst().clear();
+  srdf_config_->getPlanningScene()->clearAllowedCollisionMatrix();
 
   // Find the default collision matrix - all links that are allowed to collide
   link_pairs_ = computeDefaultCollisions(srdf_config_->getPlanningScene(), &progress_, include_never_colliding,


### PR DESCRIPTION
As discussed here:  https://github.com/orgs/ros-planning/discussions/1760#discussioncomment-4265269

This is part of simplifying locking of the planning scene.

Should be merged with the MTC PR:  https://github.com/ros-planning/moveit_task_constructor/pull/398

There are still some other PS methods that return mutable values that should get cleaned up.
