### PR TITLE
Do not allow traj execution from PlanningComponent

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -163,9 +163,6 @@ public:
   trajectory_execution_manager::TrajectoryExecutionManagerPtr getTrajectoryExecutionManagerNonConst();
 
   /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.
-   * If blocking is set to false, the execution is run in background and the function returns immediately. */
-
-  /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.
    *  \param [in] group_name MoveIt group to execute for.
    *  \param [in] robot_trajectory Contains trajectory info as well as metadata such as a RobotModel.
    *  \param [in] blocking If blocking, wait for the trajectory to execute before continuing. Defaults to `true`.
@@ -173,9 +170,13 @@ public:
    * a controller. The exact behavior of finding a controller depends on which MoveItControllerManager plugin is active.
    * \return moveit_controller_manager::ExecutionStatus::SUCCEEDED if successful
    */
-  moveit_controller_manager::ExecutionStatus
+  [[deprecated(
+      "MoveItCpp::execute() no longer requires a group_name parameter")]] moveit_controller_manager::ExecutionStatus
   execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-          bool blocking = true, const std::vector<std::string>& controllers = std::vector<std::string>());
+          bool blocking = true);
+
+  moveit_controller_manager::ExecutionStatus execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
+                                                     bool blocking = true);
 
   /** \brief Utility to terminate the given planning pipeline */
   bool terminatePlanningPipeline(const std::string& pipeline_name);

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -173,10 +173,11 @@ public:
   [[deprecated(
       "MoveItCpp::execute() no longer requires a group_name parameter")]] moveit_controller_manager::ExecutionStatus
   execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-          bool blocking = true);
+          bool blocking = true, const std::vector<std::string>& controllers = std::vector<std::string>());
 
-  moveit_controller_manager::ExecutionStatus execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-                                                     bool blocking = true);
+  moveit_controller_manager::ExecutionStatus
+  execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory, bool blocking = true,
+          const std::vector<std::string>& controllers = std::vector<std::string>());
 
   /** \brief Utility to terminate the given planning pipeline */
   bool terminatePlanningPipeline(const std::string& pipeline_name);

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -200,10 +200,6 @@ public:
        const SolutionCallbackFunction& solution_selection_callback = &getShortestSolution,
        StoppingCriterionFunction stopping_criterion_callback = nullptr);
 
-  /** \brief Execute the latest computed solution trajectory computed by plan(). By default this function terminates
-   * after the execution is complete. The execution can be run in background by setting blocking to false. */
-  bool execute(bool blocking = true);
-
   /** \brief Return the last plan solution*/
   const planning_interface::MotionPlanResponse& getLastMotionPlanResponse();
 

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -200,6 +200,10 @@ public:
        const SolutionCallbackFunction& solution_selection_callback = &getShortestSolution,
        StoppingCriterionFunction stopping_criterion_callback = nullptr);
 
+  /** \brief Execute the latest computed solution trajectory computed by plan(). By default this function terminates
+   * after the execution is complete. The execution can be run in background by setting blocking to false. */
+  [[deprecated("Use MoveItCpp::execute()")]] bool execute(bool blocking = true);
+
   /** \brief Return the last plan solution*/
   const planning_interface::MotionPlanResponse& getLastMotionPlanResponse();
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -218,13 +218,14 @@ trajectory_execution_manager::TrajectoryExecutionManagerPtr MoveItCpp::getTrajec
 
 moveit_controller_manager::ExecutionStatus
 MoveItCpp::execute(const std::string& /* group_name */, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-                   bool blocking)
+                   bool blocking, const std::vector<std::string>& /* controllers */)
 {
   return execute(robot_trajectory, blocking);
 }
 
 moveit_controller_manager::ExecutionStatus
-MoveItCpp::execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory, bool blocking)
+MoveItCpp::execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory, bool blocking,
+                   const std::vector<std::string>& controllers)
 {
   if (!robot_trajectory)
   {

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -217,14 +217,22 @@ trajectory_execution_manager::TrajectoryExecutionManagerPtr MoveItCpp::getTrajec
 }
 
 moveit_controller_manager::ExecutionStatus
-MoveItCpp::execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-                   bool blocking, const std::vector<std::string>& controllers)
+MoveItCpp::execute(const std::string& /* group_name */, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
+                   bool blocking)
+{
+  return execute(robot_trajectory, blocking);
+}
+
+moveit_controller_manager::ExecutionStatus
+MoveItCpp::execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory, bool blocking)
 {
   if (!robot_trajectory)
   {
     RCLCPP_ERROR(LOGGER, "Robot trajectory is undefined");
     return moveit_controller_manager::ExecutionStatus::ABORTED;
   }
+
+  const std::string group_name = robot_trajectory->getGroupName();
 
   // Check if there are controllers that can handle the execution
   if (!trajectory_execution_manager_->ensureActiveControllersForGroup(group_name))

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -412,7 +412,7 @@ bool PlanningComponent::execute(bool blocking)
   //  RCLCPP_ERROR("Failed to parameterize trajectory");
   //  return false;
   //}
-  return moveit_cpp_->execute(group_name_, last_plan_solution_.trajectory_, blocking);
+  return moveit_cpp_->execute(last_plan_solution_.trajectory_, blocking);
 }
 
 const planning_interface::MotionPlanResponse& PlanningComponent::getLastMotionPlanResponse()

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -396,6 +396,25 @@ bool PlanningComponent::setGoal(const std::string& goal_state_name)
   return setGoal(goal_state);
 }
 
+bool PlanningComponent::execute(bool blocking)
+{
+  if (!last_plan_solution_)
+  {
+    RCLCPP_ERROR(LOGGER, "There is no successful plan to execute");
+    return false;
+  }
+
+  // TODO(henningkayser): parameterize timestamps if required
+  // trajectory_processing::TimeOptimalTrajectoryGeneration totg;
+  // if (!totg.computeTimeStamps(*last_solution_trajectory_, max_velocity_scaling_factor_,
+  // max_acceleration_scaling_factor_))
+  //{
+  //  RCLCPP_ERROR("Failed to parameterize trajectory");
+  //  return false;
+  //}
+  return moveit_cpp_->execute(group_name_, last_plan_solution_.trajectory_, blocking);
+}
+
 const planning_interface::MotionPlanResponse& PlanningComponent::getLastMotionPlanResponse()
 {
   return last_plan_solution_;

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -396,25 +396,6 @@ bool PlanningComponent::setGoal(const std::string& goal_state_name)
   return setGoal(goal_state);
 }
 
-bool PlanningComponent::execute(bool blocking)
-{
-  if (!last_plan_solution_)
-  {
-    RCLCPP_ERROR(LOGGER, "There is no successful plan to execute");
-    return false;
-  }
-
-  // TODO(henningkayser): parameterize timestamps if required
-  // trajectory_processing::TimeOptimalTrajectoryGeneration totg;
-  // if (!totg.computeTimeStamps(*last_solution_trajectory_, max_velocity_scaling_factor_,
-  // max_acceleration_scaling_factor_))
-  //{
-  //  RCLCPP_ERROR("Failed to parameterize trajectory");
-  //  return false;
-  //}
-  return moveit_cpp_->execute(group_name_, last_plan_solution_.trajectory_, blocking);
-}
-
 const planning_interface::MotionPlanResponse& PlanningComponent::getLastMotionPlanResponse()
 {
   return last_plan_solution_;


### PR DESCRIPTION
Merge with https://github.com/ros-planning/moveit2_tutorials/pull/563

MoveItCpp and PlanningComponent have very similar `execute()` functions. ~~One does not call the other.~~ Here, I advocate for deleting the PlanningComponent version because I don't think something focused on planning should handle execution. If you like this, there are some small updates to make in moveit_tutorials but that is the only effect I foresee.


```
bool PlanningComponent::execute(bool blocking)

MoveItCpp::execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
                   bool blocking)
```

If you do NOT like this PR, then can we flip it to delete the MoveItCpp version of `execute()`? AFAIK it is not used anywhere