### PR TITLE
Fix BSD license in package.xml

### DIFF
--- a/moveit/package.xml
+++ b/moveit/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>

--- a/moveit_commander/package.xml
+++ b/moveit_commander/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_configs_utils/package.xml
+++ b/moveit_configs_utils/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>Python library for loading moveit config parameters in launch files</description>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="jafar@picknik.ai">Jafar Abdi</author>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_experimental/collision_distance_field_ros/manifest.xml
+++ b/moveit_experimental/collision_distance_field_ros/manifest.xml
@@ -5,7 +5,7 @@
 
   </description>
   <author>E. Gil Jones</author>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/collision_distance_field_ros</url>
   <depend package="collision_distance_field"/>

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/manifest.xml
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache_ros/manifest.xml
@@ -5,7 +5,7 @@
 
   </description>
   <author>Sachin Chitta</author>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/kinematics_cache_ros</url>
   <depend package="kinematics_cache"/>

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="jorge.nicho@swri.org">Jorge Nicho</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="repository">https://github.com/ros-planning/moveit2</url>

--- a/moveit_planners/chomp/chomp_interface/package.xml
+++ b/moveit_planners/chomp/chomp_interface/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <author email="gjones@willowgarage.com">Gil Jones</author>
 

--- a/moveit_planners/chomp/chomp_motion_planner/package.xml
+++ b/moveit_planners/chomp/chomp_motion_planner/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="chitt@live.in">Chittaranjan Srinivas Swaminathan</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url>http://ros.org/wiki/chomp_motion_planner</url>
 
   <author email="gjones@willowgarage.com">Gil Jones</author>

--- a/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
+++ b/moveit_planners/chomp/chomp_optimizer_adapter/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="raghavendersahdev@gmail.com">Raghavender Sahdev</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <author email="raghavendersahdev@gmail.com">Raghavender Sahdev</author>
 

--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>
   <maintainer email="i.martini@pilz.de">Immanuel Martini</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>
   <maintainer email="i.martini@pilz.de">Immanuel Martini</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_planners/test_configs/prbt_moveit_config/package.xml
+++ b/moveit_planners/test_configs/prbt_moveit_config/package.xml
@@ -14,7 +14,7 @@
   <maintainer email="h.slusarek@pilz.de">Hagen Slusarek</maintainer>
   <maintainer email="i.martini@pilz.de">Immanuel Martini</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>

--- a/moveit_planners/trajopt/package.xml
+++ b/moveit_planners/trajopt/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="omid.github@gmail.com">Omid Heidari</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_plugins/moveit_plugins/package.xml
+++ b/moveit_plugins/moveit_plugins/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
 

--- a/moveit_plugins/moveit_ros_control_interface/package.xml
+++ b/moveit_plugins/moveit_ros_control_interface/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
 
-  <license>BSD 3-Clause</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://ros-planning.github.io/moveit_tutorials</url>
 

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="jon.binney@gmail.com">Jon Binney</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_runtime/package.xml
+++ b/moveit_runtime/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="website">http://wiki.ros.org/moveit_runtime</url>

--- a/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>Various specialty plugins for MoveIt Setup Assistant</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/moveit_setup_assistant/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/moveit_setup_assistant/package.xml
@@ -10,7 +10,7 @@
   <maintainer email="moveit_releasers@googlegroups.com">MoveIt Release Team</maintainer>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_setup_assistant/moveit_setup_controllers/package.xml
+++ b/moveit_setup_assistant/moveit_setup_controllers/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>MoveIt Setup Steps for ROS 2 Control</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/moveit_setup_assistant/moveit_setup_core_plugins/package.xml
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>Core (meta) plugins for MoveIt Setup Assistant</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/moveit_setup_assistant/moveit_setup_framework/package.xml
+++ b/moveit_setup_assistant/moveit_setup_framework/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>C++ Interface for defining setup steps for MoveIt Setup Assistant</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -8,7 +8,7 @@
   </description>
   <maintainer email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>

--- a/moveit_setup_assistant/moveit_setup_simulation/package.xml
+++ b/moveit_setup_assistant/moveit_setup_simulation/package.xml
@@ -5,7 +5,7 @@
   <version>2.5.1</version>
   <description>MoveIt Setup Steps for Simulation</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/package.xml
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/package.xml
@@ -5,7 +5,7 @@
   <version>2.6.0</version>
   <description>SRDF-based plugins for MoveIt Setup Assistant</description>
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
### TL;DR
This is not a change of license, just the correction in the `package.xml`s

### Description
All the moveit2 packages are licensed under BSD-3-Clause as of [LICENSE.txt](https://github.com/ros-planning/moveit2/blob/main/LICENSE.txt), like most ROS1 packages. But the `package.xml`s mentioned BSD as license. This is wrong, because BSD refers to the original BSD (4-clause) license https://en.wikipedia.org/wiki/BSD_licenses#4-clause_license_(original_%22BSD_License%22). So it is literally another license.

I found this with https://github.com/boschresearch/ros_license_linter/blob/main/field-trials/moveit2.log which I am currently working on.