### PR TITLE
Humble: Use googletest 1.11.9000

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,9 @@ jobs:
             ROS_DISTRO: humble
             IKFAST_TEST: true
             CLANG_TIDY: pedantic
-            # Silent gmock/gtest warnings: https://github.com/ament/googletest/pull/21
+            # Silent gmock/gtest warnings by picking more recent googletest version
             AFTER_BUILD_UPSTREAM_WORKSPACE: |
-              git clone --quiet --branch clalancette/update-to-gtest-1.11 https://github.com/ament/googletest "${BASEDIR}/upstream_ws/src/googletest"
+              git clone --depth 1 --quiet --branch 1.11.9000 https://github.com/ament/googletest "${BASEDIR}/upstream_ws/src/googletest"
               builder_run_build "/opt/ros/${ROS_DISTRO}" "${BASEDIR}/upstream_ws" --packages-select gtest_vendor gmock_vendor
     env:
       CXXFLAGS: >-


### PR DESCRIPTION
Fixes #2280.
The installed PR branch has been removed by GitHub, so CI silently switched to the official ament/googletest release at version 1.10 producing compiler warnings. This fixes the version to a more recent one by installing a later release tag of the vendor package directly.