### PR TITLE
gigantic speed up to move group interface

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -817,7 +817,7 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     if (code != rclcpp_action::ResultCode::SUCCEEDED)
@@ -895,7 +895,7 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     if (code != rclcpp_action::ResultCode::SUCCEEDED)
@@ -961,7 +961,7 @@ public:
     // wait until send_goal_opts.result_callback is called
     while (!done)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     if (code != rclcpp_action::ResultCode::SUCCEEDED)


### PR DESCRIPTION
### Description

This speedup removes the 100ms delay during a planning time, which increases planning times by a substantial amount. 
For example, my 2 robot arms without this takes 600ms+ to plan. By reducing this sleep to 1ms the plans are then in the 150ms range. 

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
