### PR TITLE
Install moveit_core headers within additional moveit_core directory

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -55,34 +55,6 @@ include(ConfigExtras.cmake)
 # Set target file path for version.h
 set(VERSION_FILE_PATH ${CMAKE_BINARY_DIR}/include)
 
-set(THIS_PACKAGE_INCLUDE_DIRS
-    exceptions/include
-    collision_detection/include
-    collision_detection_fcl/include
-    collision_detection_bullet/include
-    constraint_samplers/include
-    controller_manager/include
-    distance_field/include
-    collision_distance_field/include
-    dynamics_solver/include
-    kinematics_base/include
-    kinematics_metrics/include
-    robot_model/include
-    transforms/include
-    robot_state/include
-    robot_trajectory/include
-    kinematic_constraints/include
-    macros/include
-    online_signal_smoothing/include
-    planning_interface/include
-    planning_request_adapter/include
-    planning_scene/include
-    # TODO: Port python bindings
-    # python/tools/include
-    trajectory_processing/include
-    utils/include
-)
-
 set(THIS_PACKAGE_LIBRARIES
     moveit_butterworth_filter
     moveit_collision_distance_field
@@ -96,6 +68,7 @@ set(THIS_PACKAGE_LIBRARIES
     moveit_kinematics_base
     moveit_kinematic_constraints
     moveit_kinematics_metrics
+    moveit_macros
     moveit_planning_interface
     moveit_planning_scene
     moveit_planning_request_adapter
@@ -134,13 +107,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   Bullet
   ruckig
 )
-
-include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
-  ${LIBFCL_INCLUDE_DIRS}
-)
-
-include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
-                    ${VERSION_FILE_PATH})
 
 # Generate and install version.h
 string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" MOVEIT_VERSION_MAJOR "${${PROJECT_NAME}_VERSION}")

--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(moveit_collision_detection SHARED
   src/collision_env.cpp
   src/collision_plugin_cache.cpp
 )
+target_include_directories(moveit_collision_detection PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 include(GenerateExportHeader)
 generate_export_header(moveit_collision_detection)
 
@@ -54,5 +58,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_all_valid moveit_collision_detection moveit_robot_model)
 endif()
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_export.h DESTINATION include/moveit_core)

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -7,6 +7,10 @@ add_library(moveit_collision_detection_bullet SHARED
   src/bullet_integration/contact_checker_common.cpp
   src/bullet_integration/ros_bullet_utils.cpp
 )
+target_include_directories(moveit_collision_detection_bullet PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 include(GenerateExportHeader)
 generate_export_header(moveit_collision_detection_bullet)
 target_include_directories(moveit_collision_detection_bullet PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
@@ -45,8 +49,8 @@ target_link_libraries(collision_detector_bullet_plugin
   moveit_planning_scene
 )
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_bullet_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_bullet_export.h DESTINATION include/moveit_core)
 install(TARGETS moveit_collision_detection_bullet collision_detector_bullet_plugin EXPORT export_moveit_collision_detection_bullet
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -2,6 +2,10 @@ add_library(moveit_collision_detection_fcl SHARED
   src/collision_common.cpp
   src/collision_env_fcl.cpp
 )
+target_include_directories(moveit_collision_detection_fcl PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 include(GenerateExportHeader)
 generate_export_header(moveit_collision_detection_fcl)
 target_include_directories(moveit_collision_detection_fcl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
@@ -33,8 +37,8 @@ target_link_libraries(collision_detector_fcl_plugin
   moveit_planning_scene
 )
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_fcl_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_fcl_export.h DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   if(WIN32)

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(moveit_collision_distance_field SHARED
   src/collision_env_distance_field.cpp
   src/collision_env_hybrid.cpp
 )
+target_include_directories(moveit_collision_distance_field PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 include(GenerateExportHeader)
 generate_export_header(moveit_collision_distance_field)
 target_include_directories(moveit_collision_distance_field PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
@@ -24,8 +28,8 @@ target_link_libraries(moveit_collision_distance_field
   moveit_robot_state
 )
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_distance_field_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_distance_field_export.h DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(moveit_constraint_samplers SHARED
   src/default_constraint_samplers.cpp
   src/union_constraint_sampler.cpp
 )
+target_include_directories(moveit_constraint_samplers PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_constraint_samplers PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_constraint_samplers
   urdf
@@ -20,7 +24,7 @@ target_link_libraries(moveit_constraint_samplers
   moveit_planning_scene
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/moveit_core/controller_manager/CMakeLists.txt
+++ b/moveit_core/controller_manager/CMakeLists.txt
@@ -1,1 +1,1 @@
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -3,7 +3,11 @@ add_library(moveit_distance_field SHARED
   src/find_internal_points.cpp
   src/propagation_distance_field.cpp
 )
-
+target_include_directories(moveit_distance_field PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
+target_link_libraries(moveit_distance_field moveit_macros)
 set_target_properties(moveit_distance_field PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_distance_field
   Boost
@@ -15,7 +19,7 @@ ament_target_dependencies(moveit_distance_field
   OCTOMAP
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_core/dynamics_solver/CMakeLists.txt
+++ b/moveit_core/dynamics_solver/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_dynamics_solver SHARED src/dynamics_solver.cpp)
+target_include_directories(moveit_dynamics_solver PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_dynamics_solver PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 ament_target_dependencies(moveit_dynamics_solver
@@ -12,4 +16,4 @@ target_link_libraries(moveit_dynamics_solver
   moveit_robot_state
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/exceptions/CMakeLists.txt
+++ b/moveit_core/exceptions/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_exceptions SHARED src/exceptions.cpp)
+target_include_directories(moveit_exceptions PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_exceptions PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_exceptions
   Boost
@@ -7,4 +11,4 @@ ament_target_dependencies(moveit_exceptions
   urdfdom_headers
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -8,7 +8,10 @@ add_library(moveit_kinematic_constraints SHARED
   src/kinematic_constraint.cpp
   src/utils.cpp
 )
-
+target_include_directories(moveit_kinematic_constraints PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_kinematic_constraints PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 ament_target_dependencies(moveit_kinematic_constraints
@@ -29,7 +32,7 @@ target_link_libraries(moveit_kinematic_constraints
   moveit_utils
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required(VERSION 3.22)
-
 add_library(moveit_kinematics_base SHARED src/kinematics_base.cpp)
+target_include_directories(moveit_kinematics_base PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
+target_link_libraries(moveit_kinematics_base moveit_macros moveit_robot_model)
 include(GenerateExportHeader)
 generate_export_header(moveit_kinematics_base)
 target_include_directories(moveit_kinematics_base PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)  # for this library
@@ -16,5 +19,5 @@ ament_target_dependencies(
   geometry_msgs
 )
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_kinematics_base_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_kinematics_base_export.h DESTINATION include/moveit_core)

--- a/moveit_core/kinematics_metrics/CMakeLists.txt
+++ b/moveit_core/kinematics_metrics/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_kinematics_metrics SHARED src/kinematics_metrics.cpp)
+target_include_directories(moveit_kinematics_metrics PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_kinematics_metrics PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 ament_target_dependencies(moveit_kinematics_metrics
@@ -11,4 +15,4 @@ target_link_libraries(moveit_kinematics_metrics
   moveit_robot_state
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/macros/CMakeLists.txt
+++ b/moveit_core/macros/CMakeLists.txt
@@ -1,1 +1,7 @@
-install(DIRECTORY include/ DESTINATION include)
+add_library(moveit_macros INTERFACE)
+target_include_directories(moveit_macros INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
+
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -1,45 +1,46 @@
 # Base class
-set(SMOOTHING_BASE_LIB moveit_smoothing_base)
-add_library(${SMOOTHING_BASE_LIB} SHARED
+add_library(moveit_smoothing_base SHARED
   src/smoothing_base_class.cpp
 )
-include(GenerateExportHeader)
-generate_export_header(${SMOOTHING_BASE_LIB})
-target_include_directories(${SMOOTHING_BASE_LIB} PUBLIC
+target_include_directories(moveit_smoothing_base PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include/moveit_core>
 )
-set_target_properties(${SMOOTHING_BASE_LIB} PROPERTIES VERSION
+target_link_libraries(moveit_smoothing_base moveit_macros)
+include(GenerateExportHeader)
+generate_export_header(moveit_smoothing_base)
+set_target_properties(moveit_smoothing_base PROPERTIES VERSION
   "${${PROJECT_NAME}_VERSION}"
 )
-ament_target_dependencies(${SMOOTHING_BASE_LIB}
+ament_target_dependencies(moveit_smoothing_base
   rclcpp
 )
 
 # Plugin implementations
-set(BUTTERWORTH_FILTER_LIB moveit_butterworth_filter)
-add_library(${BUTTERWORTH_FILTER_LIB} SHARED
+add_library(moveit_butterworth_filter SHARED
   src/butterworth_filter.cpp
 )
-generate_export_header(${BUTTERWORTH_FILTER_LIB})
-target_include_directories(${BUTTERWORTH_FILTER_LIB} PUBLIC
+generate_export_header(moveit_butterworth_filter)
+target_include_directories(moveit_butterworth_filter PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-set_target_properties(${BUTTERWORTH_FILTER_LIB} PROPERTIES VERSION
+set_target_properties(moveit_butterworth_filter PROPERTIES VERSION
   "${${PROJECT_NAME}_VERSION}"
 )
-target_link_libraries(${BUTTERWORTH_FILTER_LIB}
-  ${SMOOTHING_BASE_LIB}
+target_link_libraries(moveit_butterworth_filter
+  moveit_smoothing_base
   moveit_robot_model
 )
-ament_target_dependencies(${BUTTERWORTH_FILTER_LIB}
+ament_target_dependencies(moveit_butterworth_filter
   srdfdom  # include dependency from moveit_robot_model
 )
 
 # Installation
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${SMOOTHING_BASE_LIB}_export.h DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BUTTERWORTH_FILTER_LIB}_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_smoothing_base_export.h DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_butterworth_filter_export.h DESTINATION include/moveit_core)
 
 # Testing
 
@@ -49,5 +50,5 @@ if(BUILD_TESTING)
 
   # Lowpass filter unit test
   ament_add_gtest(test_butterworth_filter test/test_butterworth_filter.cpp)
-  target_link_libraries(test_butterworth_filter ${BUTTERWORTH_FILTER_LIB})
+  target_link_libraries(test_butterworth_filter moveit_butterworth_filter)
 endif()

--- a/moveit_core/planning_interface/CMakeLists.txt
+++ b/moveit_core/planning_interface/CMakeLists.txt
@@ -2,6 +2,10 @@ add_library(moveit_planning_interface SHARED
   src/planning_interface.cpp
   src/planning_response.cpp
 )
+target_include_directories(moveit_planning_interface PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_planning_interface PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_planning_interface
   moveit_msgs
@@ -12,6 +16,7 @@ ament_target_dependencies(moveit_planning_interface
 target_link_libraries(moveit_planning_interface
   moveit_robot_trajectory
   moveit_robot_state
+  moveit_utils
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/planning_request_adapter/CMakeLists.txt
+++ b/moveit_core/planning_request_adapter/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_planning_request_adapter SHARED src/planning_request_adapter.cpp)
+target_include_directories(moveit_planning_request_adapter PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_planning_request_adapter PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_planning_request_adapter
   rclcpp
@@ -10,6 +14,7 @@ ament_target_dependencies(moveit_planning_request_adapter
 )
 target_link_libraries(moveit_planning_request_adapter
   moveit_planning_scene
+  moveit_planning_interface
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_planning_scene SHARED src/planning_scene.cpp)
+target_include_directories(moveit_planning_scene PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 include(GenerateExportHeader)
 generate_export_header(moveit_planning_scene)
 target_include_directories(moveit_planning_scene PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
@@ -26,8 +30,8 @@ target_link_libraries(moveit_planning_scene
   moveit_utils
 )
 
-install(DIRECTORY include/ DESTINATION include)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_planning_scene_export.h DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_planning_scene_export.h DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_core/python/tools/CMakeLists.txt
+++ b/moveit_core/python/tools/CMakeLists.txt
@@ -12,4 +12,4 @@ install(
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.22)
-
 add_library(moveit_robot_model SHARED
   src/aabb.cpp
   src/fixed_joint_model.cpp
@@ -11,6 +9,12 @@ add_library(moveit_robot_model SHARED
   src/prismatic_joint_model.cpp
   src/revolute_joint_model.cpp
   src/robot_model.cpp
+)
+target_include_directories(moveit_robot_model PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/kinematics_base/include> # Work around cyclic dependency between this and kinematics base
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/kinematics_base> # Ditto but for finding the export header
+  $<INSTALL_INTERFACE:include/moveit_core>
 )
 set_target_properties(moveit_robot_model PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_robot_model
@@ -25,7 +29,7 @@ ament_target_dependencies(moveit_robot_model
 )
 target_link_libraries(moveit_robot_model
   moveit_exceptions
-  moveit_kinematics_base
+  moveit_macros
 )
 
 if(BUILD_TESTING)
@@ -37,4 +41,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_robot_model moveit_test_utils moveit_robot_model)
 endif()
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(moveit_robot_state SHARED
   src/robot_state.cpp
   src/cartesian_interpolator.cpp
 )
+target_include_directories(moveit_robot_state PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_robot_state PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 ament_target_dependencies(moveit_robot_state
   urdf
@@ -18,7 +22,7 @@ target_link_libraries(moveit_robot_state
   moveit_transforms
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 # Unit tests
 if(BUILD_TESTING)

--- a/moveit_core/robot_trajectory/CMakeLists.txt
+++ b/moveit_core/robot_trajectory/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(moveit_robot_trajectory SHARED src/robot_trajectory.cpp)
+target_include_directories(moveit_robot_trajectory PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_robot_trajectory PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 ament_target_dependencies(moveit_robot_trajectory
   rclcpp
@@ -11,7 +15,7 @@ target_link_libraries(moveit_robot_trajectory
   moveit_robot_state
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   ament_add_gtest(test_robot_trajectory test/test_robot_trajectory.cpp)

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -5,7 +5,10 @@ add_library(moveit_trajectory_processing SHARED
   src/trajectory_tools.cpp
   src/time_optimal_trajectory_generation.cpp
 )
-
+target_include_directories(moveit_trajectory_processing PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 set_target_properties(moveit_trajectory_processing PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_trajectory_processing
   rclcpp
@@ -22,7 +25,7 @@ target_link_libraries(moveit_trajectory_processing
   ruckig::ruckig
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 if(BUILD_TESTING)
   if(WIN32)

--- a/moveit_core/transforms/CMakeLists.txt
+++ b/moveit_core/transforms/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_library(moveit_transforms SHARED src/transforms.cpp)
+target_include_directories(moveit_transforms PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
+target_link_libraries(moveit_transforms moveit_macros)
 set_target_properties(moveit_transforms PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 ament_target_dependencies(moveit_transforms
   geometric_shapes
@@ -10,7 +15,7 @@ ament_target_dependencies(moveit_transforms
   Boost
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 # Unit tests
 if(BUILD_TESTING)

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -3,17 +3,24 @@ add_library(moveit_utils SHARED
   src/message_checks.cpp
   src/rclcpp_utils.cpp
 )
+target_include_directories(moveit_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
 ament_target_dependencies(moveit_utils Boost moveit_msgs)
 set_target_properties(moveit_utils PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/moveit_core)
 
 
 find_package(ament_index_cpp REQUIRED)
-set(MOVEIT_TEST_LIB_NAME moveit_test_utils)
-add_library(${MOVEIT_TEST_LIB_NAME} SHARED src/robot_model_test_utils.cpp)
-target_link_libraries(${MOVEIT_TEST_LIB_NAME} moveit_robot_model)
-ament_target_dependencies(${MOVEIT_TEST_LIB_NAME}
+add_library(moveit_test_utils SHARED src/robot_model_test_utils.cpp)
+target_include_directories(moveit_test_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_core>
+)
+target_link_libraries(moveit_test_utils moveit_robot_model)
+ament_target_dependencies(moveit_test_utils
   ament_index_cpp
   Boost
   geometry_msgs
@@ -22,4 +29,4 @@ ament_target_dependencies(${MOVEIT_TEST_LIB_NAME}
   urdfdom
   urdfdom_headers
 )
-set_target_properties(${MOVEIT_TEST_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+set_target_properties(moveit_test_utils PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_core/version/CMakeLists.txt
+++ b/moveit_core/version/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(moveit_version version.cpp)
+target_include_directories(moveit_version PRIVATE ${VERSION_FILE_PATH})
 install(TARGETS moveit_version RUNTIME DESTINATION bin)


### PR DESCRIPTION
### Description

I changed where headers get installed to fix issues with building MoveIt from source when another copy is already installed. By installing all headers inside a `moveit_core` directory, we add an extra layer of indirection that ensures we know what headers are getting used at any given time.

While I was at it, I also made sure to stop using `include_directories` inside moveit_core. CMake best practices are to avoid using `include_directories`, particularly in large projects like this because it makes it difficult to understand what targets have access to what include directories. Removing them from moveit_core makes it easier for us to know what headers we need to install plus it revealed an issue where kinematics_base and robot_model depended on each other. This makes me wonder if perhaps moveit_core should be consolidated into fewer targets.