### PR TITLE
Cleanup move_group CMake

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -5,40 +5,37 @@ project(moveit_ros_move_group LANGUAGES CXX)
 find_package(moveit_common REQUIRED)
 moveit_package()
 
-find_package(ament_cmake REQUIRED)
-find_package(moveit_core REQUIRED)
-find_package(moveit_ros_planning REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-
 # Finds Boost Components
 include(ConfigExtras.cmake)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   ament_cmake
+  moveit_core
+  moveit_ros_occupancy_map_monitor
+  moveit_ros_planning
+  pluginlib
   rclcpp
   rclcpp_action
   std_srvs
   tf2
   tf2_geometry_msgs
   tf2_ros
-  moveit_core
-  moveit_ros_occupancy_map_monitor
-  moveit_ros_planning
-  pluginlib
 )
 
-include_directories(include)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
 
 add_library(moveit_move_group_capabilities_base SHARED
   src/move_group_context.cpp
   src/move_group_capability.cpp
 )
+target_include_directories(moveit_move_group_capabilities_base PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_ros_move_group>
+)
+set_target_properties(moveit_move_group_capabilities_base PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
+ament_target_dependencies(moveit_move_group_capabilities_base ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(moveit_move_group_default_capabilities SHARED
   src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -53,14 +50,13 @@ add_library(moveit_move_group_default_capabilities SHARED
   src/default_capabilities/state_validation_service_capability.cpp
   src/default_capabilities/tf_publisher_capability.cpp
 )
-
-set_target_properties(moveit_move_group_capabilities_base
-  PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
-
-set_target_properties(moveit_move_group_default_capabilities
-  PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
-
-ament_target_dependencies(moveit_move_group_capabilities_base ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_include_directories(moveit_move_group_default_capabilities PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/moveit_ros_move_group>
+)
+set_target_properties(moveit_move_group_default_capabilities PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
+ament_target_dependencies(moveit_move_group_default_capabilities ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_move_group_default_capabilities moveit_move_group_capabilities_base)
 
 add_executable(move_group src/move_group.cpp)
 target_include_directories(move_group PUBLIC include)
@@ -68,17 +64,16 @@ ament_target_dependencies(move_group  ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 target_link_libraries(move_group moveit_move_group_capabilities_base)
 
 add_executable(list_move_group_capabilities src/list_capabilities.cpp)
-ament_target_dependencies(list_move_group_capabilities  ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
-
-ament_target_dependencies(moveit_move_group_default_capabilities ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_link_libraries(moveit_move_group_default_capabilities moveit_move_group_capabilities_base)
+ament_target_dependencies(list_move_group_capabilities ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(list_move_group_capabilities moveit_move_group_capabilities_base)
 
 install(
   TARGETS
     move_group
     list_move_group_capabilities
   RUNTIME
-  DESTINATION lib/moveit_ros_move_group)
+  DESTINATION lib/moveit_ros_move_group
+)
 
 install(
   TARGETS
@@ -88,13 +83,12 @@ install(
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include/moveit_ros_move_group
 )
 
-install(DIRECTORY include/ DESTINATION include/moveit_ros_move_group)
-
-ament_export_targets(moveit_ros_move_groupTargets HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+install(
+  DIRECTORY include/
+  DESTINATION include/moveit_ros_move_group
+)
 
 install(
   PROGRAMS
@@ -104,14 +98,6 @@ install(
 )
 
 pluginlib_export_plugin_description_file(moveit_ros_move_group default_capabilities_plugin_description.xml)
-
-if(BUILD_TESTING)
-# TODO(henningkayser): enable rostests
-#  find_package(rostest REQUIRED) # rostest under development in ROS2 https://github.com/ros-planning/moveit2/issues/23
-  # this test is flaky
-  # add_rostest(test/test_cancel_before_plan_execution.test)
-  # add_rostest(test/test_check_state_validity_in_empty_scene.test)
-endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -124,6 +110,14 @@ if(BUILD_TESTING)
 
   # Run all lint tests in package.xml except those listed above
   ament_lint_auto_find_test_dependencies()
+
+# TODO(henningkayser): enable rostests
+#  find_package(rostest REQUIRED) # rostest under development in ROS2 https://github.com/ros-planning/moveit2/issues/23
+  # this test is flaky
+  # add_rostest(test/test_cancel_before_plan_execution.test)
+  # add_rostest(test/test_check_state_validity_in_empty_scene.test)
 endif()
 
+ament_export_targets(moveit_ros_move_groupTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -19,18 +19,18 @@
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>moveit_common</depend>
 
+  <depend>moveit_common</depend>
   <depend>moveit_core</depend>
-  <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_occupancy_map_monitor</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
+  <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend version_gte="1.11.2">pluginlib</depend>
-  <depend>std_srvs</depend>
 
   <exec_depend>moveit_kinematics</exec_depend>
 


### PR DESCRIPTION
- Alphabetic ordering of dependencies
- Using THIS_PACKAGE_INCLUDE_DEPENDS for find_package
- build and install interface target_include_directories
- consistent formatting in CMake
- commented out tests in if test block instead of separate one