### PR TITLE
Don't use ament_export_targets from package sub folder

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -107,21 +107,21 @@ add_subdirectory(version)
 install(
   TARGETS
     moveit_butterworth_filter
-    moveit_collision_distance_field
     moveit_collision_detection
-    moveit_collision_detection_fcl
     moveit_collision_detection_bullet
-    moveit_dynamics_solver
+    moveit_collision_detection_fcl
+    moveit_collision_distance_field
     moveit_constraint_samplers
     moveit_distance_field
+    moveit_dynamics_solver
     moveit_exceptions
-    moveit_kinematics_base
     moveit_kinematic_constraints
+    moveit_kinematics_base
     moveit_kinematics_metrics
     moveit_macros
     moveit_planning_interface
-    moveit_planning_scene
     moveit_planning_request_adapter
+    moveit_planning_scene
     moveit_robot_model
     moveit_robot_state
     moveit_robot_trajectory

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -106,6 +106,7 @@ add_subdirectory(version)
 
 install(
   TARGETS
+    collision_detector_bullet_plugin
     moveit_butterworth_filter
     moveit_collision_detection
     moveit_collision_detection_bullet

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -51,12 +51,6 @@ target_link_libraries(collision_detector_bullet_plugin
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_bullet_export.h DESTINATION include/moveit_core)
-install(TARGETS moveit_collision_detection_bullet collision_detector_bullet_plugin EXPORT export_moveit_collision_detection_bullet
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-ament_export_targets(export_moveit_collision_detection_bullet HAS_LIBRARY_TARGET)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)


### PR DESCRIPTION
- Sort exports from moveit_core
- Install collision_detector_bullet_plugin from moveit_core

### Description

Fixes #1858