### PR TITLE
Suppress redundant error message in CSM

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -344,9 +344,13 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState:
     current_state_time_ = joint_state->header.stamp;
     for (std::size_t i = 0; i < n; ++i)
     {
-      const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
-      if (!jm)
+      // Skip joints that don't belong to the RobotModel
+      if (!robot_model_->hasJointModel(joint_state->name[i]))
+      {
         continue;
+      }
+
+      const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
       // ignore fixed joints, multi-dof joints (they should not even be in the message)
       if (jm->getVariableCount() != 1)
         continue;


### PR DESCRIPTION
The CSM would spam the log if /joint_states messages includes unkonwn joints. RobotModel::hasJointModel() allows for verifying joint names in a safe way without the error message.