### PR TITLE
Remove clipped cells from pointcloud_octomap_updater plugin

### DIFF
--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -334,7 +334,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::msg::PointClo
   for (const octomap::OcTreeKey& occupied_cell : occupied_cells)
     free_cells.erase(occupied_cell);
 
-  /* clipped cells are not free*/
+  /* clipped cells are not occupied*/
   for (const octomap::OcTreeKey& clip_cell : clip_cells){ 
     occupied_cells.erase(clip_cell);}
 


### PR DESCRIPTION
### Description

This PR is removes the clipped cells from the octomap.

Previously, undesired voxels would stay and not update due to the clipped cells not being removed. This is especially the case in when the camera observes a dynamic environment. A wall would form at max range from the sensor origin. This can be seen in the following images that show the scene before and after dynamic activity.

![scene_after_dynamic_activity](https://user-images.githubusercontent.com/120711993/210252860-50179620-9d3b-43e8-a885-66f379cc713f.png)
![static_scene](https://user-images.githubusercontent.com/120711993/210252864-128fd223-8b24-40d2-91ed-45c415fd211a.png)

The clipped cells where therefore erased from occupied cells and the clipped_cells nodes were updated to unoccupied.
When tested, this solved the issue and the octomap updates properly.



### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
