### PR TITLE
Update the Servo dependency on realtime_tools

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -1,4 +1,5 @@
 repositories:
+  # Keep moveit_* repos here because they are released with moveit
   moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs.git

--- a/moveit2.repos
+++ b/moveit2.repos
@@ -1,17 +1,9 @@
 repositories:
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: ros2
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources.git
     version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 2.13.0
-  generate_parameter_library:
-    type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version: 0.3.0
-  rsl:
-    type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version: 0.2.0

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -33,7 +33,6 @@ moveit_package()
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   control_msgs
   control_toolbox
-  controller_manager
   geometry_msgs
   moveit_core
   moveit_msgs
@@ -41,6 +40,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
   rclcpp
   rclcpp_components
+  realtime_tools
   sensor_msgs
   std_msgs
   std_srvs

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -25,18 +25,19 @@
 
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
-  <depend>controller_manager</depend>
   <depend>geometry_msgs</depend>
   <depend>moveit_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>pluginlib</depend>
+  <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_eigen</depend>
   <depend>trajectory_msgs</depend>
 
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
@@ -49,7 +50,6 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>controller_manager</test_depend>
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>ros_testing</test_depend>
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -42,7 +42,7 @@
 #include <chrono>
 #include <mutex>
 
-#include <controller_manager/realtime.hpp>
+#include <realtime_tools/thread_priority.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -277,9 +277,9 @@ void ServoCalcs::start()
   stop_requested_ = false;
   thread_ = std::thread([this] {
     // Check if a realtime kernel is installed. Set a higher thread priority, if so
-    if (controller_manager::has_realtime_kernel())
+    if (realtime_tools::has_realtime_kernel())
     {
-      if (!controller_manager::configure_sched_fifo(THREAD_PRIORITY))
+      if (!realtime_tools::configure_sched_fifo(THREAD_PRIORITY))
       {
         RCLCPP_WARN(LOGGER, "Could not enable FIFO RT scheduling policy");
       }


### PR DESCRIPTION
Update the location of the `thread_priority` library which was previously lumped in with the `controller_manager` package