### PR TITLE
Simplify controller manager namespacing

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -249,7 +249,8 @@ public:
    * \brief Configure interface with namespace
    * @param ns namespace of ros_control node (without /controller_manager/)
    */
-  Ros2ControlManager(const std::string& ns)
+  [[deprecated("Ros2ControlManager constructor with namespace is deprecated. Set namespace via the "
+               "ros_control_namespace parameter.")]] Ros2ControlManager(const std::string& ns)
     : ns_(ns), loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator")
   {
     RCLCPP_INFO_STREAM(LOGGER, "Started moveit_ros_control_interface::Ros2ControlManager for namespace " << ns_);
@@ -258,18 +259,12 @@ public:
   void initialize(const rclcpp::Node::SharedPtr& node) override
   {
     node_ = node;
-    if (!ns_.empty())
+    // Set the namespace from the ros_control_namespace parameter, or default to "/"
+    if (!node_->has_parameter("ros_control_namespace"))
     {
-      if (!node_->has_parameter("ros_control_namespace"))
-      {
-        ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
-      }
-      else
-      {
-        node_->get_parameter<std::string>("ros_control_namespace", ns_);
-      }
+      ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
     }
-    else if (node->has_parameter("ros_control_namespace"))
+    else
     {
       node_->get_parameter<std::string>("ros_control_namespace", ns_);
       RCLCPP_INFO_STREAM(LOGGER, "Namespace for controller manager was specified, namespace: " << ns_);


### PR DESCRIPTION
### Description
This PR attempts to simplify the logic with setting a namespace (stored in the `ns_` variable) for Ros2Control Manager.
My understanding of the original logic:
- `ns_` can be set via constructor, but its value is ignored and replaced by the parameter value.
- If that parameter doesn't exist, we default the parameter to "/" and also set `ns_` to match.
- In the case where `ns_` is not set via constructor, we try to get it from a parameter.
- If that parameter doesn't exist,  `ns_` remains an empty string.

It sounds like the desired behaviour would be to set `ns_` to the value of the `ros_control_namespace` parameter, if it exists, or otherwise default to "/", without considering the original value of `ns_`.

This PR also adds a deprecation notice to setting `ns_` via constructor, since this value is ignored anyway. I've deprecated it instead of removing it outright to be safe, but I'm not sure that this is used anywhere, given that this is used as a plugin and thus should be default constructed.