### PR TITLE
Remove boost from motion_planning_rviz_plugin

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -32,7 +32,6 @@ add_library(moveit_motion_planning_rviz_plugin_core SHARED ${SOURCE_FILES} ${HEA
 set_target_properties(moveit_motion_planning_rviz_plugin_core PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_motion_planning_rviz_plugin_core moveit_rviz_plugin_render_tools moveit_planning_scene_rviz_plugin)
 ament_target_dependencies(moveit_motion_planning_rviz_plugin_core
-  Boost
   moveit_ros_robot_interaction
   moveit_ros_planning_interface
   moveit_ros_warehouse
@@ -40,7 +39,6 @@ ament_target_dependencies(moveit_motion_planning_rviz_plugin_core
   rviz_ogre_vendor
   Qt5
   pluginlib
-  rviz_ogre_vendor
 )
 target_include_directories(moveit_motion_planning_rviz_plugin_core PRIVATE "${OGRE_PREFIX_DIR}/include")
 
@@ -48,7 +46,6 @@ add_library(moveit_motion_planning_rviz_plugin SHARED src/plugin_init.cpp)
 set_target_properties(moveit_motion_planning_rviz_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_motion_planning_rviz_plugin moveit_motion_planning_rviz_plugin_core)
 ament_target_dependencies(moveit_motion_planning_rviz_plugin
-  Boost
   moveit_ros_robot_interaction
   moveit_ros_warehouse
   pluginlib

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -428,7 +428,7 @@ void MotionPlanningDisplay::changedMetricsTextHeight()
 void MotionPlanningDisplay::displayTable(const std::map<std::string, double>& values, const Ogre::ColourValue& color,
                                          const Ogre::Vector3& pos, const Ogre::Quaternion& orient)
 {
-  if (values.size() == 0)
+  if (values.empty())
   {
     text_to_display_->setVisible(false);
     return;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -428,7 +428,8 @@ void MotionPlanningDisplay::changedMetricsTextHeight()
 void MotionPlanningDisplay::displayTable(const std::map<std::string, double>& values, const Ogre::ColourValue& color,
                                          const Ogre::Vector3& pos, const Ogre::Quaternion& orient)
 {
-  if (values.size() == 0) {
+  if (values.size() == 0)
+  {
     text_to_display_->setVisible(false);
     return;
   }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -65,10 +65,6 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/trajectory_processing/trajectory_tools.h>
 
-#include <boost/format.hpp>
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/trim.hpp>
-
 #include <QShortcut>
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
@@ -432,16 +428,18 @@ void MotionPlanningDisplay::changedMetricsTextHeight()
 void MotionPlanningDisplay::displayTable(const std::map<std::string, double>& values, const Ogre::ColourValue& color,
                                          const Ogre::Vector3& pos, const Ogre::Quaternion& orient)
 {
-  // the line we want to render
-  std::stringstream ss;
-  for (const std::pair<const std::string, double>& value : values)
-    ss << boost::format("%-10s %-4.2f") % value.first % value.second << '\n';
-
-  if (ss.str().empty())
-  {
+  if (values.size() == 0) {
     text_to_display_->setVisible(false);
     return;
   }
+
+  // the line we want to render
+  std::stringstream ss;
+  ss.setf(std::ios_base::fixed);
+  ss.precision(2);
+
+  for (const auto& [label, value] : values)
+    ss << label << ':' << value << '\n';
 
   text_to_display_->setCaption(ss.str());
   text_to_display_->setColor(color);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_scenes.cpp
@@ -53,8 +53,6 @@
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
-#include <boost/math/constants/constants.hpp>
-
 #include <memory>
 
 namespace moveit_rviz_plugin


### PR DESCRIPTION
### Description

`rviz_rendering::MovableText` can only display non-mono font family currently, it is pointless to format the values with width (and the length of some label is greater than 10).
```
ss << boost::format("%-10s %-4.2f") % value.first % value.second << '\n';
```
so we can remove `boost` from dependencies.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
