### PR TITLE
Print a warning from TOTG if the robot model mixes revolute/prismatic joints

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -207,6 +207,9 @@ private:
                                           const Eigen::VectorXd& max_velocity,
                                           const Eigen::VectorXd& max_acceleration) const;
 
+  /// @brief Check if a combination of revolute and prismatic joints is used. path_tolerance_ is not valid, if so.
+  bool checkMixedUnits(const moveit::core::JointModelGroup* group) const;
+
   const double path_tolerance_;
   const double resample_dt_;
   const double min_angle_change_;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -207,8 +207,12 @@ private:
                                           const Eigen::VectorXd& max_velocity,
                                           const Eigen::VectorXd& max_acceleration) const;
 
-  /// @brief Check if a combination of revolute and prismatic joints is used. path_tolerance_ is not valid, if so.
-  bool checkMixedUnits(const moveit::core::JointModelGroup* group) const;
+  /**
+   * @brief Check if a combination of revolute and prismatic joints is used. path_tolerance_ is not valid, if so.
+   * \param group The JointModelGroup to check.
+   * \return true if there are mixed joints.
+   */
+  bool hasMixedJointTypes(const moveit::core::JointModelGroup* group) const;
 
   const double path_tolerance_;
   const double resample_dt_;

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1096,9 +1096,10 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
     return false;
   }
 
-  if (!checkMixedUnits(group))
+  if (hasMixedJointTypes(group))
   {
-    RCLCPP_WARN(LOGGER, "There is a combination of revolute and prismatic joints in the robot model. TOTG's `path_tolerance` will not function correctly.");
+    RCLCPP_WARN(LOGGER, "There is a combination of revolute and prismatic joints in the robot model. TOTG's "
+                        "`path_tolerance` will not function correctly.");
   }
 
   const unsigned num_points = trajectory.getWayPointCount();
@@ -1185,7 +1186,7 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
   return true;
 }
 
-bool TimeOptimalTrajectoryGeneration::checkMixedUnits(const moveit::core::JointModelGroup* group) const
+bool TimeOptimalTrajectoryGeneration::hasMixedJointTypes(const moveit::core::JointModelGroup* group) const
 {
   const std::vector<const moveit::core::JointModel*>& joint_models = group->getJointModels();
 
@@ -1199,8 +1200,6 @@ bool TimeOptimalTrajectoryGeneration::checkMixedUnits(const moveit::core::JointM
         return joint_model->getType() == moveit::core::JointModel::JointType::REVOLUTE;
       });
 
-  if (have_prismatic && have_revolute)
-    return false;
-  return true;
+  return have_prismatic && have_revolute;
 }
 }  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1098,8 +1098,7 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
 
   if (!checkMixedUnits(group))
   {
-    RCLCPP_ERROR(LOGGER, "TOTG cannot process a combination of revolute and prismatic joints");
-    return false;
+    RCLCPP_WARN(LOGGER, "There is a combination of revolute and prismatic joints in the robot model. TOTG's `path_tolerance` will not function correctly.");
   }
 
   const unsigned num_points = trajectory.getWayPointCount();

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1096,6 +1096,12 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
     return false;
   }
 
+  if (!checkMixedUnits(group))
+  {
+    RCLCPP_ERROR(LOGGER, "TOTG cannot process a combination of revolute and prismatic joints");
+    return false;
+  }
+
   const unsigned num_points = trajectory.getWayPointCount();
   const std::vector<int>& idx = group->getVariableIndexList();
   const unsigned num_joints = group->getVariableCount();
@@ -1177,6 +1183,25 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
     last_t = t;
   }
 
+  return true;
+}
+
+bool TimeOptimalTrajectoryGeneration::checkMixedUnits(const moveit::core::JointModelGroup* group) const
+{
+  const std::vector<const moveit::core::JointModel*>& joint_models = group->getJointModels();
+
+  bool have_prismatic =
+      std::any_of(joint_models.cbegin(), joint_models.cend(), [](const moveit::core::JointModel* joint_model) {
+        return joint_model->getType() == moveit::core::JointModel::JointType::PRISMATIC;
+      });
+
+  bool have_revolute =
+      std::any_of(joint_models.cbegin(), joint_models.cend(), [](const moveit::core::JointModel* joint_model) {
+        return joint_model->getType() == moveit::core::JointModel::JointType::REVOLUTE;
+      });
+
+  if (have_prismatic && have_revolute)
+    return false;
   return true;
 }
 }  // namespace trajectory_processing


### PR DESCRIPTION
### Description

I believe TOTG can't handle mixed units well because the `path_tolerance_` parameter is just a scalar value. So there's no good way to measure angular error mixed with linear error. Best just to fail and print a nice warning for the user.