### PR TITLE
Revert "Temporarily switch to dockerhub for CI jobs (#1908)"

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,7 +4,7 @@
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling
-FROM moveit/moveit2:${ROS_DISTRO}-ci-testing
+FROM ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci-testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Export ROS_UNDERLAY for downstream docker containers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
-      DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
+      DOCKER_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >
         moveit2.repos
         $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)


### PR DESCRIPTION
I think we can safely switch back to GHCR, the issue seems to have been fixed with the latest switch to build-push-action@v4 https://github.com/docker/build-push-action/commit/337a09d182ee8c86aa958168dc985219e49e4b3b, and on humble everything seems fine.
