### PR TITLE
Fix wrong use of C msg headers

### DIFF
--- a/moveit_core/distance_field/src/propagation_distance_field.cpp
+++ b/moveit_core/distance_field/src/propagation_distance_field.cpp
@@ -35,7 +35,7 @@
 /* Author: Mrinal Kalakrishnan, Ken Anderson */
 
 #include <moveit/distance_field/propagation_distance_field.h>
-#include <visualization_msgs/msg/marker.h>
+#include <visualization_msgs/msg/marker.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>

--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -52,7 +52,7 @@
 
 #if VISUALIZE_PR2_RVIZ
 #include <rclcpp/rclcpp.hpp>
-#include <visualization_msgs/msg/marker.h>
+#include <visualization_msgs/msg/marker.hpp>
 #include <geometric_shapes/shape_operations.h>
 #endif
 

--- a/moveit_core/utils/include/moveit/utils/moveit_error_code.h
+++ b/moveit_core/utils/include/moveit/utils/moveit_error_code.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <moveit_msgs/msg/move_it_error_codes.h>
+#include <moveit_msgs/msg/move_it_error_codes.hpp>
 #include <string>
 
 namespace moveit

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/constraint_approximations.h
@@ -40,7 +40,7 @@
 #include <planning_scene/planning_scene.h>
 #include <kinematic_constraints/kinematic_constraint.h>
 #include <ompl/base/StateStorage.h>
-#include <visualization_msgs/msg/marker_array.h>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 namespace ompl_interface
 {

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -35,7 +35,7 @@
 #include <moveit/global_planner/global_planner_component.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/conversions.h>
-#include <moveit_msgs/msg/move_it_error_codes.h>
+#include <moveit_msgs/msg/move_it_error_codes.hpp>
 
 #include <chrono>
 #include <thread>

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_constraint_solver_interface.h
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_constraint_solver_interface.h
@@ -49,7 +49,7 @@
 
 #include <moveit_msgs/action/local_planner.hpp>
 
-#include <trajectory_msgs/msg/joint_trajectory.h>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 namespace moveit::hybrid_planning
 {

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -43,7 +43,7 @@
 #include <mutex>
 
 #include <controller_manager/realtime.hpp>
-#include <std_msgs/msg/bool.h>
+#include <std_msgs/msg/bool.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 // #include <moveit_servo/make_shared_from_pool.h> // TODO(adamp): create an issue about this

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -37,7 +37,7 @@
 
 #pragma once
 
-#include <geometry_msgs/msg/pose_stamped.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit/moveit_cpp/moveit_cpp.h>
 #include <moveit/moveit_cpp/plan_solutions.hpp>
 #include <moveit/planning_interface/planning_response.h>

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -53,7 +53,7 @@
 #include <moveit_msgs/action/execute_trajectory.hpp>
 
 #include <moveit_msgs/msg/motion_plan_request.hpp>
-#include <geometry_msgs/msg/pose_stamped.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 
 #include <rclcpp_action/rclcpp_action.hpp>
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -60,7 +60,7 @@
 #include <moveit/utils/rclcpp_utils.h>
 
 #include <std_msgs/msg/string.hpp>
-#include <geometry_msgs/msg/transform_stamped.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tf2/utils.h>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/transform_listener.h>


### PR DESCRIPTION
You inconsistently use C++ and C msg headers! This PR fixes all occurrences of wrong C header usage.

I'm really wondering why you didn't run into issues due to this before. When including `moveit/utils/moveit_error_code.h`, I'm getting these errors:
```
/opt/ros/rolling/include/moveit/utils/moveit_error_code.h:48:1: error: expected class-name before ‘{’ token
   48 | {
      | ^
/opt/ros/rolling/include/moveit/utils/moveit_error_code.h:54:43: error: ‘MoveItErrorCodes’ in namespace ‘moveit_msgs::msg’ does not name a type
   54 |   MoveItErrorCode(const moveit_msgs::msg::MoveItErrorCodes& code)
```
That's not surprising as the C++ and C types are fundamentally different, e.g.
`moveit_msgs::msg::MoveItErrorCodes` vs. `moveit_msgs__msg__MoveItErrorCodes`.

I guess you include the corresponding `.hpp` header somewhere else then...