### PR TITLE
Add xacro subsititution class and use it for loading urdf & srdf

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -217,13 +217,29 @@ class MoveItConfigsBuilder(ParameterBuilder):
             robot_description_file_path = self.__urdf_package / self.__urdf_file_path
         else:
             robot_description_file_path = self._package_path / file_path
-        self.__moveit_configs.robot_description = {
-            self.__robot_description: ParameterValue(
-                Xacro(str(robot_description_file_path), mappings=mappings),
-                value_type=str,
-            )
-        }
+        if (mappings is None) or all(
+            (isinstance(key, str) and isinstance(value, str))
+            for key, value in mappings.items()
+        ):
+            try:
+                self.__moveit_configs.robot_description = {
+                    self.__robot_description: load_xacro(
+                        robot_description_file_path, mappings=mappings
+                    )
+                }
+            except ParameterBuilderFileNotFoundError as e:
+                logging.warning(f"\x1b[33;21m{e}\x1b[0m")
+                logging.warning(
+                    f"\x1b[33;21mThe robot description will be loaded from /robot_description topic \x1b[0m"
+                )
 
+        else:
+            self.__moveit_configs.robot_description = {
+                self.__robot_description: ParameterValue(
+                    Xacro(str(robot_description_file_path), mappings=mappings),
+                    value_type=str,
+                )
+            }
         return self
 
     def robot_description_semantic(
@@ -237,16 +253,29 @@ class MoveItConfigsBuilder(ParameterBuilder):
         :param mappings: mappings to be passed when loading the xacro file.
         :return: Instance of MoveItConfigsBuilder with robot_description_semantic loaded.
         """
-        self.__moveit_configs.robot_description_semantic = {
-            self.__robot_description
-            + "_semantic": ParameterValue(
-                Xacro(
-                    str(self._package_path / (file_path or self.__srdf_file_path)),
+
+        if (mappings is None) or all(
+            (isinstance(key, str) and isinstance(value, str))
+            for key, value in mappings.items()
+        ):
+            self.__moveit_configs.robot_description_semantic = {
+                self.__robot_description
+                + "_semantic": load_xacro(
+                    self._package_path / (file_path or self.__srdf_file_path),
                     mappings=mappings,
-                ),
-                value_type=str,
-            )
-        }
+                )
+            }
+        else:
+            self.__moveit_configs.robot_description_semantic = {
+                self.__robot_description
+                + "_semantic": ParameterValue(
+                    Xacro(
+                        str(self._package_path / (file_path or self.__srdf_file_path)),
+                        mappings=mappings,
+                    ),
+                    value_type=str,
+                )
+            }
         return self
 
     def robot_description_kinematics(self, file_path: Optional[str] = None):

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -59,6 +59,9 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch_param_builder import ParameterBuilder, load_yaml, load_xacro
 from launch_param_builder.utils import ParameterBuilderFileNotFoundError
+from moveit_configs_utils.substitutions import Xacro
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch_ros.parameter_descriptions import ParameterValue
 
 moveit_configs_utils_path = Path(get_package_share_directory("moveit_configs_utils"))
 
@@ -199,35 +202,34 @@ class MoveItConfigsBuilder(ParameterBuilder):
 
         self.__robot_description = robot_description
 
-    def robot_description(self, file_path: Optional[str] = None, mappings: dict = None):
+    def robot_description(
+        self,
+        file_path: Optional[str] = None,
+        mappings: dict[SomeSubstitutionsType, SomeSubstitutionsType] = None,
+    ):
         """Load robot description.
 
         :param file_path: Absolute or relative path to the URDF file (w.r.t. robot_name_moveit_config).
         :param mappings: mappings to be passed when loading the xacro file.
         :return: Instance of MoveItConfigsBuilder with robot_description loaded.
         """
-        try:
-            if file_path is None:
-                robot_description_file_path = (
-                    self.__urdf_package / self.__urdf_file_path
-                )
-            else:
-                robot_description_file_path = self._package_path / file_path
-            self.__moveit_configs.robot_description = {
-                self.__robot_description: load_xacro(
-                    robot_description_file_path, mappings=mappings
-                )
-            }
-        except ParameterBuilderFileNotFoundError as e:
-            logging.warning(f"\x1b[33;21m{e}\x1b[0m")
-            logging.warning(
-                f"\x1b[33;21mThe robot description will be loaded from /robot_description topic \x1b[0m"
+        if file_path is None:
+            robot_description_file_path = self.__urdf_package / self.__urdf_file_path
+        else:
+            robot_description_file_path = self._package_path / file_path
+        self.__moveit_configs.robot_description = {
+            self.__robot_description: ParameterValue(
+                Xacro(str(robot_description_file_path), mappings=mappings),
+                value_type=str,
             )
+        }
 
         return self
 
     def robot_description_semantic(
-        self, file_path: Optional[str] = None, mappings: dict = None
+        self,
+        file_path: Optional[str] = None,
+        mappings: dict[SomeSubstitutionsType, SomeSubstitutionsType] = None,
     ):
         """Load semantic robot description.
 
@@ -237,9 +239,12 @@ class MoveItConfigsBuilder(ParameterBuilder):
         """
         self.__moveit_configs.robot_description_semantic = {
             self.__robot_description
-            + "_semantic": load_xacro(
-                self._package_path / (file_path or self.__srdf_file_path),
-                mappings=mappings,
+            + "_semantic": ParameterValue(
+                Xacro(
+                    str(self._package_path / (file_path or self.__srdf_file_path)),
+                    mappings=mappings,
+                ),
+                value_type=str,
             )
         }
         return self

--- a/moveit_configs_utils/moveit_configs_utils/substitutions/__init__.py
+++ b/moveit_configs_utils/moveit_configs_utils/substitutions/__init__.py
@@ -1,0 +1,1 @@
+from .xacro import Xacro

--- a/moveit_configs_utils/moveit_configs_utils/substitutions/xacro.py
+++ b/moveit_configs_utils/moveit_configs_utils/substitutions/xacro.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+from typing import Iterable, Text
+
+from launch.frontend import expose_substitution
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitution import Substitution
+from launch.utilities import normalize_to_list_of_substitutions
+from launch_param_builder import load_xacro
+
+
+@expose_substitution("xacro")
+class Xacro(Substitution):
+    """Substitution that can access load xacro file with mappings involving any subsititutable."""
+
+    def __init__(
+        self,
+        file_path: SomeSubstitutionsType,
+        *,
+        mappings: dict[SomeSubstitutionsType, SomeSubstitutionsType] | None = None,
+    ) -> None:
+        """Create a Xacro substitution."""
+        super().__init__()
+
+        self.__file_path = normalize_to_list_of_substitutions(file_path)
+        if mappings is None:
+            self.__mappings = {}
+        else:
+            self.__mappings = mappings
+
+    @classmethod
+    def parse(cls, data: Iterable[SomeSubstitutionsType]):
+        """Parse `XacroSubstitution` substitution."""
+        if len(data) != 1:
+            raise TypeError(
+                "xacro substitution expects only support one argument use 'command' subsititutoin for parsing args"
+            )
+        kwargs = {}
+        kwargs["file_path"] = data[0]
+        return cls, kwargs
+
+    @property
+    def file_path(self) -> list[Substitution]:
+        """Getter for file_path."""
+        return self.__file_path
+
+    @property
+    def mappings(self) -> dict[SomeSubstitutionsType, SomeSubstitutionsType]:
+        """Getter for mappings."""
+        return self.__mappings
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        mappings_formatted = ", ".join(
+            [f"{k.describe()}:={v.describe()}" for k, v in self.mappings.items()]
+        )
+        return f"Xacro(file_path = {self.file_path}, mappings = {mappings_formatted})"
+
+    def perform(self, context: LaunchContext) -> Text:
+        """
+        Perform the substitution by retrieving the mappings and context.
+        """
+        from launch.utilities import perform_substitutions
+
+        expanded_file_path = perform_substitutions(context, self.__file_path)
+        expanded_mappings = {}
+        for (key, value) in self.__mappings.items():
+            normalized_key = normalize_to_list_of_substitutions(key)
+            normalized_value = normalize_to_list_of_substitutions(value)
+            expanded_mappings[
+                perform_substitutions(context, normalized_key)
+            ] = perform_substitutions(context, normalized_value)
+
+        return load_xacro(Path(expanded_file_path), mappings=expanded_mappings)

--- a/moveit_configs_utils/moveit_configs_utils/substitutions/xacro.py
+++ b/moveit_configs_utils/moveit_configs_utils/substitutions/xacro.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable, Text
+from typing import Iterable, Text, Optional
 
 from launch.frontend import expose_substitution
 from launch.launch_context import LaunchContext
@@ -17,7 +17,7 @@ class Xacro(Substitution):
         self,
         file_path: SomeSubstitutionsType,
         *,
-        mappings: dict[SomeSubstitutionsType, SomeSubstitutionsType] | None = None,
+        mappings: Optional[dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
     ) -> None:
         """Create a Xacro substitution."""
         super().__init__()

--- a/moveit_configs_utils/setup.py
+++ b/moveit_configs_utils/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from glob import glob
 
 package_name = "moveit_configs_utils"
@@ -6,7 +6,7 @@ package_name = "moveit_configs_utils"
 setup(
     name=package_name,
     version="2.5.3",
-    packages=[package_name],
+    packages=find_packages(),
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),

--- a/moveit_configs_utils/test/robot.urdf.xacro
+++ b/moveit_configs_utils/test/robot.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="robot" params="test_robot number postfix">
+    <robot name="$(arg test_robot)">
+      <link name="base" />
+      <link name="link_${postfix}" />
+
+      <joint name="base_to_link_${postfix}" type="fixed">
+        <parent link="base" />
+        <child link="link_${postfix}" />
+        <origin xyz="0 ${number} 0" />
+      </joint>
+    </robot>
+  </xacro:macro>
+  <xacro:arg name="test_robot" default="testing_robot"/>
+  <xacro:arg name="number" default="testing_number"/>
+  <xacro:arg name="postfix" default="testing_postfix"/>
+  <xacro:robot test_robot="$(arg test_robot)" number="$(arg number)" postfix="$(arg postfix)" />
+</robot>

--- a/moveit_configs_utils/test/test_xacro.py
+++ b/moveit_configs_utils/test/test_xacro.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from launch import LaunchContext
+from launch.actions import SetLaunchConfiguration
+from launch.frontend.parse_substitution import parse_substitution
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    TextSubstitution,
+    ThisLaunchFileDir,
+)
+
+from moveit_configs_utils.substitutions import Xacro
+
+
+def test_xacro_subst():
+    subst = parse_substitution(r"$(xacro '$(dirname)/robot.urdf.xacro')")
+    context = LaunchContext()
+    context.extend_locals({"current_launch_file_directory": str(Path(__file__).parent)})
+    assert len(subst) == 1
+    assert isinstance(subst[0].file_path[0], ThisLaunchFileDir)
+    assert isinstance(subst[0].file_path[1], TextSubstitution)
+    assert isinstance(subst[0], Xacro)
+    subst[0].perform(context)
+
+
+def test_xacro_no_mappings():
+    xacro = Xacro([ThisLaunchFileDir(), "robot.urdf.xacro"])
+    context = LaunchContext()
+    context.extend_locals(
+        {"current_launch_file_directory": str(Path(__file__).parent) + "/"}
+    )
+    assert xacro.perform(context)
+
+
+def test_xacro_with_mappings():
+    xacro = Xacro(
+        PathJoinSubstitution([ThisLaunchFileDir(), "robot.urdf.xacro"]),
+        mappings={
+            ("test_", LaunchConfiguration("myrobot")): [
+                LaunchConfiguration("myrobot"),
+                "sadf",
+            ],
+            "number": LaunchConfiguration("number"),
+            "postfix": LaunchConfiguration("postfix"),
+        },
+    )
+    context = LaunchContext()
+    context.extend_locals(
+        {"current_launch_file_directory": str(Path(__file__).parent) + "/"}
+    )
+    SetLaunchConfiguration("myrobot", "robot").visit(context)
+    SetLaunchConfiguration("number", "2000").visit(context)
+    SetLaunchConfiguration("postfix", "mypostfix").visit(context)
+    assert xacro.perform(context)


### PR DESCRIPTION
### Description

This make it possible to pass `LaunchConfiguration` (or any other complex launch substitutable) to the xacro mappings, which remove the need to use an `OpaqueFunction` to access the context (see https://github.com/AndyZe/tiago_moveit_config/commit/054900ae668e0bcf11e831da5affd4fb061c82e4 for an example)

Another thing worth doing is making all the `file_path`s accept `SomeSubstitutionsType`