### PR TITLE
moveit_cpp: handle the case where blocking==false

### DIFF
--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -238,13 +238,17 @@ MoveItCpp::execute(const std::string& group_name, const robot_trajectory::RobotT
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
   // TODO: cambel
   // blocking is the only valid option right now. Add non-blocking use case
-  if (blocking)
+  if (!blocking)
+  {
+    RCLCPP_ERROR(LOGGER, "Currently, the `blocking` parameter must be true. Not executing the trajectory.");
+    return moveit_controller_manager::ExecutionStatus::FAILED;
+  }
+  else
   {
     trajectory_execution_manager_->push(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }
-  return moveit_controller_manager::ExecutionStatus::RUNNING;
 }
 
 bool MoveItCpp::terminatePlanningPipeline(const std::string& pipeline_name)


### PR DESCRIPTION
### Description

Currently, the `blocking` arg of `MoveItCpp::execute()` must be true. The case where it's false wasn't handled well.