### PR TITLE
Fix Servo `suddenHalt()` to halt at original state, not commanded

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -755,7 +755,7 @@ void ServoCalcs::suddenHalt(sensor_msgs::msg::JointState& joint_state,
     if (joint_it != joint_state.name.cend())
     {
       const auto joint_index = std::distance(joint_state.name.cbegin(), joint_it);
-      joint_state.position.at(joint_index) = internal_joint_state_.position.at(joint_index);
+      joint_state.position.at(joint_index) = previous_joint_state_.position.at(joint_index);
       joint_state.velocity.at(joint_index) = 0.0;
     }
   }


### PR DESCRIPTION
Found this bug against MoveIt Studio, where hitting a joint limit would make the arm continue moving since we were grabbing `internal_joint_state_` and not `previous_joint_state_` for the `suddenHalt()` function.

Even the comment a few lines above says:

```
  // Set the position to the original position, and velocity to 0 for input joints
```