### PR TITLE
Add callback for velocity scaling override + fix params namespace not being set

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -337,6 +337,8 @@ protected:
   // dynamic parameters
   std::string robot_link_command_frame_;
   rcl_interfaces::msg::SetParametersResult robotLinkCommandFrameCallback(const rclcpp::Parameter& parameter);
+  double override_velocity_scaling_factor_;
+  rcl_interfaces::msg::SetParametersResult overrideVelocityScalingFactorCallback(const rclcpp::Parameter& parameter);
 
   // Load a smoothing plugin
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_parameters.h
@@ -54,7 +54,7 @@ struct ServoParameters
   using SharedConstPtr = std::shared_ptr<const ServoParameters>;
 
   // Parameter namespace
-  const std::string ns;
+  std::string ns;
 
   // ROS Parameters
   // Note that all of these are effectively const because the only way to create one of these

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -95,6 +95,7 @@ void ServoParameters::declare(const std::string& ns,
   using rclcpp::ParameterType::PARAMETER_INTEGER;
   using rclcpp::ParameterType::PARAMETER_STRING;
   auto parameters = ServoParameters{};
+  parameters.ns = ns;
 
   // ROS Parameters
   node_parameters->declare_parameter(
@@ -265,6 +266,7 @@ ServoParameters ServoParameters::get(const std::string& ns,
                                      const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr& node_parameters)
 {
   auto parameters = ServoParameters{};
+  parameters.ns = ns;
 
   // ROS Parameters
   parameters.use_gazebo = node_parameters->get_parameter(ns + ".use_gazebo").as_bool();


### PR DESCRIPTION
This PR originally sought to add a dynamic parameter callback for the `override_velocity_scaling_factor` parameter, but then I realized that the entire dynamic param callback structure wasn't working because we were never setting the `ns` member variable of `ServoParameters` when instantiating.

Confirming this fixes things for me.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
