### PR TITLE
fix: resolve bugs in MoveGroupSequenceAction class

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_action.cpp
@@ -56,7 +56,9 @@ namespace pilz_industrial_motion_planner
 static const rclcpp::Logger LOGGER =
     rclcpp::get_logger("moveit.pilz_industrial_motion_planner.move_group_sequence_action");
 
-MoveGroupSequenceAction::MoveGroupSequenceAction() : MoveGroupCapability("SequenceAction")
+MoveGroupSequenceAction::MoveGroupSequenceAction() : 
+    MoveGroupCapability("SequenceAction"),
+    move_feedback_(std::make_shared<moveit_msgs::action::MoveGroupSequence::Feedback>())
 {
 }
 
@@ -93,7 +95,6 @@ void MoveGroupSequenceAction::executeSequenceCallback(const std::shared_ptr<Move
   // Notify that goal is being executed
   goal_handle_ = goal_handle;
   const auto goal = goal_handle->get_goal();
-  goal_handle->execute();
 
   setMoveState(move_group::PLANNING);
 
@@ -162,7 +163,7 @@ void MoveGroupSequenceAction::executeSequenceCallbackPlanAndExecute(
   opt.replan_delay_ = goal->planning_options.replan_delay;
   opt.before_execution_callback_ = [this] { startMoveExecutionCallback(); };
 
-  [this, &request = goal->request](plan_execution::ExecutableMotionPlan& plan) {
+  opt.plan_callback_ = [this, &request = goal->request](plan_execution::ExecutableMotionPlan& plan) {
     return planUsingSequenceManager(request, plan);
   };
 


### PR DESCRIPTION
### Description

Bugs fixed in MoveGroupSequenceAction class.

### Modifications

1) [Invalid goal_handle transition](https://github.com/MarcoMagriDev/moveit2/commit/312e56e68ca13465463274d19969b410f6fd06aa#diff-786763d71c09b7d98cceb9e9b210f23ae92fea36cee24fa613b2e56b97ae93d2L96)
  `[move_group-1]   what():  goal_handle attempted invalid transition from state EXECUTING with event EXECUTE, at ./src/rcl_action/goal_handle.c:95`

2) [move_feedback_ not initialized](https://github.com/MarcoMagriDev/moveit2/commit/312e56e68ca13465463274d19969b410f6fd06aa#diff-786763d71c09b7d98cceb9e9b210f23ae92fea36cee24fa613b2e56b97ae93d2R61)
  `[move_group-1] Segmentation fault (Address not mapped to object [(nil)])`

3) [plan_callback_ not assigned](https://github.com/MarcoMagriDev/moveit2/commit/312e56e68ca13465463274d19969b410f6fd06aa#diff-786763d71c09b7d98cceb9e9b210f23ae92fea36cee24fa613b2e56b97ae93d2R166)
  `[move_group-1]   what():  bad_function_call`

