### PR TITLE
Minimize use of `this->`

### DIFF
--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/bullet_utils.h
@@ -189,7 +189,7 @@ public:
     clone_cow->m_enabled = m_enabled;
     clone_cow->setBroadphaseHandle(nullptr);
     clone_cow->m_touch_links = m_touch_links;
-    clone_cow->setContactProcessingThreshold(this->getContactProcessingThreshold());
+    clone_cow->setContactProcessingThreshold(getContactProcessingThreshold());
     return clone_cow;
   }
 

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
@@ -559,7 +559,7 @@ CollisionObjectWrapper::CollisionObjectWrapper(const std::string& name, const co
     throw std::exception();
   }
 
-  this->setContactProcessingThreshold(BULLET_DEFAULT_CONTACT_DISTANCE);
+  setContactProcessingThreshold(BULLET_DEFAULT_CONTACT_DISTANCE);
   assert(!name.empty());
 
   if (active)

--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -92,7 +92,7 @@ bool PosedDistanceField::getCollisionSphereGradients(const std::vector<Collision
     Eigen::Vector3d p = sphere_centers[i];
     Eigen::Vector3d grad(0, 0, 0);
     bool in_bounds;
-    double dist = this->getDistanceGradient(p.x(), p.y(), p.z(), grad.x(), grad.y(), grad.z(), in_bounds);
+    double dist = getDistanceGradient(p.x(), p.y(), p.z(), grad.x(), grad.y(), grad.z(), in_bounds);
     if (!in_bounds && grad.norm() > 0)
     {
       // out of bounds

--- a/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
+++ b/moveit_core/distance_field/include/moveit/distance_field/voxel_grid.h
@@ -472,7 +472,7 @@ inline const T& VoxelGrid<T>::operator()(double x, double y, double z) const
 template <typename T>
 inline const T& VoxelGrid<T>::operator()(const Eigen::Vector3d& pos) const
 {
-  return this->operator()(pos.x(), pos.y(), pos.z());
+  return operator()(pos.x(), pos.y(), pos.z());
 }
 
 template <typename T>

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -68,10 +68,10 @@ RobotTrajectory::RobotTrajectory(const RobotTrajectory& other, bool deepcopy)
   *this = other;  // default assignment operator performs a shallow copy
   if (deepcopy)
   {
-    this->waypoints_.clear();
+    waypoints_.clear();
     for (const auto& waypoint : other.waypoints_)
     {
-      this->waypoints_.emplace_back(std::make_shared<moveit::core::RobotState>(*waypoint));
+      waypoints_.emplace_back(std::make_shared<moveit::core::RobotState>(*waypoint));
     }
   }
 }

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/joint_mimic.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/joint_mimic.hpp
@@ -47,7 +47,7 @@ class JointMimic
 public:
   JointMimic()
   {
-    this->reset(0);
+    reset(0);
   }
 
   /** \brief Offset for this joint value from the joint that it mimics */

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_parameters.cpp
@@ -71,10 +71,10 @@ ChompParameters::~ChompParameters() = default;
 void ChompParameters::setRecoveryParams(double learning_rate, double ridge_factor, int planning_time_limit,
                                         int max_iterations)
 {
-  this->learning_rate_ = learning_rate;
-  this->ridge_factor_ = ridge_factor;
-  this->planning_time_limit_ = planning_time_limit;
-  this->max_iterations_ = max_iterations;
+  learning_rate_ = learning_rate;
+  ridge_factor_ = ridge_factor;
+  planning_time_limit_ = planning_time_limit;
+  max_iterations_ = max_iterations;
 }
 
 const std::vector<std::string> ChompParameters::VALID_INITIALIZATION_METHODS{ "quintic-spline", "linear", "cubic",
@@ -85,7 +85,7 @@ bool ChompParameters::setTrajectoryInitializationMethod(std::string method)
   if (std::find(VALID_INITIALIZATION_METHODS.cbegin(), VALID_INITIALIZATION_METHODS.cend(), method) !=
       VALID_INITIALIZATION_METHODS.end())
   {
-    this->trajectory_initialization_method_ = std::move(method);
+    trajectory_initialization_method_ = std::move(method);
     return true;
   }
   return false;

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -407,7 +407,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     cfg.erase(it);
     const std::string planner_name = getGroupName() + "/" + name_;
     ompl_simple_setup_->setPlannerAllocator(
-        [planner_name, &spec = this->spec_, allocator = spec_.planner_selector_(type)](
+        [planner_name, &spec = spec_, allocator = spec_.planner_selector_(type)](
             const ompl::base::SpaceInformationPtr& si) { return allocator(si, planner_name, spec); });
     RCLCPP_INFO(LOGGER,
                 "Planner configuration '%s' will use planner '%s'. "

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -144,7 +144,7 @@ void TrajectoryGenerator::checkStartState(const moveit_msgs::msg::RobotState& st
 
   // does not allow start velocity
   if (!std::all_of(group_start_state.velocity.begin(), group_start_state.velocity.end(),
-                   [this](double v) { return std::fabs(v) < this->VELOCITY_TOLERANCE; }))
+                   [this](double v) { return std::fabs(v) < VELOCITY_TOLERANCE; }))
   {
     throw NonZeroVelocityInStartState("Trajectory Generator does not allow non-zero start velocity");
   }

--- a/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/velocity_profile_atrap.cpp
@@ -384,7 +384,7 @@ double VelocityProfileATrap::Acc(double time) const
 KDL::VelocityProfile* VelocityProfileATrap::Clone() const
 {
   VelocityProfileATrap* trap = new VelocityProfileATrap(max_vel_, max_acc_, max_dec_);
-  trap->setProfileAllDurations(this->start_pos_, this->end_pos_, this->t_a_, this->t_b_, this->t_c_);
+  trap->setProfileAllDurations(start_pos_, end_pos_, t_a_, t_b_, t_c_);
   return trap;
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/basecmd.h
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/basecmd.h
@@ -112,13 +112,13 @@ planning_interface::MotionPlanRequest BaseCmd<StartType, GoalType>::toRequest() 
 {
   planning_interface::MotionPlanRequest req;
   req.planner_id = getPlannerId();
-  req.group_name = this->planning_group_;
+  req.group_name = planning_group_;
 
-  req.max_velocity_scaling_factor = this->vel_scale_;
-  req.max_acceleration_scaling_factor = this->acc_scale_;
+  req.max_velocity_scaling_factor = vel_scale_;
+  req.max_acceleration_scaling_factor = acc_scale_;
 
-  req.start_state = this->start_.toMoveitMsgsRobotState();
-  req.goal_constraints.push_back(this->goal_.toGoalConstraints());
+  req.start_state = start_.toMoveitMsgsRobotState();
+  req.goal_constraints.push_back(goal_.toGoalConstraints());
 
   return req;
 }

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -49,14 +49,14 @@ HybridPlanningManager::HybridPlanningManager(const rclcpp::NodeOptions& options)
 {
   // Initialize hybrid planning component after construction
   // TODO(sjahr) Remove once life cycle component nodes are available
-  timer_ = this->create_wall_timer(1ms, [this]() {
+  timer_ = create_wall_timer(1ms, [this]() {
     if (initialized_)
     {
       timer_->cancel();
     }
     else
     {
-      if (!this->initialize())
+      if (!initialize())
       {
         const std::string error = "Failed to initialize global planner";
         timer_->cancel();
@@ -81,14 +81,14 @@ bool HybridPlanningManager::initialize()
   }
   // TODO(sjahr) Refactor parameter declaration and use repository wide solution
   std::string logic_plugin_name = "";
-  if (this->has_parameter("planner_logic_plugin_name"))
+  if (has_parameter("planner_logic_plugin_name"))
   {
-    this->get_parameter<std::string>("planner_logic_plugin_name", logic_plugin_name);
+    get_parameter<std::string>("planner_logic_plugin_name", logic_plugin_name);
   }
   else
   {
-    logic_plugin_name = this->declare_parameter<std::string>("planner_logic_plugin_name",
-                                                             "moveit::hybrid_planning/ReplanInvalidatedTrajectory");
+    logic_plugin_name = declare_parameter<std::string>("planner_logic_plugin_name",
+                                                       "moveit::hybrid_planning/ReplanInvalidatedTrajectory");
   }
   try
   {
@@ -105,8 +105,8 @@ bool HybridPlanningManager::initialize()
   }
 
   // Initialize local planning action client
-  std::string local_planning_action_name = this->declare_parameter<std::string>("local_planning_action_name", "");
-  this->get_parameter<std::string>("local_planning_action_name", local_planning_action_name);
+  std::string local_planning_action_name = declare_parameter<std::string>("local_planning_action_name", "");
+  get_parameter<std::string>("local_planning_action_name", local_planning_action_name);
   if (local_planning_action_name.empty())
   {
     RCLCPP_ERROR(LOGGER, "local_planning_action_name parameter was not defined");
@@ -121,8 +121,8 @@ bool HybridPlanningManager::initialize()
   }
 
   // Initialize global planning action client
-  std::string global_planning_action_name = this->declare_parameter<std::string>("global_planning_action_name", "");
-  this->get_parameter<std::string>("global_planning_action_name", global_planning_action_name);
+  std::string global_planning_action_name = declare_parameter<std::string>("global_planning_action_name", "");
+  get_parameter<std::string>("global_planning_action_name", global_planning_action_name);
   if (global_planning_action_name.empty())
   {
     RCLCPP_ERROR(LOGGER, "global_planning_action_name parameter was not defined");
@@ -137,17 +137,17 @@ bool HybridPlanningManager::initialize()
   }
 
   // Initialize hybrid planning action server
-  std::string hybrid_planning_action_name = this->declare_parameter<std::string>("hybrid_planning_action_name", "");
-  this->get_parameter<std::string>("hybrid_planning_action_name", hybrid_planning_action_name);
+  std::string hybrid_planning_action_name = declare_parameter<std::string>("hybrid_planning_action_name", "");
+  get_parameter<std::string>("hybrid_planning_action_name", hybrid_planning_action_name);
   if (hybrid_planning_action_name.empty())
   {
     RCLCPP_ERROR(LOGGER, "hybrid_planning_action_name parameter was not defined");
     return false;
   }
-  cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  cb_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   hybrid_planning_request_server_ = rclcpp_action::create_server<moveit_msgs::action::HybridPlanner>(
-      this->get_node_base_interface(), this->get_node_clock_interface(), this->get_node_logging_interface(),
-      this->get_node_waitables_interface(), hybrid_planning_action_name,
+      get_node_base_interface(), get_node_clock_interface(), get_node_logging_interface(),
+      get_node_waitables_interface(), hybrid_planning_action_name,
       // Goal callback
       [](const rclcpp_action::GoalUUID& /*unused*/,
          const std::shared_ptr<const moveit_msgs::action::HybridPlanner::Goal>& /*unused*/) {

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -60,7 +60,7 @@ LocalPlannerComponent::LocalPlannerComponent(const rclcpp::NodeOptions& options)
   state_ = LocalPlannerState::UNCONFIGURED;
   local_planner_feedback_ = std::make_shared<moveit_msgs::action::LocalPlanner::Feedback>();
 
-  if (!this->initialize())
+  if (!initialize())
   {
     throw std::runtime_error("Failed to initialize local planner component");
   }

--- a/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
+++ b/moveit_ros/moveit_servo/src/teleop_demo/joystick_servo_example.cpp
@@ -168,17 +168,17 @@ public:
     : Node("joy_to_twist_publisher", options), frame_to_publish_(BASE_FRAME_ID)
   {
     // Setup pub/sub
-    joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
-        JOY_TOPIC, rclcpp::SystemDefaultsQoS(),
-        [this](const sensor_msgs::msg::Joy::ConstSharedPtr& msg) { return joyCB(msg); });
+    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(JOY_TOPIC, rclcpp::SystemDefaultsQoS(),
+                                                          [this](const sensor_msgs::msg::Joy::ConstSharedPtr& msg) {
+                                                            return joyCB(msg);
+                                                          });
 
-    twist_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(TWIST_TOPIC, rclcpp::SystemDefaultsQoS());
-    joint_pub_ = this->create_publisher<control_msgs::msg::JointJog>(JOINT_TOPIC, rclcpp::SystemDefaultsQoS());
-    collision_pub_ =
-        this->create_publisher<moveit_msgs::msg::PlanningScene>("/planning_scene", rclcpp::SystemDefaultsQoS());
+    twist_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>(TWIST_TOPIC, rclcpp::SystemDefaultsQoS());
+    joint_pub_ = create_publisher<control_msgs::msg::JointJog>(JOINT_TOPIC, rclcpp::SystemDefaultsQoS());
+    collision_pub_ = create_publisher<moveit_msgs::msg::PlanningScene>("/planning_scene", rclcpp::SystemDefaultsQoS());
 
     // Create a service client to start the ServoNode
-    servo_start_client_ = this->create_client<std_srvs::srv::Trigger>("/servo_node/start_servo");
+    servo_start_client_ = create_client<std_srvs::srv::Trigger>("/servo_node/start_servo");
     servo_start_client_->wait_for_service(std::chrono::seconds(1));
     servo_start_client_->async_send_request(std::make_shared<std_srvs::srv::Trigger::Request>());
 
@@ -244,13 +244,13 @@ public:
     {
       // publish the TwistStamped
       twist_msg->header.frame_id = frame_to_publish_;
-      twist_msg->header.stamp = this->now();
+      twist_msg->header.stamp = now();
       twist_pub_->publish(std::move(twist_msg));
     }
     else
     {
       // publish the JointJog
-      joint_msg->header.stamp = this->now();
+      joint_msg->header.stamp = now();
       joint_msg->header.frame_id = "panda_link3";
       joint_pub_->publish(std::move(joint_msg));
     }

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -74,7 +74,7 @@ public:
   {
     ASSERT_TRUE(servo_parameters_.get() != nullptr);
     executor_->add_node(node_);
-    executor_thread_ = std::thread([this]() { this->executor_->spin(); });
+    executor_thread_ = std::thread([this]() { executor_->spin(); });
   }
 
   ServoFixture()

--- a/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/gil_releaser.h
+++ b/moveit_ros/planning_interface/py_bindings_tools/include/moveit/py_bindings_tools/gil_releaser.h
@@ -82,7 +82,7 @@ public:
   GILReleaser& operator=(GILReleaser&& other) noexcept
   {
     GILReleaser copy(std::move(other));
-    this->swap(copy);
+    swap(copy);
     return *this;
   }
 

--- a/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp
@@ -76,7 +76,7 @@ public:
     ee_link_ = move_group_->getEndEffectorLink();
 
     executor_->add_node(node_);
-    executor_thread_ = std::thread([this]() { this->executor_->spin(); });
+    executor_thread_ = std::thread([this]() { executor_->spin(); });
   }
 
   ConstrainedPlanningTestFixture()

--- a/moveit_ros/robot_interaction/src/interaction_handler.cpp
+++ b/moveit_ros/robot_interaction/src/interaction_handler.cpp
@@ -293,7 +293,7 @@ void InteractionHandler::updateStateGeneric(
   bool error_state_changed = setErrorState(g.marker_name_suffix, !ok);
   if (update_callback_)
   {
-    callback = [cb = this->update_callback_, error_state_changed](robot_interaction::InteractionHandler* handler) {
+    callback = [cb = update_callback_, error_state_changed](robot_interaction::InteractionHandler* handler) {
       cb(handler, error_state_changed);
     };
   }
@@ -311,7 +311,7 @@ void InteractionHandler::updateStateEndEffector(moveit::core::RobotState& state,
   bool error_state_changed = setErrorState(eef.parent_group, !ok);
   if (update_callback_)
   {
-    callback = [cb = this->update_callback_, error_state_changed](robot_interaction::InteractionHandler* handler) {
+    callback = [cb = update_callback_, error_state_changed](robot_interaction::InteractionHandler* handler) {
       cb(handler, error_state_changed);
     };
   }
@@ -332,7 +332,7 @@ void InteractionHandler::updateStateJoint(moveit::core::RobotState& state, const
   state.update();
 
   if (update_callback_)
-    callback = [cb = this->update_callback_](robot_interaction::InteractionHandler* handler) { cb(handler, false); };
+    callback = [cb = update_callback_](robot_interaction::InteractionHandler* handler) { cb(handler, false); };
 }
 
 bool InteractionHandler::inError(const EndEffectorInteraction& eef) const

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -239,7 +239,7 @@ void MotionPlanningDisplay::onInitialize()
   rviz_common::WindowManagerInterface* window_context = context_->getWindowManager();
   frame_ = new MotionPlanningFrame(this, context_, window_context ? window_context->getParentWindow() : nullptr);
 
-  connect(frame_, SIGNAL(configChanged()), this->getModel(), SIGNAL(configChanged()));
+  connect(frame_, SIGNAL(configChanged()), getModel(), SIGNAL(configChanged()));
   resetStatusTextColor();
   addStatusText("Initialized.");
 
@@ -311,7 +311,7 @@ void MotionPlanningDisplay::reset()
   // Planned Path Display
   trajectory_visual_->reset();
 
-  bool enabled = this->isEnabled();
+  bool enabled = isEnabled();
   frame_->disable();
   if (enabled)
   {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -503,7 +503,7 @@ ProgressBarEditor::ProgressBarEditor(QWidget* parent, float min, float max, int 
 {
   // if left mouse button is pressed, grab all future mouse events until button(s) released
   if (QApplication::mouseButtons() & Qt::LeftButton)
-    this->grabMouse();
+    grabMouse();
 }
 
 void ProgressBarEditor::paintEvent(QPaintEvent* /*event*/)
@@ -512,7 +512,7 @@ void ProgressBarEditor::paintEvent(QPaintEvent* /*event*/)
 
   QStyleOptionProgressBar opt;
   opt.rect = rect();
-  opt.palette = this->palette();
+  opt.palette = palette();
   opt.minimum = 0;
   opt.maximum = 1000;
   opt.progress = 1000. * (value_ - min_) / (max_ - min_);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_param_widget.cpp
@@ -67,7 +67,7 @@ void MotionPlanningParamWidget::setMoveGroup(const mpi::MoveGroupInterfacePtr& m
 void MotionPlanningParamWidget::setGroupName(const std::string& group_name)
 {
   group_name_ = group_name;
-  this->setModel(nullptr);
+  setModel(nullptr);
   if (property_tree_model_)
     delete property_tree_model_;
   property_tree_model_ = nullptr;
@@ -134,7 +134,7 @@ void MotionPlanningParamWidget::setPlannerId(const std::string& planner_id)
   rviz_common::properties::PropertyTreeModel* old_model = property_tree_model_;
   rviz_common::properties::Property* root = createPropertyTree();
   property_tree_model_ = root ? new rviz_common::properties::PropertyTreeModel(root) : nullptr;
-  this->setModel(property_tree_model_);
+  setModel(property_tree_model_);
   if (old_model)
     delete old_model;
 }

--- a/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -80,11 +80,11 @@ void TrajectoryDisplay::loadRobotModel()
 
     if (!rdf_loader_->getURDF())
     {
-      this->setStatus(rviz_common::properties::StatusProperty::Error, "Robot Model",
-                      "Failed to load from parameter " + robot_description_property_->getString());
+      setStatus(rviz_common::properties::StatusProperty::Error, "Robot Model",
+                "Failed to load from parameter " + robot_description_property_->getString());
       return;
     }
-    this->setStatus(rviz_common::properties::StatusProperty::Ok, "Robot Model", "Successfully loaded");
+    setStatus(rviz_common::properties::StatusProperty::Ok, "Robot Model", "Successfully loaded");
 
     const srdf::ModelSharedPtr& srdf =
         rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : std::make_shared<srdf::Model>();

--- a/moveit_setup_assistant/moveit_setup_app_plugins/src/launches_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/src/launches_widget.cpp
@@ -85,7 +85,7 @@ void LaunchesWidget::onInit()
   layout->addWidget(splitter);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 unsigned int getID(QListWidgetItem* item)

--- a/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/src/perception_widget.cpp
@@ -196,7 +196,7 @@ void PerceptionWidget::onInit()
   layout->setAlignment(Qt::AlignTop);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
@@ -71,7 +71,7 @@ SetupAssistantWidget::SetupAssistantWidget(const rviz_common::ros_integration::R
 
   // Setting the window icon
   auto icon_path = getSharePath("moveit_ros_visualization") / "icons/classes/MotionPlanning.png";
-  this->setWindowIcon(QIcon(icon_path.c_str()));
+  setWindowIcon(QIcon(icon_path.c_str()));
 
   // Basic widget container -----------------------------------------
   QHBoxLayout* layout = new QHBoxLayout();
@@ -157,10 +157,10 @@ SetupAssistantWidget::SetupAssistantWidget(const rviz_common::ros_integration::R
   connect(navs_view_, SIGNAL(clicked(const QModelIndex&)), this, SLOT(navigationClicked(const QModelIndex&)));
 
   // Final Layout Setup ---------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 
   // Title
-  this->setWindowTitle("MoveIt Setup Assistant");  // title of window
+  setWindowTitle("MoveIt Setup Assistant");  // title of window
 
   // Show screen before message
   QApplication::processEvents();

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
@@ -163,7 +163,7 @@ ControllerEditWidget::ControllerEditWidget(QWidget* parent, const FieldPointers&
   layout->addLayout(controls_layout);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers_widget.cpp
@@ -73,7 +73,7 @@ void ControllersWidget::onInit()
   layout->setAlignment(Qt::AlignTop);
 
   // Title
-  this->setWindowTitle("Controller Configuration");  // title of window
+  setWindowTitle("Controller Configuration");  // title of window
 
   // Top Header Area ------------------------------------------------
   auto header = new HeaderWidget("Setup " + setup_step_->getName(), setup_step_->getInstructions(), this);
@@ -112,7 +112,7 @@ void ControllersWidget::onInit()
   stacked_widget_->addWidget(joint_groups_widget_);      // screen index 3
   layout->addWidget(stacked_widget_);
 
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_controllers/src/urdf_modifications_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/urdf_modifications_widget.cpp
@@ -60,7 +60,7 @@ void UrdfModificationsWidget::onInit()
   content_widget_ = new QWidget(this);
   layout->addWidget(content_widget_);
 
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 QWidget* UrdfModificationsWidget::makeInterfacesBox(const std::string& interface_type,

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/author_information_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/author_information_widget.cpp
@@ -82,7 +82,7 @@ void AuthorInformationWidget::onInit()
   layout->addWidget(email_edit_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************
@@ -91,18 +91,18 @@ void AuthorInformationWidget::onInit()
 void AuthorInformationWidget::focusGiven()
 {
   // Allow list box to populate
-  this->name_edit_->setText(QString::fromStdString(setup_step_.getAuthorName()));
-  this->email_edit_->setText(QString::fromStdString(setup_step_.getAuthorEmail()));
+  name_edit_->setText(QString::fromStdString(setup_step_.getAuthorName()));
+  email_edit_->setText(QString::fromStdString(setup_step_.getAuthorEmail()));
 }
 
 void AuthorInformationWidget::editedName()
 {
-  setup_step_.setAuthorName(this->name_edit_->text().toStdString());
+  setup_step_.setAuthorName(name_edit_->text().toStdString());
 }
 
 void AuthorInformationWidget::editedEmail()
 {
-  setup_step_.setAuthorEmail(this->email_edit_->text().toStdString());
+  setup_step_.setAuthorEmail(email_edit_->text().toStdString());
 }
 
 }  // namespace core

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
@@ -174,7 +174,7 @@ void ConfigurationFilesWidget::onInit()
   layout->addLayout(hlayout3);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 void ConfigurationFilesWidget::setCheckSelected(bool checked)

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
@@ -178,7 +178,7 @@ void StartScreenWidget::onInit()
   layout->addLayout(load_files_layout);
 
   setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-  this->setLayout(layout);
+  setLayout(layout);
 
   // Debug mode: auto load the configuration file by clicking button after a timeout
   if (debug_)

--- a/moveit_setup_assistant/moveit_setup_framework/src/double_list_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/double_list_widget.cpp
@@ -163,7 +163,7 @@ DoubleListWidget::DoubleListWidget(QWidget* parent, const QString& long_name, co
   }
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_framework/src/helper_widgets.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/helper_widgets.cpp
@@ -74,10 +74,10 @@ HeaderWidget::HeaderWidget(const std::string& title, const std::string& instruct
   // Margin on bottom
   layout->setContentsMargins(0, 0, 0, 0);  // last 15
 
-  this->setLayout(layout);
+  setLayout(layout);
 
   // For some reason, this style sheet setting affects the placement layout!?
-  this->setStyleSheet(QString("background-color:%1;").arg(QWidget::palette().color(QWidget::backgroundRole()).name()));
+  setStyleSheet(QString("background-color:%1;").arg(QWidget::palette().color(QWidget::backgroundRole()).name()));
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_simulation/src/simulation_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_simulation/src/simulation_widget.cpp
@@ -122,7 +122,7 @@ void SimulationWidget::onInit()
   layout->addWidget(copy_urdf_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 void SimulationWidget::focusGiven()

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
@@ -58,7 +58,7 @@ QModelIndex CollisionLinearModel::mapFromSource(const QModelIndex& sourceIndex) 
   // map (row,column) index to linear index k
   // http://stackoverflow.com/questions/27086195/linear-index-upper-triangular-matrix
   int r = sourceIndex.row(), c = sourceIndex.column();
-  int n = this->sourceModel()->columnCount();
+  int n = sourceModel()->columnCount();
   if (r == c)
     return QModelIndex();  // main diagonal elements are invalid
   if (r > c)               // only consider upper triagonal matrix
@@ -81,7 +81,7 @@ QModelIndex CollisionLinearModel::mapToSource(const QModelIndex& proxyIndex) con
 
 int CollisionLinearModel::rowCount(const QModelIndex& /*parent*/) const
 {
-  int n = this->sourceModel()->rowCount();
+  int n = sourceModel()->rowCount();
   return (n * (n - 1) / 2);
 }
 
@@ -102,7 +102,7 @@ QModelIndex CollisionLinearModel::parent(const QModelIndex& /*child*/) const
 
 QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
 {
-  QModelIndex src_index = this->mapToSource(index);
+  QModelIndex src_index = mapToSource(index);
   switch (index.column())
   {
     case 0:  // link name 1
@@ -112,12 +112,12 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
       }
       else
       {
-        return this->sourceModel()->headerData(src_index.row(), Qt::Horizontal, Qt::DisplayRole);
+        return sourceModel()->headerData(src_index.row(), Qt::Horizontal, Qt::DisplayRole);
       }
     case 1:  // link name 2
       if (role != Qt::DisplayRole)
         return QVariant();
-      return this->sourceModel()->headerData(src_index.column(), Qt::Vertical, Qt::DisplayRole);
+      return sourceModel()->headerData(src_index.column(), Qt::Vertical, Qt::DisplayRole);
     case 2:  // checkbox
       if (role != Qt::CheckStateRole)
       {
@@ -125,7 +125,7 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
       }
       else
       {
-        return this->sourceModel()->data(src_index, Qt::CheckStateRole);
+        return sourceModel()->data(src_index, Qt::CheckStateRole);
       }
     case 3:  // reason
       if (role != Qt::DisplayRole)
@@ -134,7 +134,7 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
       }
       else
       {
-        return this->sourceModel()->data(src_index, Qt::ToolTipRole);
+        return sourceModel()->data(src_index, Qt::ToolTipRole);
       }
   }
   return QVariant();
@@ -142,13 +142,13 @@ QVariant CollisionLinearModel::data(const QModelIndex& index, int role) const
 
 DisabledReason CollisionLinearModel::reason(int row) const
 {
-  QModelIndex src_index = this->mapToSource(index(row, 0));
+  QModelIndex src_index = mapToSource(index(row, 0));
   return qobject_cast<CollisionMatrixModel*>(sourceModel())->reason(src_index);
 }
 
 bool CollisionLinearModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
-  QModelIndex src_index = this->mapToSource(index);
+  QModelIndex src_index = mapToSource(index);
 
   if (role == Qt::CheckStateRole)
   {
@@ -264,7 +264,7 @@ bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& s
         m->data(m->index(source_row, 2), Qt::CheckStateRole) == Qt::Checked))
     return false;  // not accepted due to check state
 
-  const QRegExp regexp = this->filterRegExp();
+  const QRegExp regexp = filterRegExp();
   if (regexp.isEmpty())
     return true;
 

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/end_effectors_widget.cpp
@@ -89,7 +89,7 @@ void EndEffectorsWidget::onInit()
   layout->addWidget(stacked_widget_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/group_edit_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/group_edit_widget.cpp
@@ -219,7 +219,7 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, PlanningGroups& setup_step) : 
   layout->addLayout(controls_layout);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/kinematic_chain_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/kinematic_chain_widget.cpp
@@ -131,7 +131,7 @@ KinematicChainWidget::KinematicChainWidget(QWidget* parent, RVizPanel* rviz_pane
   layout->addLayout(controls_layout);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 
   // Remember that we have no loaded the chains yet
   kinematic_chain_loaded_ = false;

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/passive_joints_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/passive_joints_widget.cpp
@@ -78,7 +78,7 @@ void PassiveJointsWidget::onInit()
   layout->addWidget(joints_widget_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/robot_poses_widget.cpp
@@ -87,7 +87,7 @@ void RobotPosesWidget::onInit()
   layout->addWidget(stacked_widget_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************
@@ -761,10 +761,10 @@ SliderWidget::SliderWidget(QWidget* parent, const moveit::core::JointModel* join
   // Finish GUI ----------------------------------------
   layout->addLayout(row2);
 
-  this->setContentsMargins(0, 0, 0, 0);
-  // this->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Preferred );
-  this->setGeometry(QRect(110, 80, 120, 80));
-  this->setLayout(layout);
+  setContentsMargins(0, 0, 0, 0);
+  // setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Preferred );
+  setGeometry(QRect(110, 80, 120, 80));
+  setLayout(layout);
 
   // Declare std::string as metatype so we can use it in a signal
   qRegisterMetaType<std::string>("std::string");

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/virtual_joints_widget.cpp
@@ -74,7 +74,7 @@ void VirtualJointsWidget::onInit()
   layout->addWidget(stacked_widget_);
 
   // Finish Layout --------------------------------------------------
-  this->setLayout(layout);
+  setLayout(layout);
 }
 
 // ******************************************************************************************


### PR DESCRIPTION
### Description

Using the `this` pointer is often unnecessary. MoveIt already avoids this in most cases so this PR better cements that existing pattern. In some places it must remain because a method parameter shadows a function we're trying to call so removing `this->` causes the build to break.
