### PR TITLE
Fix waitForCurrentState timeout

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -234,6 +234,7 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
   rclcpp::Duration elapsed(0, 0);
   rclcpp::Duration timeout = rclcpp::Duration::from_seconds(wait_time_s);
 
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   std::unique_lock<std::mutex> lock(state_update_lock_);
   while (current_state_time_ < t)
   {
@@ -243,27 +244,29 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
       {
         /* We cannot know if the reason of timeout is slow time or absence of
          * state messages, warn the user. */
-        rclcpp::Clock steady_clock(RCL_STEADY_TIME);
         RCLCPP_WARN_SKIPFIRST_THROTTLE(LOGGER, steady_clock, 1000,
-                                       "No state update received within 100ms of system clock");
-      }
-      else
-      {
-        elapsed = middleware_handle_->now() - start;
+                                       "No state update received within 100ms of system clock. "
+                                       "Have been waiting for %fs, timeout is %fs",
+                                       elapsed.seconds(), wait_time_s);
       }
     }
     else
     {
       state_update_condition_.wait_for(lock, (timeout - elapsed).to_chrono<std::chrono::duration<double>>());
-      elapsed = middleware_handle_->now() - start;
     }
+    elapsed = middleware_handle_->now() - start;
     if (elapsed > timeout)
     {
       RCLCPP_INFO(LOGGER,
-                  "Didn't received robot state (joint angles) with recent timestamp within "
-                  "%f seconds.\n"
+                  "Didn't receive robot state (joint angles) with recent timestamp within "
+                  "%f seconds. Requested time %f, but latest received state has time %f.\n"
                   "Check clock synchronization if your are running ROS across multiple machines!",
-                  wait_time_s);
+                  wait_time_s, current_state_time_.seconds(), t.seconds());
+      return false;
+    }
+    if (!rclcpp::ok())
+    {
+      RCLCPP_DEBUG(LOGGER, "ROS context shut down while waiting for current robot state.");
       return false;
     }
   }


### PR DESCRIPTION
### Description

CurrentStateMonitor::waitForCurrentState() was getting stuck in an endless loop when use_sim_time==True and joint_states is not being received, also, it could not be terminated by SIGINT.
Now it should always properly check for the timeout and also checks that the rcl context is still up.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
