### PR TITLE
Add Warning Message for Out of Date Controller Information

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -135,7 +135,7 @@ class Ros2ControlManager : public moveit_controller_manager::MoveItControllerMan
     if (!force && ((node_->now() - controllers_stamp_) < CONTROLLER_INFORMATION_VALIDITY_AGE))
     {
       RCLCPP_WARN_STREAM(LOGGER, "Controller information from " << list_controllers_service_->get_service_name()
-                                                               << " is out of date, skipping discovery");
+                                                                << " is out of date, skipping discovery");
       return;
     }
 

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -133,7 +133,11 @@ class Ros2ControlManager : public moveit_controller_manager::MoveItControllerMan
   {
     // Skip if controller stamp is too new for new discovery, enforce update if force==true
     if (!force && ((node_->now() - controllers_stamp_) < CONTROLLER_INFORMATION_VALIDITY_AGE))
+    {
+      RCLCPP_WARN_STREAM(LOGGER, "Controller information from" << list_controllers_service_->get_service_name()
+                                                               << " is out of date, skipping discovery");
       return;
+    }
 
     controllers_stamp_ = node_->now();
 

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -134,7 +134,7 @@ class Ros2ControlManager : public moveit_controller_manager::MoveItControllerMan
     // Skip if controller stamp is too new for new discovery, enforce update if force==true
     if (!force && ((node_->now() - controllers_stamp_) < CONTROLLER_INFORMATION_VALIDITY_AGE))
     {
-      RCLCPP_WARN_STREAM(LOGGER, "Controller information from" << list_controllers_service_->get_service_name()
+      RCLCPP_WARN_STREAM(LOGGER, "Controller information from " << list_controllers_service_->get_service_name()
                                                                << " is out of date, skipping discovery");
       return;
     }


### PR DESCRIPTION
### Description

Adds a warning message to the `Ros2ControlManager` when timestamps from the controller manager are out of date. Handy for debugging why the moveit plugin does not activate controllers that are available in a `controller_manager` with misconfigured sim time.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
