### PR TITLE
Fix kinematics plugin loader bug

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -142,6 +142,11 @@ public:
     std::scoped_lock slock(lock_);
     for (auto const& [group, solver] : possible_kinematics_solvers_)
     {
+      // Don't bother trying to load a solver for the wrong group
+      if (group != jmg->getName())
+      {
+        continue;
+      }
       try
       {
         result = kinematics_loader_->createUniqueInstance(solver);


### PR DESCRIPTION
### Description

There is a bug where the wrong IK solver plugin is assigned to the planning groups defined in the SRDF. I noticed this issue because I had multiple kinematic plugins defined in my yaml file with different IK solvers and after doing some debug logging, it was definitely apparant that groups that shouldn't be having an IK solver had one and that groups that were supposed to have an IK solver sometimes had the wrong one.

Turns out that in this for loop here within the [`allocKinematicsSolver`](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp#L143) function, we essentially try to assign the first solver within `possible_kinematics_solvers_` to the joint group passed into the function **without even checking to see if that solver even corresponds to that joint group**. Therefore when this function is called for each joint group in the SRDF in the [`robot_model_loader`](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp#L279), it is possible to get IK solvers set to groups that were never meant to have them or for the wrong one to be set. 

This PR fixes this issue. It also fixes this issue #1633 .

@AndyZe @nbbrooks @swiz23

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
