### PR TITLE
feat: adds ompl compatibility to the move_group_sequence

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -92,6 +92,14 @@ RobotTrajCont CommandListManager::solve(const planning_scene::PlanningSceneConst
 
   MotionResponseCont resp_cont{ solveSequenceItems(planning_scene, planning_pipeline, req_list) };
 
+  if (planning_pipeline->getPlannerPluginName() == "ompl_interface/OMPLPlanner")
+  {
+    for (MotionResponseCont::size_type i = 0; i < resp_cont.size(); ++i)
+    {
+      resp_cont.at(i).trajectory_->getLastWayPointPtr()->zeroAccelerations();
+    }
+  }
+  
   assert(model_);
   RadiiCont radii{ extractBlendRadii(*model_, req_list) };
   checkForOverlappingRadii(resp_cont, radii);


### PR DESCRIPTION
### Description

The current implementation of MoveGroupSequence would allow you to specify the `pipeline_id` with which to plan the motion. Choosing the OMPL pipeline as planner causes the plan to fail. 

This is due to the fact that internally to the MoveGroupSequence performs checks on the single planned path  before joining two path together. The only checks that fails (in case of path planned with the OMPL pipeline) is the one on the stationarity of the last point of each planned trajectory. In particular, the condition regarding the zero acceleration value of the last point of the trajectory is never fulfilled. 

### Proposed solution
The proposed solution to this problem is quite brutal but empirically gives good results and would allow to use MoveGroupSequence with the OMPL planner.