### PR TITLE
Fix comment formatting

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -255,7 +255,7 @@ public:
     return world_const_;
   }
 
-  // brief Get the representation of the world
+  /** \brief Get the representation of the world */
   const collision_detection::WorldPtr& getWorldNonConst()
   {
     // we always have a world representation


### PR DESCRIPTION
Small fix to comment formatting
We probably don't want the word "brief" showing up before the description like this...
![image](https://github.com/ros-planning/moveit2/assets/10466537/1450a9f9-e06d-48c1-9193-95fadb5cee8f)
