### PR TITLE
Limit underscore suffix to non-public members

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,7 +43,9 @@ CheckOptions:
   # variable names
   - key:             readability-identifier-naming.VariableCase
     value:           lower_case
-  - key:             readability-identifier-naming.ClassMemberSuffix
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
     value:           '_'
   # const static or global variables are UPPER_CASE
   - key:             readability-identifier-naming.EnumConstantCase


### PR DESCRIPTION
Augments #1939 by enforcing the new rule by clang-tidy.
[Here](https://github.com/rhaschke/moveit2/actions/runs/4185935378) is a CI job running clang-tidy on all source files (not only the diff as usually done for PRs).
