### PR TITLE
Warn if optimization objective does not match expected values

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -354,8 +354,15 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
       objective =
           std::make_shared<ompl::base::MaximizeMinClearanceObjective>(ompl_simple_setup_->getSpaceInformation());
     }
+    else if (optimizer.empty())
+    {
+      objective =
+          std::make_shared<ompl::base::PathLengthOptimizationObjective>(ompl_simple_setup_->getSpaceInformation());
+    }
     else
     {
+      RCLCPP_WARN(LOGGER, "Optimization objective %s is invalid, using PathLengthOptimizationObjective instead",
+                  optimizer.c_str());
       objective =
           std::make_shared<ompl::base::PathLengthOptimizationObjective>(ompl_simple_setup_->getSpaceInformation());
     }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -354,14 +354,9 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
       objective =
           std::make_shared<ompl::base::MaximizeMinClearanceObjective>(ompl_simple_setup_->getSpaceInformation());
     }
-    else if (optimizer.empty())
-    {
-      objective =
-          std::make_shared<ompl::base::PathLengthOptimizationObjective>(ompl_simple_setup_->getSpaceInformation());
-    }
     else
     {
-      RCLCPP_WARN(LOGGER, "Optimization objective %s is invalid, using PathLengthOptimizationObjective instead",
+      RCLCPP_WARN(LOGGER, "Optimization objective %s is invalid or not defined, using PathLengthOptimizationObjective instead",
                   optimizer.c_str());
       objective =
           std::make_shared<ompl::base::PathLengthOptimizationObjective>(ompl_simple_setup_->getSpaceInformation());

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -356,7 +356,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     }
     else
     {
-      RCLCPP_WARN(LOGGER, "Optimization objective %s is invalid or not defined, using PathLengthOptimizationObjective instead",
+      RCLCPP_WARN(LOGGER,
+                  "Optimization objective %s is invalid or not defined, using PathLengthOptimizationObjective instead",
                   optimizer.c_str());
       objective =
           std::make_shared<ompl::base::PathLengthOptimizationObjective>(ompl_simple_setup_->getSpaceInformation());


### PR DESCRIPTION
Currently, if you specify an optimization objective that does not match any of the expected values, the path length optimization objective will be used without warning the user. This can lead to unexpected behaviour if you have mistyped the optimization objective name. This PR adds a warning for this case.