### PR TITLE
Fix: TOTG can return vels/accels greater than the limits

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -87,7 +87,15 @@ public:
   Eigen::VectorXd getConfig(double s) const;
   Eigen::VectorXd getTangent(double s) const;
   Eigen::VectorXd getCurvature(double s) const;
+
+  /** @brief Get the next switching point.
+   *  @param[in] s Arc length traveled so far
+   *  @param[out] discontinuity True if this switching point is a discontinuity
+   *  @return arc length to the switching point
+   **/
   double getNextSwitchingPoint(double s, bool& discontinuity) const;
+
+  /// @brief Return a list of all switching points as a pair (arc length to switching point, discontinuity)
   std::list<std::pair<double, bool>> getSwitchingPoints() const;
 
 private:

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -831,7 +831,6 @@ Eigen::VectorXd Trajectory::getVelocity(double time) const
   const double acceleration =
       2.0 * (it->path_pos_ - previous->path_pos_ - time_step * previous->path_vel_) / (time_step * time_step);
 
-  time_step = time - previous->time_;
   const double path_pos =
       previous->path_pos_ + time_step * previous->path_vel_ + 0.5 * time_step * time_step * acceleration;
   const double path_vel = previous->path_vel_ + time_step * acceleration;
@@ -849,7 +848,6 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
   const double acceleration =
       2.0 * (it->path_pos_ - previous->path_pos_ - time_step * previous->path_vel_) / (time_step * time_step);
 
-  time_step = time - previous->time_;
   const double path_pos =
       previous->path_pos_ + time_step * previous->path_vel_ + 0.5 * time_step * time_step * acceleration;
   const double path_vel = previous->path_vel_ + time_step * acceleration;

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -97,6 +97,11 @@ TEST(time_optimal_trajectory_generation, test1)
   EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 TEST(time_optimal_trajectory_generation, test2)
@@ -135,6 +140,11 @@ TEST(time_optimal_trajectory_generation, test2)
   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 TEST(time_optimal_trajectory_generation, test3)
@@ -173,6 +183,11 @@ TEST(time_optimal_trajectory_generation, test3)
   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 // Test the version of computeTimeStamps that takes custom velocity/acceleration limits
@@ -474,6 +489,53 @@ TEST(time_optimal_trajectory_generation, testFixedNumWaypoints)
       << "Failed to compute time stamps";
   // Allow +/-1 waypoint due to floating point error
   EXPECT_NEAR(trajectory.getWayPointCount(), desired_num_waypoints, 1);
+}
+
+TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
+{
+  // Test a (prior) specific failure case
+  Eigen::VectorXd waypoint(1);
+  std::list<Eigen::VectorXd> waypoints;
+
+  const double start_position = 1.881943;
+  waypoint << start_position;
+  waypoints.push_back(waypoint);
+  waypoint << 2.600542;
+  waypoints.push_back(waypoint);
+
+  Eigen::VectorXd max_velocities(1);
+  max_velocities << 4.54;
+  Eigen::VectorXd max_accelerations(1);
+  max_accelerations << 28.0;
+
+  Trajectory trajectory(Path(waypoints, 0.1 /* path tolerance */), max_velocities, max_accelerations,
+                        0.001 /* timestep */);
+  EXPECT_TRUE(trajectory.isValid());
+
+  EXPECT_GT(trajectory.getDuration(), 0.0);
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.320681, traj_duration, 1e-3);
+
+  // Start matches
+  EXPECT_DOUBLE_EQ(start_position, trajectory.getPosition(0.0)[0]);
+  // Start at rest and end at rest
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
+
+  // Check vels and accels at all points
+  for (double time = 0; time < traj_duration; time += 0.01)
+  {
+    // This trajectory has a single switching point
+    double t_switch = 0.1603407;
+    if (time < t_switch)
+    {
+      EXPECT_NEAR(trajectory.getAcceleration(time)[0], max_accelerations[0], 1e-3) << "Time: " << time;
+    }
+    else if (time > t_switch)
+    {
+      EXPECT_NEAR(trajectory.getAcceleration(time)[0], -max_accelerations[0], 1e-3) << "Time: " << time;
+    }
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

This is a port of the MoveIt1 PR:  https://github.com/ros-planning/moveit/pull/3394

The trajectory in the new test looks like this:

Position:

![position](https://user-images.githubusercontent.com/11284393/230389192-81315524-6487-41b6-a99f-054d63972fc7.png)

Velocity:

![velocity](https://user-images.githubusercontent.com/11284393/230389207-1a1632c3-c019-4963-87fa-9f2eefe4b3ac.png)

Acceleration:

![acceleration](https://user-images.githubusercontent.com/11284393/230389256-4297f365-b555-44ca-86a9-c22d5906d00b.png)



