### PR TITLE
Ensure that planner id is set

### DIFF
--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -424,8 +424,13 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     }
   }
 
-  // Set planning pipeline to inactive
+  // Make sure that planner id is set
+  if (res.planner_id.empty())
+  {
+    res.planner_id = req.planner_id;
+  }
 
+  // Set planning pipeline to inactive
   active_ = false;
   return solved && valid;
 }


### PR DESCRIPTION
### Description

The planner id in the motion plan response does not seem to be set by our planner plugins (I tested stomp and OMPL). This fixes it plugin agnostic without overwriting whatever the plugin sets.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
