### PR TITLE
Bug demo: Add an "unwind()" unit test that currently fails

### DIFF
--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -333,6 +333,24 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryDensity)
   EXPECT_FALSE(robot_trajectory::waypoint_density(*trajectory).has_value());
 }
 
+TEST_F(RobotTrajectoryTestFixture, Unwind)
+{
+  const double EPSILON = 1e-4;
+
+  // An initial joint position needs unwinding
+  {
+    robot_trajectory::RobotTrajectoryPtr trajectory;
+    // After initTestTrajectory, trajectory has 5 waypoints of all-zeroes
+    initTestTrajectory(trajectory);
+    moveit::core::RobotStatePtr& first_waypoint = trajectory->getFirstWayPointPtr();
+    const double random_large_angle = 7.0;  // rad, should unwind to 0.71681469 rad
+    first_waypoint->setVariablePosition("panda_joint1", random_large_angle);
+    first_waypoint->update();
+    trajectory->unwind();
+    EXPECT_NEAR(trajectory->getFirstWayPoint().getVariablePosition("panda_joint1"), 0.71681469, EPSILON);
+  }
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Am I crazy or should this be a very easy test case for [RobotTrajectory unwind()](https://github.com/ros-planning/moveit2/blob/f0d3202d637569ccac5fcc357a37e0d12a077c87/moveit_core/robot_trajectory/src/robot_trajectory.cpp#L158)? I'll try to fix this.
