### PR TITLE
[Servo] Make conversion operations into free functions

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -89,7 +89,7 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
                       sensor_msgs::msg::JointState& next_joint_state,
                       pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass>& smoother);
 
-/** \brief Converts a twist command from the command frame to the MoveGroup planning frame of the robot
+/** \brief Converts a twist command from the command frame to the MoveIt planning frame of the robot
  * @param cmd The twist command received from the user
  * @param planning_frame Moveit planning frame of the robot
  * @param current_state The state of the robot

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -91,21 +91,19 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
                       pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass>& smoother);
 
 /** \brief Converts a twist command from the command frame to the MoveGroup planning frame of the robot
- * @param cmd The twist command
- * @param servo_params The servo parameters
- * @param tf_moveit_to_robot_cmd_frame Transform from MoveIt planning frame to servoing command frame
- * @param tf_moveit_to_ee_frame Transform from MoveIt planning frame to end-effector frame
+ * @param cmd The twist command received from the user
+ * @param planning_frame Moveit planning frame of the robot
  * @param current_state The state of the robot
+ * @param clock A ROS clock, for logging
  */
-void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
-                             const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
-                             const Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             const moveit::core::RobotStatePtr& current_state);
+void transformTwistToPlanningFrame(geometry_msgs::msg::TwistStamped& cmd, const std::string& planning_frame,
+                                   const moveit::core::RobotStatePtr& current_state, rclcpp::Clock& clock);
 
 /** \brief Converts the delta_x (change in cartesian position) to a pose to be used with IK solver.
  * @param delta_x The change in cartesian position
- * @param ik_base_to_tip_frame The transform from base of the robot to its end-effector
+ * @param base_to_tip_frame_transform The transform from base of the robot to its end-effector
  * @return Returns the resulting pose after applying delta_x
  */
-geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen::Isometry3d& ik_base_to_tip_frame);
+geometry_msgs::msg::Pose poseFromCartesianDelta(const Eigen::VectorXd& delta_x,
+                                                const Eigen::Isometry3d& base_to_tip_frame_transform);
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -44,7 +44,6 @@
 
 #include <moveit_servo/status_codes.h>
 #include <moveit/online_signal_smoothing/smoothing_base_class.h>
-#include <moveit_servo_lib_parameters.hpp>
 
 namespace moveit_servo
 {

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -97,14 +97,15 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
  * @param tf_moveit_to_ee_frame Transform from MoveIt planning frame to end-effector frame
  * @param current_state The state of the robot
  */
-void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, servo::Params& servo_params,
-                             Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame, Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             moveit::core::RobotStatePtr current_state);
+void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
+                             const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
+                             const Eigen::Isometry3d& tf_moveit_to_ee_frame,
+                             const moveit::core::RobotStatePtr current_state);
 
 /** \brief Converts the delta_x (change in cartesian position) to a pose to be used with IK solver.
  * @param delta_x The change in cartesian position
  * @param ik_base_to_tip_frame The transform from base of the robot to its end-effector
  * @return Returns the resulting pose after applying delta_x
  */
-geometry_msgs::msg::Pose deltaToPose(Eigen::VectorXd delta_x, Eigen::Isometry3d ik_base_to_tip_frame);
+geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd delta_x, const Eigen::Isometry3d ik_base_to_tip_frame);
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -44,6 +44,7 @@
 
 #include <moveit_servo/status_codes.h>
 #include <moveit/online_signal_smoothing/smoothing_base_class.h>
+#include <moveit_servo_lib_parameters.hpp>
 
 namespace moveit_servo
 {
@@ -88,4 +89,22 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
                       const sensor_msgs::msg::JointState& previous_joint_state,
                       sensor_msgs::msg::JointState& next_joint_state,
                       pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass>& smoother);
+
+/** \brief Converts a twist command from the command frame to the MoveGroup planning frame of the robot
+ * @param cmd The twist command
+ * @param servo_params The servo parameters
+ * @param tf_moveit_to_robot_cmd_frame Transform from MoveIt planning frame to servoing command frame
+ * @param tf_moveit_to_ee_frame Transform from MoveIt planning frame to end-effector frame
+ * @param current_state The state of the robot
+ */
+void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, servo::Params& servo_params,
+                             Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame, Eigen::Isometry3d& tf_moveit_to_ee_frame,
+                             moveit::core::RobotStatePtr current_state);
+
+/** \brief Converts the delta_x (change in cartesian position) to a pose to be used with IK solver.
+ * @param delta_x The change in cartesian position
+ * @param ik_base_to_tip_frame The transform from base of the robot to its end-effector
+ * @return Returns the resulting pose after applying delta_x
+ */
+geometry_msgs::msg::Pose deltaToPose(Eigen::VectorXd delta_x, Eigen::Isometry3d ik_base_to_tip_frame);
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -100,12 +100,12 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
 void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
                              const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
                              const Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             const moveit::core::RobotStatePtr current_state);
+                             const moveit::core::RobotStatePtr& current_state);
 
 /** \brief Converts the delta_x (change in cartesian position) to a pose to be used with IK solver.
  * @param delta_x The change in cartesian position
  * @param ik_base_to_tip_frame The transform from base of the robot to its end-effector
  * @return Returns the resulting pose after applying delta_x
  */
-geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd delta_x, const Eigen::Isometry3d ik_base_to_tip_frame);
+geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen::Isometry3d& ik_base_to_tip_frame);
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -554,20 +554,7 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
   // Use an IK solver plugin if we have one, otherwise use inverse Jacobian.
   if (ik_solver_)
   {
-    // get a transformation matrix with the desired position change &
-    // get a transformation matrix with desired orientation change
-    Eigen::Isometry3d tf_pos_delta(Eigen::Isometry3d::Identity());
-    tf_pos_delta.translate(Eigen::Vector3d(delta_x[0], delta_x[1], delta_x[2]));
-
-    Eigen::Isometry3d tf_rot_delta(Eigen::Isometry3d::Identity());
-    Eigen::Quaterniond q = Eigen::AngleAxisd(delta_x[3], Eigen::Vector3d::UnitX()) *
-                           Eigen::AngleAxisd(delta_x[4], Eigen::Vector3d::UnitY()) *
-                           Eigen::AngleAxisd(delta_x[5], Eigen::Vector3d::UnitZ());
-    tf_rot_delta.rotate(q);
-
-    // Poses passed to IK solvers are assumed to be in some tip link (usually EE) reference frame
-    // First, find the new tip link position without newly applied rotation
-    Eigen::Isometry3d ik_base_to_tip_frame =
+    const Eigen::Isometry3d ik_base_to_tip_frame =
         current_state_->getGlobalLinkTransform(ik_solver_->getBaseFrame()).inverse() *
         current_state_->getGlobalLinkTransform(ik_solver_->getTipFrame());
 

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -179,39 +179,31 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
   return true;
 }
 
-void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
-                             const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
-                             const Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             const moveit::core::RobotStatePtr& current_state)
+void transformTwistToPlanningFrame(geometry_msgs::msg::TwistStamped& cmd, const std::string& planning_frame,
+                                   const moveit::core::RobotStatePtr& current_state, rclcpp::Clock& clock)
 {
+  if (cmd.header.frame_id.empty())
+  {
+    RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, ROS_LOG_THROTTLE_PERIOD,
+                                "No frame specified for command ,will use planning_frame");
+    cmd.header.frame_id = planning_frame;
+  }
+
+  // We solve (planning_frame -> base -> cmd.header.frame_id)
+  // by computing (base->planning_frame)^-1 * (base->cmd.header.frame_id)
+  const Eigen::Isometry3d tf_moveit_to_incoming_cmd_frame =
+      current_state->getGlobalLinkTransform(planning_frame).inverse() *
+      current_state->getGlobalLinkTransform(cmd.header.frame_id);
+
+  // Apply the transform to linear and angular velocities
+  // v' = R * v  and w' = R * w
   Eigen::Vector3d translation_vector(cmd.twist.linear.x, cmd.twist.linear.y, cmd.twist.linear.z);
   Eigen::Vector3d angular_vector(cmd.twist.angular.x, cmd.twist.angular.y, cmd.twist.angular.z);
+  translation_vector = tf_moveit_to_incoming_cmd_frame.linear() * translation_vector;
+  angular_vector = tf_moveit_to_incoming_cmd_frame.linear() * angular_vector;
 
-  // If the incoming frame is empty or is the command frame, we use the previously calculated tf
-  if (cmd.header.frame_id.empty() || cmd.header.frame_id == servo_params.robot_link_command_frame)
-  {
-    translation_vector = tf_moveit_to_robot_cmd_frame.linear() * translation_vector;
-    angular_vector = tf_moveit_to_robot_cmd_frame.linear() * angular_vector;
-  }
-  else if (cmd.header.frame_id == servo_params.ee_frame_name)
-  {
-    // If the frame is the EE frame, we already have that transform as well
-    translation_vector = tf_moveit_to_ee_frame.linear() * translation_vector;
-    angular_vector = tf_moveit_to_ee_frame.linear() * angular_vector;
-  }
-  else
-  {
-    // We solve (planning_frame -> base -> cmd.header.frame_id)
-    // by computing (base->planning_frame)^-1 * (base->cmd.header.frame_id)
-    const auto tf_moveit_to_incoming_cmd_frame =
-        current_state->getGlobalLinkTransform(servo_params.planning_frame).inverse() *
-        current_state->getGlobalLinkTransform(cmd.header.frame_id);
-    translation_vector = tf_moveit_to_incoming_cmd_frame.linear() * translation_vector;
-    angular_vector = tf_moveit_to_incoming_cmd_frame.linear() * angular_vector;
-  }
-
-  // Put these components back into a TwistStamped
-  cmd.header.frame_id = servo_params.planning_frame;
+  // Update the values of the original command message to reflect the change in frame
+  cmd.header.frame_id = planning_frame;
   cmd.twist.linear.x = translation_vector(0);
   cmd.twist.linear.y = translation_vector(1);
   cmd.twist.linear.z = translation_vector(2);
@@ -220,7 +212,8 @@ void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo:
   cmd.twist.angular.z = angular_vector(2);
 }
 
-geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen::Isometry3d& ik_base_to_tip_frame)
+geometry_msgs::msg::Pose poseFromCartesianDelta(const Eigen::VectorXd& delta_x,
+                                                const Eigen::Isometry3d& base_to_tip_frame_transform)
 {
   // get a transformation matrix with the desired position change &
   // get a transformation matrix with desired orientation change
@@ -233,9 +226,8 @@ geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen
                          Eigen::AngleAxisd(delta_x[5], Eigen::Vector3d::UnitZ());
   tf_rot_delta.rotate(q);
 
-  // Poses passed to IK solvers are assumed to be in some tip link (usually EE) reference frame
-  // First, find the new tip link position without newly applied rotation
-  auto tf_no_new_rot = tf_pos_delta * ik_base_to_tip_frame;
+  // Find the new tip link position without newly applied rotation
+  const Eigen::Isometry3d tf_no_new_rot = tf_pos_delta * base_to_tip_frame_transform;
 
   // we want the rotation to be applied in the requested reference frame,
   // but we want the rotation to be about the EE point in space, not the origin.
@@ -243,12 +235,12 @@ geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen
   // Given T = transformation matrix from origin -> EE point in space (translation component of tf_no_new_rot)
   // and T' as the opposite transformation, EE point in space -> origin (translation only)
   // apply final transformation as T * R * T' * tf_no_new_rot
-  auto tf_translation = tf_no_new_rot.translation();
-  auto tf_neg_translation = Eigen::Isometry3d::Identity();  // T'
+  const Eigen::Matrix<double, 3, 1> tf_translation = tf_no_new_rot.translation();
+  Eigen::Isometry3d tf_neg_translation = Eigen::Isometry3d::Identity();  // T'
   tf_neg_translation(0, 3) = -tf_translation(0, 0);
   tf_neg_translation(1, 3) = -tf_translation(1, 0);
   tf_neg_translation(2, 3) = -tf_translation(2, 0);
-  auto tf_pos_translation = Eigen::Isometry3d::Identity();  // T
+  Eigen::Isometry3d tf_pos_translation = Eigen::Isometry3d::Identity();  // T
   tf_pos_translation(0, 3) = tf_translation(0, 0);
   tf_pos_translation(1, 3) = tf_translation(1, 0);
   tf_pos_translation(2, 3) = tf_translation(2, 0);

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -179,9 +179,10 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
   return true;
 }
 
-void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, servo::Params& servo_params,
-                             Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame, Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             moveit::core::RobotStatePtr current_state)
+void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
+                             const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
+                             const Eigen::Isometry3d& tf_moveit_to_ee_frame,
+                             const moveit::core::RobotStatePtr current_state)
 {
   Eigen::Vector3d translation_vector(cmd.twist.linear.x, cmd.twist.linear.y, cmd.twist.linear.z);
   Eigen::Vector3d angular_vector(cmd.twist.angular.x, cmd.twist.angular.y, cmd.twist.angular.z);
@@ -219,7 +220,7 @@ void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, servo::Param
   cmd.twist.angular.z = angular_vector(2);
 }
 
-geometry_msgs::msg::Pose deltaToPose(Eigen::VectorXd delta_x, Eigen::Isometry3d ik_base_to_tip_frame)
+geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd delta_x, const Eigen::Isometry3d ik_base_to_tip_frame)
 {
   // get a transformation matrix with the desired position change &
   // get a transformation matrix with desired orientation change
@@ -253,7 +254,7 @@ geometry_msgs::msg::Pose deltaToPose(Eigen::VectorXd delta_x, Eigen::Isometry3d 
   tf_pos_translation(2, 3) = tf_translation(2, 0);
 
   // T * R * T' * tf_no_new_rot
-  return std::move(tf2::toMsg(tf_pos_translation * tf_rot_delta * tf_neg_translation * tf_no_new_rot));
+  return tf2::toMsg(tf_pos_translation * tf_rot_delta * tf_neg_translation * tf_no_new_rot);
 }
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -182,7 +182,7 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
 void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo::Params& servo_params,
                              const Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame,
                              const Eigen::Isometry3d& tf_moveit_to_ee_frame,
-                             const moveit::core::RobotStatePtr current_state)
+                             const moveit::core::RobotStatePtr& current_state)
 {
   Eigen::Vector3d translation_vector(cmd.twist.linear.x, cmd.twist.linear.y, cmd.twist.linear.z);
   Eigen::Vector3d angular_vector(cmd.twist.angular.x, cmd.twist.angular.y, cmd.twist.angular.z);
@@ -220,7 +220,7 @@ void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, const servo:
   cmd.twist.angular.z = angular_vector(2);
 }
 
-geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd delta_x, const Eigen::Isometry3d ik_base_to_tip_frame)
+geometry_msgs::msg::Pose deltaToPose(const Eigen::VectorXd& delta_x, const Eigen::Isometry3d& ik_base_to_tip_frame)
 {
   // get a transformation matrix with the desired position change &
   // get a transformation matrix with desired orientation change

--- a/moveit_ros/moveit_servo/src/utilities.cpp
+++ b/moveit_ros/moveit_servo/src/utilities.cpp
@@ -179,4 +179,81 @@ bool applyJointUpdate(rclcpp::Clock& clock, const double publish_period, const E
   return true;
 }
 
+void commandToMoveGroupFrame(geometry_msgs::msg::TwistStamped& cmd, servo::Params& servo_params,
+                             Eigen::Isometry3d& tf_moveit_to_robot_cmd_frame, Eigen::Isometry3d& tf_moveit_to_ee_frame,
+                             moveit::core::RobotStatePtr current_state)
+{
+  Eigen::Vector3d translation_vector(cmd.twist.linear.x, cmd.twist.linear.y, cmd.twist.linear.z);
+  Eigen::Vector3d angular_vector(cmd.twist.angular.x, cmd.twist.angular.y, cmd.twist.angular.z);
+
+  // If the incoming frame is empty or is the command frame, we use the previously calculated tf
+  if (cmd.header.frame_id.empty() || cmd.header.frame_id == servo_params.robot_link_command_frame)
+  {
+    translation_vector = tf_moveit_to_robot_cmd_frame.linear() * translation_vector;
+    angular_vector = tf_moveit_to_robot_cmd_frame.linear() * angular_vector;
+  }
+  else if (cmd.header.frame_id == servo_params.ee_frame_name)
+  {
+    // If the frame is the EE frame, we already have that transform as well
+    translation_vector = tf_moveit_to_ee_frame.linear() * translation_vector;
+    angular_vector = tf_moveit_to_ee_frame.linear() * angular_vector;
+  }
+  else
+  {
+    // We solve (planning_frame -> base -> cmd.header.frame_id)
+    // by computing (base->planning_frame)^-1 * (base->cmd.header.frame_id)
+    const auto tf_moveit_to_incoming_cmd_frame =
+        current_state->getGlobalLinkTransform(servo_params.planning_frame).inverse() *
+        current_state->getGlobalLinkTransform(cmd.header.frame_id);
+    translation_vector = tf_moveit_to_incoming_cmd_frame.linear() * translation_vector;
+    angular_vector = tf_moveit_to_incoming_cmd_frame.linear() * angular_vector;
+  }
+
+  // Put these components back into a TwistStamped
+  cmd.header.frame_id = servo_params.planning_frame;
+  cmd.twist.linear.x = translation_vector(0);
+  cmd.twist.linear.y = translation_vector(1);
+  cmd.twist.linear.z = translation_vector(2);
+  cmd.twist.angular.x = angular_vector(0);
+  cmd.twist.angular.y = angular_vector(1);
+  cmd.twist.angular.z = angular_vector(2);
+}
+
+geometry_msgs::msg::Pose deltaToPose(Eigen::VectorXd delta_x, Eigen::Isometry3d ik_base_to_tip_frame)
+{
+  // get a transformation matrix with the desired position change &
+  // get a transformation matrix with desired orientation change
+  Eigen::Isometry3d tf_pos_delta(Eigen::Isometry3d::Identity());
+  tf_pos_delta.translate(Eigen::Vector3d(delta_x[0], delta_x[1], delta_x[2]));
+
+  Eigen::Isometry3d tf_rot_delta(Eigen::Isometry3d::Identity());
+  Eigen::Quaterniond q = Eigen::AngleAxisd(delta_x[3], Eigen::Vector3d::UnitX()) *
+                         Eigen::AngleAxisd(delta_x[4], Eigen::Vector3d::UnitY()) *
+                         Eigen::AngleAxisd(delta_x[5], Eigen::Vector3d::UnitZ());
+  tf_rot_delta.rotate(q);
+
+  // Poses passed to IK solvers are assumed to be in some tip link (usually EE) reference frame
+  // First, find the new tip link position without newly applied rotation
+  auto tf_no_new_rot = tf_pos_delta * ik_base_to_tip_frame;
+
+  // we want the rotation to be applied in the requested reference frame,
+  // but we want the rotation to be about the EE point in space, not the origin.
+  // So, we need to translate to origin, rotate, then translate back
+  // Given T = transformation matrix from origin -> EE point in space (translation component of tf_no_new_rot)
+  // and T' as the opposite transformation, EE point in space -> origin (translation only)
+  // apply final transformation as T * R * T' * tf_no_new_rot
+  auto tf_translation = tf_no_new_rot.translation();
+  auto tf_neg_translation = Eigen::Isometry3d::Identity();  // T'
+  tf_neg_translation(0, 3) = -tf_translation(0, 0);
+  tf_neg_translation(1, 3) = -tf_translation(1, 0);
+  tf_neg_translation(2, 3) = -tf_translation(2, 0);
+  auto tf_pos_translation = Eigen::Isometry3d::Identity();  // T
+  tf_pos_translation(0, 3) = tf_translation(0, 0);
+  tf_pos_translation(1, 3) = tf_translation(1, 0);
+  tf_pos_translation(2, 3) = tf_translation(2, 0);
+
+  // T * R * T' * tf_no_new_rot
+  return std::move(tf2::toMsg(tf_pos_translation * tf_rot_delta * tf_neg_translation * tf_no_new_rot));
+}
+
 }  // namespace moveit_servo


### PR DESCRIPTION
### Description

Should be merged after #2146 

This PR makes the following conversions into free functions and moves them into utilities.
1. Converting from command frame to MoveGroup frame
2. Converting change in cartesian position (delta_x) to a `Pose` 

These changes help in keeping the code more readable and will make writing tests easier.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
