### PR TITLE
fix: fix Jacobian Quarternion representation bug

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1436,15 +1436,17 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
   }
   if (use_quaternion_representation)
   {  // Quaternion representation
-    // From "Advanced Dynamics and Motion Simulation" by Paul Mitiguy
+    // From "Quaternion kinematics for the error-state KF" 1.7.2 Global perturbations
+    // https://hal.science/hal-01122406v4/file/kinematics.pdf
+    // dq/qt = 0.5 * wg ⊗ q
     // d/dt ( [w] ) = 1/2 * [ -x -y -z ]  * [ omega_1 ]
-    //        [x]           [  w -z  y ]    [ omega_2 ]
-    //        [y]           [  z  w -x ]    [ omega_3 ]
-    //        [z]           [ -y  x  w ]
+    //        [x]           [  w  z -y ]    [ omega_2 ]
+    //        [y]           [ -z  w  x ]    [ omega_3 ]
+    //        [z]           [  y -x  w ]
     Eigen::Quaterniond q(link_transform.linear());
     double w = q.w(), x = q.x(), y = q.y(), z = q.z();
     Eigen::MatrixXd quaternion_update_matrix(4, 3);
-    quaternion_update_matrix << -x, -y, -z, w, -z, y, z, w, -x, -y, x, w;
+    quaternion_update_matrix << -x, -y, -z, w, z, -y, -z, w, x, y, -x, w;
     jacobian.block(3, 0, 4, columns) = 0.5 * quaternion_update_matrix * jacobian.block(3, 0, 3, columns);
   }
   return true;


### PR DESCRIPTION
### Description

Fix: robot_state.cpp getJacobian() function quaternion representation
[reference: ](https://hal.science/hal-01122406v4/file/kinematics.pdf) 1.7.2 Global perturbations
It should be global perturbation rather than local perturbation.
I verify the resulte with the following method of estimation:
$Y = F(q)         \qquad  \Delta Y = J(q_0)  \Delta q$
$Y_0 = F(q_0) $
$Y_1 = F(q_1)  \qquad  \Delta Y_1 = J(q_0)  \Delta q_1$
$Y_2 = F(q_2)  \qquad  \Delta Y_2 = J(q_0)  \Delta q_2$
$...$
$Y_n = F(q_n)  \qquad  \Delta Y_n = J(q_0)  \Delta q_n$

$[ \Delta Y_1,  \Delta Y_2,  ... , \Delta Y_n] = J(q_0)[ \Delta q_1,  \Delta q_2, ... , \Delta q_n]$
$[ \Delta Y_1,  \Delta Y_2,  ... , \Delta Y_n] = A$
$[ \Delta q_1,  \Delta q_2, ... , \Delta q_n] = B$
$J(q_0) = AB^T(BB^T)^-1$

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
