### PR TITLE
Compute velocity using central difference

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -278,6 +278,7 @@ protected:
   // internal_joint_state_ is used in servo calculations. It shouldn't be relied on to be accurate.
   // original_joint_state_ is the same as incoming_joint_state_ except it only contains the joints the servo node acts
   // on.
+  // last_joint_state_ caches the previous `original_joint_state_`
   sensor_msgs::msg::JointState internal_joint_state_, original_joint_state_, last_joint_state_;
   std::map<std::string, std::size_t> joint_state_name_map_;
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -278,7 +278,7 @@ protected:
   // internal_joint_state_ is used in servo calculations. It shouldn't be relied on to be accurate.
   // original_joint_state_ is the same as incoming_joint_state_ except it only contains the joints the servo node acts
   // on.
-  sensor_msgs::msg::JointState internal_joint_state_, original_joint_state_;
+  sensor_msgs::msg::JointState internal_joint_state_, original_joint_state_, last_joint_state_;
   std::map<std::string, std::size_t> joint_state_name_map_;
 
   // Smoothing algorithm (loads a plugin)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -366,10 +366,10 @@ void ServoCalcs::calculateSingleIteration()
   // After we publish, status, reset it back to no warnings
   status_ = StatusCode::NO_WARNING;
 
-  // original_joint_state_ contains state x(t - 1)
-  // internal_joint_state_ will be updated with the state x(t + dt) in this iteration.
-  // last_joint_state_ will preserve the state x(t - dt) for this iteration to be used in central difference.
-  // original_joint_state_ will get updated with current state x(t) in updateJoints()
+  // original_joint_state_ contains state q(t - dt)
+  // internal_joint_state_ will be updated with the state q(t + dt) in this iteration.
+  // last_joint_state_ will preserve the state q(t - dt) for this iteration to be used in central difference.
+  // original_joint_state_ will get updated with current state q(t) in updateJoints()
   last_joint_state_ = original_joint_state_;
 
   // Always update the joints and end-effector transform for 2 reasons:
@@ -784,14 +784,14 @@ bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs
   smoother_->doSmoothing(joint_state.position);
 
   // Lambda that calculates velocity using central difference.
-  // (x(t + dt) - x(t - dt)) / ( 2 * dt )
+  // (q(t + dt) - q(t - dt)) / ( 2 * dt )
   auto compute_velocity = [&](const double& next_pos, const double& previous_pos) {
     return (next_pos - previous_pos) / (2 * parameters_->publish_period);
   };
 
   // Transform that applies the lambda to all joints.
-  // joint_state contains the future position x(t + dt)
-  // last_joint_state contains past position x(t - dt)
+  // joint_state contains the future position q(t + dt)
+  // last_joint_state contains past position q(t - dt)
   std::transform(joint_state.position.begin(), joint_state.position.end(), last_joint_state_.position.begin(),
                  joint_state.velocity.begin(), compute_velocity);
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -366,6 +366,12 @@ void ServoCalcs::calculateSingleIteration()
   // After we publish, status, reset it back to no warnings
   status_ = StatusCode::NO_WARNING;
 
+  // original_joint_state_ contains state x(t - 1)
+  // internal_joint_state_ will be updated with the state x(t + dt) in this iteration.
+  // last_joint_state_ will preserve the state x(t - dt) for next iteration to be used in for central difference.
+  // original_joint_state_ will get updated with current state x(t) in updateJoints()
+  last_joint_state_ = original_joint_state_;
+
   // Always update the joints and end-effector transform for 2 reasons:
   // 1) in case the getCommandFrameTransform() method is being used
   // 2) so the low-pass filters are up to date and don't cause a jump
@@ -971,11 +977,6 @@ void ServoCalcs::updateJoints()
 
   // Cache the original joints in case they need to be reset
   original_joint_state_ = internal_joint_state_;
-
-  // original_joint_state_ contains current state x(t)
-  // internal_joint_state_ will be updated with the state x(t + dt) in this iteration.
-  // last_joint_state_ will preserve the current state x(t) for next iteration to be used as x(t - dt) for central difference.
-  last_joint_state_ = original_joint_state_;
 }
 
 bool ServoCalcs::checkValidCommand(const control_msgs::msg::JointJog& cmd)

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -785,7 +785,7 @@ bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs
 
   // Lambda that calculates velocity using central difference.
   // (q(t + dt) - q(t - dt)) / ( 2 * dt )
-  auto compute_velocity = [&](const double& next_pos, const double& previous_pos) {
+  auto compute_velocity = [&](const double next_pos, const double previous_pos) {
     return (next_pos - previous_pos) / (2 * parameters_->publish_period);
   };
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -368,7 +368,7 @@ void ServoCalcs::calculateSingleIteration()
 
   // original_joint_state_ contains state x(t - 1)
   // internal_joint_state_ will be updated with the state x(t + dt) in this iteration.
-  // last_joint_state_ will preserve the state x(t - dt) for next iteration to be used in for central difference.
+  // last_joint_state_ will preserve the state x(t - dt) for this iteration to be used in central difference.
   // original_joint_state_ will get updated with current state x(t) in updateJoints()
   last_joint_state_ = original_joint_state_;
 

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -779,12 +779,12 @@ bool ServoCalcs::applyJointUpdate(const Eigen::ArrayXd& delta_theta, sensor_msgs
 
   // Lambda that calculates velocity using central difference.
   auto compute_velocity = [&](const double& next_pos, const double& previous_pos) {
-    return (next_pos - previous_pos) / parameters_->publish_period;
+    return (next_pos - previous_pos) / (2 * parameters_->publish_period);
   };
 
   // Transform that applies the lambda to all joints.
   std::transform(joint_state.position.begin(), joint_state.position.end(),
-                 last_sent_command_->points.back().positions.begin(), joint_state.velocity.begin(), compute_velocity);
+                 last_sent_command_->points.front().positions.begin(), joint_state.velocity.begin(), compute_velocity);
 
   return true;
 }


### PR DESCRIPTION
### Description

This PR changes the calculations in `ServoCalcs` to use the central difference to compute the joint velocities more accurately.

Fixes #2077 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
