### PR TITLE
Fix parameter handling in servo module API 

### DIFF
--- a/moveit_py/moveit/servo_client/teleop.py
+++ b/moveit_py/moveit/servo_client/teleop.py
@@ -57,7 +57,7 @@ class TeleopDevice(ABC, Node):
         self.device_name = device_name
         self.device_config = device_config
         self.declare_parameters(
-            namespace=node_name, parameters=[("ee_frame_name", "panda_link8")]
+            namespace=node_name, parameters=[("ee_frame_name", None)]
         )
         self.ee_frame_name = (
             self.get_parameter("ee_frame_name").get_parameter_value().string_value

--- a/moveit_py/moveit/servo_client/teleop.py
+++ b/moveit_py/moveit/servo_client/teleop.py
@@ -52,12 +52,16 @@ class TeleopDevice(ABC, Node):
     This class expects both the `publish_command` and `record` methods to be overridden by inheriting classes.
     """
 
-    def __init__(self, node_name, device_name, device_config, ee_frame_name):
+    def __init__(self, node_name, device_name, device_config):
         super().__init__(node_name=node_name)
         self.device_name = device_name
         self.device_config = device_config
-        self.ee_frame_name = ee_frame_name
-
+        self.declare_parameters(
+            namespace=node_name, parameters=[("ee_frame_name", "panda_link8")]
+        )
+        self.ee_frame_name = (
+            self.get_parameter("ee_frame_name").get_parameter_value().string_value
+        )
         # default subscriber and publisher setup
         self.joy_subscriber = self.create_subscription(
             Joy, "/joy", self.publish_command, 10

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -39,6 +39,17 @@ def generate_launch_description():
     servo_yaml = load_yaml("moveit_servo", "config/panda_simulated_config.yaml")
     servo_params = {"moveit_servo": servo_yaml}
 
+    # Get the ee_frame_name parameter
+    ee_frame_name_servo_param = servo_params["moveit_servo"]["ee_frame_name"]
+
+    # Declare ee_frame_name launch parameter
+    ee_frame_name_launch_arg = launch.actions.DeclareLaunchArgument(
+        "ee_frame_name",
+        default_value=launch.substitutions.TextSubstitution(
+            text=ee_frame_name_servo_param
+        ),
+    )
+
     # RViz
     rviz_config_file = (
         get_package_share_directory("moveit_servo") + "/config/demo_rviz_config.rviz"
@@ -137,6 +148,11 @@ def generate_launch_description():
         executable="servo_node_main",
         parameters=[
             servo_params,
+            {
+                "ee_frame_name": launch.substitutions.LaunchConfiguration(
+                    "ee_frame_name"
+                )
+            },
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,
@@ -146,6 +162,7 @@ def generate_launch_description():
 
     return launch.LaunchDescription(
         [
+            ee_frame_name_launch_arg,
             rviz_node,
             ros2_control_node,
             joint_state_broadcaster_spawner,


### PR DESCRIPTION
### Description

~~#1969 First declaring the `ee_frame_name` parameter (for testing purposes, may not need it) and then getting the parameter from the node parameters. Also, added namespace to solve for the confusion when multiple nodes are running~~

Update - Passed the `ee_frame_name` as a launch parameter to the `servo_node` in `servo_example.launch.py` after loading it directly from the `panda_simulated_config.yaml`.  Additionally, removed `ee_frame_name` as constructor argument and setting the it's value using the launch parameter  inside the `node_name` namespace in `teleop.py`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
