### PR TITLE
Doxygen tag

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2081,7 +2081,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = MoveIt.tag
+GENERATE_TAGFILE       = $(DOXYGEN_OUTPUT_DIRECTORY)/MoveIt.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/Doxyfile
+++ b/Doxyfile
@@ -2081,7 +2081,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = MoveIt.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -184,7 +184,7 @@ private Q_SLOTS:
 class ProgressBarEditor : public QWidget
 {
   Q_OBJECT
-  Q_PROPERTY(float value READ value WRITE setValue NOTIFY valueChanged USER true)
+  Q_PROPERTY(float value READ getValue WRITE setValue NOTIFY valueChanged USER true)
 
 public:
   /// Create a progressbar-like slider for editing values in range mix..max
@@ -194,7 +194,7 @@ public:
   {
     value_ = value;
   }
-  float value() const
+  float getValue() const
   {
     return value_;
   }


### PR DESCRIPTION
I'm working on fixing the dead links in the tutorials, and making it easier to reference the API using [doxylink](https://github.com/sphinx-contrib/doxylink). We need to install a tag file for that to work. Also, the QT property is breaking the references because of the identical naming, with the attached fixed everything works fine.