### PR TITLE
Use gcov instead of lcov for sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=moveit
 
 sonar.python.version=3
 sonar.sources=.work/target_ws/src
-sonar.cfamily.llvm-cov.reportPath=.work/target_ws/coverage.info
+sonar.cfamily.gcov.reportPath=.work/target_ws/coverage.info
 sonar.scm.exclusions.disabled=true
 sonar.exclusions=.work/target_ws/src/moveit2/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_solver.cpp
 sonar.cfamily.compile-commands=.work/target_ws/build/compile_commands.json


### PR DESCRIPTION
### Description

Use gcov config type for the code coverage file.