### PR TITLE
fix humble Dockerfiles - use humble, not rolling

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -1,11 +1,19 @@
-# ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci-testing
+# ghcr.io/ros-planning/moveit2:${OUR_ROS_DISTRO}-ci-testing
 # CI image using the ROS testing repository
 
-ARG ROS_DISTRO=rolling
 FROM osrf/ros2:testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm
+
+# Overwrite the ROS_DISTRO set in osrf/ros2:testing to the distro tied to this Dockerfile (OUR_ROS_DISTRO).
+# In case ROS_DISTRO is now different from what was set in osrf/ros2:testing, run `rosdep update` again
+# to get any missing dependencies.
+# https://docs.docker.com/engine/reference/builder/#using-arg-variables explains why ARG and ENV can't have
+# the same name (ROS_DISTRO is an ENV in the osrf/ros2:testing image).
+ARG OUR_ROS_DISTRO=rolling
+ENV ROS_DISTRO=${OUR_ROS_DISTRO}
+RUN rosdep update --rosdistro $ROS_DISTRO
 
 # Install ROS 2 base packages and build tools
 # We are installing ros-<distro>-ros-base here to mimic the behavior of the ros:<distro>-ros-base images.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: .docker/${{ github.job }}/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+          build-args: OUR_ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
           no-cache: true
           tags: |


### PR DESCRIPTION
### Description

~~The humble Dockerfiles had the ROS distro set to rolling, causing issues in downstream repositories (for example, CI on https://github.com/ros-planning/moveit2_tutorials/pull/644 would fail since there's a mismatch of ROS versions when trying to build the tutorials). This PR fixes the ROS version for the humble Dockerfiles, hopefully resolving any unexpected errors for users of these Dockerfiles as well.~~

Edit: The [`ci-testing` Dockerfile](https://github.com/ros-planning/moveit2/blob/main/.docker/ci-testing/Dockerfile) uses [`osrf/ros2:testing`](https://github.com/osrf/docker_images/blob/master/ros2/testing/testing/Dockerfile) as its base image. This base image has the `ROS_DISTRO` environment variable set to rolling. This PR updates the `ci-testing` Dockerfile to allow overwriting of the base image's `ROS_DISTRO` environment variable, so that the `ci-testing` can properly build both humble and rolling docker images (before this PR, `humble-ci-testing` images actually had rolling installed on them). This also fixes the `humble-source` images being built, since the `source` images use `ci-testing` as its base image.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
