### PR TITLE
fix for kinematic constraints parsing

### DIFF
--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -557,7 +557,7 @@ static bool collectConstraints(const rclcpp::Node::SharedPtr& node, const std::v
     const auto constraint_param = "constraints." + constraint_id;
     if (!node->has_parameter(constraint_param + ".type"))
     {
-      RCLCPP_ERROR(LOGGER, "constraint parameter does not specify its type");
+      RCLCPP_ERROR(LOGGER, "constraint parameter \"%s\" does not specify its type", constraint_param.c_str());
       return false;
     }
     std::string constraint_type;
@@ -607,7 +607,7 @@ bool constructConstraints(const rclcpp::Node::SharedPtr& node, const std::string
     return false;
 
   for (auto& constraint_id : constraint_ids)
-    constraint_id.insert(0, constraints_param);
+    constraint_id.insert(0, constraints_param + std::string("."));
 
   return collectConstraints(node, constraint_ids, constraints);
 }


### PR DESCRIPTION
### Description

Minor change to properly parse the constraints parameter loaded from a yaml file.  As described in the `kinematic_constraints::constructConstraints` function the yaml file needs to have the following structure:
```
 name: constraint_name
 constraint_ids: [constraint_1, constraint_2]
 constraints:
   constraint_1:
     type: orientation
     frame_id: world
     link_name: tool0
     orientation: [0, 0, 0]  # [r, p, y]
     tolerances: [0.01, 0.01, 3.15]
     weight: 1.0
   constraint_2:
     type: position
     frame_id: base_link
     link_name: tool0
     target_offset: [0.1, 0.1, 0.1]  # [x, y, z]
     region:
       x: [0.1, 0.4]  # [min, max]
       y: [0.2, 0.3]
       z: [0.1, 0.6]
     weight: 1.0
```
Prior to this change this yaml structure fails to load.
### Checklist
- [ x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ N/A] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ N/A] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ N/A] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ N/A]  Include a screenshot if changing a GUI
- [ x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
