### PR TITLE
Test PlanningRequestAdapterChain call sequence

### DIFF
--- a/moveit_core/planning_request_adapter/CMakeLists.txt
+++ b/moveit_core/planning_request_adapter/CMakeLists.txt
@@ -18,3 +18,14 @@ target_link_libraries(moveit_planning_request_adapter
 )
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
+
+  ament_add_gmock(test_planning_request_adapter
+    test/test_planning_request_adapter.cpp
+   )
+   target_link_libraries(test_planning_request_adapter
+	   moveit_planning_request_adapter
+   )
+endif()

--- a/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp
+++ b/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp
@@ -1,0 +1,230 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <moveit/planning_request_adapter/planning_request_adapter.h>
+
+using namespace planning_request_adapter;
+using namespace planning_interface;
+
+// A simple callback function that is used for recording the call order of adapters and planner
+using RegisterNameCallbackFn = std::function<void(const std::string&)>;
+
+/*
+ * A PlanningContext mock that allows setting planning success and planner name, which is returned on solve()
+ * using the RegisterNameCallbackFn.
+ */
+class MockPlanningContext : public PlanningContext
+{
+public:
+  /** \brief Construct a planning context named \e name for the group \e group */
+  MockPlanningContext(const std::string& name, bool succeeds, RegisterNameCallbackFn callback_fn)
+    : PlanningContext(name, "group"), succeeds_(succeeds), callback_fn_(callback_fn)
+  {
+  }
+
+  /** \brief Set the planning scene for this context */
+  void setPlanningScene(const planning_scene::PlanningSceneConstPtr& planning_scene)
+  {
+    planning_scene_ = planning_scene;
+  }
+
+  /** \brief Set the planning request for this context */
+  void setMotionPlanRequest(const MotionPlanRequest& request)
+  {
+    request_ = request;
+  }
+
+  bool solve(MotionPlanResponse& res) override
+  {
+    res.error_code.val =
+        succeeds_ ? moveit_msgs::msg::MoveItErrorCodes::SUCCESS : moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+    callback_fn_(name_);
+    return true;
+  }
+
+  // Mocks
+  MOCK_METHOD(bool, solve, (MotionPlanDetailedResponse & res), (override));
+  MOCK_METHOD(bool, terminate, (), (override));
+  MOCK_METHOD(void, clear, (), (override));
+
+private:
+  const bool succeeds_;
+  RegisterNameCallbackFn callback_fn_;
+};
+
+/*
+ * A PlannerManager mock that produces MockPlanningContext instances with the provided name and success results.
+ * The success of the planner can be set using setSucceedsFlag(). The RegisterNameCallbackFn will be called with
+ * the specified planner name on every solve() attempt.
+ */
+class MockPlannerManager : public PlannerManager
+{
+public:
+  MockPlannerManager(const std::string& name, RegisterNameCallbackFn callback_fn)
+    : name_(name), callback_fn_(callback_fn)
+  {
+  }
+  MOCK_METHOD(bool, initialize,
+              (const moveit::core::RobotModelConstPtr& model, const rclcpp::Node::SharedPtr& node,
+               const std::string& parameter_namespace),
+              (override));
+  MOCK_METHOD(std::string, getDescription, (), (const, override));
+  MOCK_METHOD(void, getPlanningAlgorithms, (std::vector<std::string> & algs), (const, override));
+  MOCK_METHOD(void, setPlannerConfigurations, (const PlannerConfigurationMap& pcs), (override));
+
+  PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                        const MotionPlanRequest& req,
+                                        moveit_msgs::msg::MoveItErrorCodes& /* error_code */) const override
+  {
+    return getPlanningContext(planning_scene, req);
+  }
+
+  PlanningContextPtr getPlanningContext(const planning_scene::PlanningSceneConstPtr& /* planning_scene */,
+                                        const MotionPlanRequest& /* req */) const
+  {
+    return std::make_shared<MockPlanningContext>(name_, succeeds_, callback_fn_);
+  }
+
+  /// \brief Determine whether this plugin instance is able to represent this planning request
+  bool canServiceRequest(const MotionPlanRequest& /*req*/) const override
+  {
+    return true;
+  }
+
+  void terminate() const
+  {
+  }
+
+  void setSucceedsFlag(bool succeeds)
+  {
+    succeeds_ = succeeds;
+  }
+
+private:
+  const std::string name_;
+  bool succeeds_{ true };
+  RegisterNameCallbackFn callback_fn_;
+};
+
+/*
+ * A PlanningRequestAdapter mock that can be positioned before or after a planner using AdapterMode,
+ * that has a predefined result for the adaptAndPlan() function, and that offers a callback for returning
+ * the name when it is being called in the adapter chain.
+ */
+enum AdapterMode
+{
+  BEFORE_PLANNER,
+  AFTER_PLANNER
+};
+class MockAdapter : public PlanningRequestAdapter
+{
+public:
+  MockAdapter(const std::string& description, AdapterMode mode, bool succeeds, RegisterNameCallbackFn callback_fn)
+    : description_(description), mode_(mode), succeeds_(succeeds), callback_fn_(callback_fn)
+  {
+  }
+
+  void initialize(const rclcpp::Node::SharedPtr& /* node */, const std::string& /* parameter_namespace */) override
+  {
+  }
+
+  std::string getDescription() const override
+  {
+    return description_;
+  }
+
+  bool adaptAndPlan(const PlannerFn& planner, const planning_scene::PlanningSceneConstPtr& planning_scene,
+                    const MotionPlanRequest& req, MotionPlanResponse& res,
+                    std::vector<std::size_t>& /* added_path_index */) const override
+  {
+    if (mode_ == AdapterMode::BEFORE_PLANNER)
+    {
+      adapt(req, res);
+    }
+
+    planner(planning_scene, req, res);
+
+    if (mode_ == AdapterMode::AFTER_PLANNER)
+    {
+      adapt(req, res);
+    }
+
+    return true;
+  }
+
+  void adapt(const MotionPlanRequest& /* req */, MotionPlanResponse& res) const
+  {
+    res.error_code.val =
+        succeeds_ ? moveit_msgs::msg::MoveItErrorCodes::SUCCESS : moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+    callback_fn_(description_);
+  }
+
+private:
+  const std::string description_;
+  const AdapterMode mode_;
+  const bool succeeds_;
+  RegisterNameCallbackFn callback_fn_;
+};
+
+/**
+ * Tests the call sequence of planner and adapters configured in an AdapterChain in succeeding and failing scenarios
+ */
+TEST(TestPlanningRequestAdapterChain, SequenceOK)
+{
+  constexpr bool SUCCEEDS = true;
+  std::vector<std::string> called_adapters;
+  RegisterNameCallbackFn register_name_on_call = [&](const std::string& adapter) { called_adapters.push_back(adapter); };
+
+  // Simple adapter chain that should result in this pipeline sequence: {A, B, PLANNER, C, D}
+  PlanningRequestAdapterChain chain;
+  chain.addAdapter(std::make_shared<MockAdapter>("A", BEFORE_PLANNER, SUCCEEDS, register_name_on_call));
+  chain.addAdapter(std::make_shared<MockAdapter>("B", BEFORE_PLANNER, SUCCEEDS, register_name_on_call));
+  chain.addAdapter(std::make_shared<MockAdapter>("C", AFTER_PLANNER, SUCCEEDS, register_name_on_call));
+  chain.addAdapter(std::make_shared<MockAdapter>("D", AFTER_PLANNER, SUCCEEDS, register_name_on_call));
+
+  auto planner = std::make_shared<MockPlannerManager>("PLANNER", register_name_on_call);
+  planning_scene::PlanningSceneConstPtr scene = nullptr;
+  MotionPlanRequest req;
+  MotionPlanResponse res;
+
+  // CASE: Planning and adapters succeed
+  // EXPECTED: All elements should be called in the correct sequence - planning fails
+  planner->setSucceedsFlag(true);
+  EXPECT_TRUE(chain.adaptAndPlan(planner, scene, req, res));
+  EXPECT_TRUE(bool(res));
+  EXPECT_THAT(called_adapters, ::testing::ElementsAre("A", "B", "PLANNER", "C", "D"));
+
+  // CASE: Planner fails
+  // EXPECTED: No adapters should be called after a failing planner - planning fails
+  called_adapters.clear();
+  planner->setSucceedsFlag(false);
+  EXPECT_TRUE(chain.adaptAndPlan(planner, scene, req, res));
+  EXPECT_FALSE(bool(res));
+  EXPECT_THAT(called_adapters, ::testing::ElementsAre("A", "B", "PLANNER"));
+
+  // CASE: Failing adapter after a succeeding plan
+  // EXPECTED: No adapters should be called after a failing adapter (here "E") - planning fails
+  chain.addAdapter(std::make_shared<MockAdapter>("fails_after", AFTER_PLANNER, !SUCCEEDS, register_name_on_call));
+  chain.addAdapter(std::make_shared<MockAdapter>("E", AFTER_PLANNER, SUCCEEDS, register_name_on_call));
+
+  called_adapters.clear();
+  planner->setSucceedsFlag(true);
+  EXPECT_TRUE(chain.adaptAndPlan(planner, scene, req, res));
+  EXPECT_FALSE(bool(res));
+  EXPECT_THAT(called_adapters, ::testing::ElementsAre("A", "B", "PLANNER", "C", "D", "fails_after"));
+
+  // CASE: Failing adapter before the planner
+  // EXPECTED: No adapters or planner should be called after a failing adapter - planning fails
+  chain.addAdapter(std::make_shared<MockAdapter>("fails_before", BEFORE_PLANNER, !SUCCEEDS, register_name_on_call));
+
+  called_adapters.clear();
+  planner->setSucceedsFlag(true);
+  EXPECT_TRUE(chain.adaptAndPlan(planner, scene, req, res));
+  EXPECT_FALSE(bool(res));
+  EXPECT_THAT(called_adapters, ::testing::ElementsAre("A", "B", "fails_before"));
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
**Motivation**
I'm currently debugging a confusing issue where failing adapters are being called in the wrong sequence. In particular, it's the FixStartStateBounds adapter failing right AFTER TimeOptimalTrajectoryGeneration complains about path tolerance. Both failures/warnings have their own reason and need to be addressed in the setup, however the planning pipeline should never put FixStartStateBounds (which should be called before the planner) after TOTG (which should always be called after the planner).

With this test I wanted to figure out what's really going on in an AdapterChain, and was already surprised multiple times. The sequence of adapters is not respected correctly, and failing adapters or plans don't result in an aborted chain (why should we trigger a motion plan if there are already fixup adapters failing before it?). To me this seems pretty serious, already the happy path.

**Problem**
Let's build a chain with OMPL + STOMP + TOTG in that order, according to the happy path (as implemented in my test case) the AdapterChain already switches up STOMP and TOTG, producing {OMPL + TOTG + STOMP}? (I'll test that exact use case next)

Maybe I'm getting something really wrong here, but to me the implementation of the adapter chain and the adapters themselves just ask for a reimplementation, where:
* BEFORE and AFTER (PreAdapter, PostAdapter) are explicitly typed
* Failing adapters or planner will actually abort the chain

With the current implementation it's almost impossible to know what's going on.

**Test log from original commit**
```
build/moveit_core/test_results/moveit_core/test_planning_request_adapter.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
- moveit_core.TestPlanningRequestAdapterChain SequenceOK
  <<< failure message
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:194
    Value of: called_adapters
    Expected: has 5 elements where
    element #0 is equal to "A",
    element #1 is equal to "B",
    element #2 is equal to "PLANNER",
    element #3 is equal to "C",
    element #4 is equal to "D"
      Actual: { "A", "B", "PLANNER", "D", "C" }, whose element #3 doesn't match
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:201
    Value of: bool(res)
      Actual: true
    Expected: false
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:202
    Value of: called_adapters
    Expected: has 3 elements where
    element #0 is equal to "A",
    element #1 is equal to "B",
    element #2 is equal to "PLANNER"
      Actual: { "A", "B", "PLANNER", "D", "C" }, which has 5 elements
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:212
    Value of: bool(res)
      Actual: true
    Expected: false
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:213
    Value of: called_adapters
    Expected: has 6 elements where
    element #0 is equal to "A",
    element #1 is equal to "B",
    element #2 is equal to "PLANNER",
    element #3 is equal to "C",
    element #4 is equal to "D",
    element #5 is equal to "fails_after"
      Actual: { "A", "B", "PLANNER", "E", "fails_after", "D", "C" }, which has 7 elements
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:222
    Value of: bool(res)
      Actual: true
    Expected: false
    /home/ubuntu/ws_ros2/src/moveit2/moveit_core/planning_request_adapter/test/test_planning_request_adapter.cpp:223
    Value of: called_adapters
    Expected: has 3 elements where
    element #0 is equal to "A",
    element #1 is equal to "B",
    element #2 is equal to "fails_before"
      Actual: { "A", "B", "fails_before", "PLANNER", "E", "fails_after", "D", "C" }, which has 8 elements
  >>>
```