### PR TITLE
Revert central differencing calculation in servo

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -216,9 +216,9 @@ protected:
   moveit::core::RobotStatePtr current_state_;
 
   // These variables are mutex protected
-  // previous_joint_state holds the state q(t - dt)
-  // current_joint_state holds the state q(t) as retrieved from the planning scene monitor.
-  sensor_msgs::msg::JointState previous_joint_state_, current_joint_state_;
+  // previous_joint_state_ holds the state q(t - dt)
+  // internal_joint_state_ holds the state q(t) as retrieved from the planning scene monitor.
+  sensor_msgs::msg::JointState previous_joint_state_, internal_joint_state_;
   std::map<std::string, std::size_t> joint_state_name_map_;
 
   // Smoothing algorithm (loads a plugin)

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -217,10 +217,8 @@ protected:
 
   // These variables are mutex protected
   // previous_joint_state holds the state q(t - dt)
-  // current_joint_state holds the  state q(t) as retrieved from the planning scene monitor.
-  // next_joint_state holds the computed state q(t + dt)
-
-  sensor_msgs::msg::JointState previous_joint_state_, current_joint_state_, next_joint_state_;
+  // current_joint_state holds the state q(t) as retrieved from the planning scene monitor.
+  sensor_msgs::msg::JointState previous_joint_state_, current_joint_state_;
   std::map<std::string, std::size_t> joint_state_name_map_;
 
   // Smoothing algorithm (loads a plugin)

--- a/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utilities.h
@@ -73,14 +73,14 @@ double velocityScalingFactorForSingularity(const moveit::core::JointModelGroup* 
                                            const double leaving_singularity_threshold_multiplier,
                                            const moveit::core::RobotStatePtr& current_state, StatusCode& status);
 
-/** \brief Joint-wise update of a sensor_msgs::msg::JointState with given delta's
+/** \brief Joint-wise update of a sensor_msgs::msg::JointState with given delta values.
  * Also filters and calculates the previous velocity
- * @param publish_period The publishing rate for servo command
- * @param delta_theta Eigen vector of joint delta's
- * @param previous_joint_state The previous joint state
- * @param next_joint_state The joint state object which will hold the next joint state.
+ * @param publish_period The publishing rate for servo command, in seconds.
+ * @param delta_theta Eigen vector of joint delta values.
+ * @param previous_joint_state The previous joint state.
+ * @param current_joint_state The joint state object which will hold the current joint state to send as a command.
  * @param smoother The trajectory smoother to be used.
- * @return Returns false if there is a problem, true otherwise
+ * @return Returns true if successful and false otherwise.
  */
 bool applyJointUpdate(const double publish_period, const Eigen::ArrayXd& delta_theta,
                       const sensor_msgs::msg::JointState& previous_joint_state,

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -120,16 +120,16 @@ ServoCalcs::ServoCalcs(const rclcpp::Node::SharedPtr& node,
   // Publish status
   status_pub_ = node_->create_publisher<std_msgs::msg::Int8>(servo_params_.status_topic, rclcpp::SystemDefaultsQoS());
 
-  current_joint_state_.name = joint_model_group_->getActiveJointModelNames();
-  num_joints_ = current_joint_state_.name.size();
-  current_joint_state_.position.resize(num_joints_);
-  current_joint_state_.velocity.resize(num_joints_);
+  internal_joint_state_.name = joint_model_group_->getActiveJointModelNames();
+  num_joints_ = internal_joint_state_.name.size();
+  internal_joint_state_.position.resize(num_joints_);
+  internal_joint_state_.velocity.resize(num_joints_);
   delta_theta_.setZero(num_joints_);
 
   for (std::size_t i = 0; i < num_joints_; ++i)
   {
     // A map for the indices of incoming joint commands
-    joint_state_name_map_[current_joint_state_.name[i]] = i;
+    joint_state_name_map_[internal_joint_state_.name[i]] = i;
   }
 
   // Load the smoothing plugin
@@ -190,7 +190,7 @@ void ServoCalcs::start()
   auto initial_joint_trajectory = std::make_unique<trajectory_msgs::msg::JointTrajectory>();
   initial_joint_trajectory->header.stamp = node_->now();
   initial_joint_trajectory->header.frame_id = servo_params_.planning_frame;
-  initial_joint_trajectory->joint_names = current_joint_state_.name;
+  initial_joint_trajectory->joint_names = internal_joint_state_.name;
   trajectory_msgs::msg::JointTrajectoryPoint point;
   point.time_from_start = rclcpp::Duration::from_seconds(servo_params_.publish_period);
   if (servo_params_.publish_joint_positions)
@@ -214,10 +214,10 @@ void ServoCalcs::start()
   last_sent_command_ = std::move(initial_joint_trajectory);
 
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
-  current_state_->copyJointGroupPositions(joint_model_group_, current_joint_state_.position);
-  current_state_->copyJointGroupVelocities(joint_model_group_, current_joint_state_.velocity);
-  // set previous state to same as current state for t = 0
-  previous_joint_state_ = current_joint_state_;
+  current_state_->copyJointGroupPositions(joint_model_group_, internal_joint_state_.position);
+  current_state_->copyJointGroupVelocities(joint_model_group_, internal_joint_state_.velocity);
+  // set previous state to same as internal state for t = 0
+  previous_joint_state_ = internal_joint_state_;
 
   // Check that all links are known to the robot
   auto check_link_is_known = [this](const std::string& frame_name) {
@@ -236,7 +236,7 @@ void ServoCalcs::start()
                                   current_state_->getGlobalLinkTransform(servo_params_.robot_link_command_frame);
 
   // Always reset the low-pass filters when first starting servo
-  resetLowPassFilters(current_joint_state_);
+  resetLowPassFilters(internal_joint_state_);
 
   stop_requested_ = false;
   thread_ = std::thread([this] {
@@ -371,8 +371,8 @@ void ServoCalcs::calculateSingleIteration()
   // 2) so the low-pass filters are up to date and don't cause a jump
   // Get the latest joint group positions
   current_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
-  current_state_->copyJointGroupPositions(joint_model_group_, current_joint_state_.position);
-  current_state_->copyJointGroupVelocities(joint_model_group_, current_joint_state_.velocity);
+  current_state_->copyJointGroupPositions(joint_model_group_, internal_joint_state_.position);
+  current_state_->copyJointGroupVelocities(joint_model_group_, internal_joint_state_.velocity);
 
   if (latest_twist_stamped_)
     twist_stamped_cmd_ = *latest_twist_stamped_;
@@ -404,7 +404,7 @@ void ServoCalcs::calculateSingleIteration()
   // joints so a jump doesn't occur when restarting
   if (wait_for_servo_commands_)
   {
-    resetLowPassFilters(current_joint_state_);
+    resetLowPassFilters(internal_joint_state_);
 
     // Check if there are any new commands with valid timestamp
     wait_for_servo_commands_ =
@@ -425,7 +425,7 @@ void ServoCalcs::calculateSingleIteration()
   {
     if (!cartesianServoCalcs(twist_stamped_cmd_, *joint_trajectory))
     {
-      resetLowPassFilters(current_joint_state_);
+      resetLowPassFilters(internal_joint_state_);
       return;
     }
   }
@@ -433,7 +433,7 @@ void ServoCalcs::calculateSingleIteration()
   {
     if (!jointServoCalcs(joint_servo_cmd_, *joint_trajectory))
     {
-      resetLowPassFilters(current_joint_state_);
+      resetLowPassFilters(internal_joint_state_);
       return;
     }
   }
@@ -489,7 +489,7 @@ void ServoCalcs::calculateSingleIteration()
 
   // Update the filters if we haven't yet
   if (!updated_filters_)
-    resetLowPassFilters(current_joint_state_);
+    resetLowPassFilters(internal_joint_state_);
 }
 
 // Perform the servoing calculations
@@ -537,13 +537,13 @@ bool ServoCalcs::cartesianServoCalcs(geometry_msgs::msg::TwistStamped& cmd,
     moveit_msgs::msg::MoveItErrorCodes err;
     kinematics::KinematicsQueryOptions opts;
     opts.return_approximate_solution = true;
-    if (ik_solver_->searchPositionIK(next_pose, current_joint_state_.position, servo_params_.publish_period / 2.0,
+    if (ik_solver_->searchPositionIK(next_pose, internal_joint_state_.position, servo_params_.publish_period / 2.0,
                                      solution, err, opts))
     {
       // find the difference in joint positions that will get us to the desired pose
       for (size_t i = 0; i < num_joints_; ++i)
       {
-        delta_theta_.coeffRef(i) = solution.at(i) - current_joint_state_.position.at(i);
+        delta_theta_.coeffRef(i) = solution.at(i) - internal_joint_state_.position.at(i);
       }
     }
     else
@@ -615,7 +615,7 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   delta_theta *= collision_scale;
 
   // Loop through joints and update them, calculate velocities, and filter
-  if (!applyJointUpdate(servo_params_.publish_period, delta_theta, previous_joint_state_, current_joint_state_,
+  if (!applyJointUpdate(servo_params_.publish_period, delta_theta, previous_joint_state_, internal_joint_state_,
                         smoother_))
   {
     RCLCPP_ERROR_STREAM_THROTTLE(LOGGER, *node_->get_clock(), ROS_LOG_THROTTLE_PERIOD,
@@ -627,12 +627,12 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
   updated_filters_ = true;
 
   // Enforce SRDF velocity limits
-  enforceVelocityLimits(joint_model_group_, servo_params_.publish_period, current_joint_state_,
+  enforceVelocityLimits(joint_model_group_, servo_params_.publish_period, internal_joint_state_,
                         servo_params_.override_velocity_scaling_factor);
 
   // Enforce SRDF position limits, might halt if needed, set prev_vel to 0
   const auto joints_to_halt =
-      enforcePositionLimits(current_joint_state_, servo_params_.joint_limit_margin, joint_model_group_);
+      enforcePositionLimits(internal_joint_state_, servo_params_.joint_limit_margin, joint_model_group_);
 
   if (!joints_to_halt.empty())
   {
@@ -647,18 +647,18 @@ bool ServoCalcs::internalServoUpdate(Eigen::ArrayXd& delta_theta,
     if ((servo_type == ServoType::JOINT_SPACE && !servo_params_.halt_all_joints_in_joint_mode) ||
         (servo_type == ServoType::CARTESIAN_SPACE && !servo_params_.halt_all_joints_in_cartesian_mode))
     {
-      suddenHalt(current_joint_state_, joints_to_halt);
+      suddenHalt(internal_joint_state_, joints_to_halt);
     }
     else
     {
-      suddenHalt(current_joint_state_, joint_model_group_->getActiveJointModels());
+      suddenHalt(internal_joint_state_, joint_model_group_->getActiveJointModels());
     }
   }
 
   // compose outgoing message
-  composeJointTrajMessage(current_joint_state_, joint_trajectory);
+  composeJointTrajMessage(internal_joint_state_, joint_trajectory);
 
-  previous_joint_state_ = current_joint_state_;
+  previous_joint_state_ = internal_joint_state_;
   return true;
 }
 
@@ -702,12 +702,12 @@ void ServoCalcs::filteredHalt(trajectory_msgs::msg::JointTrajectory& joint_traje
   joint_trajectory.joint_names = joint_model_group_->getActiveJointModelNames();
 
   // Deceleration algorithm:
-  // Set positions to current_joint_state_
+  // Set positions to internal_joint_state_
   // Filter
   // Calculate velocities
   // Check if velocities are close to zero. Round to zero, if so.
-  assert(current_joint_state_.position.size() >= num_joints_);
-  joint_trajectory.points[0].positions = current_joint_state_.position;
+  assert(internal_joint_state_.position.size() >= num_joints_);
+  joint_trajectory.points[0].positions = internal_joint_state_.position;
   smoother_->doSmoothing(joint_trajectory.points[0].positions);
   bool done_stopping = true;
   if (servo_params_.publish_joint_velocities)
@@ -716,7 +716,7 @@ void ServoCalcs::filteredHalt(trajectory_msgs::msg::JointTrajectory& joint_traje
     for (std::size_t i = 0; i < num_joints_; ++i)
     {
       joint_trajectory.points[0].velocities.at(i) =
-          (joint_trajectory.points[0].positions.at(i) - current_joint_state_.position.at(i)) /
+          (joint_trajectory.points[0].positions.at(i) - internal_joint_state_.position.at(i)) /
           servo_params_.publish_period;
       // If velocity is very close to zero, round to zero
       if (joint_trajectory.points[0].velocities.at(i) > STOPPED_VELOCITY_EPS)
@@ -737,7 +737,7 @@ void ServoCalcs::filteredHalt(trajectory_msgs::msg::JointTrajectory& joint_traje
     for (std::size_t i = 0; i < num_joints_; ++i)
     {
       joint_trajectory.points[0].accelerations.at(i) =
-          (joint_trajectory.points[0].velocities.at(i) - current_joint_state_.velocity.at(i)) /
+          (joint_trajectory.points[0].velocities.at(i) - internal_joint_state_.velocity.at(i)) /
           servo_params_.publish_period;
     }
   }
@@ -755,7 +755,7 @@ void ServoCalcs::suddenHalt(sensor_msgs::msg::JointState& joint_state,
     if (joint_it != joint_state.name.cend())
     {
       const auto joint_index = std::distance(joint_state.name.cbegin(), joint_it);
-      joint_state.position.at(joint_index) = current_joint_state_.position.at(joint_index);
+      joint_state.position.at(joint_index) = internal_joint_state_.position.at(joint_index);
       joint_state.velocity.at(joint_index) = 0.0;
     }
   }


### PR DESCRIPTION
This is effectively a revert of https://github.com/ros-planning/moveit2/pull/2080, just that flat out reverting the commit had a lot of merge conflicts due to newer PRs that landed.

We found this was affecting us in MoveIt Studio in that the velocity scaling was not kicking in correctly. For example, going from `override_velocity_scaling_factor` value of `0.1` to `1.0` did not actually increase the target velocity 10x; it was being damped out by the central difference.

After a bunch of debugging and thinking, I've convinced myself that central differencing is not what we need here -- it's useful for state estimation, but not when we're trying to calculate a command given a known current state and a desired next state. We know exactly what our target velocity should be.

To test:
* Start some kind of Servo node with the ability to command a robot
* Try change speed scaling: `ros2 param set /servo_node moveit_servo.override_velocity_scale_factor 0.1`
* Check that the velocity actually scales linearly when not scaled down by other factors (collision, singularity, etc.)
* Compare w/ `main`