### PR TITLE
Export moveit_py_utils' cmake target(s)

### DIFF
--- a/moveit_py/CMakeLists.txt
+++ b/moveit_py/CMakeLists.txt
@@ -90,4 +90,6 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
+ament_export_targets(moveit_py_utilsTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(moveit_ros_planning_interface)
 ament_package()

--- a/moveit_py/src/moveit/moveit_py_utils/CMakeLists.txt
+++ b/moveit_py/src/moveit/moveit_py_utils/CMakeLists.txt
@@ -1,14 +1,16 @@
 add_library(moveit_py_utils SHARED src/copy_ros_msg.cpp
                                    src/ros_msg_typecasters.cpp)
-target_include_directories(moveit_py_utils PUBLIC include)
-set_target_properties(moveit_py_utils PROPERTIES VERSION
-                                                 "${${PROJECT_NAME}_VERSION}")
+target_include_directories(moveit_py_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_py>
+)
+set_target_properties(moveit_py_utils PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_py_utils rclcpp moveit_msgs geometry_msgs
-                          pybind11)
+ament_target_dependencies(moveit_py_utils rclcpp moveit_msgs geometry_msgs pybind11)
 
 install(
   TARGETS moveit_py_utils
+  EXPORT moveit_py_utilsTargets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)


### PR DESCRIPTION
To use moveit_py_utils in downstream projects (e.g. MTC), its targets need to be exported.