### PR TITLE
Small terminal output adjustments

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -107,7 +107,7 @@ void KDLKinematicsPlugin::getJointWeights()
 
   RCLCPP_INFO_STREAM(
       LOGGER, "Joint weights for group '"
-                  << getGroupName() << "': \n"
+                  << getGroupName() << "': "
                   << Eigen::Map<const Eigen::VectorXd>(joint_weights_.data(), joint_weights_.size()).transpose());
 }
 

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -311,7 +311,7 @@ bool ChompOptimizer::optimize()
     double s_cost = getSmoothnessCost();
     double cost = c_cost + s_cost;
 
-    RCLCPP_INFO(LOGGER, "Collision cost %f, smoothness cost: %f", c_cost, s_cost);
+    RCLCPP_DEBUG(LOGGER, "Collision cost %f, smoothness cost: %f", c_cost, s_cost);
 
     /// TODO: HMC BASED COMMENTED CODE BELOW, Need to uncomment and perform extensive testing by varying the HMC
     /// parameters values in the chomp_planning.yaml file so that CHOMP can find optimal paths
@@ -371,7 +371,7 @@ bool ChompOptimizer::optimize()
 
     if (iteration_ % 10 == 0)
     {
-      RCLCPP_INFO(LOGGER, "iteration: %d", iteration_);
+      RCLCPP_DEBUG(LOGGER, "iteration: %d", iteration_);
       if (isCurrentTrajectoryMeshToMeshCollisionFree())
       {
         num_collision_free_iterations_ = 0;
@@ -418,7 +418,7 @@ bool ChompOptimizer::optimize()
       }
       else
       {
-        RCLCPP_INFO(LOGGER, "cCost %f over threshold %f", c_cost, parameters_->collision_threshold_);
+        RCLCPP_DEBUG(LOGGER, "cCost %f over threshold %f", c_cost, parameters_->collision_threshold_);
       }
     }
 


### PR DESCRIPTION
### Description

- Change output level of some prints in CHOMP from INFO to DEBUG to avoid a wall of text at runtime
- Remove newline in kdl_kinematics from
```bash
[moveit_run_benchmark-1] [INFO] [1671539632.233486591] [moveit_kinematics_base.kinematics_base]: Joint weights for group 'panda_arm':
[moveit_run_benchmark-1] 1 1 1 1 1 1 1
```
to
```
[moveit_run_benchmark-1] [INFO] [1671540088.585070396] [moveit_kinematics_base.kinematics_base]: Joint weights for group 'panda_arm': 1 1 1 1 1 1 1
```
I was confused of the old version because this is the only place in MoveIt2 where a new line is added to print the values and I failed to connect `1 1 1 1 1 1 1` to the line above.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
