### PR TITLE
Unit test LinearPathSegment

### DIFF
--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -41,4 +41,9 @@ if(BUILD_TESTING)
     moveit_trajectory_processing
     moveit_test_utils
   )
+
+  ament_add_gtest(test_linear_path_segment test/test_linear_path_segment.cpp)
+  target_link_libraries(test_linear_path_segment
+    moveit_trajectory_processing
+  )
 endif()

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/linear_path_segment.hpp
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/linear_path_segment.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <Eigen/Geometry>
+
+namespace trajectory_processing
+{
+/**
+ * \class LinearPathSegment
+ *
+ * \brief Subclass of PathSegment defining a linear segment.
+ *
+ * This class is a subclass of PathSegment and defines a linear segment. It has a constructor which takes two
+ * Eigen::VectorXd objects, start and end, and sets the length to the distance between them. It also contains methods
+ * to get the configuration of the segment at a given point, the tangent of the segment at a given point, the curvature
+ * of the segment at a given point, and a list of switching points. Lastly, it contains a clone method to create a deep
+ * copy of the LinearPathSegment.
+ */
+class LinearPathSegment : public PathSegment
+{
+public:
+  /**
+   * \brief Constructor for the LinearPathSegment class.
+   *
+   * This constructor takes two Eigen::VectorXd objects and sets the length of the segment to the distance between them.
+   *
+   * \param start The start position of the segment.
+   * \param end The end position of the segment.
+   */
+  LinearPathSegment(const Eigen::VectorXd& start, const Eigen::VectorXd& end)
+    : PathSegment((end - start).norm()), end_(end), start_(start)
+  {
+  }
+
+  /**
+   * \brief Gets the configuration of the segment at a given point.
+   *
+   * This method gets the configuration of the segment at a given point.
+   *
+   * \param s The point at which to get the configuration.
+   * \return The configuration of the segment at the given point.
+   */
+  Eigen::VectorXd getConfig(double s) const override
+  {
+    s /= length_;
+    s = std::max(0.0, std::min(1.0, s));
+    return (1.0 - s) * start_ + s * end_;
+  }
+
+  /**
+   * \brief Gets the tangent of the segment at a given point.
+   *
+   * This method gets the tangent of the segment at a given point.
+   *
+   * \param s The point at which to get the tangent.
+   * \return The tangent of the segment at the given point.
+   */
+  Eigen::VectorXd getTangent(double /* s */) const override
+  {
+    return (end_ - start_) / length_;
+  }
+
+  /**
+   * \brief Gets the curvature of the segment at a given point.
+   *
+   * This method gets the curvature of the segment at a given point.
+   *
+   * \param s The point at which to get the curvature.
+   * \return The curvature of the segment at the given point.
+   */
+  Eigen::VectorXd getCurvature(double /* s */) const override
+  {
+    return Eigen::VectorXd::Zero(start_.size());
+  }
+
+  /**
+   * \brief Gets a list of switching points for the segment.
+   *
+   * This method gets a list of switching points for the segment.
+   *
+   * \return A list of switching points for the segment.
+   */
+  std::list<double> getSwitchingPoints() const override
+  {
+    return std::list<double>();
+  }
+
+  /**
+   * \brief Creates a deep copy of the LinearPathSegment.
+   *
+   * This method creates a deep copy of the LinearPathSegment.
+   *
+   * \return A deep copy of the LinearPathSegment.
+   */
+  LinearPathSegment* clone() const override
+  {
+    return new LinearPathSegment(*this);
+  }
+
+  bool operator==(const LinearPathSegment& rhs) const
+  {
+    return (length_ == rhs.length_ && end_ == rhs.end_ && start_ == rhs.start_);
+  }
+
+private:
+  Eigen::VectorXd end_;
+  Eigen::VectorXd start_;
+};
+
+}  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -36,13 +36,15 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+#include <moveit/trajectory_processing/linear_path_segment.hpp>
+
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 #include <limits>
 #include <Eigen/Geometry>
 #include <algorithm>
 #include <cmath>
-#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <vector>
 
 namespace trajectory_processing
@@ -54,46 +56,6 @@ static const rclcpp::Logger LOGGER =
 constexpr double DEFAULT_TIMESTEP = 1e-3;
 constexpr double EPS = 1e-6;
 }  // namespace
-
-class LinearPathSegment : public PathSegment
-{
-public:
-  LinearPathSegment(const Eigen::VectorXd& start, const Eigen::VectorXd& end)
-    : PathSegment((end - start).norm()), end_(end), start_(start)
-  {
-  }
-
-  Eigen::VectorXd getConfig(double s) const override
-  {
-    s /= length_;
-    s = std::max(0.0, std::min(1.0, s));
-    return (1.0 - s) * start_ + s * end_;
-  }
-
-  Eigen::VectorXd getTangent(double /* s */) const override
-  {
-    return (end_ - start_) / length_;
-  }
-
-  Eigen::VectorXd getCurvature(double /* s */) const override
-  {
-    return Eigen::VectorXd::Zero(start_.size());
-  }
-
-  std::list<double> getSwitchingPoints() const override
-  {
-    return std::list<double>();
-  }
-
-  LinearPathSegment* clone() const override
-  {
-    return new LinearPathSegment(*this);
-  }
-
-private:
-  Eigen::VectorXd end_;
-  Eigen::VectorXd start_;
-};
 
 class CircularPathSegment : public PathSegment
 {

--- a/moveit_core/trajectory_processing/test/test_linear_path_segment.cpp
+++ b/moveit_core/trajectory_processing/test/test_linear_path_segment.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include <moveit/trajectory_processing/linear_path_segment.hpp>
+
+using trajectory_processing::LinearPathSegment;
+
+// Tests LinearPathSegment constructor.
+TEST(LinearPathSegment, Constructor)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Check that the length of the segment is correct.
+  EXPECT_NEAR(segment.getLength(), 5.0, 1e-6);
+}
+
+// Tests LinearPathSegment::getConfig() method.
+TEST(LinearPathSegment, GetConfig)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Check that the configuration at 0 is equal to the start.
+  EXPECT_EQ(segment.getConfig(0.0), start);
+
+  // Check that the configuration at the length is equal to the end.
+  EXPECT_EQ(segment.getConfig(segment.getLength()), end);
+
+  // Check that the configuration at an intermediate point is correct.
+  Eigen::VectorXd config(2);
+  config << 1.5, 2.0;
+  EXPECT_EQ(segment.getConfig(segment.getLength() / 2.0), config);
+}
+
+// Tests LinearPathSegment::getTangent() method.
+TEST(LinearPathSegment, GetTangent)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Check that the tangent is correct.
+  Eigen::VectorXd tangent(2);
+  tangent << 3.0 / 5.0, 4.0 / 5.0;
+  EXPECT_EQ(segment.getTangent(0.0), tangent);
+}
+
+// Tests LinearPathSegment::getCurvature() method.
+TEST(LinearPathSegment, GetCurvature)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Check that the curvature is zero.
+  EXPECT_EQ(segment.getCurvature(0.0), Eigen::VectorXd::Zero(start.size()));
+}
+
+// Tests LinearPathSegment::getSwitchingPoints() method.
+TEST(LinearPathSegment, GetSwitchingPoints)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Check that the list of switching points is empty.
+  EXPECT_TRUE(segment.getSwitchingPoints().empty());
+}
+
+// Tests LinearPathSegment::clone() method.
+TEST(LinearPathSegment, Clone)
+{
+  Eigen::VectorXd start(2);
+  start << 0.0, 0.0;
+  Eigen::VectorXd end(2);
+  end << 3.0, 4.0;
+  LinearPathSegment segment(start, end);
+
+  // Clone the segment and check that the two segments are equal.
+  LinearPathSegment* clone = segment.clone();
+  EXPECT_EQ(segment, *clone);
+
+  // Clean up.
+  delete clone;
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Description

This pull request adds tests and documentation to the LinearPathSegment class. The tests check that the constructor works correctly, that the getConfig(), getTangent(), getCurvature(), and getSwitchingPoints() methods return the expected results, and that the clone() method creates a deep copy. The documentation provides a description of the class and detailed descriptions of all the public methods.