### PR TITLE
Enable `-Wold-style-cast`

### DIFF
--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -44,7 +44,7 @@ macro(moveit_package)
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Enable warnings
     add_compile_options(-Wall -Wextra
-      -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual)
+      -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wcast-qual -Wold-style-cast)
   else()
     # Defaults for Microsoft C++ compiler
     add_compile_options(/W3 /wd4251 /wd4068 /wd4275)

--- a/moveit_core/collision_detection/src/collision_common.cpp
+++ b/moveit_core/collision_detection/src/collision_common.cpp
@@ -47,6 +47,8 @@ void CollisionResult::print() const
   rclcpp::Clock clock;
   if (!contacts.empty())
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, LOG_THROTTLE_PERIOD,
                                 "Objects in collision (printing 1st of "
                                     << contacts.size() << " pairs): " << contacts.begin()->first.first << ", "
@@ -59,6 +61,7 @@ void CollisionResult::print() const
       RCLCPP_DEBUG_STREAM_THROTTLE(LOGGER, clock, LOG_THROTTLE_PERIOD,
                                    "\t" << contact.first.first << ", " << contact.first.second);
     }
+#pragma GCC diagnostic pop
   }
 }
 

--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -279,7 +279,7 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
         int num_contacts_initial = num_contacts;
 
         // make sure we don't get more contacts than we want
-        if (want_contact_count >= (std::size_t)num_contacts)
+        if (want_contact_count >= static_cast<std::size_t>(num_contacts))
         {
           want_contact_count -= num_contacts;
         }

--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -658,7 +658,7 @@ bool PropagationDistanceField::writeToStream(std::ostream& os) const
             bs[zi] = 1;
           }
         }
-        out.write((char*)&bs, sizeof(char));
+        out.write(reinterpret_cast<char*>(&bs), sizeof(char));
       }
     }
   }

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -114,8 +114,11 @@ bool ButterworthFilterPlugin::doSmoothing(std::vector<double>& position_vector)
 {
   if (position_vector.size() != position_filters_.size())
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
                           "Position vector to be smoothed does not have the right length.");
+#pragma GCC diagnostic pop
     return false;
   }
   for (size_t i = 0; i < position_vector.size(); ++i)
@@ -130,8 +133,11 @@ bool ButterworthFilterPlugin::reset(const std::vector<double>& joint_positions)
 {
   if (joint_positions.size() != position_filters_.size())
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
                           "Position vector to be reset does not have the right length.");
+#pragma GCC diagnostic pop
     return false;
   }
   for (size_t joint_idx = 0; joint_idx < joint_positions.size(); ++joint_idx)

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1314,7 +1314,7 @@ collision_detection::OccMapTreePtr createOctomap(const octomap_msgs::msg::Octoma
     std::stringstream datastream;
     if (!map.data.empty())
     {
-      datastream.write((const char*)&map.data[0], map.data.size());
+      datastream.write(reinterpret_cast<const char*>(&map.data[0]), map.data.size());
       om->readData(datastream);
     }
   }

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1072,11 +1072,11 @@ JointModel* RobotModel::constructJointModel(const urdf::Link* child_link, const 
 
         if (new_joint_model->getType() == JointModel::JointType::PLANAR)
         {
-          ((PlanarJointModel*)new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
+          static_cast<PlanarJointModel*>(new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
         }
         else if (new_joint_model->getType() == JointModel::JointType::FLOATING)
         {
-          ((FloatingJointModel*)new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
+          static_cast<FloatingJointModel*>(new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
         }
         else
         {
@@ -1111,7 +1111,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Link* child_link, const 
           continue;
         }
 
-        ((PlanarJointModel*)new_joint_model)->setMotionModel(motion_model);
+        static_cast<PlanarJointModel*>(new_joint_model)->setMotionModel(motion_model);
       }
       else if (property.property_name_ == "min_translational_distance")
       {
@@ -1141,7 +1141,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Link* child_link, const 
           continue;
         }
 
-        ((PlanarJointModel*)new_joint_model)->setMinTranslationalDistance(min_translational_distance);
+        static_cast<PlanarJointModel*>(new_joint_model)->setMinTranslationalDistance(min_translational_distance);
       }
       else
       {

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -110,8 +110,8 @@ void RobotState::allocMemory()
   // make the memory for transforms align at EIGEN_MAX_ALIGN_BYTES
   // https://eigen.tuxfamily.org/dox/classEigen_1_1aligned__allocator.html
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  variable_joint_transforms_ = reinterpret_cast<Eigen::Isometry3d*>(((uintptr_t)memory_ + extra_alignment_bytes) &
-                                                                    ~(uintptr_t)extra_alignment_bytes);
+  variable_joint_transforms_ = reinterpret_cast<Eigen::Isometry3d*>(
+      (reinterpret_cast<uintptr_t>(memory_) + extra_alignment_bytes) & ~static_cast<uintptr_t>(extra_alignment_bytes));
   global_link_transforms_ = variable_joint_transforms_ + robot_model_->getJointModelCount();
   global_collision_body_transforms_ = global_link_transforms_ + robot_model_->getLinkModelCount();
   dirty_joint_transforms_ =
@@ -173,7 +173,7 @@ void RobotState::copyFrom(const RobotState& other)
             (robot_model_->getVariableCount() * (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
                                                  ((has_acceleration_ || has_effort_) ? 1 : 0)) +
              nr_doubles_for_dirty_joint_transforms);
-    memcpy((void*)variable_joint_transforms_, (void*)other.variable_joint_transforms_, bytes);
+    memcpy(static_cast<void*>(variable_joint_transforms_), other.variable_joint_transforms_, bytes);
   }
 
   // copy attached bodies

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -159,9 +159,9 @@ TEST(time_optimal_trajectory_generation, test_custom_limits)
   constexpr auto group_name{ "panda_arm" };
 
   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+  ASSERT_TRUE(robot_model) << "Failed to load robot model" << robot_name;
   auto group = robot_model->getJointModelGroup(group_name);
-  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+  ASSERT_TRUE(group) << "Failed to load joint model group " << group_name;
   moveit::core::RobotState waypoint_state(robot_model);
   waypoint_state.setToDefaultValues();
 
@@ -263,9 +263,9 @@ TEST(time_optimal_trajectory_generation, testLastWaypoint)
   constexpr auto group_name{ "hand" };
 
   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+  ASSERT_TRUE(robot_model) << "Failed to load robot model" << robot_name;
   auto group = robot_model->getJointModelGroup(group_name);
-  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+  ASSERT_TRUE(group) << "Failed to load joint model group " << group_name;
   moveit::core::RobotState waypoint_state(robot_model);
   waypoint_state.setToDefaultValues();
 
@@ -383,9 +383,9 @@ TEST(time_optimal_trajectory_generation, testPluginAPI)
   constexpr auto group_name{ "panda_arm" };
 
   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+  ASSERT_TRUE(robot_model) << "Failed to load robot model" << robot_name;
   auto group = robot_model->getJointModelGroup(group_name);
-  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+  ASSERT_TRUE(group) << "Failed to load joint model group " << group_name;
   moveit::core::RobotState waypoint_state(robot_model);
   waypoint_state.setToDefaultValues();
 
@@ -505,9 +505,9 @@ TEST(time_optimal_trajectory_generation, testFixedNumWaypoints)
   constexpr auto group_name{ "panda_arm" };
 
   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+  ASSERT_TRUE(robot_model) << "Failed to load robot model" << robot_name;
   auto group = robot_model->getJointModelGroup(group_name);
-  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+  ASSERT_TRUE(group) << "Failed to load joint model group " << group_name;
   moveit::core::RobotState waypoint_state(robot_model);
   waypoint_state.setToDefaultValues();
 

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -88,8 +88,8 @@ public:
 
     centers.clear();
     centers.reserve(k);
-    if (((long unsigned int)dists.rows()) < data.size() || ((long unsigned int)dists.cols()) < k)
-      dists.resize(std::max(2 * ((long unsigned int)dists.rows()) + 1, data.size()), k);
+    if (static_cast<long unsigned int>(dists.rows()) < data.size() || static_cast<long unsigned int>(dists.cols()) < k)
+      dists.resize(std::max(2 * static_cast<long unsigned int>(dists.rows()) + 1, data.size()), k);
     // first center is picked randomly
     centers.push_back(std::uniform_int_distribution<size_t>{ 0, data.size() - 1 }(rsl::rng()));
     for (unsigned i = 1; i < k; ++i)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -89,11 +89,11 @@ void IKCache::initializeCache(const std::string& robot_id, const std::string& gr
   {
     // read cache
     std::ifstream cache_file(cache_file_name_, std::ios_base::binary | std::ios_base::in);
-    cache_file.read((char*)&last_saved_cache_size_, sizeof(unsigned int));
+    cache_file.read(reinterpret_cast<char*>(&last_saved_cache_size_), sizeof(unsigned int));
     unsigned int num_dofs;
-    cache_file.read((char*)&num_dofs, sizeof(unsigned int));
+    cache_file.read(reinterpret_cast<char*>(&num_dofs), sizeof(unsigned int));
     unsigned int num_tips;
-    cache_file.read((char*)&num_tips, sizeof(unsigned int));
+    cache_file.read(reinterpret_cast<char*>(&num_tips), sizeof(unsigned int));
 
     RCLCPP_INFO(LOGGER, "Found %d IK solutions for a %d-dof system with %d end effectors in %s", last_saved_cache_size_,
                 num_dofs, num_tips, cache_file_name_.string().c_str());
@@ -232,10 +232,10 @@ void IKCache::saveCache() const
 
   // write number of IK entries and size of each configuration first
   last_saved_cache_size_ = ik_cache_.size();
-  cache_file.write((char*)&last_saved_cache_size_, sizeof(unsigned int));
+  cache_file.write(reinterpret_cast<char*>(&last_saved_cache_size_), sizeof(unsigned int));
   unsigned int sz = ik_cache_[0].second.size();
-  cache_file.write((char*)&sz, sizeof(unsigned int));
-  cache_file.write((char*)&num_tips, sizeof(unsigned int));
+  cache_file.write(reinterpret_cast<char*>(&sz), sizeof(unsigned int));
+  cache_file.write(reinterpret_cast<char*>(&num_tips), sizeof(unsigned int));
   for (const auto& entry : ik_cache_)
   {
     for (unsigned int i = 0; i < num_tips; ++i)

--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_sampler.cpp
@@ -49,7 +49,7 @@ ompl_interface::ConstrainedSampler::ConstrainedSampler(const ModelBasedPlanningC
   , constrained_success_(0)
   , constrained_failure_(0)
 {
-  inv_dim_ = space_->getDimension() > 0 ? 1.0 / (double)space_->getDimension() : 1.0;
+  inv_dim_ = space_->getDimension() > 0 ? 1.0 / static_cast<double>(space_->getDimension()) : 1.0;
 }
 
 double ompl_interface::ConstrainedSampler::getConstrainedSamplingRate() const

--- a/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constraints_library.cpp
@@ -625,7 +625,7 @@ ompl::base::StateStoragePtr ompl_interface::ConstraintsLibrary::constructConstra
           continue;
         unsigned int isteps =
             std::min<unsigned int>(options.max_explicit_points, d / options.explicit_points_resolution);
-        double step = 1.0 / (double)isteps;
+        double step = 1.0 / static_cast<double>(isteps);
         bool ok = true;
         space->interpolate(state_storage->getState(i), sj, step, int_states[0]);
         for (unsigned int k = 1; k < isteps; ++k)

--- a/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
@@ -58,7 +58,7 @@ Bounds::Bounds(const std::vector<double>& lower, const std::vector<double>& uppe
 
 Eigen::VectorXd Bounds::penalty(const Eigen::Ref<const Eigen::VectorXd>& x) const
 {
-  assert((long)lower_.size() == x.size());
+  assert(static_cast<long>(lower_.size()) == x.size());
   Eigen::VectorXd penalty(x.size());
 
   for (unsigned int i = 0; i < x.size(); ++i)
@@ -81,7 +81,7 @@ Eigen::VectorXd Bounds::penalty(const Eigen::Ref<const Eigen::VectorXd>& x) cons
 
 Eigen::VectorXd Bounds::derivative(const Eigen::Ref<const Eigen::VectorXd>& x) const
 {
-  assert((long)lower_.size() == x.size());
+  assert(static_cast<long>(lower_.size()) == x.size());
   Eigen::VectorXd derivative(x.size());
 
   for (unsigned int i = 0; i < x.size(); ++i)

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/src/forward_trajectory.cpp
@@ -81,7 +81,10 @@ ForwardTrajectory::solve(const robot_trajectory::RobotTrajectory& local_trajecto
                          trajectory_msgs::msg::JointTrajectory& local_solution)
 {
   // A message every once in awhile is useful in case the local planner gets stuck
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
   RCLCPP_INFO_THROTTLE(LOGGER, *node_->get_clock(), 2000 /* ms */, "The local planner is solving...");
+#pragma GCC diagnostic pop
 
   // Create controller command trajectory
   robot_trajectory::RobotTrajectory robot_command(local_trajectory.getRobotModel(), local_trajectory.getGroupName());

--- a/moveit_ros/moveit_servo/src/collision_check.cpp
+++ b/moveit_ros/moveit_servo/src/collision_check.cpp
@@ -66,8 +66,11 @@ CollisionCheck::CollisionCheck(const rclcpp::Node::SharedPtr& node, const ServoP
   if (parameters_->collision_check_rate < MIN_RECOMMENDED_COLLISION_RATE)
   {
     auto& clk = *node_->get_clock();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clk, ROS_LOG_THROTTLE_PERIOD,
                                 "Collision check rate is low, increase it in yaml file if CPU allows");
+#pragma GCC diagnostic pop
   }
 
   // ROS pubs/subs

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -169,7 +169,10 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
     if (!loop_rate_.sleep())
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
       RCLCPP_WARN_STREAM_THROTTLE(LOGGER, *node_->get_clock(), LOG_THROTTLE_PERIOD, "Target control rate was missed");
+#pragma GCC diagnostic pop
     }
   }
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -51,6 +51,10 @@
 #include <moveit_servo/servo_calcs.h>
 #include <moveit_servo/utilities.h>
 
+// Disable -Wold-style-cast because all _THROTTLE macros trigger this
+// It would be too noisy to disable on a per-callsite basis
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 using namespace std::chrono_literals;  // for s, ms, etc.
 
 namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -142,7 +142,10 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
         1. - (ini_condition - lower_singularity_threshold) / (upper_threshold - lower_singularity_threshold);
     status =
         dot > 0 ? StatusCode::DECELERATE_FOR_APPROACHING_SINGULARITY : StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD, SERVO_STATUS_CODE_MAP.at(status));
+#pragma GCC diagnostic pop
   }
 
   // Very close to singularity, so halt.
@@ -150,7 +153,10 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
   {
     velocity_scale = 0;
     status = StatusCode::HALT_FOR_SINGULARITY;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD, SERVO_STATUS_CODE_MAP.at(status));
+#pragma GCC diagnostic pop
   }
 
   return velocity_scale;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -260,7 +260,10 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
         if (jt == mesh_handles_[index].end())
         {
           rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
           RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Incorrect mapping of mesh handles");
+#pragma GCC diagnostic pop
           return false;
         }
         else

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -66,11 +66,19 @@ static void publishOctomap(const rclcpp::Publisher<octomap_msgs::msg::Octomap>::
   try
   {
     if (!octomap_msgs::binaryMapToMsgData(*server.getOcTreePtr(), map.data))
+    {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
       RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Could not generate OctoMap message");
+#pragma GCC diagnostic pop
+    }
   }
   catch (...)
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Exception thrown while generating OctoMap message");
+#pragma GCC diagnostic pop
   }
   server.getOcTreePtr()->unlockRead();
 

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -86,18 +86,24 @@ bool OccupancyMapUpdater::updateTransformCache(const std::string& target_frame, 
     if (!success)
     {
       rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
       RCLCPP_ERROR_THROTTLE(
           LOGGER, steady_clock, 1000,
           "Transform cache was not updated. Self-filtering may fail. If transforms were not available yet, consider "
           "setting robot_description_planning.shape_transform_cache_lookup_wait_time to wait longer for transforms");
+#pragma GCC diagnostic pop
     }
     return success;
   }
   else
   {
     rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_WARN_THROTTLE(LOGGER, steady_clock, 1000,
                          "No callback provided for updating the transform cache for octomap updaters");
+#pragma GCC diagnostic pop
     return false;
   }
 }

--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -247,8 +247,8 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
       }
       else
       {
-        average_callback_dt_ =
-            ((image_callback_count_ - 1) * average_callback_dt_ + dt_start) / (double)image_callback_count_;
+        average_callback_dt_ = ((image_callback_count_ - 1) * average_callback_dt_ + dt_start) /
+                               static_cast<double>(image_callback_count_);
       }
     }
   }
@@ -314,15 +314,21 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
         failed_tf_++;
         if (failed_tf_ > good_tf_)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
           RCLCPP_WARN_THROTTLE(LOGGER, *node_->get_clock(), 1000,
                                "More than half of the image messages discarded due to TF being unavailable (%u%%). "
                                "Transform error of sensor data: %s; quitting callback.",
                                (100 * failed_tf_) / (good_tf_ + failed_tf_), err.c_str());
+#pragma GCC diagnostic pop
         }
         else
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
           RCLCPP_DEBUG_THROTTLE(LOGGER, *node_->get_clock(), 1000,
                                 "Transform error of sensor data: %s; quitting callback", err.c_str());
+#pragma GCC diagnostic pop
         }
         if (failed_tf_ > MAX_TF_COUNTER)
         {
@@ -341,7 +347,12 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
     return;
 
   if (depth_msg->is_bigendian && !HOST_IS_BIG_ENDIAN)
+  {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(LOGGER, *node_->get_clock(), 1000, "endian problem: received image data does not match host");
+#pragma GCC diagnostic pop
+  }
 
   const int w = depth_msg->width;
   const int h = depth_msg->height;
@@ -360,8 +371,11 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
   {
     if (depth_msg->encoding != sensor_msgs::image_encodings::TYPE_32FC1)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
       RCLCPP_ERROR_THROTTLE(LOGGER, *node_->get_clock(), 1000, "Unexpected encoding type: '%s'. Ignoring input.",
                             depth_msg->encoding.c_str());
+#pragma GCC diagnostic pop
       return;
     }
     mesh_filter_->filter(&depth_msg->data[0], GL_FLOAT);
@@ -502,7 +516,7 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::msg::Image:
           // not filtered
           if (labels_row[x] == mesh_filter::MeshFilterBase::BACKGROUND)
           {
-            float zz = (float)input_row[x] * 1e-3;  // scale from mm to m
+            float zz = static_cast<float>(input_row[x]) * 1e-3;  // scale from mm to m
             float yy = y_cache_[y] * zz;
             float xx = x_cache_[x] * zz;
             /* transform to map frame */

--- a/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/moveit_ros/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -73,7 +73,8 @@ void LazyFreeSpaceUpdater::pushLazyUpdate(octomap::KeySet* occupied_cells, octom
                                           const octomap::point3d& sensor_origin)
 {
   RCLCPP_DEBUG(LOGGER, "Pushing %lu occupied cells and %lu model cells for lazy updating...",
-               (long unsigned int)occupied_cells->size(), (long unsigned int)model_cells->size());
+               static_cast<long unsigned int>(occupied_cells->size()),
+               static_cast<long unsigned int>(model_cells->size()));
   std::scoped_lock _(update_cell_sets_lock_);
   occupied_cells_sets_.push_back(occupied_cells);
   model_cells_sets_.push_back(model_cells);
@@ -125,8 +126,8 @@ void LazyFreeSpaceUpdater::processThread()
 
     RCLCPP_DEBUG(LOGGER,
                  "Begin processing batched update: marking free cells due to %lu occupied cells and %lu model cells",
-                 (long unsigned int)process_occupied_cells_set_->size(),
-                 (long unsigned int)process_model_cells_set_->size());
+                 static_cast<long unsigned int>(process_occupied_cells_set_->size()),
+                 static_cast<long unsigned int>(process_model_cells_set_->size()));
 
     rclcpp::Clock clock;
     rclcpp::Time start = clock.now();
@@ -174,7 +175,8 @@ void LazyFreeSpaceUpdater::processThread()
       free_cells1.erase(it);
       free_cells2.erase(it);
     }
-    RCLCPP_DEBUG(LOGGER, "Marking %lu cells as free...", (long unsigned int)(free_cells1.size() + free_cells2.size()));
+    RCLCPP_DEBUG(LOGGER, "Marking %lu cells as free...",
+                 static_cast<long unsigned int>(free_cells1.size() + free_cells2.size()));
 
     tree_->lockWrite();
 

--- a/moveit_ros/perception/mesh_filter/src/gl_mesh.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_mesh.cpp
@@ -55,7 +55,7 @@ mesh_filter::GLMesh::GLMesh(const Mesh& mesh, unsigned int mesh_label)
   list_ = glGenLists(1);
   glNewList(list_, GL_COMPILE);
   glBegin(GL_TRIANGLES);
-  glColor4ubv((GLubyte*)&mesh_label_);
+  glColor4ubv(reinterpret_cast<GLubyte*>(&mesh_label_));
   for (unsigned t_idx = 0; t_idx < mesh.triangle_count; ++t_idx)
   {
     unsigned v1 = 3 * mesh.triangles[3 * t_idx];

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -277,7 +277,7 @@ GLuint mesh_filter::GLRenderer::createShader(GLuint shaderType, const string& Sh
       vector<char> shader_error_message(info_log_length + 1);
       glGetShaderInfoLog(shader_id, info_log_length, nullptr, &shader_error_message[0]);
       stringstream error_stream;
-      error_stream << "Could not compile shader: " << (const char*)&shader_error_message[0];
+      error_stream << "Could not compile shader: " << const_cast<const char*>(&shader_error_message[0]);
 
       glDeleteShader(shader_id);
       throw runtime_error(error_stream.str());

--- a/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
+++ b/moveit_ros/perception/mesh_filter/src/mesh_filter_base.cpp
@@ -221,8 +221,8 @@ void mesh_filter::MeshFilterBase::setShadowThreshold(float threshold)
 
 void mesh_filter::MeshFilterBase::getModelLabels(LabelType* labels) const
 {
-  JobPtr job(
-      new FilterJob<void>([&renderer = *mesh_renderer_, labels] { renderer.getColorBuffer((unsigned char*)labels); }));
+  JobPtr job(new FilterJob<void>(
+      [&renderer = *mesh_renderer_, labels] { renderer.getColorBuffer(reinterpret_cast<unsigned char*>(labels)); }));
   addJob(job);
   job->wait();
 }
@@ -261,7 +261,7 @@ void mesh_filter::MeshFilterBase::getFilteredDepth(float* depth) const
 void mesh_filter::MeshFilterBase::getFilteredLabels(LabelType* labels) const
 {
   JobPtr job = std::make_shared<FilterJob<void>>(
-      [&filter = *depth_filter_, labels] { filter.getColorBuffer((unsigned char*)labels); });
+      [&filter = *depth_filter_, labels] { filter.getColorBuffer(reinterpret_cast<unsigned char*>(labels)); });
   addJob(job);
   job->wait();
 }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -248,8 +248,11 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
         /* We cannot know if the reason of timeout is slow time or absence of
          * state messages, warn the user. */
         rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
         RCLCPP_WARN_SKIPFIRST_THROTTLE(LOGGER, steady_clock, 1000,
                                        "No state update received within 100ms of system clock");
+#pragma GCC diagnostic pop
       }
       else
       {
@@ -321,9 +324,12 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState:
   if (joint_state->name.size() != joint_state->position.size())
   {
     rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000,
                           "State monitor received invalid joint state (number of joint names does not match number of "
                           "positions)");
+#pragma GCC diagnostic pop
     return;
   }
   bool update = false;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -541,7 +541,7 @@ void PlanningSceneMonitor::triggerSceneUpdateEvent(SceneUpdateType update_type)
 
   for (std::function<void(SceneUpdateType)>& update_callback : update_callbacks_)
     update_callback(update_type);
-  new_scene_update_ = (SceneUpdateType)(static_cast<int>(new_scene_update_) | static_cast<int>(update_type));
+  new_scene_update_ = static_cast<SceneUpdateType>(static_cast<int>(new_scene_update_) | static_cast<int>(update_type));
   new_scene_update_condition_.notify_all();
 }
 
@@ -621,18 +621,18 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
   PlanningSceneMonitor::SceneUpdateType event = PlanningSceneMonitor::UPDATE_NONE;
   if (publish_geom_updates)
   {
-    event = (PlanningSceneMonitor::SceneUpdateType)(static_cast<int>(event) |
-                                                    static_cast<int>(PlanningSceneMonitor::UPDATE_GEOMETRY));
+    event = static_cast<PlanningSceneMonitor::SceneUpdateType>(static_cast<int>(event) |
+                                                               static_cast<int>(PlanningSceneMonitor::UPDATE_GEOMETRY));
   }
   if (publish_state_updates)
   {
-    event = (PlanningSceneMonitor::SceneUpdateType)(static_cast<int>(event) |
-                                                    static_cast<int>(PlanningSceneMonitor::UPDATE_STATE));
+    event = static_cast<PlanningSceneMonitor::SceneUpdateType>(static_cast<int>(event) |
+                                                               static_cast<int>(PlanningSceneMonitor::UPDATE_STATE));
   }
   if (publish_transform_updates)
   {
-    event = (PlanningSceneMonitor::SceneUpdateType)(static_cast<int>(event) |
-                                                    static_cast<int>(PlanningSceneMonitor::UPDATE_TRANSFORMS));
+    event = static_cast<PlanningSceneMonitor::SceneUpdateType>(
+        static_cast<int>(event) | static_cast<int>(PlanningSceneMonitor::UPDATE_TRANSFORMS));
   }
   if (publish_planning_scene)
   {
@@ -736,16 +736,16 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
     {
       upd = UPDATE_NONE;
       if (!moveit::core::isEmpty(scene.world))
-        upd = (SceneUpdateType)(static_cast<int>(upd) | static_cast<int>(UPDATE_GEOMETRY));
+        upd = static_cast<SceneUpdateType>(static_cast<int>(upd) | static_cast<int>(UPDATE_GEOMETRY));
 
       if (!scene.fixed_frame_transforms.empty())
-        upd = (SceneUpdateType)(static_cast<int>(upd) | static_cast<int>(UPDATE_TRANSFORMS));
+        upd = static_cast<SceneUpdateType>(static_cast<int>(upd) | static_cast<int>(UPDATE_TRANSFORMS));
 
       if (!moveit::core::isEmpty(scene.robot_state))
       {
-        upd = (SceneUpdateType)(static_cast<int>(upd) | static_cast<int>(UPDATE_STATE));
+        upd = static_cast<SceneUpdateType>(static_cast<int>(upd) | static_cast<int>(UPDATE_STATE));
         if (!scene.robot_state.attached_collision_objects.empty() || !scene.robot_state.is_diff)
-          upd = (SceneUpdateType)(static_cast<int>(upd) | static_cast<int>(UPDATE_GEOMETRY));
+          upd = static_cast<SceneUpdateType>(static_cast<int>(upd) | static_cast<int>(UPDATE_GEOMETRY));
       }
     }
   }
@@ -1204,7 +1204,10 @@ bool PlanningSceneMonitor::getShapeTransformCache(const std::string& target_fram
   catch (tf2::TransformException& ex)
   {
     rclcpp::Clock steady_clock = rclcpp::Clock();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000, "Transform error: %s", ex.what());
+#pragma GCC diagnostic pop
     return false;
   }
   return true;
@@ -1450,8 +1453,11 @@ void PlanningSceneMonitor::updateSceneWithCurrentState()
         (time - current_state_monitor_->getMonitorStartTime()).seconds() > 1.0)
     {
       std::string missing_str = boost::algorithm::join(missing, ", ");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
       RCLCPP_WARN_THROTTLE(LOGGER, steady_clock, 1000, "The complete state of the robot is not yet known.  Missing %s",
                            missing_str.c_str());
+#pragma GCC diagnostic pop
     }
 
     {
@@ -1465,8 +1471,11 @@ void PlanningSceneMonitor::updateSceneWithCurrentState()
   }
   else
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     RCLCPP_ERROR_THROTTLE(LOGGER, steady_clock, 1000,
                           "State monitor is not active. Unable to set the planning scene state");
+#pragma GCC diagnostic pop
   }
 }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_objects.cpp
@@ -154,7 +154,7 @@ void MotionPlanningFrame::clearScene()
 
 void MotionPlanningFrame::sceneScaleChanged(int value)
 {
-  const double scaling_factor = (double)value / 100.0;  // The GUI slider gives percent values
+  const double scaling_factor = static_cast<double>(value) / 100.0;  // The GUI slider gives percent values
   if (scaled_object_)
   {
     planning_scene_monitor::LockedPlanningSceneRW ps = planning_display_->getPlanningSceneRW();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -58,7 +58,7 @@ OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree>& octree,
   }
   else
   {
-    octree_depth_ = std::min(max_octree_depth, (std::size_t)octree->getTreeDepth());
+    octree_depth_ = std::min(max_octree_depth, static_cast<std::size_t>(octree->getTreeDepth()));
   }
 
   scene_node_ = parent_node->createChildSceneNode();

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -256,7 +256,8 @@ void TrajectoryVisualization::changedShowTrail()
 
   int stepsize = trail_step_size_property_->getInt();
   // always include last trajectory point
-  trajectory_trail_.resize(static_cast<int>(std::ceil((t->getWayPointCount() + stepsize - 1) / (float)stepsize)));
+  trajectory_trail_.resize(
+      static_cast<int>(std::ceil((t->getWayPointCount() + stepsize - 1) / static_cast<float>(stepsize))));
   for (std::size_t i = 0; i < trajectory_trail_.size(); ++i)
   {
     int waypoint_i = std::min(i * stepsize, t->getWayPointCount() - 1);  // limit to last trajectory point

--- a/moveit_ros/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/src/broadcast.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   executor.add_node(node);
 
-  rclcpp::Rate rate((int64_t)delay * 1000ms);
+  rclcpp::Rate rate(static_cast<int64_t>(delay) * 1000ms);
 
   // publish the scene
   if (vm.count("scene"))

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/compute_default_collisions.cpp
@@ -482,7 +482,8 @@ unsigned int disableAlwaysInCollision(planning_scene::PlanningScene& scene, Link
 {
   // Trial count variables
   static const unsigned int SMALL_TRIAL_COUNT = 200;
-  static const unsigned int SMALL_TRIAL_LIMIT = (unsigned int)((double)SMALL_TRIAL_COUNT * min_collision_faction);
+  static const unsigned int SMALL_TRIAL_LIMIT =
+      static_cast<unsigned int>(static_cast<double>(SMALL_TRIAL_COUNT) * min_collision_faction);
 
   bool done = false;
   unsigned int num_disabled = 0;


### PR DESCRIPTION
### Description

Add `-Wold-style-cast` and fix all new warnings. Expands on #1628.

In many places I'm just using C++ casts and those are fine. However, the big issue is that all the ROS `_THROTTLE` logging macros (through a few more macros nested within) eventually call `RCUTILS_LOG_CONDITION_THROTTLE_BEFORE` which being from a C library understandably uses a C-style cast. See `rcutils/logging_macros.h:176` copied below for convenience.

```c
/**
 * \def RCUTILS_LOG_CONDITION_THROTTLE_BEFORE
 * A macro initializing and checking the `throttle` condition.
 */
#define RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(get_time_point_value, duration) { \
    static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS((rcutils_duration_value_t)duration); \
    static rcutils_time_point_value_t __rcutils_logging_last_logged = 0; \
    rcutils_time_point_value_t __rcutils_logging_now = 0; \
    bool __rcutils_logging_condition = true; \
    if (get_time_point_value(&__rcutils_logging_now) != RCUTILS_RET_OK) { \
      rcutils_log( \
        &__rcutils_logging_location, RCUTILS_LOG_SEVERITY_ERROR, "", \
        "%s() at %s:%d getting current steady time failed\n", \
        __func__, __FILE__, __LINE__); \
    } else { \
      __rcutils_logging_condition = __rcutils_logging_now >= __rcutils_logging_last_logged + __rcutils_logging_duration; \
    } \
 \
    if (RCUTILS_LIKELY(__rcutils_logging_condition)) { \
      __rcutils_logging_last_logged = __rcutils_logging_now;
```

A proper fix would be to upstream a fix that adds pragmas within these macros that silence the warnings, preferably at the source inside `RCUTILS_LOG_CONDITION_THROTTLE_BEFORE` but potentially at a higher level inside rclcpp macros. My use of `#pragma`s is a noisy but practical option that lets us silence these warnings at the callsite while still enabling the warning which as seen by this PR, has caught many remaining C-style casts.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
