### PR TITLE
Add ament export

### DIFF
--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -43,13 +43,14 @@ set(THIS_PACKAGE_LIBRARIES
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
-  Boost
+  Eigen3
   class_loader
   generate_parameter_library
   kdl_parser
   moveit_core
   moveit_msgs
   moveit_ros_planning
+  orocos_kdl_vendor
   pluginlib
   random_numbers
   rclcpp
@@ -80,7 +81,7 @@ install(
 )
 
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -6,18 +6,19 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 find_package(ament_cmake REQUIRED)
+
 find_package(Eigen3 REQUIRED)
-find_package(orocos_kdl REQUIRED)
-find_package(tf2_kdl REQUIRED)
-find_package(kdl_parser REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(random_numbers REQUIRED)
 find_package(class_loader REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(moveit_core REQUIRED)
-find_package(moveit_ros_planning REQUIRED)
-find_package(moveit_msgs REQUIRED)
 find_package(generate_parameter_library REQUIRED)
+find_package(kdl_parser REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(orocos_kdl REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(random_numbers REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_kdl REQUIRED)
 
 # Finds Boost Components
 include(ConfigExtras.cmake)
@@ -42,11 +43,17 @@ set(THIS_PACKAGE_LIBRARIES
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
-  pluginlib
-  moveit_core
-  moveit_ros_planning
   Boost
+  class_loader
   generate_parameter_library
+  kdl_parser
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning
+  pluginlib
+  random_numbers
+  rclcpp
+  tf2_kdl
 )
 
 pluginlib_export_plugin_description_file(moveit_core kdl_kinematics_plugin_description.xml)


### PR DESCRIPTION
Also sort `find_package` entries alphabetically.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

### Description

I had an issue when trying to compile a package that depended on `moveit_kinematics`. IIRC the issue was with `tf2_kdl` but I added also all other packages except `orocos_kdl` which is added separately as `orocos_kdl_vendor` for some reason.

I didn't change and `find_package` line, just sorted them alphabetically.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
