### PR TITLE
Add velocity and acceleration scaling when using custom limits in Time Parameterization

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -45,10 +45,25 @@ namespace trajectory_processing
 class RuckigSmoothing
 {
 public:
+  /**
+   * \brief Apply smoothing to a time-parameterized trajectory so that jerk limits are not violated.
+   * \param[in,out] trajectory A path which needs smoothing.
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
                              const double max_velocity_scaling_factor = 1.0,
                              const double max_acceleration_scaling_factor = 1.0);
 
+  /**
+   * \brief Apply smoothing to a time-parameterized trajectory so that jerk limits are not violated.
+   * \param[in,out] trajectory A path which needs smoothing.
+   * \param velocity_limits Joint names and velocity limits in rad/s
+   * \param acceleration_limits Joint names and acceleration limits in rad/s^2
+   * \param jerk_limits Joint names and jerk limits in rad/s^3
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
                              const std::unordered_map<std::string, double>& velocity_limits,
                              const std::unordered_map<std::string, double>& acceleration_limits,
@@ -56,6 +71,14 @@ public:
                              const double max_velocity_scaling_factor = 1.0,
                              const double max_acceleration_scaling_factor = 1.0);
 
+  /**
+   * \brief Apply smoothing to a time-parameterized trajectory so that jerk limits are not violated.
+   * \param[in,out] trajectory A path which needs smoothing.
+   * \param joint_limits Joint names and corresponding velocity limits in rad/s, acceleration limits in rad/s^2,
+   * and jerk limits in rad/s^3
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
                              const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
                              const double max_velocity_scaling_factor = 1.0,

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -56,6 +56,11 @@ public:
                              const double max_velocity_scaling_factor = 1.0,
                              const double max_acceleration_scaling_factor = 1.0);
 
+  static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
+                             const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
+                             const double max_velocity_scaling_factor = 1.0,
+                             const double max_acceleration_scaling_factor = 1.0);
+
 private:
   /**
    * \brief A utility function to check if the group is defined.

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -52,7 +52,9 @@ public:
   static bool applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
                              const std::unordered_map<std::string, double>& velocity_limits,
                              const std::unordered_map<std::string, double>& acceleration_limits,
-                             const std::unordered_map<std::string, double>& jerk_limits);
+                             const std::unordered_map<std::string, double>& jerk_limits,
+                             const double max_velocity_scaling_factor = 1.0,
+                             const double max_acceleration_scaling_factor = 1.0);
 
 private:
   /**

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -51,7 +51,8 @@ enum LimitType
   ACCELERATION
 };
 
-std::unordered_map<LimitType, std::string> LIMIT_TYPES = { { VELOCITY, "velocity" }, { ACCELERATION, "acceleration" } };
+const std::unordered_map<LimitType, std::string> LIMIT_TYPES = { { VELOCITY, "velocity" },
+                                                                 { ACCELERATION, "acceleration" } };
 class PathSegment
 {
 public:

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -206,6 +206,11 @@ public:
                          const double max_velocity_scaling_factor = 1.0,
                          const double max_acceleration_scaling_factor = 1.0) const override;
 
+  bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
+                         const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
+                         const double max_velocity_scaling_factor = 1.0,
+                         const double max_acceleration_scaling_factor = 1.0) const override;
+
 private:
   bool doTimeParameterizationCalculations(robot_trajectory::RobotTrajectory& trajectory,
                                           const Eigen::VectorXd& max_velocity,

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -45,6 +45,13 @@
 
 namespace trajectory_processing
 {
+enum LimitType
+{
+  VELOCITY,
+  ACCELERATION
+};
+
+std::unordered_map<LimitType, std::string> LIMIT_TYPES = { { VELOCITY, "velocity" }, { ACCELERATION, "acceleration" } };
 class PathSegment
 {
 public:
@@ -216,7 +223,7 @@ public:
   * meters for prismatic joints.
   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
   * time-parameterized; this function will re-time-parameterize it.
-  * \param joint_limits Joint names and corresponding velocity limits in rad/s and acceleration limits in rad/S^2
+  * \param joint_limits Joint names and corresponding velocity limits in rad/s and acceleration limits in rad/s^2
   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
   */
@@ -237,6 +244,15 @@ private:
    * \return true if there are mixed joints.
    */
   bool hasMixedJointTypes(const moveit::core::JointModelGroup* group) const;
+
+  /**
+   * @brief Check if the max scaling factor is valid and if not, set it to the specified default value
+   * \param[in,out] scaling_factor The default scaling factor that should be applied
+   * if the `max_scaling_factor` is invalid
+   * \param max_scaling_factor The desired maximum scaling factor to apply to the velocity or acceleration limits
+   * \param limit_type Whether the velocity or acceleration scaling factor is being verified
+   */
+  void verifyScalingFactor(double& scaling_factor, const double max_scaling_factor, const LimitType limit_type) const;
 
   const double path_tolerance_;
   const double resample_dt_;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -206,6 +206,21 @@ public:
                          const double max_velocity_scaling_factor = 1.0,
                          const double max_acceleration_scaling_factor = 1.0) const override;
 
+  // clang-format off
+/**
+  * \brief Compute a trajectory with waypoints spaced equally in time (according to resample_dt_).
+  * Resampling the trajectory doesn't change the start and goal point,
+  * and all re-sampled waypoints will be on the path of the original trajectory (within path_tolerance_).
+  * However, controller execution is separate from MoveIt and may deviate from the intended path between waypoints.
+  * path_tolerance_ is defined in configuration space, so the unit is rad for revolute joints,
+  * meters for prismatic joints.
+  * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
+  * time-parameterized; this function will re-time-parameterize it.
+  * \param joint_limits Joint names and corresponding velocity limits in rad/s and acceleration limits in rad/S^2
+  * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+  * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+  */
+  // clang-format on
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                          const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
                          const double max_velocity_scaling_factor = 1.0,

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -247,13 +247,12 @@ private:
   bool hasMixedJointTypes(const moveit::core::JointModelGroup* group) const;
 
   /**
-   * @brief Check if the max scaling factor is valid and if not, set it to the specified default value
-   * \param[in,out] scaling_factor The default scaling factor that should be applied
-   * if the `max_scaling_factor` is invalid
-   * \param max_scaling_factor The desired maximum scaling factor to apply to the velocity or acceleration limits
+   * @brief Check if the requested scaling factor is valid and if not, return 1.0.
+   * \param requested_scaling_factor The desired maximum scaling factor to apply to the velocity or acceleration limits
    * \param limit_type Whether the velocity or acceleration scaling factor is being verified
+   * \return The user requested scaling factor, if it is valid. Otherwise, return 1.0.
    */
-  void verifyScalingFactor(double& scaling_factor, const double max_scaling_factor, const LimitType limit_type) const;
+  double verifyScalingFactor(const double requested_scaling_factor, const LimitType limit_type) const;
 
   const double path_tolerance_;
   const double resample_dt_;

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -196,11 +196,15 @@ public:
   * time-parameterized; this function will re-time-parameterize it.
   * \param velocity_limits Joint names and velocity limits in rad/s
   * \param acceleration_limits Joint names and acceleration limits in rad/s^2
+  * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+  * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
   */
   // clang-format on
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                          const std::unordered_map<std::string, double>& velocity_limits,
-                         const std::unordered_map<std::string, double>& acceleration_limits) const override;
+                         const std::unordered_map<std::string, double>& acceleration_limits,
+                         const double max_velocity_scaling_factor = 1.0,
+                         const double max_acceleration_scaling_factor = 1.0) const override;
 
 private:
   bool doTimeParameterizationCalculations(robot_trajectory::RobotTrajectory& trajectory,

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
@@ -17,6 +17,8 @@ public:
                                  const double max_acceleration_scaling_factor = 1.0) const = 0;
   virtual bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                                  const std::unordered_map<std::string, double>& velocity_limits,
-                                 const std::unordered_map<std::string, double>& acceleration_limits) const = 0;
+                                 const std::unordered_map<std::string, double>& acceleration_limits,
+                                 const double max_velocity_scaling_factor = 1.0,
+                                 const double max_acceleration_scaling_factor = 1.0) const = 0;
 };
 }  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
@@ -12,14 +12,41 @@ class TimeParameterization
 {
 public:
   virtual ~TimeParameterization() = default;
+
+  /**
+   * \brief Compute a trajectory with waypoints spaced equally in time
+   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
+   * time-parameterized; this function will re-time-parameterize it.
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   virtual bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                                  const double max_velocity_scaling_factor = 1.0,
                                  const double max_acceleration_scaling_factor = 1.0) const = 0;
+
+  /**
+   * \brief Compute a trajectory with waypoints spaced equally in time
+   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
+   * time-parameterized; this function will re-time-parameterize it.
+   * \param velocity_limits Joint names and velocity limits in rad/s
+   * \param acceleration_limits Joint names and acceleration limits in rad/s^2
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   virtual bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                                  const std::unordered_map<std::string, double>& velocity_limits,
                                  const std::unordered_map<std::string, double>& acceleration_limits,
                                  const double max_velocity_scaling_factor = 1.0,
                                  const double max_acceleration_scaling_factor = 1.0) const = 0;
+
+  /**
+   * \brief Compute a trajectory with waypoints spaced equally in time
+   * \param[in,out] trajectory A path which needs time-parameterization. It's OK if this path has already been
+   * time-parameterized; this function will re-time-parameterize it.
+   * \param joint_limits Joint names and corresponding velocity limits in rad/s and acceleration limits in rad/s^2
+   * \param max_velocity_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   * \param max_acceleration_scaling_factor A factor in the range [0,1] which can slow down the trajectory.
+   */
   virtual bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
                                  const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
                                  const double max_velocity_scaling_factor = 1.0,

--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_parameterization.h
@@ -20,5 +20,9 @@ public:
                                  const std::unordered_map<std::string, double>& acceleration_limits,
                                  const double max_velocity_scaling_factor = 1.0,
                                  const double max_acceleration_scaling_factor = 1.0) const = 0;
+  virtual bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
+                                 const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
+                                 const double max_velocity_scaling_factor = 1.0,
+                                 const double max_acceleration_scaling_factor = 1.0) const = 0;
 };
 }  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -223,6 +223,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   std::unordered_map<std::string, double> jerk_limits;
   for (const auto& limit : joint_limits)
   {
+    // If custom limits are not defined here, they will be supplied from getRobotModelBounds() later
     if (limit.has_velocity_limits)
     {
       velocity_limits[limit.joint_name] = limit.max_velocity;

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -213,6 +213,33 @@ RuckigSmoothing::runRuckigInBatches(const size_t num_waypoints, const robot_traj
   return std::make_optional<robot_trajectory::RobotTrajectory>(output_trajectory, true /* deep copy */);
 }
 
+bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajectory,
+                                     const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
+                                     const double max_velocity_scaling_factor,
+                                     const double max_acceleration_scaling_factor)
+{
+  std::unordered_map<std::string, double> velocity_limits;
+  std::unordered_map<std::string, double> acceleration_limits;
+  std::unordered_map<std::string, double> jerk_limits;
+  for (const auto& limit : joint_limits)
+  {
+    if (limit.has_velocity_limits)
+    {
+      velocity_limits[limit.joint_name] = limit.max_velocity;
+    }
+    if (limit.has_acceleration_limits)
+    {
+      acceleration_limits[limit.joint_name] = limit.max_acceleration;
+    }
+    if (limit.has_jerk_limits)
+    {
+      jerk_limits[limit.joint_name] = limit.max_jerk;
+    }
+  }
+  return applySmoothing(trajectory, velocity_limits, acceleration_limits, jerk_limits, max_velocity_scaling_factor,
+                        max_acceleration_scaling_factor);
+}
+
 bool RuckigSmoothing::validateGroup(const robot_trajectory::RobotTrajectory& trajectory)
 {
   moveit::core::JointModelGroup const* const group = trajectory.getGroup();

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -967,6 +967,28 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   return doTimeParameterizationCalculations(trajectory, max_velocity, max_acceleration);
 }
 
+bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory,
+                                                        const std::vector<moveit_msgs::msg::JointLimits>& joint_limits,
+                                                        const double max_velocity_scaling_factor,
+                                                        const double max_acceleration_scaling_factor) const
+{
+  std::unordered_map<std::string, double> velocity_limits;
+  std::unordered_map<std::string, double> acceleration_limits;
+  for (const auto& limit : joint_limits)
+  {
+    if (limit.has_velocity_limits)
+    {
+      velocity_limits[limit.joint_name] = limit.max_velocity;
+    }
+    if (limit.has_acceleration_limits)
+    {
+      acceleration_limits[limit.joint_name] = limit.max_acceleration;
+    }
+  }
+  return computeTimeStamps(trajectory, velocity_limits, acceleration_limits, max_velocity_scaling_factor,
+                           max_acceleration_scaling_factor);
+}
+
 bool TimeOptimalTrajectoryGeneration::computeTimeStamps(
     robot_trajectory::RobotTrajectory& trajectory, const std::unordered_map<std::string, double>& velocity_limits,
     const std::unordered_map<std::string, double>& acceleration_limits, const double max_velocity_scaling_factor,

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -948,6 +948,7 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   std::unordered_map<std::string, double> acceleration_limits;
   for (const auto& limit : joint_limits)
   {
+    // If custom limits are not defined here, they will be supplied from getRobotModelBounds() later
     if (limit.has_velocity_limits)
     {
       velocity_limits[limit.joint_name] = limit.max_velocity;

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -881,36 +881,10 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
 
   // Validate scaling
   double velocity_scaling_factor = 1.0;
-  if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
-  {
-    velocity_scaling_factor = max_velocity_scaling_factor;
-  }
-  else if (max_velocity_scaling_factor == 0.0)
-  {
-    RCLCPP_DEBUG(LOGGER, "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                 velocity_scaling_factor);
-  }
-  else
-  {
-    RCLCPP_WARN(LOGGER, "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
-                max_velocity_scaling_factor, velocity_scaling_factor);
-  }
+  verifyScalingFactor(velocity_scaling_factor, max_velocity_scaling_factor, VELOCITY);
 
   double acceleration_scaling_factor = 1.0;
-  if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
-  {
-    acceleration_scaling_factor = max_acceleration_scaling_factor;
-  }
-  else if (max_acceleration_scaling_factor == 0.0)
-  {
-    RCLCPP_DEBUG(LOGGER, "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                 acceleration_scaling_factor);
-  }
-  else
-  {
-    RCLCPP_WARN(LOGGER, "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
-                max_acceleration_scaling_factor, acceleration_scaling_factor);
-  }
+  verifyScalingFactor(acceleration_scaling_factor, max_acceleration_scaling_factor, ACCELERATION);
 
   const std::vector<std::string>& vars = group->getVariableNames();
   const moveit::core::RobotModel& rmodel = group->getParentModel();
@@ -1007,36 +981,10 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(
 
   // Validate scaling
   double velocity_scaling_factor = 1.0;
-  if (max_velocity_scaling_factor > 0.0 && max_velocity_scaling_factor <= 1.0)
-  {
-    velocity_scaling_factor = max_velocity_scaling_factor;
-  }
-  else if (max_velocity_scaling_factor == 0.0)
-  {
-    RCLCPP_DEBUG(LOGGER, "A max_velocity_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                 velocity_scaling_factor);
-  }
-  else
-  {
-    RCLCPP_WARN(LOGGER, "Invalid max_velocity_scaling_factor %f specified, defaulting to %f instead.",
-                max_velocity_scaling_factor, velocity_scaling_factor);
-  }
+  verifyScalingFactor(velocity_scaling_factor, max_velocity_scaling_factor, VELOCITY);
 
   double acceleration_scaling_factor = 1.0;
-  if (max_acceleration_scaling_factor > 0.0 && max_acceleration_scaling_factor <= 1.0)
-  {
-    acceleration_scaling_factor = max_acceleration_scaling_factor;
-  }
-  else if (max_acceleration_scaling_factor == 0.0)
-  {
-    RCLCPP_DEBUG(LOGGER, "A max_acceleration_scaling_factor of 0.0 was specified, defaulting to %f instead.",
-                 acceleration_scaling_factor);
-  }
-  else
-  {
-    RCLCPP_WARN(LOGGER, "Invalid max_acceleration_scaling_factor %f specified, defaulting to %f instead.",
-                max_acceleration_scaling_factor, acceleration_scaling_factor);
-  }
+  verifyScalingFactor(acceleration_scaling_factor, max_acceleration_scaling_factor, ACCELERATION);
 
   const unsigned num_joints = group->getVariableCount();
   const std::vector<std::string>& vars = group->getVariableNames();
@@ -1261,5 +1209,32 @@ bool TimeOptimalTrajectoryGeneration::hasMixedJointTypes(const moveit::core::Joi
       });
 
   return have_prismatic && have_revolute;
+}
+
+void TimeOptimalTrajectoryGeneration::verifyScalingFactor(double& scaling_factor, const double max_scaling_factor,
+                                                          const LimitType limit_type) const
+{
+  std::string limit_type_str;
+  auto limit_type_it = LIMIT_TYPES.find(limit_type);
+
+  if (limit_type_it != LIMIT_TYPES.end())
+  {
+    limit_type_str = limit_type_it->second + "_";
+  }
+
+  if (max_scaling_factor > 0.0 && max_scaling_factor <= 1.0)
+  {
+    scaling_factor = max_scaling_factor;
+  }
+  else if (max_scaling_factor == 0.0)
+  {
+    RCLCPP_DEBUG(LOGGER, "A max_%sscaling_factor of 0.0 was specified, defaulting to %f instead.",
+                 limit_type_str.c_str(), scaling_factor);
+  }
+  else
+  {
+    RCLCPP_WARN(LOGGER, "Invalid max_%sscaling_factor %f specified, defaulting to %f instead.", limit_type_str.c_str(),
+                max_scaling_factor, scaling_factor);
+  }
 }
 }  // namespace trajectory_processing


### PR DESCRIPTION
### Description

In an effort to use dynamic joint velocity, acceleration, or jerk limits it was mentioned by @henningkayser in my moveit_msgs PR here https://github.com/ros-planning/moveit_msgs/pull/144#discussion_r972178123 that scaling should be applied regardless if using default limits or custom limits. This PR creates the necessary changes to accomplish this. 
@AndyZe 

EDIT

This PR also adds another overloaded `computeTimeStamps` function for passing in a vector of JointLimit messages. I found this to be easier to work with in my implementation for integrating dynamic joint limits.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
