### PR TITLE
Fix linking error with cached_ik_kinematics_plugin

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -9,7 +9,6 @@ ament_target_dependencies(moveit_cached_ik_kinematics_base
   moveit_core
   moveit_msgs
 )
-target_link_libraries(moveit_cached_ik_kinematics_base moveit_cached_ik_kinematics_plugin)
 
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
@@ -19,6 +18,10 @@ generate_parameter_library(
   cached_ik_kinematics_parameters # cmake target name for the parameter library
   include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml # path to input yaml file
 )
+
+target_link_libraries(moveit_cached_ik_kinematics_base
+  cached_ik_kinematics_parameters
+  moveit_kdl_kinematics_plugin)
 
 add_library(moveit_cached_ik_kinematics_plugin SHARED src/cached_ik_kinematics_plugin.cpp)
 set_target_properties(moveit_cached_ik_kinematics_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
@@ -31,7 +34,8 @@ ament_target_dependencies(moveit_cached_ik_kinematics_plugin
 target_link_libraries(moveit_cached_ik_kinematics_plugin
     cached_ik_kinematics_parameters
     moveit_kdl_kinematics_plugin
-    moveit_srv_kinematics_plugin)
+    moveit_srv_kinematics_plugin
+    moveit_cached_ik_kinematics_base)
 if(trac_ik_kinematics_plugin_FOUND)
     target_link_libraries(moveit_cached_ik_kinematics_plugin ${trac_ik_kinematics_plugin_LIBRARIES})
     set_target_properties(moveit_cached_ik_kinematics_plugin PROPERTIES COMPILE_DEFINITIONS "CACHED_IK_KINEMATICS_TRAC_IK")

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(ur_kinematics QUIET)
 
 add_library(moveit_cached_ik_kinematics_base SHARED src/ik_cache.cpp)
 set_target_properties(moveit_cached_ik_kinematics_base PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cached_ik_kinematics_base
+ament_target_dependencies(moveit_cached_ik_kinematics_base PUBLIC
   rclcpp
   moveit_core
   moveit_msgs
@@ -19,19 +19,19 @@ generate_parameter_library(
   include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_parameters.yaml # path to input yaml file
 )
 
-target_link_libraries(moveit_cached_ik_kinematics_base
+target_link_libraries(moveit_cached_ik_kinematics_base PUBLIC
   cached_ik_kinematics_parameters
   moveit_kdl_kinematics_plugin)
 
 add_library(moveit_cached_ik_kinematics_plugin SHARED src/cached_ik_kinematics_plugin.cpp)
 set_target_properties(moveit_cached_ik_kinematics_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cached_ik_kinematics_plugin
+ament_target_dependencies(moveit_cached_ik_kinematics_plugin PUBLIC
   rclcpp
   moveit_core
   moveit_msgs
   rsl
 )
-target_link_libraries(moveit_cached_ik_kinematics_plugin
+target_link_libraries(moveit_cached_ik_kinematics_plugin PRIVATE
     cached_ik_kinematics_parameters
     moveit_kdl_kinematics_plugin
     moveit_srv_kinematics_plugin


### PR DESCRIPTION
### Description

This fixes a bug caused by #1677 which accidentally inverted the dependency between the plugin and the base library. This fixes it by making the plugin again depend on the base library, and adding missing dependencies to the base library.

I'm not sure why the base library is necessary. It seems like we could add `ik_cache.cpp` to the plugin library, but I fixed it this way because I would like to request this fix be backported to ROS Iron.

Steps to reproduce (sorry I didn't spend the time to make an MRE)

1. Launch a `moveit_ros_move_group move_group` node with parameters that includes

```yaml
robot_description_kinematics:
  some_group_name:
    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
```

2. Observe that it errors with:

```
symbol lookup error: /path/to/ws/install/moveit_kinematics/lib/libmoveit_cached_ik_kinematics_plugin.so: undefined symbol: _ZN27cached_ik_kinematics_plugin7IKCacheC1Ev
```



### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
