### PR TITLE
Set response planner id in planner plugins and warn if it is not set

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -53,6 +53,7 @@ bool ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
                          planning_interface::MotionPlanDetailedResponse& res) const
 {
   auto start_time = std::chrono::system_clock::now();
+  res.planner_id = std::string("chomp");
   if (!planning_scene)
   {
     RCLCPP_ERROR(LOGGER, "No planning scene initialized.");

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -307,6 +307,7 @@ bool TrajectoryGenerator::generate(const planning_scene::PlanningSceneConstPtr& 
   RCLCPP_INFO_STREAM(LOGGER, "Generating " << req.planner_id << " trajectory...");
   rclcpp::Time planning_begin = clock_->now();
 
+  res.planner_id = req.planner_id;
   try
   {
     validateRequest(req);

--- a/moveit_planners/stomp/src/stomp_moveit_planning_context.cpp
+++ b/moveit_planners/stomp/src/stomp_moveit_planning_context.cpp
@@ -209,6 +209,7 @@ bool StompPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   // Start time
   auto time_start = std::chrono::steady_clock::now();
 
+  res.planner_id = std::string("stomp");
   // Default to happy path
   res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -427,6 +427,9 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
   // Make sure that planner id is set
   if (res.planner_id.empty())
   {
+    RCLCPP_WARN(LOGGER, "The planner plugin did not fill out the 'planner_id' field of the MotionPlanResponse. Setting "
+                        "it to the planner ID name of the MotionPlanRequest assuming that the planner plugin does warn "
+                        "you if it does not use the requested planner.");
     res.planner_id = req.planner_id;
   }
 


### PR DESCRIPTION
### Description

Follow up to #2202: Explicitly set the `planner_id` in all the available planner plugins + warn if we're making assumptions about the ID because the planner plugin does not handle it correctly.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
