### PR TITLE
Remove third-party workspace dependencies

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -3,15 +3,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_resources.git
     version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 2.13.0
-  generate_parameter_library:
-    type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version: 0.3.0
-  rsl:
-    type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version: 0.2.0


### PR DESCRIPTION
This removes third-party packages that should be build against debians. Building with debian dependencies only should succeed by default, so that we can actually detect upstream breakages. An exception can be made for things that we would release at the same time (say, moveit_msgs, moveit_resources), everything else should be handled either in a backwards-compatible way, or by preparing and fixing breaking changes when they actually occur (this is the case if the testing build fails in CI). If we are paranoid that we won't have enough time, I'm open for adding a staging CI build that includes the latest head of third-party repos.
 
See #1826 for additional reasoning.

(this PR will probably fail, even though it shouldn't)