### PR TITLE
Only add planning group if it has a kinematics solver

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -250,8 +250,6 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
       // read the list of plugin names for possible kinematics solvers
       for (const srdf::Model::Group& known_group : known_groups)
       {
-        groups_.push_back(known_group.name_);
-
         std::string kinematics_param_prefix = robot_description_ + "_kinematics." + known_group.name_;
         group_param_listener_.try_emplace(known_group.name_,
                                           std::make_shared<kinematics::ParamListener>(node_, kinematics_param_prefix));
@@ -265,6 +263,9 @@ moveit::core::SolverAllocatorFn KinematicsPluginLoader::getLoaderFunction(const 
           RCLCPP_DEBUG(LOGGER, "No kinematics solver specified for group '%s'.", known_group.name_.c_str());
           continue;
         }
+
+        // Only push back a group if it has a kinematics solver.
+        groups_.push_back(known_group.name_);
 
         possible_kinematics_solvers[known_group.name_] = kinematics_solver;
         RCLCPP_DEBUG(LOGGER, "Found kinematics solver '%s' for group '%s'.", kinematics_solver.c_str(),


### PR DESCRIPTION
### Description

There is currently a bug within the `getLoaderFunction` where...even if a planning group does not contain a kinematics solver, it is still added to the `groups_` member variable. This variable as specified [here](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h#L68) is meant to only hold those planning groups that have a solver specified for them.

This bug can be fixed by moving the line of code that adds a planning group to the `groups_` variable to be after the check to see if that group has a kinematics solver associated with it.

This fixes Issue #1633 (verified by testing on a local project).

@mechwiz, @AndyZe , @nbbrooks 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
