### PR TITLE
Make distance_factor a constructor argument

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -139,6 +139,16 @@ public:
    */
   JointModel(const std::string& name, size_t joint_index, size_t first_variable_index);
 
+  /**
+   * @brief      Constructs a joint named \e name with a specified distance factor
+   *
+   * @param[in]  name                   The joint name
+   * @param[in]  index                  The index of the joint in the RobotModel
+   * @param[in]  first_variable_index   The index of the first variable in the RobotModel
+   * @param[in]  distance_factor        The factor applied to the distance between two joint states
+   */
+  JointModel(const std::string& name, size_t joint_index, size_t first_variable_index, double distance_factor);
+
   virtual ~JointModel();
 
   /** \brief Get the name of the joint */
@@ -469,6 +479,9 @@ private:
 protected:
   void computeVariableBoundsMsg();
 
+  /** \brief The factor applied to the distance between two joint states */
+  double distance_factor_;
+
   /** \brief The type of joint */
   JointType type_;
 
@@ -517,9 +530,6 @@ protected:
 
   /** \brief Specify whether this joint is marked as passive in the SRDF */
   bool passive_;
-
-  /** \brief The factor applied to the distance between two joint states */
-  double distance_factor_;
 };
 
 /** \brief Operator overload for printing variable bounds to a stream */

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -44,10 +44,11 @@ namespace moveit
 {
 namespace core
 {
-JointModel::JointModel(const std::string& name, size_t joint_index, size_t first_variable_index)
+JointModel::JointModel(const std::string& name, size_t joint_index, size_t first_variable_index, double distance_factor)
   : name_(name)
   , joint_index_(joint_index)
   , first_variable_index_(first_variable_index)
+  , distance_factor_(distance_factor)
   , type_(UNKNOWN)
   , parent_link_model_(nullptr)
   , child_link_model_(nullptr)
@@ -55,7 +56,11 @@ JointModel::JointModel(const std::string& name, size_t joint_index, size_t first
   , mimic_factor_(1.0)
   , mimic_offset_(0.0)
   , passive_(false)
-  , distance_factor_(1.0)
+{
+}
+
+JointModel::JointModel(const std::string& name, size_t joint_index, size_t first_variable_index)
+  : JointModel(name, joint_index, first_variable_index, 1.0)
 {
 }
 


### PR DESCRIPTION


### Description

This commit used a delegating constructor to add distance_factor to arguments list. When distance_factor is not specified, it is defaulted to 1.0 as in old code.
This PR is addressing #2013. This is my first time contributing to MoveIt, so I may miss a rule. Please feel free to review and give me feedback. Thank you!

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
