### PR TITLE
Fix unreachable child logger instance

### DIFF
--- a/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/src/planning_request_adapter.cpp
@@ -42,7 +42,7 @@
 
 namespace planning_request_adapter
 {
-rclcpp::Logger LOGGER = rclcpp::get_logger("moveit").get_child("planning_request_adapter");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.planning_request_adapter");
 
 namespace
 {


### PR DESCRIPTION
https://github.com/ros2/rcl/pull/921 fixed child loggers so that CI now detected an issue with one of our loggers. The problem was that the parent logger instance was no longer available at call time. The fix here creates a new logger instance for the child's namespace that would not go out of scope.