### PR TITLE
Add a default stopping criterion for parallel planning

### DIFF
--- a/moveit_ros/planning/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning/moveit_cpp/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(moveit_cpp SHARED
   src/moveit_cpp.cpp
+  src/parallel_planning_callbacks.cpp
   src/planning_component.cpp
 )
 set_target_properties(moveit_cpp PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/parallel_planning_callbacks.hpp
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/parallel_planning_callbacks.hpp
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Sebastian Jahr
+   Desc: Common callback functions for parallel planning */
+
+#pragma once
+
+#include <moveit/moveit_cpp/planning_component.h>
+
+namespace moveit_cpp
+{
+/** \brief A callback function that can be used as a parallel planning stop criterion.
+ *          It stops parallel planning as soon as any planner finds a solution. */
+bool stopAtFirstSolution(PlanSolutions const& plan_solutions,
+                         PlanningComponent::MultiPipelinePlanRequestParameters const& /*plan_request_parameters*/);
+}  // namespace moveit_cpp

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
@@ -80,7 +80,7 @@ private:
  *  \param [in] solutions Vector of solutions to chose the shortest one from
  *  \return Shortest solution, trajectory_ of the returned MotionPlanResponse is a nullptr if no solution is found!
  */
-static planning_interface::MotionPlanResponse
+static inline planning_interface::MotionPlanResponse
 getShortestSolution(const std::vector<planning_interface::MotionPlanResponse>& solutions)
 {
   // Find trajectory with minimal path

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/plan_solutions.hpp
@@ -80,7 +80,7 @@ private:
  *  \param [in] solutions Vector of solutions to chose the shortest one from
  *  \return Shortest solution, trajectory_ of the returned MotionPlanResponse is a nullptr if no solution is found!
  */
-planning_interface::MotionPlanResponse
+static planning_interface::MotionPlanResponse
 getShortestSolution(const std::vector<planning_interface::MotionPlanResponse>& solutions)
 {
   // Find trajectory with minimal path

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -209,11 +209,6 @@ public:
   const planning_interface::MotionPlanResponse& getLastMotionPlanResponse();
 
 private:
-  /** \brief A callback function that is used as the default parallel planning stop criterion.
-   *          It stops parallel planning as soon as any planner finds a solution. */
-  static bool stopAtFirstSolution(PlanSolutions const& plan_solutions,
-                                  PlanningComponent::MultiPipelinePlanRequestParameters const& plan_request_parameters);
-
   // Core properties and instances
   rclcpp::Node::SharedPtr node_;
   MoveItCppPtr moveit_cpp_;

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -49,6 +49,7 @@
 namespace moveit_cpp
 {
 MOVEIT_CLASS_FORWARD(PlanningComponent);  // Defines PlanningComponentPtr, ConstPtr, WeakPtr... etc
+
 class PlanningComponent
 {
 public:
@@ -194,7 +195,8 @@ public:
   planning_interface::MotionPlanResponse plan(const PlanRequestParameters& parameters, const bool store_solution = true);
 
   /** \brief Run a plan from start or current state to fulfill the last goal constraints provided by setGoal() using the
-   * provided PlanRequestParameters. */
+   * provided PlanRequestParameters. This defaults to taking the full planning time (null stopping_criterion_callback)
+   * and finding the shortest solution in joint space. */
   planning_interface::MotionPlanResponse
   plan(const MultiPipelinePlanRequestParameters& parameters,
        const SolutionCallbackFunction& solution_selection_callback = &getShortestSolution,
@@ -208,6 +210,11 @@ public:
   const planning_interface::MotionPlanResponse& getLastMotionPlanResponse();
 
 private:
+  /** \brief A callback function that is used as the default parallel planning stop criterion.
+   *          It stops parallel planning as soon as any planner finds a solution. */
+  static bool stopAtFirstSolution(PlanSolutions const& plan_solutions,
+                                  PlanningComponent::MultiPipelinePlanRequestParameters const& plan_request_parameters);
+
   // Core properties and instances
   rclcpp::Node::SharedPtr node_;
   MoveItCppPtr moveit_cpp_;

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/planning_component.h
@@ -53,7 +53,6 @@ MOVEIT_CLASS_FORWARD(PlanningComponent);  // Defines PlanningComponentPtr, Const
 class PlanningComponent
 {
 public:
-  using MoveItErrorCode [[deprecated("Use moveit::core::MoveItErrorCode")]] = moveit::core::MoveItErrorCode;
   /// Planner parameters provided with the MotionPlanRequest
   struct PlanRequestParameters
   {

--- a/moveit_ros/planning/moveit_cpp/src/parallel_planning_callbacks.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/parallel_planning_callbacks.cpp
@@ -1,0 +1,59 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Sebastian Jahr */
+
+#include <moveit/moveit_cpp/parallel_planning_callbacks.hpp>
+
+namespace moveit_cpp
+{
+/** \brief A callback function that can be used as a parallel planning stop criterion.
+ *          It stops parallel planning as soon as any planner finds a solution. */
+bool stopAtFirstSolution(PlanSolutions const& plan_solutions,
+                         PlanningComponent::MultiPipelinePlanRequestParameters const& /*plan_request_parameters*/)
+{
+  // Stop at the first successful plan
+  for (auto const& solution : plan_solutions.getSolutions())
+  {
+    // bool(solution) is shorthand to evaluate the error code of the solution, checking for SUCCESS
+    if (bool(solution))
+    {
+      // Return true to abort the other pipelines
+      return true;
+    }
+  }
+  // Return false when parallel planning should continue because it hasn't found a successful solution yet
+  return false;
+}
+}  // namespace moveit_cpp

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -419,4 +419,23 @@ const planning_interface::MotionPlanResponse& PlanningComponent::getLastMotionPl
 {
   return last_plan_solution_;
 }
+
+bool PlanningComponent::stopAtFirstSolution(
+    PlanSolutions const& plan_solutions,
+    PlanningComponent::MultiPipelinePlanRequestParameters const& /*plan_request_parameters*/)
+{
+  // Stop at the first successful plan
+  for (auto const& solution : plan_solutions.getSolutions())
+  {
+    // bool(solution) is shorthand to evaluate the error code of the solution, checking for SUCCESS
+    if (bool(solution))
+    {
+      // Return true to abort the other pipelines
+      return true;
+    }
+  }
+  // Return false when parallel planning should continue because it hasn't found a successful solution yet
+  return false;
+}
+
 }  // namespace moveit_cpp

--- a/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/planning_component.cpp
@@ -419,23 +419,4 @@ const planning_interface::MotionPlanResponse& PlanningComponent::getLastMotionPl
 {
   return last_plan_solution_;
 }
-
-bool PlanningComponent::stopAtFirstSolution(
-    PlanSolutions const& plan_solutions,
-    PlanningComponent::MultiPipelinePlanRequestParameters const& /*plan_request_parameters*/)
-{
-  // Stop at the first successful plan
-  for (auto const& solution : plan_solutions.getSolutions())
-  {
-    // bool(solution) is shorthand to evaluate the error code of the solution, checking for SUCCESS
-    if (bool(solution))
-    {
-      // Return true to abort the other pipelines
-      return true;
-    }
-  }
-  // Return false when parallel planning should continue because it hasn't found a successful solution yet
-  return false;
-}
-
 }  // namespace moveit_cpp


### PR DESCRIPTION
Add a parallel planning stop condition that will be commonly used. It stops at the first solution from any planner.