### PR TITLE
[WIP] Fix Formatting in Python Documentation

### DIFF
--- a/moveit_py/src/moveit/moveit_core/collision_detection/collision_matrix.cpp
+++ b/moveit_py/src/moveit/moveit_core/collision_detection/collision_matrix.cpp
@@ -65,6 +65,7 @@ void init_acm(py::module& m)
       .def(py::init<std::vector<std::string>&, bool>(),
            R"(
        Initialize the allowed collision matrix using a list of names of collision objects.
+
        Args:
            names (list of str): A list of names of the objects in the collision world (corresponding to object IDs in the collision world).
            allowed (bool): If false, indicates that collisions between all elements must be checked for and no collisions will be ignored.
@@ -73,12 +74,14 @@ void init_acm(py::module& m)
 
       .def("get_entry", &moveit_py::bind_collision_detection::get_entry,
            R"(
-       Get the allowed collision entry for a pair of objects.
-       Args:
-	   name1 (str): The name of the first object.
-	   name2 (str): The name of the second object.
-       Returns:
-	   (bool, str): Whether the collision is allowed and the type of allowed collision.
+           Get the allowed collision entry for a pair of objects.
+
+           Args:
+                name1 (str): The name of the first object.
+                name2 (str): The name of the second object.
+
+	   Returns:
+                (bool, str): Whether the collision is allowed and the type of allowed collision.
        )",
            py::arg("name1"), py::arg("name2"))
 
@@ -86,22 +89,26 @@ void init_acm(py::module& m)
            py::overload_cast<const std::string&, const std::string&, bool>(
                &collision_detection::AllowedCollisionMatrix::setEntry),
            py::arg("name1"), py::arg("name2"), py::arg("allowed"),
-           R"(Set the allowed collision state between two objects.
-	   Args:
-	   	name1 (str): The name of the first object.
-	   	name2 (str): The name of the second object.
-	   	allowed (bool): If true, indicates that the collision between the two objects is allowed. If false, indicates that the collision between the two objects is not allowed.
+           R"(
+           Set the allowed collision state between two objects.
+
+           Args:
+                name1 (str): The name of the first object.
+                name2 (str): The name of the second object.
+                allowed (bool): If true, indicates that the collision between the two objects is allowed. If false, indicates that the collision between the two objects is not allowed.
        )")
 
       .def("remove_entry",
            py::overload_cast<const std::string&, const std::string&>(
                &collision_detection::AllowedCollisionMatrix::removeEntry),
            py::arg("name1"), py::arg("name2"),
-           R"(Remove an entry corresponding to a pair of elements. Nothing happens if the pair does not exist in the collision matrix.
-	   Args:
-		name1 (str): The name of the first object.
-	   	name2 (str): The name of the second object.
-	"))
+           R"(
+           Remove an entry corresponding to a pair of elements. Nothing happens if the pair does not exist in the collision matrix.
+
+           Args:
+                name1 (str): The name of the first object.
+                name2 (str): The name of the second object.
+           )")
 
       .def("clear", &collision_detection::AllowedCollisionMatrix::clear, R"(Clear the allowed collision matrix.)");
 }

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -119,7 +119,7 @@ void init_planning_scene(py::module& m)
              return planning_scene::PlanningScene::clone(self->shared_from_this());
            })
       .def("__deepcopy__",
-           [](const planning_scene::PlanningScene* self, py::dict /* memo */) {
+           [](const planning_scene::PlanningScene* self, py::dict /* memo */) {  // NOLINT
              return planning_scene::PlanningScene::clone(self->shared_from_this());
            })
       .def("knows_frame_transform",

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -78,8 +78,8 @@ void init_planning_scene(py::module& m)
   py::class_<planning_scene::PlanningScene, std::shared_ptr<planning_scene::PlanningScene>>(planning_scene,
                                                                                             "PlanningScene",
                                                                                             R"(
-      		     Representation of the environment as seen by a planning instance. The environment geometry, the robot geometry and state are maintained.
-      		     )")
+                     Representation of the environment as seen by a planning instance. The environment geometry, the robot geometry and state are maintained.
+                     )")
 
       .def(py::init<const moveit::core::RobotModelConstPtr&, const collision_detection::WorldPtr&>(),
            py::arg("robot_model"), py::arg("world") = std::make_shared<collision_detection::World>())
@@ -127,12 +127,13 @@ void init_planning_scene(py::module& m)
                &planning_scene::PlanningScene::knowsFrameTransform, py::const_),
            py::arg("robot_state"), py::arg("frame_id"),
            R"(
-           Check if a transform to the frame id is known.
-           This will be known if id is a link name, an attached body id or a collision object.
-           Args:
+           Check if a transform to the frame id is known. This will be known if id is a link name, an attached body id or a collision object.
+
+	   Args:
                robot_state (:py:class:`moveit_py.core.RobotState`): The robot state to check.
                frame_id (str): The frame id to check.
-           Returns:
+
+	   Returns:
                bool: True if the transform is known, false otherwise.
            )")
 
@@ -140,11 +141,12 @@ void init_planning_scene(py::module& m)
            py::overload_cast<const std::string&>(&planning_scene::PlanningScene::knowsFrameTransform, py::const_),
            py::arg("frame_id"),
            R"(
-           Check if a transform to the frame id is known.
-           This will be known if id is a link name, an attached body id or a collision object.
-           Args:
+           Check if a transform to the frame id is known. This will be known if id is a link name, an attached body id or a collision object.
+
+	   Args:
                frame_id (str): The frame id to check.
-           Returns:
+
+	   Returns:
                bool: True if the transform is known, false otherwise.
            )")
 
@@ -152,42 +154,49 @@ void init_planning_scene(py::module& m)
            R"(
            Get the transform corresponding to the frame id.
            This will be known if id is a link name, an attached body id or a collision object. Return identity when no transform is available.
-           Args:
+
+	   Args:
                frame_id (str): The frame id to get the transform for.
-           Returns:
+
+	   Returns:
                :py:class:`numpy.ndarray`: The transform corresponding to the frame id.
            )")
 
       // writing to the planning scene
       .def("process_planning_scene_world", &planning_scene::PlanningScene::processPlanningSceneWorldMsg, py::arg("msg"),
            R"(
-	   Process a planning scene world message.
+           Process a planning scene world message.
+
 	   Args:
-	       msg (:py:class:`moveit_msgs.msg.PlanningSceneWorld`): The planning scene world message.
-	   )")
+               msg (:py:class:`moveit_msgs.msg.PlanningSceneWorld`): The planning scene world message.
+           )")
 
       .def("apply_collision_object", &moveit_py::bind_planning_scene::apply_collision_object,
            py::arg("collision_object_msg"), py::arg("color_msg") = nullptr,
            R"(
            Apply a collision object to the planning scene.
-           Args:
-	   	object (moveit_msgs.msg.CollisionObject): The collision object to apply to the planning scene.
-		color (moveit_msgs.msg.ObjectColor, optional): The color of the collision object. Defaults to None if not specified.
+
+	   Args:
+               object (moveit_msgs.msg.CollisionObject): The collision object to apply to the planning scene.
+               color (moveit_msgs.msg.ObjectColor, optional): The color of the collision object. Defaults to None if not specified.
            )")
 
       .def("set_object_color", &planning_scene::PlanningScene::setObjectColor, py::arg("object_id"),
-           py::arg("color_msg"), R"(
-	   Set the color of a collision object.
+           py::arg("color_msg"),
+           R"(
+           Set the color of a collision object.
+
 	   Args:
-	       object_id (str): The id of the collision object to set the color of.
-	       color (std_msgs.msg.ObjectColor): The color of the collision object.
-	   )")
+               object_id (str): The id of the collision object to set the color of.
+               color (std_msgs.msg.ObjectColor): The color of the collision object.
+           )")
 
       .def("process_attached_collision_object", &planning_scene::PlanningScene::processAttachedCollisionObjectMsg,
            py::arg("object"),
            R"(
            Apply an attached collision object to the planning scene.
-           Args:
+
+	   Args:
                object (moveit_msgs.msg.AttachedCollisionObject): The attached collision object to apply to the planning scene.
            )")
 
@@ -196,14 +205,15 @@ void init_planning_scene(py::module& m)
            py::arg("msg"),
            R"(
            Apply an octomap to the planning scene.
-           Args:
+
+	   Args:
                octomap (moveit_msgs.msg.Octomap): The octomap to apply to the planning scene.
            )")
 
       .def("remove_all_collision_objects", &planning_scene::PlanningScene::removeAllCollisionObjects,
            R"(
            Removes collision objects from the planning scene.
-	   This method will remove all collision object from the scene except for attached collision objects.
+           This method will remove all collision object from the scene except for attached collision objects.
            )")
 
       // checking state validity
@@ -216,7 +226,8 @@ void init_planning_scene(py::module& m)
            py::arg("joint_model_group_name"), py::arg("verbose") = false,
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the group to check collision for.
                verbose (bool): If true, print the link names of the links in collision.
            Returns:
@@ -229,7 +240,8 @@ void init_planning_scene(py::module& m)
            py::arg("robot_state"), py::arg("joint_model_group_name"), py::arg("verbose") = false,
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                robot_state (:py:class:`moveit_py.core.RobotState`): The robot state to check collision for.
                joint_model_group_name (str): The name of the group to check collision for.
                verbose (bool): If true, print the link names of the links in collision.
@@ -243,10 +255,11 @@ void init_planning_scene(py::module& m)
            py::arg("state"), py::arg("constraints"), py::arg("verbose") = false,
            R"(
            Check if the robot state fulfills the passed constraints
-           Args:
+
+	   Args:
                state (moveit_py.core.RobotState): The robot state to check constraints for.
-	       constraints (moveit_msgs.msg.Constraints): The constraints to check.
-	       verbose (bool):
+               constraints (moveit_msgs.msg.Constraints): The constraints to check.
+               verbose (bool):
            Returns:
                bool: true if state is constrained otherwise false.
            )")
@@ -257,14 +270,15 @@ void init_planning_scene(py::module& m)
            py::arg("trajectory"), py::arg("joint_model_group_name"), py::arg("verbose") = false,
            py::arg("invalid_index") = nullptr,
            R"(
-           Check if a given path is valid.
-           Each state is checked for validity (collision avoidance and feasibility)
-           Args:
+           Check if a given path is valid. Each state is checked for validity (collision avoidance and feasibility)
+
+	   Args:
                trajectory (:py:class:`moveit_py.core.RobotTrajectory`): The trajectory to check.
                joint_model_group_name (str): The joint model group to check the path against.
                verbose (bool):
-	       invalid_index (list):
-           Returns:
+               invalid_index (list):
+
+	   Returns:
                bool: true if the path is valid otherwise false.
            )")
 
@@ -276,10 +290,12 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"),
            R"(
            Check whether the current state is in collision, and if needed, updates the collision transforms of the current state before the computation.
-           Args:
+
+	   Args:
                collision_request (:py:class:`moveit_py.core.CollisionRequest`): The collision request to use.
                collision_result (:py:class:`moveit_py.core.CollisionResult`): The collision result to update
-           Returns:
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -289,11 +305,13 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
                state ():
-           Returns:
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -304,12 +322,14 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"), py::arg("acm"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
                state ():
-           acm ():
-           Returns:
+               acm ():
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -319,10 +339,12 @@ void init_planning_scene(py::module& m)
            py::arg("req"), py::arg("result"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
-           Returns:
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -333,11 +355,13 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
                state ():
-           Returns:
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -348,12 +372,14 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"), py::arg("acm"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
                state ():
-           acm ():
-           Returns:
+               acm ():
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -363,10 +389,12 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision_request ():
                collision_result ():
-           Returns:
+
+	   Returns:
                bool: true if state is in collision otherwise false.
            )")
 
@@ -376,11 +404,13 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision request ():
                collision_result ():
                state ():
-           Returns:
+
+	   Returns:
                bool: true if state is in self collision otherwise false.
            )")
 
@@ -391,12 +421,14 @@ void init_planning_scene(py::module& m)
            py::arg("collision_request"), py::arg("collision_result"), py::arg("state"), py::arg("acm"),
            R"(
            Check if the robot state is in collision.
-           Args:
+
+	   Args:
                collision request ():
                collision_result ():
                state ():
-           acm():
-           Returns:
+               acm():
+
+	   Returns:
                bool: true if state is in self collision otherwise false.
            )");
 }

--- a/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
@@ -224,9 +224,7 @@ void init_robot_state(py::module& m)
 
   py::class_<moveit::core::RobotState, std::shared_ptr<moveit::core::RobotState>>(robot_state, "RobotState",
                                                                                   R"(
-          Representation of a robot's state.
-          At the lowest level, a state is a collection of variables. Each variable has a name and can have position, velocity, acceleration and effort associated to it. Effort and acceleration share the memory area for efficiency reasons (one should not set both acceleration and effort in the same state and expect things to work). Often variables correspond to joint names as well (joints with one degree of freedom have one variable), but joints with multiple degrees of freedom have more variables. Operations are allowed at variable level, joint level (see JointModel) and joint group level (see JointModelGroup).
-                  For efficiency reasons a state computes forward kinematics in a lazy fashion. This can sometimes lead to problems if the update() function was not called on the state.
+          Representation of a robot's state. At the lowest level, a state is a collection of variables. Each variable has a name and can have position, velocity, acceleration and effort associated to it. Effort and acceleration share the memory area for efficiency reasons (one should not set both acceleration and effort in the same state and expect things to work). Often variables correspond to joint names as well (joints with one degree of freedom have one variable), but joints with multiple degrees of freedom have more variables. Operations are allowed at variable level, joint level (see JointModel) and joint group level (see JointModelGroup). For efficiency reasons a state computes forward kinematics in a lazy fashion. This can sometimes lead to problems if the update() function was not called on the state.
           )")
 
       .def(py::init<const std::shared_ptr<const moveit::core::RobotModel>&>(),
@@ -256,22 +254,24 @@ void init_robot_state(py::module& m)
       .def("get_frame_transform", &moveit_py::bind_robot_state::get_frame_transform, py::arg("frame_id"),
            py::return_value_policy::move,
            R"(
-           Get the transformation matrix from the model frame (root of model) to the frame identified by frame_id.
-           If frame_id was not found, frame_found is set to false and an identity transform is returned.
-       This method is restricted to frames defined within the robot state and doesn't include collision object present in the collision world. Please use the PlanningScene.get_frame_transform method for collision world objects.
-           Args:
+           Get the transformation matrix from the model frame (root of model) to the frame identified by frame_id. If frame_id was not found, frame_found is set to false and an identity transform is returned. This method is restricted to frames defined within the robot state and doesn't include collision object present in the collision world. Please use the PlanningScene.get_frame_transform method for collision world objects.
+
+	   Args:
                frame_id (str): The id of the frame to get the transform for.
-           Returns:
+
+	   Returns:
                :py:class:`numpy.ndarray`: The transformation matrix from the model frame to the frame identified by frame_id.
            )")
 
       .def("get_pose", &moveit_py::bind_robot_state::get_pose, py::arg("link_name"),
            R"(
            Get the pose of a link that is defined in the robot model.
-           Args:
+
+	   Args:
                link_name (str): The name of the link to get the pose for.
-           Returns:
-               :py:class: `geometry_msgs.msg.Pose`: A ROS geometry message containing the pose of the link.
+
+	   Returns:
+               geometry_msgs.msg.Pose: A ROS geometry message containing the pose of the link.
            )")
 
       .def("get_jacobian",
@@ -280,12 +280,15 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"), py::arg("reference_point_position"), py::return_value_policy::move,
            R"(
            Compute the Jacobian with reference to the last link of a specified group.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to compute the Jacobian for.
                reference_point_position (:py:class:`numpy.ndarray`): The position of the reference point in the link frame.
-           Returns:
+
+	   Returns:
                :py:class:`numpy.ndarray`: The Jacobian of the specified group with respect to the reference point.
-           Raises:
+
+	   Raises:
                Exception: If the group is not a chain.
            )")
 
@@ -296,12 +299,14 @@ void init_robot_state(py::module& m)
            py::arg("use_quaternion_representation") = false, py::return_value_policy::move,
            R"(
            Compute the Jacobian with reference to a particular point on a given link, for a specified group.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to compute the Jacobian for.
                link_name (str): The name of the link model to compute the Jacobian for.
                reference_point_position (:py:class:`numpy.ndarray`): The position of the reference point in the link frame.
 	       use_quaternion_representation (bool): If true, the Jacobian will be represented using a quaternion representation, if false it defaults to euler angle representation.
-           Returns:
+
+	   Returns:
                :py:class:`numpy.ndarray`: The Jacobian of the specified group with respect to the reference point.
            )")
 
@@ -321,8 +326,8 @@ void init_robot_state(py::module& m)
           },
           py::return_value_policy::move,
           R"(
-	  str: the state information of the robot state.
-	  )")
+    str: the state information of the robot state.
+    )")
 
       // Getting and setting joint model group positions, velocities, accelerations
       .def_property("joint_positions", &moveit_py::bind_robot_state::get_joint_positions,
@@ -343,7 +348,8 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"), py::arg("position_values"),
            R"(
            Sets the positions of the joints in the specified joint model group.
-           Args:
+
+	   Args:
                joint_model_group_name (str):
                position_values (:py:class:`numpy.ndarray`): The positions of the joints in the joint model group.
        )")
@@ -365,10 +371,12 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"),
            R"(
            For a given group, get the position values of the variables that make up the group.
-           Args:
-               joint_model_group_name (str): The name of the joint model group to copy the positions for.
-           Returns:
-               :py:class:`numpy.ndarray`: The positions of the joints in the joint model group.
+
+	   Args:
+	       joint_model_group_name (str): The name of the joint model group to copy the positions for.
+
+	   Returns:
+	       :py:class:`numpy.ndarray`: The positions of the joints in the joint model group.
            )")
 
       .def("set_joint_group_velocities",
@@ -377,7 +385,8 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"), py::arg("velocity_values"),
            R"(
            Sets the velocities of the joints in the specified joint model group.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to set the velocities for.
                velocity_values (:py:class:`numpy.ndarray`): The velocities of the joints in the joint model group.
            )")
@@ -409,9 +418,11 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"),
            R"(
            For a given group, get the acceleration values of the variables that make up the group.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to copy the accelerations for.
-           Returns:
+
+	   Returns:
                :py:class:`numpy.ndarray`: The accelerations of the joints in the joint model group.
            )")
 
@@ -419,8 +430,10 @@ void init_robot_state(py::module& m)
       .def("get_global_link_transform", &moveit_py::bind_robot_state::get_global_link_transform, py::arg("link_name"),
            R"(
        Returns the transform of the specified link in the global frame.
+
        Args:
            link_name (str): The name of the link to get the transform for.
+
        Returns:
            :py:class:`numpy.ndarray`: The transform of the specified link in the global frame.
        )")
@@ -434,9 +447,10 @@ void init_robot_state(py::module& m)
           py::arg("joint_model_group_name"), py::arg("geometry_pose"), py::arg("tip_name"), py::arg("timeout") = 0.0,
           R"(
            Sets the state of the robot to the one that results from solving the inverse kinematics for the specified group.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to set the state for.
-               geometry_pose (:py:class: `geometry_msgs.msg.Pose`): The pose of the end-effector to solve the inverse kinematics for.
+               geometry_pose (geometry_msgs.msg.Pose): The pose of the end-effector to solve the inverse kinematics for.
                tip_name (str): The name of the link that is the tip of the end-effector.
                timeout (float): The amount of time to wait for the IK solution to be found.
            )")
@@ -454,7 +468,8 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group"), py::arg("name"),
            R"(
            Set the joints in group to the position name defined in the SRDF.
-           Args:
+
+	   Args:
                joint_model_group (:py:class:`moveit_py.core.JointModelGroup`): The joint model group to set the default values for.
                name (str): The name of a predefined state which is defined in the robot model SRDF.
            )")
@@ -465,7 +480,8 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group_name"), py::arg("name"),
            R"(
            Set the joints in group to the position name defined in the SRDF.
-           Args:
+
+	   Args:
                joint_model_group_name (str): The name of the joint model group to set the default values for.
                name (str): The name of a predefined state which is defined in the robot model SRDF.
        )")
@@ -480,24 +496,23 @@ void init_robot_state(py::module& m)
            py::arg("joint_model_group"),
            R"(
            Set all joints in the joint model group to random positions within the default bounds.
-           Args:
+
+	   Args:
                joint_model_group (:py:class:`moveit_py.core.JointModelGroup`): The joint model group to set the random values for.
            )")
 
       .def("clear_attached_bodies", py::overload_cast<>(&moveit::core::RobotState::clearAttachedBodies),
            R"(
-      	   Clear all attached bodies.
-
-      	   We only allow for attaching of objects via the PlanningScene instance. This method allows any attached objects that are associated to this RobotState instance to be removed.
-	   )")
+           Clear all attached bodies. We only allow for attaching of objects via the PlanningScene instance. This method allows any attached objects that are associated to this RobotState instance to be removed.
+     )")
 
       .def("update", &moveit_py::bind_robot_state::update, py::arg("force") = false, py::arg("type") = "all",
            R"(
              Update state transforms.
 
              Args:
-	     	force (bool): when true forces the update of the transforms from scratch.
-		category (str): specifies the category to update. All indicates updating all transforms while "links_only" and "collisions_only" ensure that only links or collision transforms are updated. )");
+	         force (bool): when true forces the update of the transforms from scratch.
+		 category (str): specifies the category to update. All indicates updating all transforms while "links_only" and "collisions_only" ensure that only links or collision transforms are updated. )");
 }
 }  // namespace bind_robot_state
 }  // namespace moveit_py

--- a/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
@@ -79,8 +79,7 @@ Eigen::MatrixXd get_global_link_transform(const moveit::core::RobotState* self, 
 
 geometry_msgs::msg::Pose get_pose(const moveit::core::RobotState* self, const std::string& link_name)
 {
-  Eigen::Isometry3d pose = self->getGlobalLinkTransform(link_name);
-  return tf2::toMsg(pose);
+  return tf2::toMsg(self->getGlobalLinkTransform(link_name));
 }
 
 std::map<std::string, double> get_joint_positions(const moveit::core::RobotState* self)
@@ -236,8 +235,8 @@ void init_robot_state(py::module& m)
 
            )")
       .def("__copy__", [](const moveit::core::RobotState* self) { return moveit::core::RobotState{ *self }; })
-      .def("__deepcopy__",
-           [](const moveit::core::RobotState* self, py::dict /* memo */) { return moveit::core::RobotState{ *self }; })
+      .def("__deepcopy__", [](const moveit::core::RobotState* self,
+                              py::dict /* memo */) { return moveit::core::RobotState{ *self }; })  // NOLINT
 
       // Get underlying robot model, frame transformations and jacobian
       .def_property("robot_model", &moveit::core::RobotState::getRobotModel, nullptr,

--- a/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
@@ -92,14 +92,14 @@ void init_robot_trajectory(py::module& m)
 
       .def("__len__", &robot_trajectory::RobotTrajectory::getWayPointCount,
            R"(
-                    Returns:
-                        int: The number of waypoints in the trajectory.
+	   Returns:
+	       int: The number of waypoints in the trajectory.
                     )")
 
       .def("__reverse__", &robot_trajectory::RobotTrajectory::reverse,
            R"(
-     	   Reverse the trajectory.
-     	   )")
+           Reverse the trajectory.
+           )")
 
       .def_property("joint_model_group_name", &robot_trajectory::RobotTrajectory::getGroupName,
                     &robot_trajectory::RobotTrajectory::setGroupName,
@@ -125,25 +125,27 @@ void init_robot_trajectory(py::module& m)
       .def("unwind", py::overload_cast<>(&robot_trajectory::RobotTrajectory::unwind),
            R"(
            Unwind the trajectory.
-      	   )")
+           )")
 
       .def("get_waypoint_durations", &robot_trajectory::RobotTrajectory::getWayPointDurations,
            R"(
            Get the durations from the previous waypoint in the trajectory.
+
            Returns:
                list of float: The duration from previous of each waypoint in the trajectory.
            )")
       .def("get_robot_trajectory_msg", &moveit_py::bind_robot_trajectory::get_robot_trajectory_msg,
            py::arg("joint_filter") = std::vector<std::string>(),
            R"(
-           Get the trajectory as a `moveit_msgs.msg.RobotTrajectory` message.
-           Returns:
+           Get the trajectory as a moveit_msgs.msg.RobotTrajectory message.
+
+	   Returns:
                moveit_msgs.msg.RobotTrajectory: A ROS robot trajectory message.
            )")
       .def("set_robot_trajectory_msg", &moveit_py::bind_robot_trajectory::set_robot_trajectory_msg,
            py::arg("robot_state"), py::arg("msg"),
            R"(
-           Set the trajectory from a `moveit_msgs.msg.RobotTrajectory` message.
+           Set the trajectory from a moveit_msgs.msg.RobotTrajectory message.
            )");
   // TODO (peterdavidfagan): support other methods such as appending trajectories
 }

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/planning_component.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/planning_component.cpp
@@ -191,8 +191,8 @@ void init_plan_request_parameters(py::module& m)
   py::class_<moveit_cpp::PlanningComponent::PlanRequestParameters,
              std::shared_ptr<moveit_cpp::PlanningComponent::PlanRequestParameters>>(m, "PlanRequestParameters",
                                                                                     R"(
-			     Planner parameters provided with a MotionPlanRequest.
-			     )")
+                             Planner parameters provided with a MotionPlanRequest.
+                             )")
       .def(py::init([](std::shared_ptr<moveit_cpp::MoveItCpp>& moveit_cpp, const std::string& ns) {
         const rclcpp::Node::SharedPtr& node = moveit_cpp->getNode();
         moveit_cpp::PlanningComponent::PlanRequestParameters params;
@@ -233,8 +233,8 @@ void init_multi_plan_request_parameters(py::module& m)
              std::shared_ptr<moveit_cpp::PlanningComponent::MultiPipelinePlanRequestParameters>>(
       m, "MultiPipelinePlanRequestParameters",
       R"(
-			     Planner parameters provided with a MotionPlanRequest.
-			     )")
+                             Planner parameters provided with a MotionPlanRequest.
+                             )")
       .def(py::init([](std::shared_ptr<moveit_cpp::MoveItCpp>& moveit_cpp,
                        const std::vector<std::string>& planning_pipeline_names) {
         const rclcpp::Node::SharedPtr& node = moveit_cpp->getNode();
@@ -255,7 +255,8 @@ void init_planning_component(py::module& m)
            py::arg("joint_model_group_name"), py::arg("moveit_py_instance"),
            R"(
             Constructs a PlanningComponent instance.
-            Args:
+
+	    Args:
                 joint_model_group_name (str): The name of the joint model group to plan for.
                 moveit_py_instance (:py:class:`moveit_py.core.MoveItPy`): The MoveItPy instance to use.
         )")
@@ -286,11 +287,12 @@ void init_planning_component(py::module& m)
       .def("set_start_state", &moveit_py::bind_planning_component::set_start_state,
            py::arg("configuration_name") = nullptr, py::arg("robot_state") = nullptr,
            R"(
-	   Set the start state of the plan to the given robot state.
+           Set the start state of the plan to the given robot state.
+
 	   Args:
-	       configuration_name (str): The name of the configuration to use as the start state.
-	       robot_state (:py:class:`moveit_msgs.msg.RobotState`): The robot state to use as the start state.
-	   )")
+               configuration_name (str): The name of the configuration to use as the start state.
+               robot_state (:py:class:`moveit_msgs.msg.RobotState`): The robot state to use as the start state.
+           )")
 
       .def("get_start_state", &moveit_cpp::PlanningComponent::getStartState,
            py::return_value_policy::reference_internal,
@@ -308,14 +310,15 @@ void init_planning_component(py::module& m)
            py::arg("pose_stamped_msg") = nullptr, py::arg("pose_link") = nullptr,
            py::arg("motion_plan_constraints") = nullptr,
            R"(
-	   Set the goal state for the planning component.
+           Set the goal state for the planning component.
+
 	   Args:
-	       configuration_name (str): The name of the configuration to set the goal to.
-	       robot_state (moveit_py.core.RobotState): The state to set the goal to.
-	       pose_stamped_msg (geometry_msgs.msg.PoseStamped): A PoseStamped ros message.
-	       pose_link (str): The name of the link for which the pose constraint is specified.
-	       motion_plan_constraints (list): The motion plan constraints to set the goal to.
-	   )")
+               configuration_name (str): The name of the configuration to set the goal to.
+               robot_state (moveit_py.core.RobotState): The state to set the goal to.
+               pose_stamped_msg (geometry_msgs.msg.PoseStamped): A PoseStamped ros message.
+               pose_link (str): The name of the link for which the pose constraint is specified.
+               motion_plan_constraints (list): The motion plan constraints to set the goal to.
+           )")
 
       // plan/execution methods
 
@@ -324,16 +327,18 @@ void init_planning_component(py::module& m)
            py::arg("multi_plan_parameters") = nullptr, py::arg("solution_selection_function") = nullptr,
            py::arg("stopping_criterion_callback") = nullptr, py::return_value_policy::move,
            R"(
-      	   Plan a motion plan using the current start and goal states.
-      	   Args:
-      	       plan_parameters (moveit_py.core.PlanParameters): The parameters to use for planning.
-      	   )")
+           Plan a motion plan using the current start and goal states.
+
+	   Args:
+               plan_parameters (moveit_py.core.PlanParameters): The parameters to use for planning.
+           )")
 
       .def("set_path_constraints", &moveit_cpp::PlanningComponent::setPathConstraints, py::arg("path_constraints"),
            py::return_value_policy::move,
            R"(
            Set the path constraints generated from a moveit msg Constraints.
-           Args:
+
+	   Args:
                path_constraints (moveit_msgs.msg.Constraints): The path constraints.
         )")
 
@@ -341,9 +346,9 @@ void init_planning_component(py::module& m)
       .def("set_workspace", &moveit_cpp::PlanningComponent::setWorkspace, py::arg("min_x"), py::arg("min_y"),
            py::arg("min_z"), py::arg("max_x"), py::arg("max_y"), py::arg("max_z"),
            R"(
-           Specify the workspace bounding box.
-           The box is specified in the planning frame (i.e. relative to the robot root link start position). The workspace applies only to the root joint of a mobile robot (driving base, quadrotor) and does not limit the workspace of a robot arm.
-           Args:
+           Specify the workspace bounding box. The box is specified in the planning frame (i.e. relative to the robot root link start position). The workspace applies only to the root joint of a mobile robot (driving base, quadrotor) and does not limit the workspace of a robot arm.
+
+	   Args:
                min_x (float): The minimum x value of the workspace.
                min_y (float): The minimum y value of the workspace.
                min_z (float): The minimum z value of the workspace.


### PR DESCRIPTION
### Description

Fixing warnings that occur when running [htmlproofer](https://github.com/ros-planning/moveit2_tutorials/blob/main/htmlproofer.sh) against Python API sphinx documentation.

### Checklist
- [x] Verify htmlproofer successfully runs without warnings
