### PR TITLE
Fix collision checking in VisibilityConstraint

### DIFF
--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -842,10 +842,8 @@ protected:
    */
   bool decideContact(const collision_detection::Contact& contact) const;
 
-  // collision_detection::CollisionEnvPtr collision_env_; /**< \brief A copy of the collision robot maintained for
-  //                                                             collision checking the cone against robot links */
-
-  moveit::core::RobotModelConstPtr robot_model_;
+  moveit::core::RobotModelConstPtr robot_model_; /**< \brief A copy of the robot model used to create collision
+                                                             environments to check the cone against robot links */
 
   bool mobile_sensor_frame_;      /**< \brief True if the sensor is a non-fixed frame relative to the transform frame */
   bool mobile_target_frame_;      /**< \brief True if the target is a non-fixed frame relative to the transform frame */

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -811,7 +811,8 @@ public:
    *
    * @return The shape associated with the cone
    */
-  shapes::Mesh* getVisibilityCone(const moveit::core::RobotState& state) const;
+  shapes::Mesh* getVisibilityCone(const Eigen::Isometry3d& tform_world_to_sensor,
+                                  const Eigen::Isometry3d& tform_world_to_target) const;
 
   /**
    * \brief Adds markers associated with the visibility cone, sensor

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -842,8 +842,11 @@ protected:
    */
   bool decideContact(const collision_detection::Contact& contact) const;
 
-  collision_detection::CollisionEnvPtr collision_env_; /**< \brief A copy of the collision robot maintained for
-                                                              collision checking the cone against robot links */
+  // collision_detection::CollisionEnvPtr collision_env_; /**< \brief A copy of the collision robot maintained for
+  //                                                             collision checking the cone against robot links */
+
+  moveit::core::RobotModelConstPtr robot_model_;
+
   bool mobile_sensor_frame_;      /**< \brief True if the sensor is a non-fixed frame relative to the transform frame */
   bool mobile_target_frame_;      /**< \brief True if the target is a non-fixed frame relative to the transform frame */
   std::string target_frame_id_;   /**< \brief The target frame id */

--- a/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
+++ b/moveit_core/kinematic_constraints/include/moveit/kinematic_constraints/kinematic_constraint.h
@@ -774,9 +774,13 @@ public:
    * \brief Configure the constraint based on a
    * moveit_msgs::msg::VisibilityConstraint
    *
-   * For the configure command to be successful, the target radius
-   * must be non-zero (negative values will have the absolute value
-   * taken).  If cone sides are less than 3, a value of 3 will be used.
+   * For the configure command to be successful, one of the three possible
+   * constraint criteria must be set to a non-zero value:
+   * - The target radius (negative values will have the absolute value taken).
+   * - The range angle.
+   * - The view angle.
+   *
+   * If cone sides are less than 3, a value of 3 will be used.
    *
    * @param [in] vc moveit_msgs::msg::VisibilityConstraint for configuration
    *
@@ -807,7 +811,8 @@ public:
   /**
    * \brief Gets a trimesh shape representing the visibility cone
    *
-   * @param [in] state The state from which to produce the cone
+   * @param [in] tform_world_to_sensor Transform from the world to the sensor frame
+   * @param [in] tform_world_to_target Transform from the world to the target frame
    *
    * @return The shape associated with the cone
    */
@@ -846,14 +851,12 @@ protected:
   moveit::core::RobotModelConstPtr robot_model_; /**< \brief A copy of the robot model used to create collision
                                                              environments to check the cone against robot links */
 
-  bool mobile_sensor_frame_;      /**< \brief True if the sensor is a non-fixed frame relative to the transform frame */
-  bool mobile_target_frame_;      /**< \brief True if the target is a non-fixed frame relative to the transform frame */
-  std::string target_frame_id_;   /**< \brief The target frame id */
-  std::string sensor_frame_id_;   /**< \brief The sensor frame id */
-  Eigen::Isometry3d sensor_pose_; /**< \brief The sensor pose transformed into the transform frame */
-  int sensor_view_direction_;     /**< \brief Storage for the sensor view direction */
-  Eigen::Isometry3d target_pose_; /**< \brief The target pose transformed into the transform frame */
-  unsigned int cone_sides_;       /**< \brief Storage for the cone sides  */
+  std::string target_frame_id_;      /**< \brief The target frame id */
+  std::string sensor_frame_id_;      /**< \brief The sensor frame id */
+  Eigen::Isometry3d sensor_pose_;    /**< \brief The sensor pose transformed into the transform frame */
+  int sensor_view_direction_;        /**< \brief Storage for the sensor view direction */
+  Eigen::Isometry3d target_pose_;    /**< \brief The target pose transformed into the transform frame */
+  unsigned int cone_sides_;          /**< \brief Storage for the cone sides  */
   EigenSTL::vector_Vector3d points_; /**< \brief A set of points along the base of the circle */
   double target_radius_;             /**< \brief Storage for the target radius */
   double max_view_angle_;            /**< \brief Storage for the max view angle */

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -786,8 +786,7 @@ void OrientationConstraint::print(std::ostream& out) const
 }
 
 VisibilityConstraint::VisibilityConstraint(const moveit::core::RobotModelConstPtr& model)
-  : KinematicConstraint(model)
-  , robot_model_{ model }
+  : KinematicConstraint(model), robot_model_{ model }
 {
   type_ = VISIBILITY_CONSTRAINT;
 }
@@ -1113,7 +1112,8 @@ ConstraintEvaluationResult VisibilityConstraint::decide(const moveit::core::Robo
     }
     if (max_range_angle_ > 0.0)
     {
-      const Eigen::Vector3d& dir = (tform_world_to_target.translation() - tform_world_to_sensor.translation()).normalized();
+      const Eigen::Vector3d& dir =
+          (tform_world_to_target.translation() - tform_world_to_sensor.translation()).normalized();
       double dp = sensor_view_axis.dot(dir);
       if (dp < 0.0)
       {

--- a/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+++ b/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
@@ -787,7 +787,6 @@ void OrientationConstraint::print(std::ostream& out) const
 
 VisibilityConstraint::VisibilityConstraint(const moveit::core::RobotModelConstPtr& model)
   : KinematicConstraint(model)
-  // , collision_env_(std::make_shared<collision_detection::CollisionEnvFCL>(model))
   , robot_model_{ model }
 {
   type_ = VISIBILITY_CONSTRAINT;


### PR DESCRIPTION
### Description

Previously, planning with the VisibilityConstraint could cause segfaults because modifying collision objects in the collision environment is not thread-safe. The planning threads would interfere with each other by trying to add and remove the visibility cone collision object out of sync.

This PR fixes that by creating a local collision environment within `VisibilityConstraint::decide`.

I also modified how VisibilityConstraints are evaluated so that if a negative or zero `target_radius` value is used but valid `max_range_angle` and `max_view_angle` are provided, then the visibility cone check is skipped and the range and view angle checks are performed as usual. Previously setting an invalid `target_radius` value would cause the entire constraint evaluation to be skipped.

While I was at it I renamed some of the variables used for transforms to be more verbose and easier to follow.

Note: I'm keeping this as a draft for now since I'm still testing, but I'd be happy to get feedback on what I have so far.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
