### PR TITLE
Regarding Issue #859: Do not pass and return simple types by const ref #859.

### DIFF
--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -48,15 +48,15 @@
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_collision_detection.collision_octomap_filter");
 
 // forward declarations
-bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const double& spacing, const double& iso_value,
-                                  const double& r_multiple, const octomath::Vector3& contact_point,
+bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const double spacing, const double iso_value,
+                                  const double r_multiple, const octomath::Vector3& contact_point,
                                   octomath::Vector3& normal, double& depth, bool estimate_depth);
 
-bool findSurface(const octomap::point3d_list& cloud, const double& spacing, const double& iso_value,
-                 const double& r_multiple, const octomath::Vector3& seed, octomath::Vector3& surface_point,
+bool findSurface(const octomap::point3d_list& cloud, const double spacing, const double iso_value,
+                 const double r_multiple, const octomath::Vector3& seed, octomath::Vector3& surface_point,
                  octomath::Vector3& normal);
 
-bool sampleCloud(const octomap::point3d_list& cloud, const double& spacing, const double& r_multiple,
+bool sampleCloud(const octomap::point3d_list& cloud, const double spacing, const double r_multiple,
                  const octomath::Vector3& position, double& intensity, octomath::Vector3& gradient);
 
 int collision_detection::refineContactNormals(const World::ObjectConstPtr& object, CollisionResult& res,
@@ -170,8 +170,8 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
   return modified;
 }
 
-bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const double& spacing, const double& iso_value,
-                                  const double& r_multiple, const octomath::Vector3& contact_point,
+bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const double spacing, const double iso_value,
+                                  const double r_multiple, const octomath::Vector3& contact_point,
                                   octomath::Vector3& normal, double& depth, const bool estimate_depth)
 {
   double intensity;
@@ -207,8 +207,8 @@ bool getMetaballSurfaceProperties(const octomap::point3d_list& cloud, const doub
 // This algorithm is from Salisbury & Tarr's 1997 paper.  It will find the
 // closest point on the surface starting from a seed point that is close by
 // following the direction of the field gradient.
-bool findSurface(const octomap::point3d_list& cloud, const double& spacing, const double& iso_value,
-                 const double& r_multiple, const octomath::Vector3& seed, octomath::Vector3& surface_point,
+bool findSurface(const octomap::point3d_list& cloud, const double spacing, const double iso_value,
+                 const double r_multiple, const octomath::Vector3& seed, octomath::Vector3& surface_point,
                  octomath::Vector3& normal)
 {
   const double epsilon = 1e-10;
@@ -234,7 +234,7 @@ bool findSurface(const octomap::point3d_list& cloud, const double& spacing, cons
   //    return p;
 }
 
-bool sampleCloud(const octomap::point3d_list& cloud, const double& spacing, const double& r_multiple,
+bool sampleCloud(const octomap::point3d_list& cloud, const double spacing, const double r_multiple,
                  const octomath::Vector3& position, double& intensity, octomath::Vector3& gradient)
 {
   intensity = 0.f;

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/basic_types.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/basic_types.h
@@ -59,7 +59,7 @@ struct ContactTestData
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  ContactTestData(const std::vector<std::string>& active, const double& contact_distance,
+  ContactTestData(const std::vector<std::string>& active, const double contact_distance,
                   collision_detection::CollisionResult& res, const collision_detection::CollisionRequest& req)
     : active(active), contact_distance(contact_distance), res(res), req(req), done(false), pair_done(false)
   {
@@ -68,7 +68,7 @@ struct ContactTestData
   const std::vector<std::string>& active;
 
   /** \brief If after a positive broadphase check the distance is below this threshold, a contact is added. */
-  const double& contact_distance;
+  const double contact_distance;
 
   collision_detection::CollisionResult& res;
   const collision_detection::CollisionRequest& req;

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.cpp
@@ -198,7 +198,7 @@ void PR2ArmIK::getSolverInfo(moveit_msgs::msg::KinematicSolverInfo& info)
   info = solver_info_;
 }
 
-void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double& t1_in,
+void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double t1_in,
                                     std::vector<std::vector<double> >& solution) const
 {
   // t1 = shoulder/turret pan is specified
@@ -463,7 +463,7 @@ void PR2ArmIK::computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double&
   }
 }
 
-void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double& t3,
+void PR2ArmIK::computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double t3,
                                      std::vector<std::vector<double> >& solution) const
 {
   std::vector<double> solution_ik(NUM_JOINTS_ARM7DOF, 0.0);
@@ -779,7 +779,7 @@ bool PR2ArmIK::checkJointLimits(const std::vector<double>& joint_values) const
   return true;
 }
 
-bool PR2ArmIK::checkJointLimits(const double& joint_value, const int& joint_num) const
+bool PR2ArmIK::checkJointLimits(const double joint_value, const int joint_num) const
 {
   double jv;
   if (continuous_joint_[joint_num])

--- a/moveit_core/constraint_samplers/test/pr2_arm_ik.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_ik.h
@@ -58,7 +58,7 @@ inline double distance(const urdf::Pose& transform)
               transform.position.z * transform.position.z);
 }
 
-inline bool solveQuadratic(const double& a, const double& b, const double& c, double* x1, double* x2)
+inline bool solveQuadratic(const double a, const double b, const double c, double* x1, double* x2)
 {
   double discriminant = b * b - 4 * a * c;
   if (fabs(a) < IK_EPS)
@@ -88,7 +88,7 @@ inline bool solveQuadratic(const double& a, const double& b, const double& c, do
   }
 }
 
-inline bool solveCosineEqn(const double& a, const double& b, const double& c, double& soln1, double& soln2)
+inline bool solveCosineEqn(const double a, const double b, const double c, double& soln1, double& soln2)
 {
   double theta1 = atan2(b, a);
   double denom = sqrt(a * a + b * b);
@@ -140,7 +140,7 @@ public:
      @param Input pose for end-effector
      @param Initial guess for shoulder pan angle
   */
-  void computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double& shoulder_pan_initial_guess,
+  void computeIKShoulderPan(const Eigen::Isometry3f& g_in, const double shoulder_pan_initial_guess,
                             std::vector<std::vector<double> >& solution) const;
 
   /**
@@ -148,7 +148,7 @@ public:
      h       @param Input pose for end-effector
      @param Initial guess for shoulder roll angle
   */
-  void computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double& shoulder_roll_initial_guess,
+  void computeIKShoulderRoll(const Eigen::Isometry3f& g_in, const double shoulder_roll_initial_guess,
                              std::vector<std::vector<double> >& solution) const;
 
   //  std::vector<std::vector<double> > solution_ik_;/// a vector of ik solutions
@@ -172,7 +172,7 @@ private:
 
   bool checkJointLimits(const std::vector<double>& joint_values) const;
 
-  bool checkJointLimits(const double& joint_value, const int& joint_num) const;
+  bool checkJointLimits(const double joint_value, const int joint_num) const;
 
   Eigen::Isometry3f grhs_, gf_, home_inv_;
 

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.cpp
@@ -50,7 +50,7 @@ namespace pr2_arm_kinematics
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_constraint_samplers.test.pr2_arm_kinematics_plugin");
 
-bool PR2ArmIKSolver::getCount(int& count, const int& max_count, const int& min_count)
+bool PR2ArmIKSolver::getCount(int& count, const int max_count, const int min_count)
 {
   if (count > 0)
   {
@@ -87,8 +87,8 @@ bool PR2ArmIKSolver::getCount(int& count, const int& max_count, const int& min_c
 }
 
 PR2ArmIKSolver::PR2ArmIKSolver(const urdf::ModelInterface& robot_model, const std::string& root_frame_name,
-                               const std::string& tip_frame_name, const double& search_discretization_angle,
-                               const int& free_angle)
+                               const std::string& tip_frame_name, const double search_discretization_angle,
+                               const int free_angle)
   : ChainIkSolverPos()
 {
   search_discretization_angle_ = search_discretization_angle;
@@ -160,7 +160,7 @@ int PR2ArmIKSolver::CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_i
 }
 
 int PR2ArmIKSolver::cartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame& p_in, KDL::JntArray& q_out,
-                                    const double& timeout)
+                                    const double timeout)
 {
   const bool verbose = false;
   KDL::JntArray q_init = q_in;

--- a/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
+++ b/moveit_core/constraint_samplers/test/pr2_arm_kinematics_plugin.h
@@ -80,7 +80,7 @@ public:
    *  to return multiple solutions from an inverse kinematics computation.
    */
   PR2ArmIKSolver(const urdf::ModelInterface& robot_model, const std::string& root_frame_name,
-                 const std::string& tip_frame_name, const double& search_discretization_angle, const int& free_angle);
+                 const std::string& tip_frame_name, const double search_discretization_angle, const int free_angle);
 
   ~PR2ArmIKSolver() override{};
 
@@ -98,7 +98,7 @@ public:
 
   int CartToJnt(const KDL::JntArray& q_init, const KDL::Frame& p_in, KDL::JntArray& q_out) override;
 
-  int cartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame& p_in, KDL::JntArray& q_out, const double& timeout);
+  int cartToJntSearch(const KDL::JntArray& q_in, const KDL::Frame& p_in, KDL::JntArray& q_out, const double timeout);
 
   void getSolverInfo(moveit_msgs::msg::KinematicSolverInfo& response)
   {
@@ -106,7 +106,7 @@ public:
   }
 
 private:
-  bool getCount(int& count, const int& max_count, const int& min_count);
+  bool getCount(int& count, const int max_count, const int min_count);
 
   double search_discretization_angle_;
 

--- a/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
+++ b/moveit_core/kinematics_metrics/include/moveit/kinematics_metrics/kinematics_metrics.h
@@ -129,7 +129,7 @@ public:
     penalty_multiplier_ = fabs(multiplier);
   }
 
-  const double& getPenaltyMultiplier() const
+  const double getPenaltyMultiplier() const
   {
     return penalty_multiplier_;
   }

--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -302,7 +302,7 @@ public:
    *  @param The waypoint index after (or equal to) the supplied duration.
    *  @param The progress (0 to 1) between the two waypoints, based on time (not based on joint distances).
    */
-  void findWayPointIndicesForDurationAfterStart(const double& duration, int& before, int& after, double& blend) const;
+  void findWayPointIndicesForDurationAfterStart(const double duration, int& before, int& after, double& blend) const;
 
   // TODO support visitor function for interpolation, or at least different types.
   /** @brief Gets a robot state corresponding to a supplied duration from start for the trajectory, using linear time

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -490,7 +490,7 @@ RobotTrajectory& RobotTrajectory::setRobotTrajectoryMsg(const moveit::core::Robo
   return setRobotTrajectoryMsg(st, trajectory);
 }
 
-void RobotTrajectory::findWayPointIndicesForDurationAfterStart(const double& duration, int& before, int& after,
+void RobotTrajectory::findWayPointIndicesForDurationAfterStart(const double duration, int& before, int& after,
                                                                double& blend) const
 {
   if (duration < 0.0)

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/ikfast61_moveit_plugin_template.cpp
@@ -352,7 +352,7 @@ private:
   double enforceLimits(double val, double min, double max) const;
 
   void fillFreeParams(int count, int* array);
-  bool getCount(int& count, const int& max_count, const int& min_count) const;
+  bool getCount(int& count, const int max_count, const int min_count) const;
 
   /**
    * @brief samples the designated redundant joint using the chosen discretization method
@@ -727,7 +727,7 @@ void IKFastKinematicsPlugin::fillFreeParams(int count, int* array)
     free_params_.push_back(array[i]);
 }
 
-bool IKFastKinematicsPlugin::getCount(int& count, const int& max_count, const int& min_count) const
+bool IKFastKinematicsPlugin::getCount(int& count, const int max_count, const int min_count) const
 {
   if (count > 0)
   {

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
@@ -446,7 +446,7 @@ ompl::base::ConstraintPtr createOMPLConstraints(const moveit::core::RobotModelCo
  * https://ethz.ch/content/dam/ethz/special-interest/mavt/robotics-n-intelligent-systems/rsl-dam/documents/RobotDynamics2016/RD2016script.pdf
  * Eq. 2.107
  * */
-inline Eigen::Matrix3d angularVelocityToAngleAxis(const double& angle, const Eigen::Ref<const Eigen::Vector3d>& axis)
+inline Eigen::Matrix3d angularVelocityToAngleAxis(const double angle, const Eigen::Ref<const Eigen::Vector3d>& axis)
 {
   double t{ std::abs(angle) };
   Eigen::Matrix3d r_skew;

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -126,7 +126,7 @@ bool verifySampleJointLimits(const std::map<std::string, double>& position_last,
 bool generateJointTrajectory(const planning_scene::PlanningSceneConstPtr& scene,
                              const JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
                              const std::string& group_name, const std::string& link_name,
-                             const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
+                             const std::map<std::string, double>& initial_joint_position, const double sampling_time,
                              trajectory_msgs::msg::JointTrajectory& joint_trajectory,
                              moveit_msgs::msg::MoveItErrorCodes& error_code, bool check_self_collision = false);
 
@@ -196,11 +196,11 @@ bool isRobotStateStationary(const moveit::core::RobotState& state, const std::st
  * @param index The intersection index which has to be determined.
  */
 bool linearSearchIntersectionPoint(const std::string& link_name, const Eigen::Vector3d& center_position,
-                                   const double& r, const robot_trajectory::RobotTrajectoryPtr& traj, bool inverseOrder,
+                                   const double r, const robot_trajectory::RobotTrajectoryPtr& traj, bool inverseOrder,
                                    std::size_t& index);
 
 bool intersectionFound(const Eigen::Vector3d& p_center, const Eigen::Vector3d& p_current, const Eigen::Vector3d& p_next,
-                       const double& r);
+                       const double r);
 
 /**
  * @brief Checks if current robot state is in self collision.

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -136,8 +136,8 @@ protected:
    * The trap profile returns uses the longer distance of translational and
    * rotational motion.
    */
-  std::unique_ptr<KDL::VelocityProfile> cartesianTrapVelocityProfile(const double& max_velocity_scaling_factor,
-                                                                     const double& max_acceleration_scaling_factor,
+  std::unique_ptr<KDL::VelocityProfile> cartesianTrapVelocityProfile(const double max_velocity_scaling_factor,
+                                                                     const double max_acceleration_scaling_factor,
                                                                      const std::unique_ptr<KDL::Path>& path) const;
 
 private:
@@ -157,7 +157,7 @@ private:
 
   virtual void plan(const planning_scene::PlanningSceneConstPtr& scene,
                     const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                    const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory) = 0;
+                    const double sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory) = 0;
 
 private:
   /**
@@ -247,9 +247,9 @@ private:
   /**
    * @return True if scaling factor is valid, otherwise false.
    */
-  static bool isScalingFactorValid(const double& scaling_factor);
-  static void checkVelocityScaling(const double& scaling_factor);
-  static void checkAccelerationScaling(const double& scaling_factor);
+  static bool isScalingFactorValid(const double scaling_factor);
+  static void checkVelocityScaling(const double scaling_factor);
+  static void checkAccelerationScaling(const double scaling_factor);
 
   /**
    * @return True if ONE position + ONE orientation constraint given,
@@ -277,7 +277,7 @@ protected:
   const std::unique_ptr<rclcpp::Clock> clock_;
 };
 
-inline bool TrajectoryGenerator::isScalingFactorValid(const double& scaling_factor)
+inline bool TrajectoryGenerator::isScalingFactorValid(const double scaling_factor)
 {
   return (scaling_factor > MIN_SCALING_FACTOR && scaling_factor <= MAX_SCALING_FACTOR);
 }

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
@@ -91,7 +91,7 @@ private:
                              const planning_interface::MotionPlanRequest& req, MotionPlanInfo& info) const final;
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, const double sampling_time,
             trajectory_msgs::msg::JointTrajectory& joint_trajectory) override;
 
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
@@ -74,7 +74,7 @@ private:
                              const planning_interface::MotionPlanRequest& req, MotionPlanInfo& info) const final;
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, const double sampling_time,
             trajectory_msgs::msg::JointTrajectory& joint_trajectory) override;
 
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
@@ -79,11 +79,11 @@ private:
    * @param sampling_time
    */
   void planPTP(const std::map<std::string, double>& start_pos, const std::map<std::string, double>& goal_pos,
-               trajectory_msgs::msg::JointTrajectory& joint_trajectory, const double& velocity_scaling_factor,
-               const double& acceleration_scaling_factor, const double& sampling_time);
+               trajectory_msgs::msg::JointTrajectory& joint_trajectory, const double velocity_scaling_factor,
+               const double acceleration_scaling_factor, const double sampling_time);
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, const double sampling_time,
             trajectory_msgs::msg::JointTrajectory& joint_trajectory) override;
 
 private:

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -206,7 +206,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
     const planning_scene::PlanningSceneConstPtr& scene,
     const pilz_industrial_motion_planner::JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
     const std::string& group_name, const std::string& link_name,
-    const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
+    const std::map<std::string, double>& initial_joint_position, const double sampling_time,
     trajectory_msgs::msg::JointTrajectory& joint_trajectory, moveit_msgs::msg::MoveItErrorCodes& error_code,
     bool check_self_collision)
 {
@@ -531,7 +531,7 @@ bool pilz_industrial_motion_planner::isRobotStateStationary(const moveit::core::
 
 bool pilz_industrial_motion_planner::linearSearchIntersectionPoint(const std::string& link_name,
                                                                    const Eigen::Vector3d& center_position,
-                                                                   const double& r,
+                                                                   const double r,
                                                                    const robot_trajectory::RobotTrajectoryPtr& traj,
                                                                    bool inverseOrder, std::size_t& index)
 {
@@ -569,7 +569,7 @@ bool pilz_industrial_motion_planner::linearSearchIntersectionPoint(const std::st
 
 bool pilz_industrial_motion_planner::intersectionFound(const Eigen::Vector3d& p_center,
                                                        const Eigen::Vector3d& p_current, const Eigen::Vector3d& p_next,
-                                                       const double& r)
+                                                       const double r)
 {
   return ((p_current - p_center).norm() <= r) && ((p_next - p_center).norm() >= r);
 }

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -79,7 +79,7 @@ void TrajectoryGenerator::cmdSpecificRequestValidation(const planning_interface:
   // to provide a command specific request validation.
 }
 
-void TrajectoryGenerator::checkVelocityScaling(const double& scaling_factor)
+void TrajectoryGenerator::checkVelocityScaling(const double scaling_factor)
 {
   if (!isScalingFactorValid(scaling_factor))
   {
@@ -90,7 +90,7 @@ void TrajectoryGenerator::checkVelocityScaling(const double& scaling_factor)
   }
 }
 
-void TrajectoryGenerator::checkAccelerationScaling(const double& scaling_factor)
+void TrajectoryGenerator::checkAccelerationScaling(const double scaling_factor)
 {
   if (!isScalingFactorValid(scaling_factor))
   {
@@ -281,8 +281,8 @@ void TrajectoryGenerator::setFailureResponse(const rclcpp::Time& planning_start,
 }
 
 std::unique_ptr<KDL::VelocityProfile>
-TrajectoryGenerator::cartesianTrapVelocityProfile(const double& max_velocity_scaling_factor,
-                                                  const double& max_acceleration_scaling_factor,
+TrajectoryGenerator::cartesianTrapVelocityProfile(const double max_velocity_scaling_factor,
+                                                  const double max_acceleration_scaling_factor,
                                                   const std::unique_ptr<KDL::Path>& path) const
 {
   std::unique_ptr<KDL::VelocityProfile> vp_trans = std::make_unique<KDL::VelocityProfile_Trap>(

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -194,7 +194,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
 
 void TrajectoryGeneratorCIRC::plan(const planning_scene::PlanningSceneConstPtr& scene,
                                    const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                   const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
+                                   const double sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
 {
   std::unique_ptr<KDL::Path> cart_path(setPathCIRC(plan_info));
   std::unique_ptr<KDL::VelocityProfile> vel_profile(

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -148,7 +148,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
 
 void TrajectoryGeneratorLIN::plan(const planning_scene::PlanningSceneConstPtr& scene,
                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                  const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
+                                  const double sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
 {
   // create Cartesian path for lin
   std::unique_ptr<KDL::Path> path(setPathLIN(plan_info.start_pose, plan_info.goal_pose));

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -91,8 +91,8 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const moveit::core::RobotModelCon
 void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_pos,
                                      const std::map<std::string, double>& goal_pos,
                                      trajectory_msgs::msg::JointTrajectory& joint_trajectory,
-                                     const double& velocity_scaling_factor, const double& acceleration_scaling_factor,
-                                     const double& sampling_time)
+                                     const double velocity_scaling_factor, const double acceleration_scaling_factor,
+                                     const double sampling_time)
 {
   // initialize joint names
   for (const auto& item : goal_pos)
@@ -245,7 +245,7 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
 
 void TrajectoryGeneratorPTP::plan(const planning_scene::PlanningSceneConstPtr& /*scene*/,
                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                  const double& sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
+                                  const double sampling_time, trajectory_msgs::msg::JointTrajectory& joint_trajectory)
 {
   // plan the ptp trajectory
   planPTP(plan_info.start_joint_position, plan_info.goal_joint_position, joint_trajectory,

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -926,7 +926,7 @@ bool testutils::checkBlendingCartSpaceContinuity(const pilz_industrial_motion_pl
   return true;
 }
 
-bool testutils::checkThatPointsInRadius(const std::string& link_name, const double& r, Eigen::Isometry3d& circ_pose,
+bool testutils::checkThatPointsInRadius(const std::string& link_name, const double r, Eigen::Isometry3d& circ_pose,
                                         const pilz_industrial_motion_planner::TrajectoryBlendResponse& res)
 {
   bool result = true;
@@ -1052,8 +1052,8 @@ bool testutils::getBlendTestData(const rclcpp::Node::SharedPtr& node, const size
 bool testutils::generateTrajFromBlendTestData(
     const planning_scene::PlanningSceneConstPtr& scene,
     const std::shared_ptr<pilz_industrial_motion_planner::TrajectoryGenerator>& tg, const std::string& group_name,
-    const std::string& link_name, const testutils::BlendTestData& data, const double& sampling_time_1,
-    const double& sampling_time_2, planning_interface::MotionPlanResponse& res_1,
+    const std::string& link_name, const testutils::BlendTestData& data, const double sampling_time_1,
+    const double sampling_time_2, planning_interface::MotionPlanResponse& res_1,
     planning_interface::MotionPlanResponse& res_2, double& dis_1, double& dis_2)
 {
   const moveit::core::RobotModelConstPtr robot_model = scene->getRobotModel();

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
@@ -344,7 +344,7 @@ bool checkBlendingCartSpaceContinuity(const pilz_industrial_motion_planner::Traj
  * @brief Checks if all points of the blending trajectory lie within the
  * blending radius.
  */
-bool checkThatPointsInRadius(const std::string& link_name, const double& r, Eigen::Isometry3d& circ_pose,
+bool checkThatPointsInRadius(const std::string& link_name, const double r, Eigen::Isometry3d& circ_pose,
                              const pilz_industrial_motion_planner::TrajectoryBlendResponse& res);
 
 /**
@@ -434,8 +434,8 @@ bool checkBlendResult(const pilz_industrial_motion_planner::TrajectoryBlendReque
 bool generateTrajFromBlendTestData(const planning_scene::PlanningSceneConstPtr& scene,
                                    const std::shared_ptr<pilz_industrial_motion_planner::TrajectoryGenerator>& tg,
                                    const std::string& group_name, const std::string& link_name,
-                                   const BlendTestData& data, const double& sampling_time_1,
-                                   const double& sampling_time_2, planning_interface::MotionPlanResponse& res_lin_1,
+                                   const BlendTestData& data, const double sampling_time_1,
+                                   const double sampling_time_2, planning_interface::MotionPlanResponse& res_lin_1,
                                    planning_interface::MotionPlanResponse& res_lin_2, double& dis_lin_1,
                                    double& dis_lin_2);
 
@@ -474,7 +474,7 @@ checkCartesianRotationalPath(const robot_trajectory::RobotTrajectoryConstPtr& tr
                              const double rot_axis_tol = DEFAULT_ROTATION_AXIS_EQUALITY_TOLERANCE,
                              const double acc_tol = DEFAULT_ACCELERATION_EQUALITY_TOLERANCE);
 
-inline bool isMonotonouslyDecreasing(const std::vector<double>& vec, const double& tol)
+inline bool isMonotonouslyDecreasing(const std::vector<double>& vec, const double tol)
 {
   return std::is_sorted(vec.begin(), vec.end(), [tol](double a, double b) {
     return !(std::abs(a - b) < tol || a < b);  // true -> a is ordered before b -> list is not sorted

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -127,7 +127,7 @@ protected:
    * @param epsilon
    * @return
    */
-  bool tfNear(const Eigen::Isometry3d& pose1, const Eigen::Isometry3d& pose2, const double& epsilon);
+  bool tfNear(const Eigen::Isometry3d& pose1, const Eigen::Isometry3d& pose2, const double epsilon);
 
 protected:
   // ros stuff
@@ -147,7 +147,7 @@ protected:
 };
 
 bool TrajectoryFunctionsTestBase::tfNear(const Eigen::Isometry3d& pose1, const Eigen::Isometry3d& pose2,
-                                         const double& epsilon)
+                                         const double epsilon)
 {
   for (std::size_t i = 0; i < 3; ++i)
   {

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -358,7 +358,7 @@ private:
   double enforceLimits(double val, double min, double max) const;
 
   void fillFreeParams(int count, int* array);
-  bool getCount(int& count, const int& max_count, const int& min_count) const;
+  bool getCount(int& count, const int max_count, const int min_count) const;
 
   /**
    * @brief samples the designated redundant joint using the chosen discretization method
@@ -732,7 +732,7 @@ void IKFastKinematicsPlugin::fillFreeParams(int count, int* array)
     free_params_.push_back(array[i]);
 }
 
-bool IKFastKinematicsPlugin::getCount(int& count, const int& max_count, const int& min_count) const
+bool IKFastKinematicsPlugin::getCount(int& count, const int max_count, const int min_count) const
 {
   if (count > 0)
   {

--- a/moveit_planners/trajopt/src/problem_description.cpp
+++ b/moveit_planners/trajopt/src/problem_description.cpp
@@ -58,7 +58,7 @@
  * @param apply_first If true and only one value is given, broadcast value to length of expected_size
  */
 void checkParameterSize(trajopt::DblVec& parameter, const unsigned int& expected_size, const std::string& name,
-                        const bool& apply_first = true)
+                        const bool apply_first = true)
 {
   if (apply_first == true && parameter.size() == 1)
   {
@@ -242,7 +242,7 @@ TrajOptProblemPtr ConstructProblem(const ProblemInfo& pci)
   // Apply constraint to each fixed dof to its initial value for all timesteps (freeze that column)
   if (!bi.dofs_fixed.empty())
   {
-    for (const int& dof_ind : bi.dofs_fixed)
+    for (const int dof_ind : bi.dofs_fixed)
     {
       for (int i = 1; i < prob->GetNumSteps(); ++i)
       {

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/gl_renderer.h
@@ -150,14 +150,14 @@ public:
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \return distance of near clipping plane in meters
    */
-  const float& getNearClippingDistance() const;
+  const float getNearClippingDistance() const;
 
   /**
    * \brief returns the distance of the far clipping plane in meters
    * \author Suat Gedikli (gedikli@willowgarage.com)
    * \return distance of the far clipping plane in meters
    */
-  const float& getFarClippingDistance() const;
+  const float getFarClippingDistance() const;
 
   /**
    * \brief returns the width of the frame buffer objectsin pixels

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -246,12 +246,12 @@ const GLuint& mesh_filter::GLRenderer::getProgramID() const
   return program_;
 }
 
-const float& mesh_filter::GLRenderer::getNearClippingDistance() const
+const float mesh_filter::GLRenderer::getNearClippingDistance() const
 {
   return near_;
 }
 
-const float& mesh_filter::GLRenderer::getFarClippingDistance() const
+const float mesh_filter::GLRenderer::getFarClippingDistance() const
 {
   return far_;
 }

--- a/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/navigation_widget.hpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/include/moveit_setup_assistant/navigation_widget.hpp
@@ -58,10 +58,10 @@ public:
   explicit NavigationWidget(QWidget* parent = nullptr);
 
   void setNavs(const QList<QString>& navs);
-  void setEnabled(const int& index, bool enabled);
-  void setSelected(const int& index);
+  void setEnabled(const int index, bool enabled);
+  void setSelected(const int index);
 
-  bool isEnabled(const int& index) const;
+  bool isEnabled(const int index) const;
 
 private:
   QStandardItemModel* model_;

--- a/moveit_setup_assistant/moveit_setup_assistant/src/navigation_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/navigation_widget.cpp
@@ -90,7 +90,7 @@ void NavigationWidget::setNavs(const QList<QString>& navs)
   setModel(model_);
 }
 
-void NavigationWidget::setEnabled(const int& index, bool enabled)
+void NavigationWidget::setEnabled(const int index, bool enabled)
 {
   if (enabled)
   {
@@ -103,7 +103,7 @@ void NavigationWidget::setEnabled(const int& index, bool enabled)
   }
 }
 
-void NavigationWidget::setSelected(const int& index)
+void NavigationWidget::setSelected(const int index)
 {
   // First make sure item is enabled
   setEnabled(index, true);
@@ -117,7 +117,7 @@ void NavigationWidget::setSelected(const int& index)
   selectionModel()->select(selection, QItemSelectionModel::Select);
 }
 
-bool NavigationWidget::isEnabled(const int& index) const
+bool NavigationWidget::isEnabled(const int index) const
 {
   return model_->item(index)->flags() > Qt::NoItemFlags;
 }


### PR DESCRIPTION

### Description

Replacing pass and return of simple type from const reference to const
value. This was done by searching through all files using the regex:
"\b(const\s(bool|char|short|int|long|float|double))\s*&\s*"
The changed lines where checked manually afterwards.
Variables which are declared as const references where kept e.g.: const double& contact_distance;.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
