### PR TITLE
Prefer to use the active controller if multiple controllers apply

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -539,9 +539,9 @@ struct OrderPotentialControllerCombination
       return false;
 
     // and then to active ones
-    if (nractive[a] < nractive[b])
-      return true;
     if (nractive[a] > nractive[b])
+      return true;
+    if (nractive[a] < nractive[b])
       return false;
 
     return false;


### PR DESCRIPTION
### Description

Resolves #1631 

Currently, if controller `a` is active , `nractive[a]` will be `1`. If it is inactive, `nractive[a]` will be `0`. Assuming controller `a` is active (`nractive[a] = 1`) and controller `b` is inactive (`nractive[b] = 0`), we would follow the second condition (`nractive[a] > nractive[b]`)and return `false`. This means that preference is given to inactive controllers.

In practice, if two controllers A and B are able to control the same number of joints and only controller A is active, `TrajectoryExecutionManager` will select the inactive controller B first and activate it. For a subsequent move, we select the now-inactive controller A, and use that, switching between controller A and B for each move.

This change prioritizes the active controller first, such that if controller A is active, it will be used for all subsequent moves until it is deactivated. 