### PR TITLE
Fix mimic joints with TOTG

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -166,19 +166,6 @@ public:
     return active_joint_model_name_vector_;
   }
 
-  /** \brief Get the names of the active variables that make up the joints included in this group. The number of
-      returned elements is always equal to getVariableCount(). This does not include mimic joints. */
-  const std::vector<std::string>& getActiveVariableNames() const
-  {
-    return active_variable_names_;
-  }
-
-  /** \brief Get the active index locations in the complete robot state for all the variables in this group */
-  const std::vector<int>& getActiveVariableIndexList() const
-  {
-    return active_variable_index_list_;
-  }
-
   /** \brief Get the fixed joints that are part of this group */
   const std::vector<const JointModel*>& getFixedJointModels() const
   {
@@ -595,9 +582,11 @@ public:
   bool isValidVelocityMove(const double* from_joint_pose, const double* to_joint_pose, std::size_t array_size,
                            double dt) const;
 
-protected:
-  bool computeIKIndexBijection(const std::vector<std::string>& ik_jnames, std::vector<size_t>& joint_bijection) const;
+  /** \brief Computes the indices of joint variables given a vector of joint names to look up */
+  bool computeJointVariableIndices(const std::vector<std::string>& joint_names,
+                                   std::vector<size_t>& joint_bijection) const;
 
+protected:
   /** \brief Update the variable values for the state of a group with respect to the mimic joints. This only updates
       mimic joints that have the parent in this group. If there is a joint mimicking one that is outside the group,
       there are no values to be read (\e values is only the group state) */
@@ -637,14 +626,6 @@ protected:
   /** \brief The names of the DOF that make up this group (this is just a sequence of joint variable names; not
       necessarily joint names!) */
   std::set<std::string> variable_names_set_;
-
-  /** \brief The names of the active DOF that make up this group (this is just a sequence of joint variable names;
-      not necessarily joint names!) */
-  std::vector<std::string> active_variable_names_;
-
-  /** \brief The list of active index values this group includes, with respect to a full robot state;
-      this does not include mimic joints. */
-  std::vector<int> active_variable_index_list_;
 
   /** \brief A map from joint names to their instances. This includes all joints in the group. */
   JointModelMapConst joint_model_map_;

--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h
@@ -166,6 +166,19 @@ public:
     return active_joint_model_name_vector_;
   }
 
+  /** \brief Get the names of the active variables that make up the joints included in this group. The number of
+      returned elements is always equal to getVariableCount(). This does not include mimic joints. */
+  const std::vector<std::string>& getActiveVariableNames() const
+  {
+    return active_variable_names_;
+  }
+
+  /** \brief Get the active index locations in the complete robot state for all the variables in this group */
+  const std::vector<int>& getActiveVariableIndexList() const
+  {
+    return active_variable_index_list_;
+  }
+
   /** \brief Get the fixed joints that are part of this group */
   const std::vector<const JointModel*>& getFixedJointModels() const
   {
@@ -624,6 +637,14 @@ protected:
   /** \brief The names of the DOF that make up this group (this is just a sequence of joint variable names; not
       necessarily joint names!) */
   std::set<std::string> variable_names_set_;
+
+  /** \brief The names of the active DOF that make up this group (this is just a sequence of joint variable names;
+      not necessarily joint names!) */
+  std::vector<std::string> active_variable_names_;
+
+  /** \brief The list of active index values this group includes, with respect to a full robot state;
+      this does not include mimic joints. */
+  std::vector<int> active_variable_index_list_;
 
   /** \brief A map from joint names to their instances. This includes all joints in the group. */
   JointModelMapConst joint_model_map_;

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -641,7 +641,7 @@ void JointModelGroup::setSolverAllocators(const std::pair<SolverAllocatorFn, Sol
     {
       group_kinematics_.first.solver_instance_->setDefaultTimeout(group_kinematics_.first.default_ik_timeout_);
       if (!computeJointVariableIndices(group_kinematics_.first.solver_instance_->getJointNames(),
-                                   group_kinematics_.first.bijection_))
+                                       group_kinematics_.first.bijection_))
         group_kinematics_.first.reset();
     }
   }

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -138,7 +138,9 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
       if (vc > 1)
         is_single_dof_ = false;
       const std::vector<std::string>& name_order = joint_model->getVariableNames();
-      if (joint_model->getMimic() == nullptr)
+
+      const bool is_active = (joint_model->getMimic() == nullptr);
+      if (is_active)
       {
         active_joint_model_vector_.push_back(joint_model);
         active_joint_model_name_vector_.push_back(joint_model->getName());
@@ -152,12 +154,20 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
       {
         variable_names_.push_back(name);
         variable_names_set_.insert(name);
+        if (is_active)
+        {
+          active_variable_names_.push_back(name);
+        }
       }
 
       int first_index = joint_model->getFirstVariableIndex();
       for (std::size_t j = 0; j < name_order.size(); ++j)
       {
         variable_index_list_.push_back(first_index + j);
+        if (is_active)
+        {
+          active_variable_index_list_.push_back(first_index + j);
+        }
         joint_variables_index_map_[name_order[j]] = variable_count_ + j;
       }
       joint_variables_index_map_[joint_model->getName()] = variable_count_;
@@ -730,8 +740,7 @@ void JointModelGroup::printGroupInfo(std::ostream& out) const
     out << '\n';
     out << "        " << parent_model_->getVariableBounds(variable_name) << '\n';
   }
-  out << "  * Variables Index List:\n";
-  out << "    ";
+  out << "  * Variables Index List:\n    ";
   for (int variable_index : variable_index_list_)
     out << variable_index << ' ';
   if (is_contiguous_index_list_)
@@ -742,6 +751,10 @@ void JointModelGroup::printGroupInfo(std::ostream& out) const
   {
     out << "(non-contiguous)";
   }
+  out << '\n';
+  out << "  * Active Variables Index List:\n    ";
+  for (int active_variable_index : active_variable_index_list_)
+    out << active_variable_index << ' ';
   out << '\n';
   if (group_kinematics_.first)
   {

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1550,7 +1550,7 @@ void RobotModel::setKinematicsAllocators(const std::map<std::string, SolverAlloc
           std::set_difference(joints.begin(), joints.end(), sub_joints.begin(), sub_joints.end(),
                               std::inserter(joint_model_set, joint_model_set.end()));
           // TODO: instead of maintaining disjoint joint sets here,
-          // should we leave that work to JMG's setSolverAllocators() / computeIKIndexBijection()?
+          // should we leave that work to JMG's setSolverAllocators() / computeJointVariableIndices()?
           // There, a disjoint bijection from joints to solvers is computed anyway.
           // Underlying question: How do we resolve overlaps? Now the first considered sub group "wins"
           // But, if the overlap only involves fixed joints, we could consider all sub groups

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -884,11 +884,11 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
   double velocity_scaling_factor = verifyScalingFactor(max_velocity_scaling_factor, VELOCITY);
   double acceleration_scaling_factor = verifyScalingFactor(max_acceleration_scaling_factor, ACCELERATION);
 
-  const std::vector<std::string>& vars = group->getVariableNames();
+  // Get the velocity and acceleration limits for all active joints
   const moveit::core::RobotModel& rmodel = group->getParentModel();
-  const unsigned num_joints = group->getVariableCount();
+  const std::vector<std::string>& vars = group->getActiveVariableNames();
+  const unsigned num_joints = group->getActiveVariableCount();
 
-  // Get the vel/accel limits
   Eigen::VectorXd max_velocity(num_joints);
   Eigen::VectorXd max_acceleration(num_joints);
   for (size_t j = 0; j < num_joints; ++j)
@@ -982,9 +982,9 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(
   double velocity_scaling_factor = verifyScalingFactor(max_velocity_scaling_factor, VELOCITY);
   double acceleration_scaling_factor = verifyScalingFactor(max_acceleration_scaling_factor, ACCELERATION);
 
-  const unsigned num_joints = group->getVariableCount();
-  const std::vector<std::string>& vars = group->getVariableNames();
   const moveit::core::RobotModel& rmodel = group->getParentModel();
+  const std::vector<std::string>& vars = group->getActiveVariableNames();
+  const unsigned num_joints = group->getActiveVariableCount();
 
   Eigen::VectorXd max_velocity(num_joints);
   Eigen::VectorXd max_acceleration(num_joints);
@@ -1192,7 +1192,7 @@ bool TimeOptimalTrajectoryGeneration::doTimeParameterizationCalculations(robot_t
 
 bool TimeOptimalTrajectoryGeneration::hasMixedJointTypes(const moveit::core::JointModelGroup* group) const
 {
-  const std::vector<const moveit::core::JointModel*>& joint_models = group->getJointModels();
+  const std::vector<const moveit::core::JointModel*>& joint_models = group->getActiveJointModels();
 
   bool have_prismatic =
       std::any_of(joint_models.cbegin(), joint_models.cend(), [](const moveit::core::JointModel* joint_model) {


### PR DESCRIPTION
### Description

Made some modifications to TOTG and joint model group to reason in *active* joints, which solves issues with TOTG with mimic joints. I can confirm this change fixed things for a robot configuration with a Robotiq 2f-85 gripper that has mimic joints.

Fixes https://github.com/ros-planning/moveit2/issues/586.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
