### PR TITLE
Don't default to random algorithm if no plugin is defined

### DIFF
--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -198,7 +198,7 @@ void planning_pipeline::PlanningPipeline::configure()
   }
   else
   {
-    RCLCPP_INFO(LOGGER, "No planning request adapter names specified.");
+    RCLCPP_WARN(LOGGER, "No planning request adapter names specified.");
   }
   displayComputedMotionPlans(true);
   checkSolutionPaths(true);


### PR DESCRIPTION
### Description

Currently, if `planner_plugin_name_.empty()` & multiple planner plugin classes are defined, we default to the first one (In many cases that is CHOMP because the elements seem to be alphabetically ordered :shrug: ). This PR changes that to throw in case no planner plugin name is defined and multiple options are available because it is more useful to throw here rather than loading a random pipeline.

Also, I added throw statements at the end of the plugin lib exception catch blocks to propagate the exception upwards. Please correct me if that is not correct.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
