### PR TITLE
Fix moveit_kinematics dependency on moveit_ros_planning

### DIFF
--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -33,13 +33,13 @@
   <depend>tf2_kdl</depend>
   <depend>orocos_kdl_vendor</depend>
   <depend>moveit_msgs</depend>
+  <depend>moveit_ros_planning</depend>
   <depend>rsl</depend>
 
   <!-- some requirements of ikfast scripts -->
   <exec_depend>urdfdom</exec_depend> <!-- provides check_urdf -->
   <exec_depend>python3-lxml</exec_depend>
 
-  <test_depend>moveit_ros_planning</test_depend>
   <test_depend>moveit_resources_fanuc_description</test_depend>
   <test_depend>moveit_resources_fanuc_moveit_config</test_depend>
   <test_depend>moveit_resources_panda_description</test_depend>


### PR DESCRIPTION
### Description

This dependency is unconditionally used even if tests are disabled.

The dependency is referenced here:
https://github.com/ros-planning/moveit2/blob/3e847e1a3b5548824db8c8ffcd74adcf4513c828/moveit_kinematics/CMakeLists.txt#L16

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
