### PR TITLE
Add stale GHA

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,26 @@
+name: 'Stale issues and PRs'
+description: 'Labels inactive issues and PRs as stale, and only closes stale issues after ongoing inactivity'
+on:
+  schedule:
+    # UTC noon every workday
+    - cron: '0 12 * * MON-FRI'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: 'This issue is being labeled as stale because it has been open 45 days with no activity. It will be automatically closed after another 45 days without follow-ups.'
+          close-issue-message: 'This issue was closed because it has been stalled for 45 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open for 45 days with no activity. Please tag a maintainer for help on completing this PR, or close it if you think it has become obsolete.'
+          days-before-stale: 45
+          days-before-close: 45
+          days-before-pr-close: -1
+          exempt-all-milestones: true
+          exempt-issue-labels: good first issue,persistent,release,roadmap,Epic


### PR DESCRIPTION
Enables a [stale action](https://github.com/marketplace/actions/close-stale-issues) that labels issues and PRs as stale after 45 days, and closes issues after another 45 days. The action also takes care about warning the author appropriately, and it ignores a set of persistent labels. The intention of this is to really only keep issues open that are persistent explicitly (there is a new label for that), or that belong to a roadmap, milestone, etc.. All other issues should require at least some activity within the 3 months of time it would take for this GHA to close them.

Fixes https://github.com/ros-planning/moveit2/pull/2022