### PR TITLE
Add URDF Loader Exceptions and Fix Infinite While-Loop when URDF file isn't in a ROS Package

### DIFF
--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
@@ -312,8 +312,8 @@ void StartScreenWidget::onUrdfPathChanged(const QString& path)
   }
   catch (const std::runtime_error& e)
   {
-    RCLCPP_ERROR(setup_step_.getLogger(), "%s", e.what());
-    QMessageBox::warning(this, "Error Loading URDF path", QString(e.what()));
+    RCLCPP_ERROR(setup_step_.getLogger(), "Error Loading URDF Path. %s", e.what());
+    QMessageBox::warning(this, "Error Loading URDF Path", QString(e.what()));
   }
 }
 
@@ -351,7 +351,7 @@ bool StartScreenWidget::loadExistingFiles()
   }
   catch (const std::runtime_error& e)
   {
-    RCLCPP_ERROR(setup_step_.getLogger(), "%s", e.what());
+    RCLCPP_ERROR(setup_step_.getLogger(), "Error Loading SRDF. %s", e.what());
     QMessageBox::warning(this, "Error Loading SRDF", QString(e.what()));
     return false;
   }

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
@@ -305,8 +305,16 @@ void StartScreenWidget::onPackagePathChanged(const QString& /*path*/)
 
 void StartScreenWidget::onUrdfPathChanged(const QString& path)
 {
-  setup_step_.loadURDFFile(path.toStdString(), urdf_file_->getArgs().toStdString());
-  urdf_file_->setArgsEnabled(setup_step_.isXacroFile());
+  try
+  {
+    setup_step_.loadURDFFile(path.toStdString(), urdf_file_->getArgs().toStdString());
+    urdf_file_->setArgsEnabled(setup_step_.isXacroFile());
+  }
+  catch (const std::runtime_error& e)
+  {
+    RCLCPP_ERROR(setup_step_.getLogger(), "%s", e.what());
+    QMessageBox::warning(this, "Error Loading URDF path", QString(e.what()));
+  }
 }
 
 bool StartScreenWidget::loadPackageSettings(bool show_warnings)
@@ -343,8 +351,8 @@ bool StartScreenWidget::loadExistingFiles()
   }
   catch (const std::runtime_error& e)
   {
-    QMessageBox::warning(this, "Error Loading SRDF", QString(e.what()));
     RCLCPP_ERROR(setup_step_.getLogger(), "%s", e.what());
+    QMessageBox::warning(this, "Error Loading SRDF", QString(e.what()));
     return false;
   }
 

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <ament_index_cpp/get_package_prefix.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <filesystem>
 #include <string>
@@ -49,7 +50,14 @@ namespace moveit_setup
  */
 inline std::filesystem::path getSharePath(const std::string& package_name)
 {
-  return std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
+  try
+  {
+    return std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
+  }
+  catch (const ament_index_cpp::PackageNotFoundError& e)
+  {
+    return std::filesystem::path();
+  }
 }
 
 /**

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
@@ -54,7 +54,7 @@ inline std::filesystem::path getSharePath(const std::string& package_name)
   {
     return std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name));
   }
-  catch (const ament_index_cpp::PackageNotFoundError& e)
+  catch (const std::runtime_error& e)
   {
     return std::filesystem::path();
   }

--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -97,20 +97,18 @@ void URDFConfig::setPackageName()
   {
     urdf_pkg_name_ = "";
     urdf_pkg_relative_path_ = urdf_path_;  // just the absolute path
+    throw std::runtime_error("URDF/COLLADA file package not found: " + urdf_path_.string());
   }
-  else
-  {
-    // Check that ROS can find the package
-    const std::filesystem::path robot_desc_pkg_path = getSharePath(urdf_pkg_name_);
+  // Check that ROS can find the package
+  const std::filesystem::path robot_desc_pkg_path = getSharePath(urdf_pkg_name_);
 
-    if (robot_desc_pkg_path.empty())
-    {
-      RCLCPP_WARN(*logger_,
-                  "Package Not Found In ROS Workspace. ROS was unable to find the package name '%s'"
-                  " within the ROS workspace. This may cause issues later.",
-                  urdf_pkg_name_.c_str());
-    }
-  }
+  if (robot_desc_pkg_path.empty())
+  {
+    RCLCPP_WARN(*logger_,
+                "Package Not Found In ROS Workspace. ROS was unable to find the package name '%s'"
+                " within the ROS workspace. This may cause issues later.",
+                urdf_pkg_name_.c_str());
+  } 
 }
 
 void URDFConfig::loadFromPackage(const std::filesystem::path& package_name, const std::filesystem::path& relative_path,
@@ -132,6 +130,11 @@ void URDFConfig::load()
   if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string_, urdf_path_, xacro_args_vec_))
   {
     throw std::runtime_error("URDF/COLLADA file not found: " + urdf_path_.string());
+  }
+
+  if (urdf_pkg_name_ == "")
+  {
+    throw std::runtime_error("URDF/COLLADA file package not found: " + urdf_path_.string());
   }
 
   if (urdf_string_.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_path_))

--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -97,7 +97,6 @@ void URDFConfig::setPackageName()
   {
     urdf_pkg_name_ = "";
     urdf_pkg_relative_path_ = urdf_path_;  // just the absolute path
-    throw std::runtime_error("URDF/COLLADA file package not found: " + urdf_path_.string());
   }
   // Check that ROS can find the package
   const std::filesystem::path robot_desc_pkg_path = getSharePath(urdf_pkg_name_);
@@ -108,7 +107,7 @@ void URDFConfig::setPackageName()
                 "Package Not Found In ROS Workspace. ROS was unable to find the package name '%s'"
                 " within the ROS workspace. This may cause issues later.",
                 urdf_pkg_name_.c_str());
-  } 
+  }
 }
 
 void URDFConfig::loadFromPackage(const std::filesystem::path& package_name, const std::filesystem::path& relative_path,
@@ -134,7 +133,7 @@ void URDFConfig::load()
 
   if (urdf_pkg_name_ == "")
   {
-    throw std::runtime_error("URDF/COLLADA file package not found: " + urdf_path_.string());
+    throw std::runtime_error("URDF/COLLADA package not found for file path: " + urdf_path_.string());
   }
 
   if (urdf_string_.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_path_))

--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -131,7 +131,7 @@ void URDFConfig::load()
     throw std::runtime_error("URDF/COLLADA file not found: " + urdf_path_.string());
   }
 
-  if (urdf_pkg_name_ == "")
+  if (urdf_pkg_name_.empty())
   {
     throw std::runtime_error("URDF/COLLADA package not found for file path: " + urdf_path_.string());
   }

--- a/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
@@ -53,7 +53,8 @@ bool extractPackageNameFromPath(const std::filesystem::path& path, std::string& 
   }
 
   // truncate path step by step and check if it contains a package.xml
-  while (!sub_path.empty())
+  // This runs until the path is either empty "" or at the root "/" or "C:\\"
+  while (!sub_path.empty() && sub_path != sub_path.root_path())
   {
     if (std::filesystem::is_regular_file(sub_path / "package.xml"))
     {


### PR DESCRIPTION
### Description
This PR fixes [Issue 1944](https://github.com/ros-planning/moveit2/issues/1944). When selecting a URDF from a file path, MSA would hang forever before needing to be killed if the URDF was not in a ROS package; with no error messages printed. This was due to an infinite while-loop in the moveit_setup_framework/src/utilities.cpp file when extracting the package name from the file path. This fixes that while-condition to check against the root file path when truncating the path. Also added a catch so if ament throws an error finding the package it will just return an empty filepath instead. 

This PR also adds some error handling to the start screen widget to propagate URDF loading errors to the user via the GUI, rather than just crash. Previous behavior was that when selecting an invalid URDF, the MSA tool crashed and the ROS logs displayed the exception.

Partially based off of initial work done by @mikeferguson 

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
