### PR TITLE
Fix moveit_core dependency on tf2_kdl

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -55,6 +55,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_kdl</depend>
   <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>ruckig</depend>
@@ -64,7 +65,6 @@
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_resources_pr2_description</test_depend>
   <test_depend>angles</test_depend>
-  <test_depend>tf2_kdl</test_depend>
   <test_depend>orocos_kdl_vendor</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>


### PR DESCRIPTION
### Description

This is a proper dependency, and not only a test dependency. It is still needed when building moveit_core with -DBUILD_TESTING=OFF.

The dependency is unconditionally referenced here:
https://github.com/ros-planning/moveit2/blob/fca8e9bd3f41e6bff5aadbf75c494b5cc3fa25ee/moveit_core/CMakeLists.txt#L50

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
