### PR TITLE
Ignore more common tooling-generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *~
 ~$
 .swp$
+
+# colcon
 build/
+install/
+log/
+
 bin/
 lib/
 msg_gen/
@@ -64,3 +69,10 @@ _autosummary
 
 # VSCode Devcontainer
 .devcontainer
+
+# clangd
+.cache
+
+# source dependencies (see moveit2.repos)
+moveit_msgs
+moveit_resources


### PR DESCRIPTION
### Description

Ignore colcon `install/` and `log/` and clangd `.cache`.
- it's pretty reasonable to use the `moveit2` repo root as your workspace root for `colcon` if you're making quick changes.
  - accordingly, also ignore the two folders that would be generated from a vcs import.
- Myself and many others use the `clangd` tooling in VS Code or other IDEs