### PR TITLE
Improve naming and test coverage of graph resource name sanitization helper functions

### DIFF
--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -25,3 +25,10 @@ ament_target_dependencies(${MOVEIT_TEST_LIB_NAME}
   urdfdom_headers
 )
 set_target_properties(${MOVEIT_TEST_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_rclcpp_utils test/test_rclcpp_utils.cpp)
+  target_link_libraries(test_rclcpp_utils ${MOVEIT_LIB_NAME})
+endif()

--- a/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
+++ b/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
@@ -35,7 +35,7 @@ namespace rclcpp
 namespace names
 {
 /**
- * Removes instances of "//" and trailing '/' characters from a string.
+ * Replaces instances of "//" with "/" and removes trailing '/' characters from a string.
  *
  * @param name The graph resource name string.
  * @return The modified graph resource name string.
@@ -43,7 +43,7 @@ namespace names
 std::string sanitizeGraphResourceName(const std::string& name);
 
 /**
- * Concatenates two strings with a "/" then removes instances of "//" and trailing '/' characters from a string.
+ * Concatenates two strings with a "/" then replaces instances of "//" with "/" and removes trailing '/' characters.
  *
  * @param left The first string.
  * @param right The second string.

--- a/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
+++ b/moveit_core/utils/include/moveit/utils/rclcpp_utils.h
@@ -34,8 +34,21 @@ namespace rclcpp
 {
 namespace names
 {
-std::string clean(const std::string& name);
+/**
+ * Removes instances of "//" and trailing '/' characters from a string.
+ *
+ * @param name The graph resource name string.
+ * @return The modified graph resource name string.
+ */
+std::string sanitizeGraphResourceName(const std::string& name);
 
-std::string append(const std::string& left, const std::string& right);
+/**
+ * Concatenates two strings with a "/" then removes instances of "//" and trailing '/' characters from a string.
+ *
+ * @param left The first string.
+ * @param right The second string.
+ * @return The modified string.
+ */
+std::string appendAndSanitizeGraphResourceName(const std::string& left, const std::string& right);
 }  // namespace names
 }  // namespace rclcpp

--- a/moveit_core/utils/src/rclcpp_utils.cpp
+++ b/moveit_core/utils/src/rclcpp_utils.cpp
@@ -37,22 +37,18 @@ std::string clean(const std::string& name)
   std::string clean = name;
 
   // Search for the substring "//" in "clean"
-  size_t pos = clean.find("//");
-
-  // While the substring is found, remove the first '/' character and update the search position
-  while (pos != std::string::npos)
+  while (auto pos = clean.find("//"); pos != std::string::npos)
   {
+    // While the substring is found, remove the first '/' character
     clean.erase(pos, 1);
-    pos = clean.find("//", pos);
   }
 
   // If the last character of "clean" is a '/', remove it
-  if (!name.empty() && *clean.rbegin() == '/')
+  if (!name.empty() && *std::rbegin(clean) == '/')
   {
-    clean.erase(clean.size() - 1, 1);
+    clean.pop_back();
   }
 
-  // Return the modified string
   return clean;
 }
 

--- a/moveit_core/utils/src/rclcpp_utils.cpp
+++ b/moveit_core/utils/src/rclcpp_utils.cpp
@@ -33,24 +33,30 @@ namespace names
 {
 std::string clean(const std::string& name)
 {
+  // Initialize a new string "clean" to be a copy of "name"
   std::string clean = name;
 
+  // Search for the substring "//" in "clean"
   size_t pos = clean.find("//");
+
+  // While the substring is found, remove the first '/' character and update the search position
   while (pos != std::string::npos)
   {
     clean.erase(pos, 1);
     pos = clean.find("//", pos);
   }
 
+  // If the last character of "clean" is a '/', remove it
   if (!name.empty() && *clean.rbegin() == '/')
   {
     clean.erase(clean.size() - 1, 1);
   }
 
+  // Return the modified string
   return clean;
 }
 
-std::string append(const std::string& left, const std::string& right)
+std::string appendAndSanitizeGraphResourceName(const std::string& left, const std::string& right)
 {
   return clean(left + "/" + right);
 }

--- a/moveit_core/utils/test/test_rclcpp_utils.cpp
+++ b/moveit_core/utils/test/test_rclcpp_utils.cpp
@@ -1,0 +1,92 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+#include <string>
+#include <moveit/utils/rclcpp_utils.h>
+
+TEST(sanitizeGraphResourceNameTest, RemovesDoubleSlashes)
+{
+  // Test that "//" is replaced with a single "/"
+  std::string input = "path//to/file";
+  std::string expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::sanitizeGraphResourceName(input), expected_output);
+
+  // Test that multiple instances of "//" are removed
+  input = "path////to/file";
+  expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::sanitizeGraphResourceName(input), expected_output);
+}
+
+TEST(sanitizeGraphResourceNameTest, RemovesTrailingSlash)
+{
+  // Test that a trailing '/' is removed
+  std::string input = "path/to/file/";
+  std::string expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::sanitizeGraphResourceName(input), expected_output);
+
+  // Test that multiple trailing '/' characters are removed
+  input = "path/to/file////";
+  expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::sanitizeGraphResourceName(input), expected_output);
+}
+
+TEST(sanitizeGraphResourceNameTest, HandlesEmptyInput)
+{
+  // Test that an empty string is returned for an empty input string
+  std::string input = "";
+  std::string expected_output = "";
+  EXPECT_EQ(rclcpp::names::sanitizeGraphResourceName(input), expected_output);
+}
+
+TEST(appendAndSanitizeGraphResourceNameTest, CorrectlyAppendsAndCleansNames)
+{
+  // Test that "left" and "right" are correctly appended and cleaned
+  std::string left = "path/to";
+  std::string right = "file/";
+  std::string expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::appendAndSanitizeGraphResourceName(left, right), expected_output);
+
+  // Test that "left" and "right" are correctly cleaned even if they contain "//" or trailing '/' characters
+  left = "path//to/";
+  right = "file////";
+  expected_output = "path/to/file";
+  EXPECT_EQ(rclcpp::names::appendAndSanitizeGraphResourceName(left, right), expected_output);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -228,7 +228,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
    */
   std::string getAbsName(const std::string& name)
   {
-    return rclcpp::names::append(ns_, name);
+    return rclcpp::names::appendAndSanitizeGraphResourceName(ns_, name);
   }
 
 public:

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -144,35 +144,35 @@ public:
     pose_reference_frame_ = getRobotModel()->getModelFrame();
     // Append the slash between two topic components
     trajectory_event_publisher_ = node_->create_publisher<std_msgs::msg::String>(
-        rclcpp::names::append(opt_.move_group_namespace_,
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_,
                               trajectory_execution_manager::TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC),
         1);
     attached_object_publisher_ = node_->create_publisher<moveit_msgs::msg::AttachedCollisionObject>(
-        rclcpp::names::append(opt_.move_group_namespace_,
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_,
                               planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC),
         1);
 
     current_state_monitor_ = getSharedStateMonitor(node_, robot_model_, tf_buffer_);
 
     move_action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(
-        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::MOVE_ACTION), callback_group_);
+        node_, rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::MOVE_ACTION), callback_group_);
     move_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
     execute_action_client_ = rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(
-        node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::EXECUTE_ACTION_NAME), callback_group_);
+        node_, rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::EXECUTE_ACTION_NAME), callback_group_);
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
 
     query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
     get_params_service_ = node_->create_client<moveit_msgs::srv::GetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
     set_params_service_ = node_->create_client<moveit_msgs::srv::SetPlannerParams>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
 
     cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
-        rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
+        rclcpp::names::appendAndSanitizeGraphResourceName(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1141,7 +1141,7 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
   robot_interaction_ = std::make_shared<robot_interaction::RobotInteraction>(
-      getRobotModel(), node_, rclcpp::names::append(getMoveGroupNS(), "rviz_moveit_motion_planning_display"));
+      getRobotModel(), node_, rclcpp::names::appendAndSanitizeGraphResourceName(getMoveGroupNS(), "rviz_moveit_motion_planning_display"));
   robot_interaction::KinematicOptions o;
   o.state_validity_callback_ = [this](moveit::core::RobotState* robot_state,
                                       const moveit::core::JointModelGroup* joint_group,

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -395,7 +395,7 @@ void PlanningSceneDisplay::changedPlanningSceneTopic()
     planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
     std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
     if (!getMoveGroupNS().empty())
-      service_name = rclcpp::names::append(getMoveGroupNS(), service_name);
+      service_name = rclcpp::names::appendAndSanitizeGraphResourceName(getMoveGroupNS(), service_name);
     auto bg_func = [=]() {
       if (planning_scene_monitor_->requestPlanningSceneState(service_name))
         addMainLoopJob([this] { onNewPlanningSceneState(); });


### PR DESCRIPTION
### Description

This is an experiment in quickly adding unit test coverage via Chat GPT
- Goto https://app.codecov.io/gh/ros-planning/moveit2?displayType=list and sort by least test coverage
- Find a file with "simple" helper functions
- Run through Chat GPT
- Paste results into a PR

The above took ~10min (my first time trying chat GPT for this), I used these prompts
- Rewrite these functions in C++ 17 (paste in C++ blocks)
- Add comments to these functions
- Generate those comments for the function header
- Write gtests
- Write a description for the pull request (I didn't use this, too verbose)

Things I did manually afterwards
- CMakeLists.txt changes
- Renaming the functions to better suit their functionality
- Haven't run clang or tried compiling yet

This was somewhat complicated by the comment about `ros_comm` not being ported to ROS 2. I think the closest functionality is in https://github.com/ros2/rcpputils/tree/rolling/include/rcpputils but I don't think they handle the particular sanitization case covered here. We can discuss about if we want these functions at all and possibly throw out this PR entirely, this was mostly an experiment in how we can get a common workflow going to quickly improve test coverage. We'll probably need some sort of "take a penny, leave a penny" so that when people submit a PR via this workflow, they also review one.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
