### PR TITLE
Update description of moveit_ros_planning_interface

### DIFF
--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>moveit_ros_planning_interface</name>
   <version>2.7.1</version>
-  <description>Components of MoveIt that offer simpler interfaces to planning and execution</description>
+  <description>Components of MoveIt that offer simpler remote (From another ROS 2 node to a node that is running MoveIt 2) interfaces to planning and execution</description>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <maintainer email="tyler@picknik.ai">Tyler Weaver</maintainer>
   <maintainer email="me@v4hn.de">Michael Görner</maintainer>


### PR DESCRIPTION
### Description

Make the package description of `moveit_ros_planning_interface` a bit more precise. What do you think about renaming the package to a more verbose name (like moveit_ros_remote_interface(s?))? Right now, I think it is a bit confusing that we have the `moveit_ros_planning_interface` package and `moveit_planning_interface` library with both depending on ROS.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
