### PR TITLE
Added butterworth_filter_coeff parameter

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(trajectory_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(common_interfaces REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 # TODO: Port python bindings
 # find_package(pybind11 REQUIRED)
 
@@ -86,6 +87,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 
 set(THIS_PACKAGE_LIBRARIES
     moveit_butterworth_filter
+    moveit_butterworth_parameters
     moveit_collision_distance_field
     moveit_collision_detection
     moveit_collision_detection_fcl
@@ -114,6 +116,7 @@ set(THIS_PACKAGE_LIBRARIES
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   angles
+  generate_parameter_library
   eigen_stl_containers
   geometric_shapes
   geometry_msgs

--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -27,9 +27,12 @@ target_include_directories(${BUTTERWORTH_FILTER_LIB} PUBLIC
 set_target_properties(${BUTTERWORTH_FILTER_LIB} PROPERTIES VERSION
   "${${PROJECT_NAME}_VERSION}"
 )
+generate_parameter_library(moveit_butterworth_parameters src/butterworth_parameters.yaml)
 target_link_libraries(${BUTTERWORTH_FILTER_LIB}
   ${SMOOTHING_BASE_LIB}
+  moveit_butterworth_parameters
   moveit_robot_model
+  moveit_smoothing_base
 )
 ament_target_dependencies(${BUTTERWORTH_FILTER_LIB}
   srdfdom  # include dependency from moveit_robot_model

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
@@ -34,12 +34,14 @@
 
 /* Author: Andy Zelenak
    Description: A first-order Butterworth low-pass filter. There is only one parameter to tune.
+   The first-order Butterworth filter has the nice property that it will not overshoot.
  */
 
 #pragma once
 
 #include <cstddef>
 
+#include <moveit_butterworth_parameters.hpp>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/online_signal_smoothing/smoothing_base_class.h>
 
@@ -50,15 +52,24 @@ namespace online_signal_smoothing
  * This is a first-order Butterworth low-pass filter. First-order was chosen for 2 reasons:
  * - It doesn't overshoot
  * - Computational efficiency
+ * This filter has been parameterized so there is only one parameter to tune.
+ * See "Digital Implementation of Butterworth First–Order Filter Type IIR" by
+ * Horvath, Cervenanska, and Kotianova, 2019 and
+ * Mienkina, M., Filter-Based Algorithm for Metering Applications,
+ * https://www.nxp.com/docs/en/application-note/AN4265.pdf, 2016
+ * It comes from finding the bilinear transform equivalent of the analog transfer function and
+ * further applying the inverse z-transform.
+ * The parameter "low_pass_filter_coeff" equals (2*pi / tan(omega_d * T))
+ * where omega_d is the cutoff frequency and T is the samping period in sec.
  */
 class ButterworthFilter
 {
 public:
   /**
    * Constructor.
-   * @param low_pass_filter_coeff Larger filter_coeff-> more smoothing of servo commands, but more lag.
-   * Rough plot, with cutoff frequency on the y-axis:
-   * https://www.wolframalpha.com/input/?i=plot+arccot(c)
+   * @param low_pass_filter_coeff Larger filter_coeff-> more smoothing of commands, but more lag.
+   * low_pass_filter_coeff = (2*pi / tan(omega_d * T))
+   * where omega_d is the cutoff frequency and T is the samping period in sec.
    */
   ButterworthFilter(double low_pass_filter_coeff);
   ButterworthFilter() = delete;

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -96,12 +96,12 @@ bool ButterworthFilterPlugin::initialize(rclcpp::Node::SharedPtr node, moveit::c
 {
   node_ = node;
   num_joints_ = num_joints;
+  auto param_listener = std::make_unique<online_signal_smoothing::ParamListener>(node_);
+  auto filter_coeff = param_listener->get_params().butterworth_filter_coeff;
 
   for (std::size_t i = 0; i < num_joints_; ++i)
   {
-    // Low-pass filters for the joint positions
-    // TODO(andyz): read a parameter
-    position_filters_.emplace_back(1.5 /* filter coefficient, should be >1 */);
+    position_filters_.emplace_back(filter_coeff);
   }
   return true;
 };

--- a/moveit_core/online_signal_smoothing/src/butterworth_parameters.yaml
+++ b/moveit_core/online_signal_smoothing/src/butterworth_parameters.yaml
@@ -1,0 +1,9 @@
+online_signal_smoothing:
+  butterworth_filter_coeff: {
+        type: double,
+        default_value: 1.5,
+        description: "Filter coefficient for the Butterworth filter",
+        validation: {
+          gt<>: 1.0
+        }
+      }

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -25,6 +25,7 @@
   <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <depend>generate_parameter_library</depend>
   <depend>moveit_common</depend>
 
   <depend>angles</depend>


### PR DESCRIPTION
### Description

Made butterworth filter coefficient configurable as a parameter, like in https://github.com/ros-planning/moveit2/pull/2091

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
