### PR TITLE
Add optional list of controllers to MoveItCpp::execute()

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -164,9 +164,18 @@ public:
 
   /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.
    * If blocking is set to false, the execution is run in background and the function returns immediately. */
-  moveit_controller_manager::ExecutionStatus execute(const std::string& group_name,
-                                                     const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-                                                     bool blocking = true);
+
+  /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.
+   *  \param [in] group_name MoveIt group to execute for.
+   *  \param [in] robot_trajectory Contains trajectory info as well as metadata such as a RobotModel.
+   *  \param [in] blocking If blocking, wait for the trajectory to execute before continuing. Defaults to `true`.
+   *  \param [in] controllers An optional list of ros2_controllers to execute with. If none, MoveIt will attempt to find
+   * a controller. The exact behavior of finding a controller depends on which MoveItControllerManager plugin is active.
+   * \return moveit_controller_manager::ExecutionStatus::SUCCEEDED if successful
+   */
+  moveit_controller_manager::ExecutionStatus
+  execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
+          bool blocking = true, const std::vector<std::string>& controllers = std::vector<std::string>(1, ""));
 
   /** \brief Utility to terminate the given planning pipeline */
   bool terminatePlanningPipeline(const std::string& pipeline_name);

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -175,7 +175,7 @@ public:
    */
   moveit_controller_manager::ExecutionStatus
   execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-          bool blocking = true, const std::vector<std::string>& controllers = std::vector<std::string>(1, ""));
+          bool blocking = true, const std::vector<std::string>& controllers = std::vector<std::string>());
 
   /** \brief Utility to terminate the given planning pipeline */
   bool terminatePlanningPipeline(const std::string& pipeline_name);

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -218,7 +218,7 @@ trajectory_execution_manager::TrajectoryExecutionManagerPtr MoveItCpp::getTrajec
 
 moveit_controller_manager::ExecutionStatus
 MoveItCpp::execute(const std::string& group_name, const robot_trajectory::RobotTrajectoryPtr& robot_trajectory,
-                   bool blocking)
+                   bool blocking, const std::vector<std::string>& controllers)
 {
   if (!robot_trajectory)
   {
@@ -240,7 +240,7 @@ MoveItCpp::execute(const std::string& group_name, const robot_trajectory::RobotT
   // blocking is the only valid option right now. Add non-blocking use case
   if (blocking)
   {
-    trajectory_execution_manager_->push(robot_trajectory_msg);
+    trajectory_execution_manager_->push(robot_trajectory_msg, controllers);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -51,7 +51,6 @@
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit_msgs/action/execute_trajectory.hpp>
-#include <moveit_msgs/srv/execute_known_trajectory.hpp>
 #include <moveit_msgs/srv/query_planner_interfaces.hpp>
 #include <moveit_msgs/srv/get_cartesian_path.hpp>
 #include <moveit_msgs/srv/grasp_planning.hpp>


### PR DESCRIPTION
### Description

One of our projects has had some difficulty in switching between a joint trajectory controller and an admittance controller. This adds a parameter so the user can specify which controller they want to execute the trajectory.