### PR TITLE
Fix ci testing

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -2,15 +2,59 @@
 # CI image using the ROS testing repository
 
 ARG ROS_DISTRO=rolling
-FROM moveit/moveit2:${ROS_DISTRO}-ci
+FROM osrf/ros2:testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
-# Switch to ros-testing
-RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2-latest.list
+ENV TERM xterm
 
-# Upgrade packages to ros-testing and clean apt-cache within one RUN command
-RUN apt-get -qq update && \
-    apt-get -qq upgrade && \
+# Install ROS 2 base packages and build tools
+# We are installing ros-<distro>-ros-base here to mimic the behavior of the ros:<distro>-ros-base images.
+# This step is split into a separate layer so that we can rely on cached dependencies instead of having
+# to install them with every new build. The testing image and packages will only update every couple weeks.
+RUN \
+    # Update apt package list as previous containers clear the cache
+    apt-get -q update && \
+    apt-get -q -y upgrade && \
+    #
+    # Install base dependencies
+    apt-get -q install --no-install-recommends -y \
+        # Some basic requirements
+        wget git sudo curl \
+        # Preferred build tools
+        clang clang-format-14 clang-tidy clang-tools \
+        ccache \
+        ros-${ROS_DISTRO}-ros-base && \
+    #
+    # Clear apt-cache to reduce image size
+    rm -rf /var/lib/apt/lists/* && \
+    #
+    # Globally disable git security
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced
+    git config --global --add safe.directory "*" && \
+
+# Setup (temporary) ROS workspace
+WORKDIR /root/ws_moveit
+
+# Copy MoveIt sources from docker context
+COPY . src/moveit2
+
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
+RUN \
+    # Update apt package list as previous containers clear the cache
+    apt-get -q update && \
+    apt-get -q -y upgrade && \
+    #
+    # Fetch all dependencies from moveit2.repos
+    vcs import src < src/moveit2/moveit2.repos && \
+    if [ -r src/moveit2/moveit2_${ROS_DISTRO}.repos ] ; then vcs import src < src/moveit2/moveit2_${ROS_DISTRO}.repos ; fi && \
+    #
+    # Download all dependencies of MoveIt
+    rosdep update && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    # Remove the source code from this container
+    rm -rf src && \
     #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/*

--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -7,6 +7,9 @@ LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm
 
+# Setup (temporary) ROS workspace
+WORKDIR /root/ws_moveit
+
 # Install ROS 2 base packages and build tools
 # We are installing ros-<distro>-ros-base here to mimic the behavior of the ros:<distro>-ros-base images.
 # This step is split into a separate layer so that we can rely on cached dependencies instead of having
@@ -23,7 +26,7 @@ RUN \
         # Preferred build tools
         clang clang-format-14 clang-tidy clang-tools \
         ccache \
-        ros-${ROS_DISTRO}-ros-base && \
+        ros-"$ROS_DISTRO"-ros-base && \
     #
     # Clear apt-cache to reduce image size
     rm -rf /var/lib/apt/lists/* && \
@@ -31,9 +34,6 @@ RUN \
     # Globally disable git security
     # https://github.blog/2022-04-12-git-security-vulnerability-announced
     git config --global --add safe.directory "*" && \
-
-# Setup (temporary) ROS workspace
-WORKDIR /root/ws_moveit
 
 # Copy MoveIt sources from docker context
 COPY . src/moveit2
@@ -47,12 +47,12 @@ RUN \
     #
     # Fetch all dependencies from moveit2.repos
     vcs import src < src/moveit2/moveit2.repos && \
-    if [ -r src/moveit2/moveit2_${ROS_DISTRO}.repos ] ; then vcs import src < src/moveit2/moveit2_${ROS_DISTRO}.repos ; fi && \
+    if [ -r src/moveit2/moveit2_"$ROS_DISTRO".repos ] ; then vcs import src < src/moveit2/moveit2_"$ROS_DISTRO".repos ; fi && \
     #
     # Download all dependencies of MoveIt
     rosdep update && \
     DEBIAN_FRONTEND=noninteractive \
-    rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    rosdep install -y --from-paths src --ignore-src --rosdistro "$ROS_DISTRO" --as-root=apt:false && \
     # Remove the source code from this container
     rm -rf src && \
     #

--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -26,11 +26,7 @@ RUN \
         ros-"$ROS_DISTRO"-ros-base && \
     #
     # Clear apt-cache to reduce image size
-    rm -rf /var/lib/apt/lists/* && \
-    #
-    # Globally disable git security
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced
-    git config --global --add safe.directory "*" \
+    rm -rf /var/lib/apt/lists/*
 
 # Setup (temporary) ROS workspace
 WORKDIR /root/ws_moveit
@@ -44,6 +40,10 @@ RUN \
     # Update apt package list as previous containers clear the cache
     apt-get -q update && \
     apt-get -q -y upgrade && \
+    #
+    # Globally disable git security
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced
+    git config --global --add safe.directory "*" && \
     #
     # Fetch all dependencies from moveit2.repos
     vcs import src < src/moveit2/moveit2.repos && \

--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -7,9 +7,6 @@ LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm
 
-# Setup (temporary) ROS workspace
-WORKDIR /root/ws_moveit
-
 # Install ROS 2 base packages and build tools
 # We are installing ros-<distro>-ros-base here to mimic the behavior of the ros:<distro>-ros-base images.
 # This step is split into a separate layer so that we can rely on cached dependencies instead of having
@@ -33,7 +30,10 @@ RUN \
     #
     # Globally disable git security
     # https://github.blog/2022-04-12-git-security-vulnerability-announced
-    git config --global --add safe.directory "*" && \
+    git config --global --add safe.directory "*" \
+
+# Setup (temporary) ROS workspace
+WORKDIR /root/ws_moveit
 
 # Copy MoveIt sources from docker context
 COPY . src/moveit2

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -98,7 +98,6 @@ jobs:
             ${{ env.DH_IMAGE }}
 
   ci-testing:
-    needs: ci
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes https://github.com/ros-planning/moveit2/issues/1970.

The underlying issue was that ci-testing was based on ros-base which didn't provide the same package dependencies. Apt can fix removed or added packages with `dist-upgrade`, but that command is discouraged by hadolint, and it also wouldn't make much sense in the context of reusing image layers in docker.

The fix is to rely on osrf's testing image and to manually install the base dependencies directly from testing. This adds more work to our testing build, but by splitting it out into a separate RUN command we can rely on the build cache most of the time (testing is updated very rarely).

New docker images have already been created pushed from this branch.
