### PR TITLE
reading namespace from parameter

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -264,7 +264,7 @@ public:
         node_->get_parameter<std::string>("ros_control_namespace", ns_);
       }
     }
-    else if(node->has_parameter("ros_control_namespace"))
+    else if (node->has_parameter("ros_control_namespace"))
     {
       node_->get_parameter<std::string>("ros_control_namespace", ns_);
       RCLCPP_INFO_STREAM(LOGGER, "Namespace for controller manager was specified, namespace: " << ns_);

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -257,6 +257,8 @@ public:
     {
       if (!node_->has_parameter("ros_control_namespace"))
         ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
+      else
+        node_->get_parameter<std::string>("ros_control_namespace", ns_);
     }
     else if(node->has_parameter("ros_control_namespace"))
     {

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -258,6 +258,12 @@ public:
       if (!node_->has_parameter("ros_control_namespace"))
         ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
     }
+    else if(node->has_parameter("ros_control_namespace"))
+    {
+      node_->get_parameter<std::string>("ros_control_namespace", ns_);
+      RCLCPP_INFO_STREAM(LOGGER, "Namespace for controller manager was specified, namespace: " << ns_);
+    }
+
     list_controllers_service_ = node_->create_client<controller_manager_msgs::srv::ListControllers>(
         getAbsName("controller_manager/list_controllers"));
     switch_controller_service_ = node_->create_client<controller_manager_msgs::srv::SwitchController>(

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -256,9 +256,13 @@ public:
     if (!ns_.empty())
     {
       if (!node_->has_parameter("ros_control_namespace"))
+      {
         ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
+      }
       else
+      {
         node_->get_parameter<std::string>("ros_control_namespace", ns_);
+      }
     }
     else if(node->has_parameter("ros_control_namespace"))
     {


### PR DESCRIPTION
### Description

The ros_control_namespace cant be used with the current code.
It was needed to execute a dual arm demo using two separated namespaces for ros2_control controller manager and move_group node.