### PR TITLE
Backport #1908 and #2035

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -1,11 +1,19 @@
-# ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci-testing
+# ghcr.io/ros-planning/moveit2:${OUR_ROS_DISTRO}-ci-testing
 # CI image using the ROS testing repository
 
-ARG ROS_DISTRO=rolling
-FROM moveit/moveit2:${ROS_DISTRO}-ci
+FROM osrf/ros2:testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm
+
+# Overwrite the ROS_DISTRO set in osrf/ros2:testing to the distro tied to this Dockerfile (OUR_ROS_DISTRO).
+# In case ROS_DISTRO is now different from what was set in osrf/ros2:testing, run `rosdep update` again
+# to get any missing dependencies.
+# https://docs.docker.com/engine/reference/builder/#using-arg-variables explains why ARG and ENV can't have
+# the same name (ROS_DISTRO is an ENV in the osrf/ros2:testing image).
+ARG OUR_ROS_DISTRO=rolling
+ENV ROS_DISTRO=${OUR_ROS_DISTRO}
+RUN rosdep update --rosdistro $ROS_DISTRO
 
 # Install ROS 2 base packages and build tools
 # We are installing ros-<distro>-ros-base here to mimic the behavior of the ros:<distro>-ros-base images.

--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -2,7 +2,7 @@
 # CI image using the ROS testing repository
 
 ARG ROS_DISTRO=rolling
-FROM osrf/ros2:testing
+FROM moveit/moveit2:${ROS_DISTRO}-ci
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,7 +4,7 @@
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling
-FROM ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci-testing
+FROM moveit/moveit2:${ROS_DISTRO}-ci-testing
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Export ROS_UNDERLAY for downstream docker containers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,10 @@ jobs:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
-      DOCKER_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.env.IMAGE }}
-      UPSTREAM_WORKSPACE: moveit2.repos $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
+      DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
+      UPSTREAM_WORKSPACE: >
+        moveit2.repos
+        $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       # Uninstall binaries that are duplicated in the .repos file

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: .docker/${{ github.job }}/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+          build-args: OUR_ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
           no-cache: true
           tags: |


### PR DESCRIPTION
### Description

Replaces #2042 

In attempt to make CI green on the humble branch as well, we are backporting #2039 (see #2040). However, #2040 is currently blocked by a backport of #1908 (https://github.com/ros-planning/moveit2/pull/2040#issuecomment-1481799820). I also believe that we should backport #2035 so that Docker images behave as expected and don't break CI.

Once this PR is merged into `humble`, we should re-trigger the CI on #2040 to make sure it's green. If so, we can merge #2040 as well.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
