### PR TITLE
[Servo] Add an optional "Anti-drift" mode

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -69,3 +69,10 @@ check_collisions: true # Check collisions?
 collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
+
+## Joint drift thresholding
+# Joints of certain robots such as Kinova and Ignition simulations tend to drift over time.
+# It often manifests as a slow sag due to gravity.
+# This enables a special mode to prevent joint drift by only updating positions of the actuated joints.
+# A value of false is fine for most arms with good position control, such as UR robots.
+apply_anti_drift: false

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -62,3 +62,10 @@ check_collisions: true # Check collisions?
 collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
 scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
+
+## Joint drift thresholding
+# Joints of certain robots such as Kinova and Ignition simulations tend to drift over time.
+# It often manifests as a slow sag due to gravity.
+# This enables a special mode to prevent joint drift by only updating positions of the actuated joints.
+# A value of false is fine for most arms with good position control such as UR robots.
+apply_anti_drift: false

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -176,10 +176,6 @@ protected:
    */
   std::vector<const moveit::core::JointModel*> enforcePositionLimits(sensor_msgs::msg::JointState& joint_state) const;
 
-  /** \brief Compose the outgoing JointTrajectory message */
-  void composeJointTrajMessage(const sensor_msgs::msg::JointState& joint_state,
-                               trajectory_msgs::msg::JointTrajectory& joint_trajectory);
-
   /** \brief Set the filters to the specified values */
   void resetLowPassFilters(const sensor_msgs::msg::JointState& joint_state);
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -105,6 +105,8 @@ struct ServoParameters
   double collision_check_rate{ 10.0 };
   double self_collision_proximity_threshold{ 0.01 };
   double scene_collision_proximity_threshold{ 0.02 };
+  // Joint drift thresholding
+  bool apply_anti_drift{ false };
 
   /**
    * Declares, reads, and validates parameters used for moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -41,6 +41,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
+#include <moveit_servo/servo_parameters.h>
 #include <moveit_servo/status_codes.h>
 
 namespace moveit_servo
@@ -77,5 +78,10 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
                                            const double lower_singularity_threshold,
                                            const double leaving_singularity_threshold_multiplier, rclcpp::Clock& clock,
                                            const moveit::core::RobotStatePtr& current_state, StatusCode& status);
+
+/** \brief Compose a JointTrajectory message from a JointState */
+void composeJointTrajMessage(const std::shared_ptr<const moveit_servo::ServoParameters>& parameters,
+                             const sensor_msgs::msg::JointState& joint_state,
+                             trajectory_msgs::msg::JointTrajectory& joint_trajectory);
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -262,6 +262,11 @@ void ServoParameters::declare(const std::string& ns,
                                      ParameterDescriptorBuilder{}
                                          .type(PARAMETER_DOUBLE)
                                          .description("Start decelerating when a scene collision is this far [m]"));
+
+  // Joint drift_velocity threshold
+  node_parameters->declare_parameter(
+      ns + ".apply_anti_drift", ParameterValue{ parameters.apply_anti_drift },
+      ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Enable a special mode to mitigate joint drift"));
 }
 
 ServoParameters ServoParameters::get(const std::string& ns,
@@ -347,6 +352,9 @@ ServoParameters ServoParameters::get(const std::string& ns,
       node_parameters->get_parameter(ns + ".self_collision_proximity_threshold").as_double();
   parameters.scene_collision_proximity_threshold =
       node_parameters->get_parameter(ns + ".scene_collision_proximity_threshold").as_double();
+
+  // Joint drift thresholding
+  parameters.apply_anti_drift = node_parameters->get_parameter(ns + ".apply_anti_drift").as_bool();
 
   return parameters;
 }
@@ -450,6 +458,7 @@ std::optional<ServoParameters> ServoParameters::validate(ServoParameters paramet
                         "greater than zero. Check yaml file.");
     return std::nullopt;
   }
+
   return parameters;
 }
 


### PR DESCRIPTION
### Description

Addresses #1857

Also moves `composeJointTraj()` to a free utility function. That's better for:

- testing
- should decrease the size of the `servo_calcs` translation unit, which is starting to become a problem in CI:  https://github.com/ros-planning/moveit2/issues/1428
