### PR TITLE
Temporarily switch to dockerhub for CI jobs

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -2,7 +2,7 @@
 # CI image using the ROS testing repository
 
 ARG ROS_DISTRO=rolling
-FROM ros-planning/moveit2:${ROS_DISTRO}-ci
+FROM moveit/moveit2:${ROS_DISTRO}-ci
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Switch to ros-testing

--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -2,7 +2,7 @@
 # CI image using the ROS testing repository
 
 ARG ROS_DISTRO=rolling
-FROM ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci
+FROM ros-planning/moveit2:${ROS_DISTRO}-ci
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Switch to ros-testing

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,7 +4,7 @@
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling
-FROM ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci-testing
+FROM ros-planning/moveit2:${ROS_DISTRO}-ci-testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Export ROS_UNDERLAY for downstream docker containers

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,7 +4,7 @@
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling
-FROM ros-planning/moveit2:${ROS_DISTRO}-ci-testing
+FROM moveit/moveit2:${ROS_DISTRO}-ci-testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Export ROS_UNDERLAY for downstream docker containers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
-      DOCKER_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.env.IMAGE }}
+      DOCKER_IMAGE: ros-planning/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >
         moveit2.repos
         $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
-      DOCKER_IMAGE: ros-planning/moveit2:${{ matrix.env.IMAGE }}
+      DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >
         moveit2.repos
         $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)


### PR DESCRIPTION
CI has been failing for a while and I have a feeling that we run out of pulls or ghcr is just broken now (though I haven't find any bug reports with a quick search). This PR switches CI jobs to use dockerhub instead of ghcr, I will try to switch back in the first of Feb to see if that was a pull issue.