### PR TITLE
Parse xacro args from .setup_assistant config in MoveIt Configs Builder

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -162,6 +162,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
 
         self.__urdf_package = None
         self.__urdf_file_path = None
+        self.__urdf_xacro_args = None
         self.__srdf_file_path = None
 
         modified_urdf_path = Path("config") / (self.__robot_name + ".urdf.xacro")
@@ -178,6 +179,9 @@ class MoveItConfigsBuilder(ParameterBuilder):
                     get_package_share_directory(urdf_config["package"])
                 )
                 self.__urdf_file_path = Path(urdf_config["relative_path"])
+                
+                if "xacro_args" in urdf_config:
+                    self.__urdf_xacro_args = dict(arg.split(":=") for arg in urdf_config["xacro_args"].split(' '))
 
             srdf_config = config.get("srdf", config.get("SRDF"))
             if srdf_config:
@@ -217,6 +221,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
             robot_description_file_path = self.__urdf_package / self.__urdf_file_path
         else:
             robot_description_file_path = self._package_path / file_path
+        mappings = self.__urdf_xacro_args
         if (mappings is None) or all(
             (isinstance(key, str) and isinstance(value, str))
             for key, value in mappings.items()
@@ -253,7 +258,6 @@ class MoveItConfigsBuilder(ParameterBuilder):
         :param mappings: mappings to be passed when loading the xacro file.
         :return: Instance of MoveItConfigsBuilder with robot_description_semantic loaded.
         """
-
         if (mappings is None) or all(
             (isinstance(key, str) and isinstance(value, str))
             for key, value in mappings.items()

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -179,9 +179,11 @@ class MoveItConfigsBuilder(ParameterBuilder):
                     get_package_share_directory(urdf_config["package"])
                 )
                 self.__urdf_file_path = Path(urdf_config["relative_path"])
-                
+
                 if "xacro_args" in urdf_config:
-                    self.__urdf_xacro_args = dict(arg.split(":=") for arg in urdf_config["xacro_args"].split(' '))
+                    self.__urdf_xacro_args = dict(
+                        arg.split(":=") for arg in urdf_config["xacro_args"].split(" ")
+                    )
 
             srdf_config = config.get("srdf", config.get("SRDF"))
             if srdf_config:

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -223,7 +223,6 @@ class MoveItConfigsBuilder(ParameterBuilder):
             robot_description_file_path = self.__urdf_package / self.__urdf_file_path
         else:
             robot_description_file_path = self._package_path / file_path
-        mappings = self.__urdf_xacro_args
         if (mappings is None) or all(
             (isinstance(key, str) and isinstance(value, str))
             for key, value in mappings.items()

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -231,7 +231,8 @@ class MoveItConfigsBuilder(ParameterBuilder):
             try:
                 self.__moveit_configs.robot_description = {
                     self.__robot_description: load_xacro(
-                        robot_description_file_path, mappings=mappings
+                        robot_description_file_path,
+                        mappings=mappings or self.__urdf_xacro_args,
                     )
                 }
             except ParameterBuilderFileNotFoundError as e:

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -180,9 +180,9 @@ class MoveItConfigsBuilder(ParameterBuilder):
                 )
                 self.__urdf_file_path = Path(urdf_config["relative_path"])
 
-                if "xacro_args" in urdf_config:
+                if (xacro_args := urdf_config.get("xacro_args")) is not None:
                     self.__urdf_xacro_args = dict(
-                        arg.split(":=") for arg in urdf_config["xacro_args"].split(" ")
+                        arg.split(":=") for arg in xacro_args.split(" ") if arg
                     )
 
             srdf_config = config.get("srdf", config.get("SRDF"))
@@ -260,6 +260,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
         :param mappings: mappings to be passed when loading the xacro file.
         :return: Instance of MoveItConfigsBuilder with robot_description_semantic loaded.
         """
+
         if (mappings is None) or all(
             (isinstance(key, str) and isinstance(value, str))
             for key, value in mappings.items()


### PR DESCRIPTION
### Description

Update MoveIt Config Builder to parse xacro_args parameter from MSA generated MoveIt 2 configs that use xacro generated robot descriptions.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
