### PR TITLE
add missing dependencies on config utils

### DIFF
--- a/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>moveit_configs_utils</depend>
   <depend>moveit_ros_visualization</depend>
   <depend>moveit_setup_framework</depend>
   <depend>pluginlib</depend>

--- a/moveit_setup_assistant/moveit_setup_controllers/package.xml
+++ b/moveit_setup_assistant/moveit_setup_controllers/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_configs_utils</test_depend>
   <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
 


### PR DESCRIPTION
### Description

when installing ros-humble-moveit-setup-assistant from debs, the package cannot currently run due to this missing depend

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
