### PR TITLE
Servo: Reflect Servo Paused Status

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -251,10 +251,6 @@ protected:
   void changeControlDimensions(const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Request>& req,
                                const std::shared_ptr<moveit_msgs::srv::ChangeControlDimensions::Response>& res);
 
-  /** \brief Service callback to reset Servo status, e.g. so the arm can move again after a collision */
-  bool resetServoStatus(const std::shared_ptr<std_srvs::srv::Empty::Request>& req,
-                        const std::shared_ptr<std_srvs::srv::Empty::Response>& res);
-
   // Pointer to the ROS node
   std::shared_ptr<rclcpp::Node> node_;
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -296,7 +296,6 @@ protected:
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr multiarray_outgoing_cmd_pub_;
   rclcpp::Service<moveit_msgs::srv::ChangeControlDimensions>::SharedPtr control_dimensions_server_;
   rclcpp::Service<moveit_msgs::srv::ChangeDriftDimensions>::SharedPtr drift_dimensions_server_;
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_servo_status_;
 
   // Main tracking / result publisher loop
   std::thread thread_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/status_codes.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/status_codes.h
@@ -52,7 +52,8 @@ enum class StatusCode : int8_t
   DECELERATE_FOR_COLLISION = 3,
   HALT_FOR_COLLISION = 4,
   JOINT_BOUND = 5,
-  DECELERATE_FOR_LEAVING_SINGULARITY = 6
+  DECELERATE_FOR_LEAVING_SINGULARITY = 6,
+  PAUSED = 7
 };
 
 const std::unordered_map<StatusCode, std::string> SERVO_STATUS_CODE_MAP(
@@ -63,5 +64,6 @@ const std::unordered_map<StatusCode, std::string> SERVO_STATUS_CODE_MAP(
       { StatusCode::DECELERATE_FOR_COLLISION, "Close to a collision, decelerating" },
       { StatusCode::HALT_FOR_COLLISION, "Collision detected, emergency stop" },
       { StatusCode::JOINT_BOUND, "Close to a joint bound (position or velocity), halting" },
-      { StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY, "Moving away from a singularity, decelerating" } });
+      { StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY, "Moving away from a singularity, decelerating" },
+      { StatusCode::PAUSED, "Paused" } });
 }  // namespace moveit_servo


### PR DESCRIPTION
### Description

This pull request adds paused status code to moveit_servo as suggested by @AndyZe since currently there is no way to know when servo is paused. This is a breaking change as servo status will now be `StatusCode::PAUSED` instead `StatusCode::NO_WARNING` when servo is paused. Also removed `resetServoStatus` which serves no purpose.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
