### PR TITLE
Fix timeout in waitForCurrentState

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -125,6 +125,13 @@ public:
     virtual bool sleepFor(const std::chrono::nanoseconds& nanoseconds) const = 0;
 
     /**
+     * @brief      Uses rclcpp::ok to check the context status
+     *
+     * @return     Return of rclcpp::ok
+     */
+    virtual bool ok() const = 0;
+
+    /**
      * @brief      Get the static transform topic name
      *
      * @return     The static transform topic name.

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor_middleware_handle.hpp
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor_middleware_handle.hpp
@@ -111,6 +111,13 @@ public:
   bool sleepFor(const std::chrono::nanoseconds& nanoseconds) const override;
 
   /**
+   * @brief      Uses rclcpp::ok to check the context status
+   *
+   * @return     Return of rclcpp::ok
+   */
+  bool ok() const override;
+
+  /**
    * @brief      Get the static transform topic name
    *
    * @return     The static transform topic name.

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -238,6 +238,7 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
   rclcpp::Duration elapsed(0, 0);
   rclcpp::Duration timeout = rclcpp::Duration::from_seconds(wait_time_s);
 
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   std::unique_lock<std::mutex> lock(state_update_lock_);
   while (current_state_time_ < t)
   {
@@ -247,30 +248,32 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
       {
         /* We cannot know if the reason of timeout is slow time or absence of
          * state messages, warn the user. */
-        rclcpp::Clock steady_clock(RCL_STEADY_TIME);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
         RCLCPP_WARN_SKIPFIRST_THROTTLE(LOGGER, steady_clock, 1000,
-                                       "No state update received within 100ms of system clock");
+                                       "No state update received within 100ms of system clock. "
+                                       "Have been waiting for %fs, timeout is %fs",
+                                       elapsed.seconds(), wait_time_s);
 #pragma GCC diagnostic pop
-      }
-      else
-      {
-        elapsed = middleware_handle_->now() - start;
       }
     }
     else
     {
       state_update_condition_.wait_for(lock, (timeout - elapsed).to_chrono<std::chrono::duration<double>>());
-      elapsed = middleware_handle_->now() - start;
     }
+    elapsed = middleware_handle_->now() - start;
     if (elapsed > timeout)
     {
       RCLCPP_INFO(LOGGER,
-                  "Didn't received robot state (joint angles) with recent timestamp within "
-                  "%f seconds.\n"
+                  "Didn't receive robot state (joint angles) with recent timestamp within "
+                  "%f seconds. Requested time %f, but latest received state has time %f.\n"
                   "Check clock synchronization if your are running ROS across multiple machines!",
-                  wait_time_s);
+                  wait_time_s, t.seconds(), current_state_time_.seconds());
+      return false;
+    }
+    if (!rclcpp::ok())
+    {
+      RCLCPP_DEBUG(LOGGER, "ROS context shut down while waiting for current robot state.");
       return false;
     }
   }

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -271,7 +271,7 @@ bool CurrentStateMonitor::waitForCurrentState(const rclcpp::Time& t, double wait
                   wait_time_s, t.seconds(), current_state_time_.seconds());
       return false;
     }
-    if (!rclcpp::ok())
+    if (!middleware_handle_->ok())
     {
       RCLCPP_DEBUG(LOGGER, "ROS context shut down while waiting for current robot state.");
       return false;

--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor_middleware_handle.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor_middleware_handle.cpp
@@ -95,6 +95,11 @@ bool CurrentStateMonitorMiddlewareHandle::sleepFor(const std::chrono::nanosecond
   return rclcpp::sleep_for(nanoseconds);
 }
 
+bool CurrentStateMonitorMiddlewareHandle::ok() const
+{
+  return rclcpp::ok();
+}
+
 void CurrentStateMonitorMiddlewareHandle::createDynamicTfSubscription(TfCallback callback)
 {
   transform_subscriber_ =

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_tests.cpp
@@ -53,6 +53,7 @@ struct MockMiddlewareHandle : public planning_scene_monitor::CurrentStateMonitor
   MOCK_METHOD(void, resetJointStateSubscription, (), (override));
   MOCK_METHOD(std::string, getJointStateTopicName, (), (const, override));
   MOCK_METHOD(bool, sleepFor, (const std::chrono::nanoseconds& nanoseconds), (const, override));
+  MOCK_METHOD(bool, ok, (), (const, override));
   MOCK_METHOD(void, createStaticTfSubscription, (TfCallback callback), (override));
   MOCK_METHOD(void, createDynamicTfSubscription, (TfCallback callback), (override));
   MOCK_METHOD(std::string, getStaticTfTopicName, (), (const, override));

--- a/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/trajectory_monitor_tests.cpp
@@ -62,6 +62,7 @@ struct MockCurrentStateMonitorMiddlewareHandle : public planning_scene_monitor::
   MOCK_METHOD(void, resetJointStateSubscription, (), (override));
   MOCK_METHOD(std::string, getJointStateTopicName, (), (const, override));
   MOCK_METHOD(bool, sleepFor, (const std::chrono::nanoseconds& nanoseconds), (const, override));
+  MOCK_METHOD(bool, ok, (), (const, override));
   MOCK_METHOD(void, createStaticTfSubscription, (TfCallback callback), (override));
   MOCK_METHOD(void, createDynamicTfSubscription, (TfCallback callback), (override));
   MOCK_METHOD(std::string, getStaticTfTopicName, (), (const, override));


### PR DESCRIPTION
### Description

CurrentStateMonitor::waitForCurrentState() was getting stuck in an endless loop when use_sim_time==True and joint_states is not being received, also, it could not be terminated by SIGINT.
Now it should always properly check for the timeout and also checks that the rcl context is still up.

(Originally made for humble branch: see [https://github.com/ros-planning/moveit2/pull/1894](https://github.com/ros-planning/moveit2/pull/1894))

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
