### PR TITLE
Temporarily disable TestPathConstraints with the Panda robot

### DIFF
--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -321,10 +321,11 @@ TEST_F(PandaTestPlanningContext, testSimpleRequest)
   testSimpleRequest({ 0., -0.785, 0., -2.356, 0, 1.571, 0.785 }, { 0., -0.785, 0., -2.356, 0, 1.571, 0.685 });
 }
 
-TEST_F(PandaTestPlanningContext, testPathConstraints)
-{
-  testPathConstraints({ 0., -0.785, 0., -2.356, 0., 1.571, 0.785 }, { .0, -0.785, 0., -2.356, 0., 1.571, 0.685 });
-}
+// TODO(seng): This test is temporarily disabled as it is flaky since #1300. Re-enable when #2015 is resolved.
+// TEST_F(PandaTestPlanningContext, testPathConstraints)
+// {
+//   testPathConstraints({ 0., -0.785, 0., -2.356, 0., 1.571, 0.785 }, { .0, -0.785, 0., -2.356, 0., 1.571, 0.685 });
+// }
 
 /***************************************************************************
  * Run all tests on the Fanuc robot


### PR DESCRIPTION
This test has become flaky since it was modified to use the OMPL constrained state space. #2015 tracks the flaky test issue.