### PR TITLE
Add MoveIt Python Library Citation

### DIFF
--- a/moveit_py/CITATION.cff
+++ b/moveit_py/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+authors:
+  - family-names: Fagan
+    given-names: Peter David
+date-released: 2023-03-20
+message: "If you use this software, please cite it as below."
+title: "MoveIt 2 Python Library: A Software Library for Robotics Education and Research"
+url: "https://github.com/ros-planning/moveit2/tree/main/moveit_py"

--- a/moveit_py/README.md
+++ b/moveit_py/README.md
@@ -20,5 +20,16 @@ Community contributions are welcome.
 
 For detailed contribution guidelines please consult the official [MoveIt contribution guidelines](https://moveit.ros.org/documentation/contributing/).
 
+## Citing the Library
+If you use this library in your work please use the following citation:
+```bibtex
+@software{fagan2023moveitpy,
+  author = {Fagan, Peter David},
+  title = {{MoveIt 2 Python Library: A Software Library for Robotics Education and Research}},
+  url = {https://github.com/ros-planning/moveit2/tree/main/moveit_py},
+  year = {2023}
+}
+```
+
 ## Acknowledgements
 Thank you to the [Google Summer of Code program](https://summerofcode.withgoogle.com/) for sponsoring the development of this Python library. Thank you to the MoveIt maintainers Henning Kayser (@henningkayser) and Michael Gorner (@v4hn) for their guidance as supervisors of my GSoC project. Finally thank you to the [ML Collective](https://mlcollective.org/) for providing compute support for this project.


### PR DESCRIPTION
### Description

Adds citation to README.md to enable those who use the library to cite it within their work.

Note: the authors list needs to be expanded upon.