### PR TITLE
Changed C-style cast to C++-style cast for void data type

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_pr2.h
@@ -90,7 +90,7 @@ protected:
 #ifdef NDEBUG
 #define EXPECT_TIME_LT(EXPR, VAL) EXPECT_LT(EXPR, VAL)
 #else  // Don't perform timing checks in Debug mode (but evaluate expression)
-#define EXPECT_TIME_LT(EXPR, VAL) (void)(EXPR)
+#define EXPECT_TIME_LT(EXPR, VAL) static_cast<void>(EXPR)
 #endif
 
 TYPED_TEST_CASE_P(CollisionDetectorTest);

--- a/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
+++ b/moveit_core/collision_detection_bullet/src/bullet_integration/bullet_utils.cpp
@@ -85,7 +85,7 @@ bool acmCheck(const std::string& body_1, const std::string& body_2,
 
 btCollisionShape* createShapePrimitive(const shapes::Box* geom, const CollisionObjectType& collision_object_type)
 {
-  (void)(collision_object_type);
+  static_cast<void>(collision_object_type);
   assert(collision_object_type == CollisionObjectType::USE_SHAPE_TYPE);
   const double* size = geom->size;
   btScalar a = static_cast<btScalar>(size[0] / 2);
@@ -97,14 +97,14 @@ btCollisionShape* createShapePrimitive(const shapes::Box* geom, const CollisionO
 
 btCollisionShape* createShapePrimitive(const shapes::Sphere* geom, const CollisionObjectType& collision_object_type)
 {
-  (void)(collision_object_type);
+  static_cast<void>(collision_object_type);
   assert(collision_object_type == CollisionObjectType::USE_SHAPE_TYPE);
   return (new btSphereShape(static_cast<btScalar>(geom->radius)));
 }
 
 btCollisionShape* createShapePrimitive(const shapes::Cylinder* geom, const CollisionObjectType& collision_object_type)
 {
-  (void)(collision_object_type);
+  static_cast<void>(collision_object_type);
   assert(collision_object_type == CollisionObjectType::USE_SHAPE_TYPE);
   btScalar r = static_cast<btScalar>(geom->radius);
   btScalar l = static_cast<btScalar>(geom->length / 2);
@@ -113,7 +113,7 @@ btCollisionShape* createShapePrimitive(const shapes::Cylinder* geom, const Colli
 
 btCollisionShape* createShapePrimitive(const shapes::Cone* geom, const CollisionObjectType& collision_object_type)
 {
-  (void)(collision_object_type);
+  static_cast<void>(collision_object_type);
   assert(collision_object_type == CollisionObjectType::USE_SHAPE_TYPE);
   btScalar r = static_cast<btScalar>(geom->radius);
   btScalar l = static_cast<btScalar>(geom->length);

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -71,7 +71,7 @@ void checkFCLCapabilities(const DistanceRequest& req)
                           FCL_MAJOR_VERSION, FCL_MINOR_VERSION, FCL_PATCH_VERSION);
   }
 #else
-  (void)(req);  // silent -Wunused-parameter
+  static_cast<void>(req);  // silent -Wunused-parameter
 #endif
 }
 }  // namespace


### PR DESCRIPTION
### Description

Changed C-style cast to C++-style cast for the `main` branch. Implemented for void data type.
Changed (data_type)(expression) to static_cast<data_type>(expression) in multiple files and tested by building the packages via colcon.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Solves issue #862 for `void` data type.

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
