### PR TITLE
[Servo] Avoid unnecessary checks for initializing `ik_base_to_tip_frame`

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -43,6 +43,7 @@
 #include <mutex>
 #include <thread>
 #include <atomic>
+#include <optional>
 
 // ROS
 #include <control_msgs/msg/joint_jog.hpp>
@@ -337,6 +338,6 @@ protected:
   // Load a smoothing plugin
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;
 
-  kinematics::KinematicsBaseConstPtr ik_solver_ = NULL;
+  kinematics::KinematicsBaseConstPtr ik_solver_ = nullptr;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -338,7 +338,6 @@ protected:
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;
 
   kinematics::KinematicsBaseConstPtr ik_solver_;
-  Eigen::Isometry3d ik_base_to_tip_frame_;
   bool use_inv_jacobian_ = false;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -337,7 +337,6 @@ protected:
   // Load a smoothing plugin
   pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader_;
 
-  kinematics::KinematicsBaseConstPtr ik_solver_;
-  bool use_inv_jacobian_ = false;
+  kinematics::KinematicsBaseConstPtr ik_solver_ = NULL;
 };
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -39,11 +39,11 @@
 #pragma once
 
 // C++
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <thread>
-#include <atomic>
 #include <optional>
+#include <thread>
 
 // ROS
 #include <control_msgs/msg/joint_jog.hpp>

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -42,7 +42,6 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <optional>
 #include <thread>
 
 // ROS

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -600,10 +600,10 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
 
     // Poses passed to IK solvers are assumed to be in some tip link (usually EE) reference frame
     // First, find the new tip link position without newly applied rotation
-    Eigen::Isometry3d ik_base_to_tip_frame_ =
+    Eigen::Isometry3d ik_base_to_tip_frame =
         current_state_->getGlobalLinkTransform(ik_solver_->getBaseFrame()).inverse() *
         current_state_->getGlobalLinkTransform(ik_solver_->getTipFrame());
-    auto tf_no_new_rot = tf_pos_delta * ik_base_to_tip_frame_;
+    auto tf_no_new_rot = tf_pos_delta * ik_base_to_tip_frame;
     // we want the rotation to be applied in the requested reference frame,
     // but we want the rotation to be about the EE point in space, not the origin.
     // So, we need to translate to origin, rotate, then translate back

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -180,7 +180,6 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   ik_solver_ = joint_model_group_->getSolverInstance();
   if (!ik_solver_)
   {
-    use_inv_jacobian_ = true;
     RCLCPP_WARN(
         LOGGER,
         "No kinematics solver instantiated for group '%s'. Will use inverse Jacobian for servo calculations instead.",
@@ -188,7 +187,7 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   }
   else if (!ik_solver_->supportsGroup(joint_model_group_))
   {
-    use_inv_jacobian_ = true;
+    ik_solver_ = NULL;
     RCLCPP_WARN(LOGGER,
                 "The loaded kinematics plugin does not support group '%s'. Will use inverse Jacobian for servo "
                 "calculations instead.",
@@ -586,7 +585,7 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
 
   // Convert from cartesian commands to joint commands
   // Use an IK solver plugin if we have one, otherwise use inverse Jacobian.
-  if (!use_inv_jacobian_)
+  if (ik_solver_)
   {
     // get a transformation matrix with the desired position change &
     // get a transformation matrix with desired orientation change

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -601,8 +601,9 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
 
     // Poses passed to IK solvers are assumed to be in some tip link (usually EE) reference frame
     // First, find the new tip link position without newly applied rotation
-    ik_base_to_tip_frame_ = current_state_->getGlobalLinkTransform(ik_solver_->getBaseFrame()).inverse() *
-                            current_state_->getGlobalLinkTransform(ik_solver_->getTipFrame());
+    Eigen::Isometry3d ik_base_to_tip_frame_ =
+        current_state_->getGlobalLinkTransform(ik_solver_->getBaseFrame()).inverse() *
+        current_state_->getGlobalLinkTransform(ik_solver_->getTipFrame());
     auto tf_no_new_rot = tf_pos_delta * ik_base_to_tip_frame_;
     // we want the rotation to be applied in the requested reference frame,
     // but we want the rotation to be about the EE point in space, not the origin.

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -187,7 +187,7 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   }
   else if (!ik_solver_->supportsGroup(joint_model_group_))
   {
-    ik_solver_ = NULL;
+    ik_solver_ = nullptr;
     RCLCPP_WARN(LOGGER,
                 "The loaded kinematics plugin does not support group '%s'. Will use inverse Jacobian for servo "
                 "calculations instead.",


### PR DESCRIPTION
### Description

The variable `ik_base_to_tip_frame_` was being initialized in `ServoCalcs::start()` and  `ServoCalcs::calculateSingleIteration()`  and both places checked if `use_inv_jacobian` was `False`.
Since this variable is only used in [this block](https://github.com/ros-planning/moveit2/blob/dc7643502adbeaa41dfd370605460cfd45f26b7f/moveit_ros/moveit_servo/src/servo_calcs.cpp#L616) which is already inside a ` if (!use_inv_jacobian_)` check. 
The previous 2 initializations can be removed and replaced with a single initialization at the place it is used.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

