### PR TITLE
Add a "lookahead time" parameter

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -15,6 +15,10 @@ scale:
 # Optionally override Servo's internal velocity scaling when near singularity or collision (0.0 = use internal velocity scaling)
 # override_velocity_scaling_factor = 0.0 # valid range [0.0:1.0]
 
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.05
+
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]
 low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -17,7 +17,7 @@ scale:
 
 # This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
 # It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
-target_pose_lookahead_time: 0.05
+lookahead_time: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -15,6 +15,10 @@ scale:
 # Optionally override Servo's internal velocity scaling when near singularity or collision (0.0 = use internal velocity scaling)
 # override_velocity_scaling_factor = 0.0 # valid range [0.0:1.0]
 
+# This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
+# It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
+target_pose_lookahead_time: 0.05
+
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]
 

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -17,7 +17,7 @@ scale:
 
 # This is an optional factor to account for any latency or low-level controller ramp up/ramp down in the system.
 # It increases the timestep when calculating the target pose, to move the target pose farther away. [seconds]
-target_pose_lookahead_time: 0.05
+lookahead_time: 0.05
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -71,7 +71,7 @@ struct ServoParameters
   double joint_scale{ 0.5 };
   // Properties of Servo calculations
   double override_velocity_scaling_factor{ 0.0 };
-  double target_pose_lookahead_time{ 0.0 };
+  double lookahead_time{ 0.0 };
   // Properties of outgoing commands
   std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
   double publish_period{ 0.034 };

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -71,6 +71,7 @@ struct ServoParameters
   double joint_scale{ 0.5 };
   // Properties of Servo calculations
   double override_velocity_scaling_factor{ 0.0 };
+  double target_pose_lookahead_time{ 0.0 };
   // Properties of outgoing commands
   std::string command_out_topic{ "/panda_arm_controller/joint_trajectory" };
   double publish_period{ 0.034 };

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1056,6 +1056,11 @@ Eigen::VectorXd ServoCalcs::scaleCartesianCommand(const geometry_msgs::msg::Twis
   Eigen::VectorXd result(6);
   result.setZero();  // Or the else case below leads to misery
 
+  // Add a user-defined, constant delay to the timestep.
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
+
   // Apply user-defined scaling if inputs are unitless [-1:1]
   if (parameters_->command_in_type == "unitless")
   {
@@ -1089,6 +1094,11 @@ Eigen::VectorXd ServoCalcs::scaleJointCommand(const control_msgs::msg::JointJog&
 {
   Eigen::VectorXd result(num_joints_);
   result.setZero();
+
+  // Add a user-defined, constant delay to the timestep.
+  // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
+  // Effectively it moves the target pose farther ahead.
+  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
 
   std::size_t c;
   for (std::size_t m = 0; m < command.joint_names.size(); ++m)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -1059,27 +1059,27 @@ Eigen::VectorXd ServoCalcs::scaleCartesianCommand(const geometry_msgs::msg::Twis
   // Add a user-defined, constant delay to the timestep.
   // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
   // Effectively it moves the target pose farther ahead.
-  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
+  double timestep = parameters_->publish_period + parameters_->lookahead_time;
 
   // Apply user-defined scaling if inputs are unitless [-1:1]
   if (parameters_->command_in_type == "unitless")
   {
-    result[0] = parameters_->linear_scale * parameters_->publish_period * command.twist.linear.x;
-    result[1] = parameters_->linear_scale * parameters_->publish_period * command.twist.linear.y;
-    result[2] = parameters_->linear_scale * parameters_->publish_period * command.twist.linear.z;
-    result[3] = parameters_->rotational_scale * parameters_->publish_period * command.twist.angular.x;
-    result[4] = parameters_->rotational_scale * parameters_->publish_period * command.twist.angular.y;
-    result[5] = parameters_->rotational_scale * parameters_->publish_period * command.twist.angular.z;
+    result[0] = parameters_->linear_scale * timestep * command.twist.linear.x;
+    result[1] = parameters_->linear_scale * timestep * command.twist.linear.y;
+    result[2] = parameters_->linear_scale * timestep * command.twist.linear.z;
+    result[3] = parameters_->rotational_scale * timestep * command.twist.angular.x;
+    result[4] = parameters_->rotational_scale * timestep * command.twist.angular.y;
+    result[5] = parameters_->rotational_scale * timestep * command.twist.angular.z;
   }
   // Otherwise, commands are in m/s and rad/s
   else if (parameters_->command_in_type == "speed_units")
   {
-    result[0] = command.twist.linear.x * parameters_->publish_period;
-    result[1] = command.twist.linear.y * parameters_->publish_period;
-    result[2] = command.twist.linear.z * parameters_->publish_period;
-    result[3] = command.twist.angular.x * parameters_->publish_period;
-    result[4] = command.twist.angular.y * parameters_->publish_period;
-    result[5] = command.twist.angular.z * parameters_->publish_period;
+    result[0] = command.twist.linear.x * timestep;
+    result[1] = command.twist.linear.y * timestep;
+    result[2] = command.twist.linear.z * timestep;
+    result[3] = command.twist.angular.x * timestep;
+    result[4] = command.twist.angular.y * timestep;
+    result[5] = command.twist.angular.z * timestep;
   }
   else
   {
@@ -1098,7 +1098,7 @@ Eigen::VectorXd ServoCalcs::scaleJointCommand(const control_msgs::msg::JointJog&
   // Add a user-defined, constant delay to the timestep.
   // This can help if ramp-up / ramp-down of the low-level controllers cause jitter, or to account for network latency.
   // Effectively it moves the target pose farther ahead.
-  double timestep = parameters_->publish_period + parameters_->target_pose_lookahead_time;
+  double timestep = parameters_->publish_period + parameters_->lookahead_time;
 
   std::size_t c;
   for (std::size_t m = 0; m < command.joint_names.size(); ++m)
@@ -1116,12 +1116,12 @@ Eigen::VectorXd ServoCalcs::scaleJointCommand(const control_msgs::msg::JointJog&
     // Apply user-defined scaling if inputs are unitless [-1:1]
     if (parameters_->command_in_type == "unitless")
     {
-      result[c] = command.velocities[m] * parameters_->joint_scale * parameters_->publish_period;
+      result[c] = command.velocities[m] * parameters_->joint_scale * timestep;
       // Otherwise, commands are in m/s and rad/s
     }
     else if (parameters_->command_in_type == "speed_units")
     {
-      result[c] = command.velocities[m] * parameters_->publish_period;
+      result[c] = command.velocities[m] * timestep;
     }
     else
     {

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -146,12 +146,12 @@ void ServoParameters::declare(const std::string& ns,
                                          .description("Override constant scalar of how fast the robot should jog."
                                                       "Valid values are between 0-1.0"));
 
-  node_parameters->declare_parameter(
-      ns + ".target_pose_lookahead_time", ParameterValue{ parameters.target_pose_lookahead_time },
-      ParameterDescriptorBuilder{}
-          .type(PARAMETER_DOUBLE)
-          .description("An optional parameter to smooth jitter due to latency in the system "
-                       "or low-level controller ramp up / ramp down"));
+  node_parameters->declare_parameter(ns + ".lookahead_time", ParameterValue{ parameters.lookahead_time },
+                                     ParameterDescriptorBuilder{}
+                                         .type(PARAMETER_DOUBLE)
+                                         .description(
+                                             "An optional parameter to smooth jitter due to latency in the system "
+                                             "or low-level controller ramp up / ramp down"));
 
   // Properties of outgoing commands
   node_parameters->declare_parameter(

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -146,6 +146,13 @@ void ServoParameters::declare(const std::string& ns,
                                          .description("Override constant scalar of how fast the robot should jog."
                                                       "Valid values are between 0-1.0"));
 
+  node_parameters->declare_parameter(
+      ns + ".target_pose_lookahead_time", ParameterValue{ parameters.target_pose_lookahead_time },
+      ParameterDescriptorBuilder{}
+          .type(PARAMETER_DOUBLE)
+          .description("An optional parameter to smooth jitter due to latency in the system "
+                       "or low-level controller ramp up / ramp down"));
+
   // Properties of outgoing commands
   node_parameters->declare_parameter(
       ns + ".command_out_topic", ParameterValue{ parameters.command_out_topic },


### PR DESCRIPTION
### Description

This is the second time I've made a PR like this (prev. #886). It looks like Ignition testing requires it again.

The idea is, increase the timestep when calculating the target pose, to move the target pose farther away. Here's a hypothetical example where it helps:

> If there is a net latency of 30 ms (from when the Servo message is published to when the low-level controller executes), it can reduce the path-tracking error quite a bit. Thus the robot's low-level PID output is small --> the robot moves slowly. In the perfect world where the latency is 0, the path-tracking accuracy will be much larger and the robot would move with the expected speed.
