### PR TITLE
keep printf color change on the same line

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -99,12 +99,12 @@ public:
       {
         if (capabilities_.empty())
         {
-          printf(MOVEIT_CONSOLE_COLOR_BLUE "\nmove_group is running but no capabilities are "
-                                           "loaded.\n\n" MOVEIT_CONSOLE_COLOR_RESET);
+          printf("\n" MOVEIT_CONSOLE_COLOR_BLUE
+                 "move_group is running but no capabilities are loaded." MOVEIT_CONSOLE_COLOR_RESET "\n\n");
         }
         else
         {
-          printf(MOVEIT_CONSOLE_COLOR_GREEN "\nYou can start planning now!\n\n" MOVEIT_CONSOLE_COLOR_RESET);
+          printf("\n" MOVEIT_CONSOLE_COLOR_GREEN "You can start planning now!" MOVEIT_CONSOLE_COLOR_RESET "\n\n");
         }
         fflush(stdout);
       }
@@ -175,7 +175,7 @@ private:
     {
       try
       {
-        printf(MOVEIT_CONSOLE_COLOR_CYAN "Loading '%s'...\n" MOVEIT_CONSOLE_COLOR_RESET, capability.c_str());
+        printf(MOVEIT_CONSOLE_COLOR_CYAN "Loading '%s'..." MOVEIT_CONSOLE_COLOR_RESET "\n", capability.c_str());
         MoveGroupCapabilityPtr cap = capability_plugin_loader_->createUniqueInstance(capability);
         cap->setContext(context_);
         cap->initialize();


### PR DESCRIPTION
### Description

I found that the `printf` statements were not actually resetting colors in the terminal. So this is a change to keep `printf` color change on the same line. This ensures the color reset is applied because printing the color reset after new lines seems to prevent the color from actually being reset.

Example before making this change:
![Screenshot from 2022-12-22 10-26-18-before](https://user-images.githubusercontent.com/1305536/209167435-6d9b40d0-0888-45e6-a843-630268a3cd0e.png)

Example after this change:
![Screenshot from 2022-12-22 10-23-58-after](https://user-images.githubusercontent.com/1305536/209167424-5c154a29-c9f9-4aa9-bf98-bf9b18bf5ea1.png)


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
