### PR TITLE
[Servo] Restore namespace to parameters

### DIFF
--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description():
     )
 
     # Get parameters for the Pose Tracking node
-    pid_params = {
+    pose_tracker_params = {
         "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/pose_tracking_settings.yaml")
         .to_dict()
@@ -63,7 +63,7 @@ def generate_launch_description():
         executable="servo_pose_tracking_demo",
         # prefix=['xterm -e gdb -ex run --args'],
         output="screen",
-        parameters=[moveit_config.to_dict(), servo_params, pid_params],
+        parameters=[moveit_config.to_dict(), servo_params, pose_tracker_params],
     )
 
     # ros2_control using FakeSystem as hardware

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -14,16 +14,17 @@ def generate_launch_description():
     )
 
     # Get parameters for the Pose Tracking node
-    pid_params = (
-        ParameterBuilder("moveit_servo")
+    pid_params = {
+        "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/pose_tracking_settings.yaml")
         .to_dict()
-    )
-    servo_params = (
-        ParameterBuilder("moveit_servo")
+    }
+
+    servo_params = {
+        "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/panda_simulated_config_pose_tracking.yaml")
         .to_dict()
-    )
+    }
 
     # RViz
     rviz_config_file = (

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -19,6 +19,7 @@ def generate_launch_description():
         .yaml("config/panda_simulated_config.yaml")
         .to_dict()
     )
+    servo_params = {"moveit_servo": servo_params}
     # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
     low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
 

--- a/moveit_ros/moveit_servo/launch/servo_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/servo_example.launch.py
@@ -14,12 +14,12 @@ def generate_launch_description():
     )
 
     # Get parameters for the Servo node
-    servo_params = (
-        ParameterBuilder("moveit_servo")
+    servo_params = {
+        "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/panda_simulated_config.yaml")
         .to_dict()
-    )
-    servo_params = {"moveit_servo": servo_params}
+    }
+
     # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
     low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
 

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
   executor.add_node(node);
   std::thread executor_thread([&executor]() { executor.spin(); });
 
-  auto servo_param_listener = std::make_unique<const servo::ParamListener>(node);
+  auto servo_param_listener = std::make_unique<const servo::ParamListener>(node, "moveit_servo");
   auto servo_parameters = servo_param_listener->get_params();
 
   // Load the planning scene monitor

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -68,7 +68,7 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
   node_->get_parameter_or("robot_description_name", robot_description_name, robot_description_name);
 
   // Get the servo parameters
-  auto param_listener = std::make_unique<const servo::ParamListener>(node_);
+  auto param_listener = std::make_unique<const servo::ParamListener>(node_, "moveit_servo");
   auto servo_parameters = param_listener->get_params();
   // Validate the parameters first.
   validateParams(servo_parameters);

--- a/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
+++ b/moveit_ros/moveit_servo/test/launch/servo_launch_test_common.py
@@ -13,11 +13,11 @@ def generate_servo_test_description(
     start_position_path: launch.some_substitutions_type.SomeSubstitutionsType = ""
 ):
     # Get parameters using the demo config file
-    servo_params = (
-        ParameterBuilder("moveit_servo")
+    servo_params = {
+        "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/panda_simulated_config.yaml")
         .to_dict()
-    )
+    }
 
     # Get URDF and SRDF
     if start_position_path:

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -19,12 +19,12 @@ def generate_servo_test_description(
     )
 
     # Get parameters for the Pose Tracking and Servo nodes
-    servo_params = (
-        ParameterBuilder("moveit_servo")
+    servo_params = {
+        "moveit_servo": ParameterBuilder("moveit_servo")
         .yaml("config/pose_tracking_settings.yaml")
         .yaml("config/panda_simulated_config_pose_tracking.yaml")
         .to_dict()
-    )
+    }
 
     # ros2_control using FakeSystem as hardware
     ros2_controllers_path = os.path.join(

--- a/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
+++ b/moveit_ros/moveit_servo/test/pose_tracking_test.cpp
@@ -65,7 +65,7 @@ public:
     executor_->add_node(node_);
     executor_thread_ = std::thread([this]() { this->executor_->spin(); });
 
-    auto servo_param_listener = std::make_unique<const servo::ParamListener>(node_);
+    auto servo_param_listener = std::make_unique<const servo::ParamListener>(node_, "moveit_servo");
     servo_parameters_ = servo_param_listener->get_params();
 
     // store test constants as shared pointer to constant struct

--- a/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
+++ b/moveit_ros/moveit_servo/test/servo_launch_test_common.hpp
@@ -81,7 +81,7 @@ public:
     : node_(std::make_shared<rclcpp::Node>("servo_testing"))
     , executor_(std::make_shared<rclcpp::executors::SingleThreadedExecutor>())
   {
-    auto servo_param_listener = std::make_unique<const servo::ParamListener>(node_);
+    auto servo_param_listener = std::make_unique<const servo::ParamListener>(node_, "moveit_servo");
     servo_parameters_ = servo_param_listener->get_params();
     // store test constants as shared pointer to constant struct
     {

--- a/moveit_ros/moveit_servo/test/test_servo_interface.cpp
+++ b/moveit_ros/moveit_servo/test/test_servo_interface.cpp
@@ -169,7 +169,8 @@ TEST_F(ServoFixture, DynamicParameterTest)
   auto request = std::make_shared<rcl_interfaces::srv::SetParameters::Request>();
 
   // This is a dynamic parameter
-  request->parameters.push_back(rclcpp::Parameter("robot_link_command_frame", "panda_link4").to_parameter_msg());
+  request->parameters.push_back(
+      rclcpp::Parameter("moveit_servo.robot_link_command_frame", "panda_link4").to_parameter_msg());
 
   // This is not even a parameter that is declared (it should fail)
   request->parameters.push_back(rclcpp::Parameter("moveit_servo.not_set_parameter", 1.0).to_parameter_msg());


### PR DESCRIPTION
### Description

Fixes #2162 
This PR adds the `moveit_servo` namespace to MoveIt Servo parameters.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

