### PR TITLE
Fix trajectory unwind bug

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -292,6 +292,8 @@ public:
   RobotTrajectory& reverse();
 
   RobotTrajectory& unwind();
+
+  /** @brief Unwind, starting from an initial state **/
   RobotTrajectory& unwind(const moveit::core::RobotState& state);
 
   /** @brief Finds the waypoint indices before and after a duration from start.

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -216,9 +216,13 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
     double last_value = waypoints_[0]->getJointPositions(cont_joint)[0];
     cont_joint->enforcePositionBounds(&last_value);
     if (last_value > reference_value + M_PI)
+    {
       running_offset -= 2.0 * M_PI;
+    }
     else if (last_value < reference_value - M_PI)
+    {
       running_offset += 2.0 * M_PI;
+    }
     double current_start_value = last_value + running_offset;
     waypoints_[0]->setJointPositions(cont_joint, &current_start_value);
 

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -168,10 +168,13 @@ RobotTrajectory& RobotTrajectory::unwind()
     // unwrap continuous joints
     double running_offset = 0.0;
     double last_value = waypoints_[0]->getJointPositions(cont_joint)[0];
+    cont_joint->enforcePositionBounds(&last_value);
+    waypoints_[0]->setJointPositions(cont_joint, &last_value);
 
     for (std::size_t j = 1; j < waypoints_.size(); ++j)
     {
       double current_value = waypoints_[j]->getJointPositions(cont_joint)[0];
+      cont_joint->enforcePositionBounds(&current_value);
       if (last_value > current_value + M_PI)
       {
         running_offset += 2.0 * M_PI;
@@ -182,12 +185,8 @@ RobotTrajectory& RobotTrajectory::unwind()
       }
 
       last_value = current_value;
-      if (running_offset > std::numeric_limits<double>::epsilon() ||
-          running_offset < -std::numeric_limits<double>::epsilon())
-      {
-        current_value += running_offset;
-        waypoints_[j]->setJointPositions(cont_joint, &current_value);
-      }
+      current_value += running_offset;
+      waypoints_[j]->setJointPositions(cont_joint, &current_value);
     }
   }
   for (moveit::core::RobotStatePtr& waypoint : waypoints_)
@@ -231,6 +230,7 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
     for (std::size_t j = 1; j < waypoints_.size(); ++j)
     {
       double current_value = waypoints_[j]->getJointPositions(cont_joint)[0];
+      cont_joint->enforcePositionBounds(&current_value);
       if (last_value > current_value + M_PI)
       {
         running_offset += 2.0 * M_PI;
@@ -241,16 +241,14 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
       }
 
       last_value = current_value;
-      if (running_offset > std::numeric_limits<double>::epsilon() ||
-          running_offset < -std::numeric_limits<double>::epsilon())
-      {
-        current_value += running_offset;
-        waypoints_[j]->setJointPositions(cont_joint, &current_value);
-      }
+      current_value += running_offset;
+      waypoints_[j]->setJointPositions(cont_joint, &current_value);
     }
   }
   for (moveit::core::RobotStatePtr& waypoint : waypoints_)
+  {
     waypoint->update();
+  }
 
   return *this;
 }

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -215,8 +215,12 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
 
     double last_value = waypoints_[0]->getJointPositions(cont_joint)[0];
     cont_joint->enforcePositionBounds(&last_value);
-    double current_value = last_value + running_offset;
-    waypoints_[0]->setJointPositions(cont_joint, &current_value);
+    if (last_value > reference_value + M_PI)
+      running_offset -= 2.0 * M_PI;
+    else if (last_value < reference_value - M_PI)
+      running_offset += 2.0 * M_PI;
+    double current_start_value = last_value + running_offset;
+    waypoints_[0]->setJointPositions(cont_joint, &current_start_value);
 
     for (std::size_t j = 1; j < waypoints_.size(); ++j)
     {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -214,6 +214,7 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
     double running_offset = reference_value0 - reference_value;
 
     double last_value = waypoints_[0]->getJointPositions(cont_joint)[0];
+    cont_joint->enforcePositionBounds(&last_value);
     if (running_offset > std::numeric_limits<double>::epsilon() ||
         running_offset < -std::numeric_limits<double>::epsilon())
     {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -215,12 +215,8 @@ RobotTrajectory& RobotTrajectory::unwind(const moveit::core::RobotState& state)
 
     double last_value = waypoints_[0]->getJointPositions(cont_joint)[0];
     cont_joint->enforcePositionBounds(&last_value);
-    if (running_offset > std::numeric_limits<double>::epsilon() ||
-        running_offset < -std::numeric_limits<double>::epsilon())
-    {
-      double current_value = last_value + running_offset;
-      waypoints_[0]->setJointPositions(cont_joint, &current_value);
-    }
+    double current_value = last_value + running_offset;
+    waypoints_[0]->setJointPositions(cont_joint, &current_value);
 
     for (std::size_t j = 1; j < waypoints_.size(); ++j)
     {

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -191,7 +191,9 @@ RobotTrajectory& RobotTrajectory::unwind()
     }
   }
   for (moveit::core::RobotStatePtr& waypoint : waypoints_)
+  {
     waypoint->update();
+  }
 
   return *this;
 }

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -38,6 +38,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/utils/robot_model_test_utils.h>
+#include <urdf_parser/urdf_parser.h>
 #include <gtest/gtest.h>
 
 class RobotTrajectoryTestFixture : public testing::Test
@@ -148,6 +149,209 @@ protected:
     trajectory_first_waypoint_after_update.copyJointGroupPositions(arm_jmg_name_, trajectory_first_state_after_update);
     EXPECT_NE(trajectory_first_state[0], trajectory_first_state_after_update[0]);
   }
+};
+
+class OneRobot : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    static const std::string MODEL2 =
+        "<?xml version=\"1.0\" ?>"
+        "<robot name=\"one_robot\">"
+        "<link name=\"base_link\">"
+        "  <inertial>"
+        "    <mass value=\"2.81\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision name=\"my_collision\">"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<joint name=\"panda_joint0\" type=\"continuous\">"
+        "   <axis xyz=\"0 0 1\"/>"
+        "   <parent link=\"base_link\"/>"
+        "   <child link=\"link_a\"/>"
+        "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
+        "</joint>"
+        "<link name=\"link_a\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<joint name=\"joint_b\" type=\"fixed\">"
+        "  <parent link=\"link_a\"/>"
+        "  <child link=\"link_b\"/>"
+        "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
+        "</joint>"
+        "<link name=\"link_b\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "  <joint name=\"panda_joint1\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
+        "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" "
+        "soft_upper_limit=\"0.089\"/>"
+        "    <parent link=\"link_b\"/>"
+        "    <child link=\"link_c\"/>"
+        "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
+        "  </joint>"
+        "<link name=\"link_c\">"
+        "  <inertial>"
+        "    <mass value=\"1.0\"/>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
+        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+        "  </inertial>"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "  <joint name=\"mim_f\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+        "    <parent link=\"link_c\"/>"
+        "    <child link=\"link_d\"/>"
+        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+        "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
+        "  </joint>"
+        "  <joint name=\"joint_f\" type=\"prismatic\">"
+        "    <axis xyz=\"1 0 0\"/>"
+        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+        "    <parent link=\"link_d\"/>"
+        "    <child link=\"link_e\"/>"
+        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+        "  </joint>"
+        "<link name=\"link_d\">"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "<link name=\"link_e\">"
+        "  <collision>"
+        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </collision>"
+        "  <visual>"
+        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+        "    <geometry>"
+        "      <box size=\"1 2 1\" />"
+        "    </geometry>"
+        "  </visual>"
+        "</link>"
+        "</robot>";
+
+    static const std::string SMODEL2 =
+        "<?xml version=\"1.0\" ?>"
+        "<robot name=\"one_robot\">"
+        "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
+        "<group name=\"panda_arm\">"
+        "<chain base_link=\"base_link\" tip_link=\"link_e\"/>"
+        "<joint name=\"base_joint\"/>"
+        "</group>"
+        "</robot>";
+
+    urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
+    srdf::ModelSharedPtr srdf_model = std::make_shared<srdf::Model>();
+    srdf_model->initString(*urdf_model, SMODEL2);
+    robot_model_ = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
+    robot_state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
+    robot_state_->setToDefaultValues();
+    robot_state_->setVariableVelocity(/*index*/ 0, /*value*/ 1.0);
+    robot_state_->setVariableAcceleration(/*index*/ 0, /*value*/ -0.1);
+    robot_state_->update();
+  }
+
+  void TearDown() override
+  {
+  }
+
+  void initTestTrajectory(robot_trajectory::RobotTrajectoryPtr& trajectory)
+  {
+    // Init a traj
+    ASSERT_TRUE(robot_model_->hasJointModelGroup(arm_jmg_name_))
+        << "Robot model does not have group: " << arm_jmg_name_;
+
+    trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(robot_model_, arm_jmg_name_);
+
+    EXPECT_EQ(trajectory->getGroupName(), arm_jmg_name_) << "Generated trajectory group name does not match";
+    EXPECT_TRUE(trajectory->empty()) << "Generated trajectory not empty";
+
+    double duration_from_previous = 0.1;
+    std::size_t waypoint_count = 5;
+    for (std::size_t ix = 0; ix < waypoint_count; ++ix)
+      trajectory->addSuffixWayPoint(*robot_state_, duration_from_previous);
+    // Quick check that getDuration is working correctly
+    EXPECT_EQ(trajectory->getDuration(), duration_from_previous * waypoint_count)
+        << "Generated trajectory duration incorrect";
+    EXPECT_EQ(waypoint_count, trajectory->getWayPointDurations().size())
+        << "Generated trajectory has the wrong number of waypoints";
+    EXPECT_EQ(waypoint_count, trajectory->size());
+  }
+
+protected:
+  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotStatePtr robot_state_;
+  const std::string arm_jmg_name_ = "panda_arm";
 };
 
 TEST_F(RobotTrajectoryTestFixture, ModifyFirstWaypointByPtr)
@@ -354,7 +558,7 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDensity)
   EXPECT_FALSE(robot_trajectory::waypoint_density(*trajectory).has_value());
 }
 
-TEST_F(RobotTrajectoryTestFixture, Unwind)
+TEST_F(OneRobot, Unwind)
 {
   const double EPSILON = 1e-4;
 
@@ -364,10 +568,10 @@ TEST_F(RobotTrajectoryTestFixture, Unwind)
     initTestTrajectory(trajectory);
     moveit::core::RobotStatePtr& first_waypoint = trajectory->getFirstWayPointPtr();
     const double random_large_angle = 20.2;  // rad, should unwind to 1.350444 rad
-    first_waypoint->setVariablePosition("panda_joint1", random_large_angle);
+    first_waypoint->setVariablePosition("panda_joint0", random_large_angle);
     first_waypoint->update();
     trajectory->unwind();
-    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint1"), 1.350444, EPSILON);
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), 1.350444, EPSILON);
   }
 }
 

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -316,6 +316,7 @@ protected:
     robot_model_ = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
     robot_state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
     robot_state_->setToDefaultValues();
+    robot_state_->setVariablePositions({ "panda_joint0" }, { -3.1416 });
     robot_state_->setVariableVelocity(/*index*/ 0, /*value*/ 1.0);
     robot_state_->setVariableAcceleration(/*index*/ 0, /*value*/ -0.1);
     robot_state_->update();

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -577,7 +577,7 @@ TEST_F(OneRobot, Unwind)
 
 TEST_F(OneRobot, UnwindFromState)
 {
-  const double EPSILON = 1e-4;
+  const double epsilon = 1e-4;
 
   // Unwind a trajectory from a robot state
   {
@@ -590,7 +590,7 @@ TEST_F(OneRobot, UnwindFromState)
     first_waypoint.update();
     // Unwind the trajectory from the wound up robot state
     trajectory->unwind(first_waypoint);
-    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), wrapped_angle, EPSILON);
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), wrapped_angle, epsilon);
   }
 }
 

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -560,7 +560,7 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDensity)
 
 TEST_F(OneRobot, Unwind)
 {
-  const double EPSILON = 1e-4;
+  const double epsilon = 1e-4;
 
   // An initial joint position needs unwinding
   {
@@ -571,7 +571,7 @@ TEST_F(OneRobot, Unwind)
     first_waypoint->setVariablePosition("panda_joint0", random_large_angle);
     first_waypoint->update();
     trajectory->unwind();
-    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), 1.350444, EPSILON);
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), 1.350444, epsilon);
   }
 }
 

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -575,6 +575,25 @@ TEST_F(OneRobot, Unwind)
   }
 }
 
+TEST_F(OneRobot, UnwindFromState)
+{
+  const double EPSILON = 1e-4;
+
+  // Unwind a trajectory from a robot state
+  {
+    robot_trajectory::RobotTrajectoryPtr trajectory;
+    initTestTrajectory(trajectory);
+    moveit::core::RobotState first_waypoint = trajectory->getFirstWayPoint();
+    // Wrap the continuous joint by 4PI as if this happened to be the current state of the robot
+    const double wrapped_angle = first_waypoint.getVariablePosition("panda_joint0") + 12.566371;
+    first_waypoint.setVariablePosition("panda_joint0", wrapped_angle);
+    first_waypoint.update();
+    // Unwind the trajectory from the wound up robot state
+    trajectory->unwind(first_waypoint);
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint0"), wrapped_angle, EPSILON);
+  }
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -354,6 +354,26 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDensity)
   EXPECT_FALSE(robot_trajectory::waypoint_density(*trajectory).has_value());
 }
 
+TEST_F(RobotTrajectoryTestFixture, Unwind)
+{
+  // TODO(andyz): this fails! It's a bug.
+  /*
+    const double EPSILON = 1e-4;
+
+    // An initial joint position needs unwinding
+    {
+      robot_trajectory::RobotTrajectoryPtr trajectory;
+      initTestTrajectory(trajectory);
+      moveit::core::RobotStatePtr& first_waypoint = trajectory->getFirstWayPointPtr();
+      const double random_large_angle = 20.2;  // rad, should unwind to 1.350444 rad
+      first_waypoint->setVariablePosition("panda_joint1", random_large_angle);
+      first_waypoint->update();
+      trajectory->unwind();
+      EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint1"), 1.350444, EPSILON);
+    }
+  */
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -356,22 +356,19 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDensity)
 
 TEST_F(RobotTrajectoryTestFixture, Unwind)
 {
-  // TODO(andyz): this fails! It's a bug.
-  /*
-    const double EPSILON = 1e-4;
+  const double EPSILON = 1e-4;
 
-    // An initial joint position needs unwinding
-    {
-      robot_trajectory::RobotTrajectoryPtr trajectory;
-      initTestTrajectory(trajectory);
-      moveit::core::RobotStatePtr& first_waypoint = trajectory->getFirstWayPointPtr();
-      const double random_large_angle = 20.2;  // rad, should unwind to 1.350444 rad
-      first_waypoint->setVariablePosition("panda_joint1", random_large_angle);
-      first_waypoint->update();
-      trajectory->unwind();
-      EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint1"), 1.350444, EPSILON);
-    }
-  */
+  // An initial joint position needs unwinding
+  {
+    robot_trajectory::RobotTrajectoryPtr trajectory;
+    initTestTrajectory(trajectory);
+    moveit::core::RobotStatePtr& first_waypoint = trajectory->getFirstWayPointPtr();
+    const double random_large_angle = 20.2;  // rad, should unwind to 1.350444 rad
+    first_waypoint->setVariablePosition("panda_joint1", random_large_angle);
+    first_waypoint->update();
+    trajectory->unwind();
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint1"), 1.350444, EPSILON);
+  }
 }
 
 int main(int argc, char** argv)

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -349,7 +349,7 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
 
   // push the trajectories we have slated for execution to the trajectory execution manager
   int prev = -1;
-  for (std::size_t i = 0; i < plan.plan_components_.size(); ++i)
+  for (size_t component_idx = 0; component_idx < plan.plan_components_.size(); ++component_idx)
   {
     // \todo should this be in trajectory_execution ? Maybe. Then that will have to use kinematic_trajectory too;
     // splitting trajectories for controllers becomes interesting: tied to groups instead of joints. this could cause
@@ -357,15 +357,19 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
     // in the meantime we do a hack:
 
     bool unwound = false;
-    for (int j = i - 1; j >= 0; --j)
+    for (int prev_component = component_idx - 1; prev_component >= 0; --prev_component)
     {
-      // if we ran unwind on a path for the same group
-      if (plan.plan_components_[j].trajectory_ &&
-          plan.plan_components_[j].trajectory_->getGroup() == plan.plan_components_[i].trajectory_->getGroup() &&
-          !plan.plan_components_[j].trajectory_->empty())
+      // Search backward for a previous component having the same group.
+      // If the group is the same, unwind this component based on the last waypoint of the previous one.
+      if (plan.plan_components_.at(prev_component).trajectory_ &&
+          plan.plan_components_.at(prev_component).trajectory_->getGroup() ==
+              plan.plan_components_.at(prev_component).trajectory_->getGroup() &&
+          !plan.plan_components_.at(prev_component).trajectory_->empty())
       {
-        plan.plan_components_[i].trajectory_->unwind(plan.plan_components_[j].trajectory_->getLastWayPoint());
+        plan.plan_components_.at(component_idx)
+            .trajectory_->unwind(plan.plan_components_.at(prev_component).trajectory_->getLastWayPoint());
         unwound = true;
+        // Break so each component is only unwound once
         break;
       }
     }
@@ -375,24 +379,25 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
       // unwind the path to execute based on the current state of the system
       if (prev < 0)
       {
-        plan.plan_components_[i].trajectory_->unwind(
+        plan.plan_components_[component_idx].trajectory_->unwind(
             plan.planning_scene_monitor_ && plan.planning_scene_monitor_->getStateMonitor() ?
                 *plan.planning_scene_monitor_->getStateMonitor()->getCurrentState() :
                 plan.planning_scene_->getCurrentState());
       }
       else
       {
-        plan.plan_components_[i].trajectory_->unwind(plan.plan_components_[prev].trajectory_->getLastWayPoint());
+        plan.plan_components_[component_idx].trajectory_->unwind(
+            plan.plan_components_[prev].trajectory_->getLastWayPoint());
       }
     }
 
-    if (plan.plan_components_[i].trajectory_ && !plan.plan_components_[i].trajectory_->empty())
-      prev = i;
+    if (plan.plan_components_[component_idx].trajectory_ && !plan.plan_components_[component_idx].trajectory_->empty())
+      prev = component_idx;
 
     // convert to message, pass along
     moveit_msgs::msg::RobotTrajectory msg;
-    plan.plan_components_[i].trajectory_->getRobotTrajectoryMsg(msg);
-    if (!trajectory_execution_manager_->push(msg, plan.plan_components_[i].controller_names_))
+    plan.plan_components_[component_idx].trajectory_->getRobotTrajectoryMsg(msg);
+    if (!trajectory_execution_manager_->push(msg, plan.plan_components_[component_idx].controller_names_))
     {
       trajectory_execution_manager_->clear();
       RCLCPP_ERROR(LOGGER, "Apparently trajectory initialization failed");

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -357,7 +357,7 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
     // in the meantime we do a hack:
 
     bool unwound = false;
-    for (std::size_t j = 0; j < i; ++j)
+    for (int j = i - 1; j >= 0; --j)
     {
       // if we ran unwind on a path for the same group
       if (plan.plan_components_[j].trajectory_ &&


### PR DESCRIPTION
### Description
This PR fixes some unwinding/bounds issues for continuous joints.

1. If a trajectory that is being unwound from a reference-state starts (i.e. has an initial waypoint) where the continuous joint has a value above 2PI or below -2PI as could be the case when a trajectory from MTC is generated, I have noticed in a project that I was working on that the `running_offset` can be off by a multiple of 2PI leading to 2PI jumps in the command for that continous joint. This occurs because in the current implementation, the running_offset is not only being calculated using the offset between the reference state and the unwound reference state but also the offset between the initial waypoint (**which may not be unwound**) and the unwound current state which is not valid and is like comparing apples and oranges. To fix this, the initial waypoint of the trajectory also has its bounds enforced so that when it's being compared to the reference value, it's comparing apples to apples. Furthermore, I added logic to ensure that the running_offset takes into account when the unwound reference state and the unwound initial waypoint are not on the same side of PI by adding 2PI or subtracting 2PI accordingly.
2. When `executeAndMonitor` is called, unwinding is not handled properly if there are multiple trajectories within the plan as would happen when executing a task or a serial container from MTC. The way unwinding should work is that the current plan_component's trajectory (item i) should be unwound based on any group-matching previous plan_component's trajectory (item j). The current implementation for some unknown reason is starting at index zero and working up (which is not valid since there could be a matching group plan-component but it might not be the one that precedes component "i") instead of starting at the previous plan compoment and working down.

Fixes #1777 

@AndyZe 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
