### PR TITLE
Remove "new" from smart pointer instantiation

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_command_list_manager.cpp
@@ -130,19 +130,19 @@ void IntegrationTestCommandListManager::SetUp()
  */
 TEST_F(IntegrationTestCommandListManager, TestExceptionErrorCodeMapping)
 {
-  std::shared_ptr<NegativeBlendRadiusException> nbr_ex{ new NegativeBlendRadiusException("") };
+  auto nbr_ex = std::make_shared<NegativeBlendRadiusException>("");
   EXPECT_EQ(nbr_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
 
-  std::shared_ptr<LastBlendRadiusNotZeroException> lbrnz_ex{ new LastBlendRadiusNotZeroException("") };
+  auto lbrnz_ex = std::make_shared<LastBlendRadiusNotZeroException>("");
   EXPECT_EQ(lbrnz_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
 
-  std::shared_ptr<StartStateSetException> sss_ex{ new StartStateSetException("") };
+  auto sss_ex = std::make_shared<StartStateSetException>("");
   EXPECT_EQ(sss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
 
-  std::shared_ptr<OverlappingBlendRadiiException> obr_ex{ new OverlappingBlendRadiiException("") };
+  auto obr_ex = std::make_shared<OverlappingBlendRadiiException>("");
   EXPECT_EQ(obr_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
 
-  std::shared_ptr<PlanningPipelineException> pp_ex{ new PlanningPipelineException("") };
+  auto pp_ex = std::make_shared<PlanningPipelineException>("");
   EXPECT_EQ(pp_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integration_tests/src/integrationtest_plan_components_builder.cpp
@@ -82,16 +82,16 @@ void IntegrationTestPlanComponentBuilder::SetUp()
  */
 TEST_F(IntegrationTestPlanComponentBuilder, TestExceptionErrorCodeMapping)
 {
-  std::shared_ptr<NoBlenderSetException> nbs_ex{ new NoBlenderSetException("") };
+  auto nbs_ex = std::make_shared<NoBlenderSetException>("");
   EXPECT_EQ(nbs_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
 
-  std::shared_ptr<NoTipFrameFunctionSetException> ntffse_ex{ new NoTipFrameFunctionSetException("") };
+  auto ntffse_ex = std::make_shared<NoTipFrameFunctionSetException>("");
   EXPECT_EQ(ntffse_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
 
-  std::shared_ptr<NoRobotModelSetException> nrms_ex{ new NoRobotModelSetException("") };
+  auto nrms_ex = std::make_shared<NoRobotModelSetException>("");
   EXPECT_EQ(nrms_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
 
-  std::shared_ptr<BlendingFailedException> bf_ex{ new BlendingFailedException("") };
+  auto bf_ex = std::make_shared<BlendingFailedException>("");
   EXPECT_EQ(bf_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_get_solver_tip_frame.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_get_solver_tip_frame.cpp
@@ -89,12 +89,12 @@ void GetSolverTipFrameTest::SetUp()
 TEST_F(GetSolverTipFrameTest, TestExceptionErrorCodeMapping)
 {
   {
-    std::shared_ptr<NoSolverException> nse_ex{ new NoSolverException("") };
+    auto nse_ex = std::make_shared<NoSolverException>("");
     EXPECT_EQ(nse_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
   }
 
   {
-    std::shared_ptr<MoreThanOneTipFrameException> ex{ new MoreThanOneTipFrameException("") };
+    auto ex = std::make_shared<MoreThanOneTipFrameException>("");
     EXPECT_EQ(ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
   }
 }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_pilz_industrial_motion_planner_direct.cpp
@@ -44,8 +44,8 @@ using namespace pilz_industrial_motion_planner;
 
 TEST(CommandPlannerTestDirect, ExceptionCoverage)
 {
-  std::shared_ptr<PlanningException> p_ex{ new PlanningException("") };
-  std::shared_ptr<ContextLoaderRegistrationException> clr_ex{ new ContextLoaderRegistrationException("") };
+  auto p_ex = std::make_shared<PlanningException>("");
+  auto clr_ex = std::make_shared<ContextLoaderRegistrationException>("");
 }
 
 /**

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator.cpp
@@ -47,94 +47,92 @@ using namespace pilz_industrial_motion_planner;
 TEST(TrajectoryGeneratorTest, TestExceptionErrorCodeMapping)
 {
   {
-    std::shared_ptr<TrajectoryGeneratorInvalidLimitsException> tgil_ex{ new TrajectoryGeneratorInvalidLimitsException(
-        "") };
+    auto tgil_ex = std::make_shared<TrajectoryGeneratorInvalidLimitsException>("");
     EXPECT_EQ(tgil_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
   }
 
   {
-    std::shared_ptr<VelocityScalingIncorrect> vsi_ex{ new VelocityScalingIncorrect("") };
+    auto vsi_ex = std::make_shared<VelocityScalingIncorrect>("");
     EXPECT_EQ(vsi_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<AccelerationScalingIncorrect> asi_ex{ new AccelerationScalingIncorrect("") };
+    auto asi_ex = std::make_shared<AccelerationScalingIncorrect>("");
     EXPECT_EQ(asi_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<UnknownPlanningGroup> upg_ex{ new UnknownPlanningGroup("") };
+    auto upg_ex = std::make_shared<UnknownPlanningGroup>("");
     EXPECT_EQ(upg_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GROUP_NAME);
   }
 
   {
-    std::shared_ptr<NoJointNamesInStartState> njniss_ex{ new NoJointNamesInStartState("") };
+    auto njniss_ex = std::make_shared<NoJointNamesInStartState>("");
     EXPECT_EQ(njniss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<SizeMismatchInStartState> smiss_ex{ new SizeMismatchInStartState("") };
+    auto smiss_ex = std::make_shared<SizeMismatchInStartState>("");
     EXPECT_EQ(smiss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<JointsOfStartStateOutOfRange> jofssoor_ex{ new JointsOfStartStateOutOfRange("") };
+    auto jofssoor_ex = std::make_shared<JointsOfStartStateOutOfRange>("");
     EXPECT_EQ(jofssoor_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<NonZeroVelocityInStartState> nzviss_ex{ new NonZeroVelocityInStartState("") };
+    auto nzviss_ex = std::make_shared<NonZeroVelocityInStartState>("");
     EXPECT_EQ(nzviss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<NotExactlyOneGoalConstraintGiven> neogcg_ex{ new NotExactlyOneGoalConstraintGiven("") };
+    auto neogcg_ex = std::make_shared<NotExactlyOneGoalConstraintGiven>("");
     EXPECT_EQ(neogcg_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<OnlyOneGoalTypeAllowed> oogta_ex{ new OnlyOneGoalTypeAllowed("") };
+    auto oogta_ex = std::make_shared<OnlyOneGoalTypeAllowed>("");
     EXPECT_EQ(oogta_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<StartStateGoalStateMismatch> ssgsm_ex{ new StartStateGoalStateMismatch("") };
+    auto ssgsm_ex = std::make_shared<StartStateGoalStateMismatch>("");
     EXPECT_EQ(ssgsm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<JointConstraintDoesNotBelongToGroup> jcdnbtg_ex{ new JointConstraintDoesNotBelongToGroup("") };
+    auto jcdnbtg_ex = std::make_shared<JointConstraintDoesNotBelongToGroup>("");
     EXPECT_EQ(jcdnbtg_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<JointsOfGoalOutOfRange> jogoor_ex{ new JointsOfGoalOutOfRange("") };
+    auto jogoor_ex = std::make_shared<JointsOfGoalOutOfRange>("");
     EXPECT_EQ(jogoor_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<PositionConstraintNameMissing> pcnm_ex{ new PositionConstraintNameMissing("") };
+    auto pcnm_ex = std::make_shared<PositionConstraintNameMissing>("");
     EXPECT_EQ(pcnm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<OrientationConstraintNameMissing> ocnm_ex{ new OrientationConstraintNameMissing("") };
+    auto ocnm_ex = std::make_shared<OrientationConstraintNameMissing>("");
     EXPECT_EQ(ocnm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<PositionOrientationConstraintNameMismatch> pocnm_ex{ new PositionOrientationConstraintNameMismatch(
-        "") };
+    auto pocnm_ex = std::make_shared<PositionOrientationConstraintNameMismatch>("");
     EXPECT_EQ(pocnm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<NoIKSolverAvailable> nisa_ex{ new NoIKSolverAvailable("") };
+    auto nisa_ex = std::make_shared<NoIKSolverAvailable>("");
     EXPECT_EQ(nisa_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::NO_IK_SOLUTION);
   }
 
   {
-    std::shared_ptr<NoPrimitivePoseGiven> nppg_ex{ new NoPrimitivePoseGiven("") };
+    auto nppg_ex = std::make_shared<NoPrimitivePoseGiven>("");
     EXPECT_EQ(nppg_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_circ.cpp
@@ -214,57 +214,57 @@ protected:
 TEST_F(TrajectoryGeneratorCIRCTest, TestExceptionErrorCodeMapping)
 {
   {
-    std::shared_ptr<CircleNoPlane> cnp_ex{ new CircleNoPlane("") };
+    auto cnp_ex = std::make_shared<CircleNoPlane>("");
     EXPECT_EQ(cnp_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<CircleToSmall> cts_ex{ new CircleToSmall("") };
+    auto cts_ex = std::make_shared<CircleToSmall>("");
     EXPECT_EQ(cts_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<CenterPointDifferentRadius> cpdr_ex{ new CenterPointDifferentRadius("") };
+    auto cpdr_ex = std::make_shared<CenterPointDifferentRadius>("");
     EXPECT_EQ(cpdr_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<CircTrajectoryConversionFailure> ctcf_ex{ new CircTrajectoryConversionFailure("") };
+    auto ctcf_ex = std::make_shared<CircTrajectoryConversionFailure>("");
     EXPECT_EQ(ctcf_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<UnknownPathConstraintName> upcn_ex{ new UnknownPathConstraintName("") };
+    auto upcn_ex = std::make_shared<UnknownPathConstraintName>("");
     EXPECT_EQ(upcn_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<NoPositionConstraints> npc_ex{ new NoPositionConstraints("") };
+    auto npc_ex = std::make_shared<NoPositionConstraints>("");
     EXPECT_EQ(npc_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<NoPrimitivePose> npp_ex{ new NoPrimitivePose("") };
+    auto npp_ex = std::make_shared<NoPrimitivePose>("");
     EXPECT_EQ(npp_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN);
   }
 
   {
-    std::shared_ptr<UnknownLinkNameOfAuxiliaryPoint> ulnoap_ex{ new UnknownLinkNameOfAuxiliaryPoint("") };
+    auto ulnoap_ex = std::make_shared<UnknownLinkNameOfAuxiliaryPoint>("");
     EXPECT_EQ(ulnoap_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_LINK_NAME);
   }
 
   {
-    std::shared_ptr<NumberOfConstraintsMismatch> nocm_ex{ new NumberOfConstraintsMismatch("") };
+    auto nocm_ex = std::make_shared<NumberOfConstraintsMismatch>("");
     EXPECT_EQ(nocm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<CircJointMissingInStartState> cjmiss_ex{ new CircJointMissingInStartState("") };
+    auto cjmiss_ex = std::make_shared<CircJointMissingInStartState>("");
     EXPECT_EQ(cjmiss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<CircInverseForGoalIncalculable> cifgi_ex{ new CircInverseForGoalIncalculable("") };
+    auto cifgi_ex = std::make_shared<CircInverseForGoalIncalculable>("");
     EXPECT_EQ(cifgi_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::NO_IK_SOLUTION);
   }
 }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_lin.cpp
@@ -183,22 +183,22 @@ protected:
 TEST_F(TrajectoryGeneratorLINTest, TestExceptionErrorCodeMapping)
 {
   {
-    std::shared_ptr<LinTrajectoryConversionFailure> ltcf_ex{ new LinTrajectoryConversionFailure("") };
+    auto ltcf_ex = std::make_shared<LinTrajectoryConversionFailure>("");
     EXPECT_EQ(ltcf_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
   }
 
   {
-    std::shared_ptr<JointNumberMismatch> jnm_ex{ new JointNumberMismatch("") };
+    auto jnm_ex = std::make_shared<JointNumberMismatch>("");
     EXPECT_EQ(jnm_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
   }
 
   {
-    std::shared_ptr<LinJointMissingInStartState> ljmiss_ex{ new LinJointMissingInStartState("") };
+    auto ljmiss_ex = std::make_shared<LinJointMissingInStartState>("");
     EXPECT_EQ(ljmiss_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::INVALID_ROBOT_STATE);
   }
 
   {
-    std::shared_ptr<LinInverseForGoalIncalculable> lifgi_ex{ new LinInverseForGoalIncalculable("") };
+    auto lifgi_ex = std::make_shared<LinInverseForGoalIncalculable>("");
     EXPECT_EQ(lifgi_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::NO_IK_SOLUTION);
   }
 }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_generator_ptp.cpp
@@ -158,12 +158,12 @@ protected:
 TEST_F(TrajectoryGeneratorPTPTest, TestExceptionErrorCodeMapping)
 {
   {
-    std::shared_ptr<PtpVelocityProfileSyncFailed> pvpsf_ex{ new PtpVelocityProfileSyncFailed("") };
+    auto pvpsf_ex = std::make_shared<PtpVelocityProfileSyncFailed>("");
     EXPECT_EQ(pvpsf_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::FAILURE);
   }
 
   {
-    std::shared_ptr<PtpNoIkSolutionForGoalPose> pnisfgp_ex{ new PtpNoIkSolutionForGoalPose("") };
+    auto pnisfgp_ex = std::make_shared<PtpNoIkSolutionForGoalPose>("");
     EXPECT_EQ(pnisfgp_ex->getErrorCode(), moveit_msgs::msg::MoveItErrorCodes::NO_IK_SOLUTION);
   }
 }
@@ -294,8 +294,8 @@ TEST_F(TrajectoryGeneratorPTPTest, testInsufficientLimit)
 
   EXPECT_THROW(
       {
-        std::unique_ptr<TrajectoryGeneratorPTP> ptp_error(
-            new TrajectoryGeneratorPTP(robot_model_, insufficient_planner_limits, planning_group_));
+        auto ptp_error =
+            std::make_unique<TrajectoryGeneratorPTP>(robot_model_, insufficient_planner_limits, planning_group_);
       },
       TrajectoryGeneratorInvalidLimitsException);
 
@@ -333,8 +333,8 @@ TEST_F(TrajectoryGeneratorPTPTest, testInsufficientLimit)
   sufficient_planner_limits.setJointLimits(sufficient_joint_limits);
 
   EXPECT_NO_THROW({
-    std::unique_ptr<TrajectoryGeneratorPTP> ptp_no_error(
-        new TrajectoryGeneratorPTP(robot_model_, sufficient_planner_limits, planning_group_));
+    auto ptp_no_error =
+        std::make_unique<TrajectoryGeneratorPTP>(robot_model_, sufficient_planner_limits, planning_group_);
   });
 }
 


### PR DESCRIPTION
### Description

Got rid of "new" operator calls by using std::make_shared instead of std::shared_ptr (similarly for std::unique_ptr).
Solves issue #868.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials/documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
