### PR TITLE
Servo: always keep publishing zero-velocity cmds. Eliminate possibility of joint jumps

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -47,9 +47,6 @@ robot_link_command_frame:  panda_link0  # commands must be given in the frame of
 
 ## Stopping behaviour
 incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
-# If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
-# Important because ROS may drop some messages and we need the robot to halt reliably.
-num_outgoing_halt_msgs_to_publish: 4
 
 ## Configure handling of singularities and joint limits
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -40,9 +40,6 @@ robot_link_command_frame:  panda_hand  # commands must be given in the frame of 
 
 ## Stopping behaviour
 incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
-# If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
-# Important because ROS may drop some messages and we need the robot to halt reliably.
-num_outgoing_halt_msgs_to_publish: 4
 
 ## Configure handling of singularities and joint limits
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -305,14 +305,12 @@ protected:
   // Main tracking / result publisher loop
   std::thread thread_;
   bool stop_requested_;
-  std::atomic<bool> done_stopping_;
 
   // Status
   StatusCode status_ = StatusCode::NO_WARNING;
   std::atomic<bool> paused_;
   bool twist_command_is_stale_ = false;
   bool joint_command_is_stale_ = false;
-  bool ok_to_publish_ = false;
   double collision_velocity_scale_ = 1.0;
 
   // Use ArrayXd type to enable more coefficient-wise operations

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -264,10 +264,6 @@ protected:
   // Pointer to the collision environment
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
-  // Track the number of cycles during which motion has not occurred.
-  // Will avoid re-publishing zero velocities endlessly.
-  int zero_velocity_count_ = 0;
-
   // Flag for staying inactive while there are no incoming commands
   bool wait_for_servo_commands_ = true;
 
@@ -340,11 +336,6 @@ protected:
   control_msgs::msg::JointJog::ConstSharedPtr latest_joint_cmd_;
   rclcpp::Time latest_twist_command_stamp_ = rclcpp::Time(0., RCL_ROS_TIME);
   rclcpp::Time latest_joint_command_stamp_ = rclcpp::Time(0., RCL_ROS_TIME);
-
-  // Nonzero status flags
-  std::atomic<bool> latest_twist_cmd_is_nonzero_{ false };
-  std::atomic<bool> latest_joint_cmd_is_nonzero_{ false };
-  bool have_nonzero_command_ = false;
 
   // input condition variable used for low latency mode
   std::condition_variable input_cv_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -274,11 +274,6 @@ protected:
   // Flag saying if the filters were updated during the timer callback
   bool updated_filters_ = false;
 
-  // Nonzero status flags
-  bool have_nonzero_twist_stamped_ = false;
-  bool have_nonzero_joint_command_ = false;
-  bool have_nonzero_command_ = false;
-
   // Incoming command messages
   geometry_msgs::msg::TwistStamped twist_stamped_cmd_;
   control_msgs::msg::JointJog joint_servo_cmd_;
@@ -345,8 +340,11 @@ protected:
   control_msgs::msg::JointJog::ConstSharedPtr latest_joint_cmd_;
   rclcpp::Time latest_twist_command_stamp_ = rclcpp::Time(0., RCL_ROS_TIME);
   rclcpp::Time latest_joint_command_stamp_ = rclcpp::Time(0., RCL_ROS_TIME);
-  bool latest_twist_cmd_is_nonzero_ = false;
-  bool latest_joint_cmd_is_nonzero_ = false;
+
+  // Nonzero status flags
+  std::atomic<bool> latest_twist_cmd_is_nonzero_{ false };
+  std::atomic<bool> latest_joint_cmd_is_nonzero_{ false };
+  bool have_nonzero_command_ = false;
 
   // input condition variable used for low latency mode
   std::condition_variable input_cv_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -45,12 +45,6 @@
 
 namespace moveit_servo
 {
-// Helper function for detecting zeroed message
-bool isNonZero(const geometry_msgs::msg::TwistStamped& msg);
-
-// Helper function for detecting zeroed message
-bool isNonZero(const control_msgs::msg::JointJog& msg);
-
 // Helper function for converting Eigen::Isometry3d to geometry_msgs/TransformStamped
 geometry_msgs::msg::TransformStamped convertIsometryToTransform(const Eigen::Isometry3d& eigen_tf,
                                                                 const std::string& parent_frame,

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -212,9 +212,6 @@ void ServoParameters::declare(const std::string& ns,
                        "if the robot is stationary.Otherwise, specify num.to publish. Important because ROS may drop "
                        "some messages and we need the robot to halt reliably."));
   node_parameters->declare_parameter(
-      ns + ".num_outgoing_halt_msgs_to_publish", ParameterValue{ parameters.num_outgoing_halt_msgs_to_publish },
-      ParameterDescriptorBuilder{}.type(PARAMETER_INTEGER).description("Num outgoing halt msgs to publish"));
-  node_parameters->declare_parameter(
       ns + ".halt_all_joints_in_joint_mode", ParameterValue{ parameters.halt_all_joints_in_joint_mode },
       ParameterDescriptorBuilder{}.type(PARAMETER_BOOL).description("Halt all joints in joint mode"));
   node_parameters->declare_parameter(
@@ -313,8 +310,6 @@ ServoParameters ServoParameters::get(const std::string& ns,
 
   // Stopping behaviour
   parameters.incoming_command_timeout = node_parameters->get_parameter(ns + ".incoming_command_timeout").as_double();
-  parameters.num_outgoing_halt_msgs_to_publish =
-      node_parameters->get_parameter(ns + ".num_outgoing_halt_msgs_to_publish").as_int();
   parameters.halt_all_joints_in_joint_mode =
       node_parameters->get_parameter(ns + ".halt_all_joints_in_joint_mode").as_bool();
   parameters.halt_all_joints_in_cartesian_mode =
@@ -358,11 +353,6 @@ std::optional<ServoParameters> ServoParameters::validate(ServoParameters paramet
   {
     RCLCPP_WARN(LOGGER, "Parameter 'publish_period' should be "
                         "greater than zero. Check yaml file.");
-    return std::nullopt;
-  }
-  if (parameters.num_outgoing_halt_msgs_to_publish < 0)
-  {
-    RCLCPP_WARN(LOGGER, "Parameter 'num_outgoing_halt_msgs_to_publish' should be greater than zero. Check yaml file.");
     return std::nullopt;
   }
   if (parameters.leaving_singularity_threshold_multiplier <= 0)

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -42,24 +42,6 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.utilities"
 constexpr auto ROS_LOG_THROTTLE_PERIOD = std::chrono::milliseconds(3000).count();
 }  // namespace
 
-/** \brief Helper function for detecting zeroed message **/
-bool isNonZero(const geometry_msgs::msg::TwistStamped& msg)
-{
-  return msg.twist.linear.x != 0.0 || msg.twist.linear.y != 0.0 || msg.twist.linear.z != 0.0 ||
-         msg.twist.angular.x != 0.0 || msg.twist.angular.y != 0.0 || msg.twist.angular.z != 0.0;
-}
-
-/** \brief Helper function for detecting zeroed message **/
-bool isNonZero(const control_msgs::msg::JointJog& msg)
-{
-  bool all_zeros = true;
-  for (double delta : msg.velocities)
-  {
-    all_zeros &= (delta == 0.0);
-  }
-  return !all_zeros;
-}
-
 /** \brief Helper function for converting Eigen::Isometry3d to geometry_msgs/TransformStamped **/
 geometry_msgs::msg::TransformStamped convertIsometryToTransform(const Eigen::Isometry3d& eigen_tf,
                                                                 const std::string& parent_frame,


### PR DESCRIPTION
### Description

Likely fixes #1036, #1885 

There are a lot of simplifications here:

- Always keep publishing zero-velocity commands. Previously, we kept track of the number of zero-velocity commands published to try to  prevent spammy messages. I think the extra complexity wasn't worth it.
- If there is not a valid command, don't jump back to the previously-commanded state. This was causing issue #1885. Instead, come to a gradual halt based on the robot's current position.

This was tested by the bug reporter here:  https://github.com/ros-planning/moveit2/issues/1885#issuecomment-1406923402