### PR TITLE
Cancel goal doesn't work for move action server because execution is blocking

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -69,8 +69,9 @@ void MoveGroupMoveAction::initialize()
         preemptMoveCallback();
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](std::shared_ptr<MGActionGoal> goal) { std::thread{ std::bind( & MoveGroupMoveAction::executeMoveCallback, this, std::placeholders::_1), goal }.detach();
- });
+      [this](std::shared_ptr<MGActionGoal> goal) {
+        std::thread{ std::bind(&MoveGroupMoveAction::executeMoveCallback, this, std::placeholders::_1), goal }.detach();
+      });
 }
 
 void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -64,17 +64,20 @@ void MoveGroupMoveAction::initialize()
         RCLCPP_INFO(LOGGER, "Received request");
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
-      [](const std::shared_ptr<MGActionGoal>& /*unused*/) {
+      [this](const std::shared_ptr<MGActionGoal>& /*unused*/) {
         RCLCPP_INFO(LOGGER, "Received request to cancel goal");
+        preemptMoveCallback();
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](const std::shared_ptr<MGActionGoal>& goal) { return executeMoveCallback(goal); });
+      [this](std::shared_ptr<MGActionGoal> goal) { std::thread{ std::bind( & MoveGroupMoveAction::executeMoveCallback, this, std::placeholders::_1), goal }.detach();
+ });
 }
 
 void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal)
 {
+  goal_ = goal;
   RCLCPP_INFO(LOGGER, "executing..");
-  setMoveState(PLANNING, goal);
+  setMoveState(PLANNING, goal_);
   // before we start planning, ensure that we have the latest robot state received...
   auto node = context_->moveit_cpp_->getNode();
   context_->planning_scene_monitor_->waitForCurrentRobotState(node->get_clock()->now());
@@ -103,8 +106,9 @@ void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal
   else
     goal->abort(action_res);
 
-  setMoveState(IDLE, goal);
+  setMoveState(IDLE, goal_);
   preempt_requested_ = false;
+  goal_.reset();
 }
 
 void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const std::shared_ptr<MGActionGoal>& goal,
@@ -212,7 +216,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const std::shared_ptr<MGAc
 bool MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::MotionPlanRequest& req,
                                                     plan_execution::ExecutableMotionPlan& plan)
 {
-  setMoveState(PLANNING, nullptr);
+  setMoveState(PLANNING, goal_);
 
   bool solved = false;
   planning_interface::MotionPlanResponse res;
@@ -248,12 +252,12 @@ bool MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::Mo
 
 void MoveGroupMoveAction::startMoveExecutionCallback()
 {
-  setMoveState(MONITOR, nullptr);
+  setMoveState(MONITOR, goal_);
 }
 
 void MoveGroupMoveAction::startMoveLookCallback()
 {
-  setMoveState(LOOK, nullptr);
+  setMoveState(LOOK, goal_);
 }
 
 void MoveGroupMoveAction::preemptMoveCallback()

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -72,5 +72,6 @@ private:
 
   MoveGroupState move_state_;
   bool preempt_requested_;
+  std::shared_ptr< MGActionGoal > goal_;
 };
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.h
@@ -72,6 +72,6 @@ private:
 
   MoveGroupState move_state_;
   bool preempt_requested_;
-  std::shared_ptr< MGActionGoal > goal_;
+  std::shared_ptr<MGActionGoal> goal_;
 };
 }  // namespace move_group


### PR DESCRIPTION
### Description
Cancel goal request for the move_action action does not currently work. 

Using both the rclpy action client cancel_goal() API call as well CLI ros2 service call to /move_action/_action/cancel_goal both do not work. These calls to cancel goal do not return and I receive no response from the action server.

I believe the issue is due to the fact that the move execution is blocking. I have moved the move execution callback into its own thread and now the cancel goal request works. 

I also added call to preempt move callback on cancel to stop execution.

Finally I added local copy storage of the current goal handle in order to publish proper feedback/action server state. The goal handle is needed to publish feedback and because it is not being currently stored, certain states are not sent as feedback because the goal handle is null.

I have tested these changes on with ROS2 Humble on Ubuntu 22.04 and works well.
