### PR TITLE
No default IK solver

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_parameters.yaml
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_parameters.yaml
@@ -1,11 +1,8 @@
 kinematics:
   kinematics_solver: {
     type: string,
-    default_value: kdl_kinematics_plugin/KDLKinematicsPlugin,
+    default_value: "",
     description: "Kinematics solver",
-    validation: {
-      not_empty<>: []
-    }
   }
   kinematics_solver_search_resolution: {
     type: double,

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -259,6 +259,13 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
 
         std::string kinematics_solver_param_name = kinematics_param_prefix + ".kinematics_solver";
         const auto kinematics_solver = group_params_.at(known_group.name_).kinematics_solver;
+
+        if (kinematics_solver.empty())
+        {
+          RCLCPP_DEBUG(LOGGER, "No kinematics solver specified for group '%s'.", known_group.name_.c_str());
+          continue;
+        }
+
         possible_kinematics_solvers[known_group.name_] = kinematics_solver;
         RCLCPP_DEBUG(LOGGER, "Found kinematics solver '%s' for group '%s'.", kinematics_solver.c_str(),
                      known_group.name_.c_str());


### PR DESCRIPTION
### Description

Before converting to generate_parameter_library there was no default IK solver. This meant that if you did not specify an IK solver for a given joint group it wouldn't create one. This restores that behavior. 

