### PR TITLE
Refactor cartesian interpolator into free function

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -225,26 +225,6 @@ public:
       const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn(),
       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
-  /** \brief Tests joint space jumps of a trajectory.
-
-     If \e jump_threshold_factor is non-zero, we test for relative jumps.
-     If \e revolute_jump_threshold  or \e prismatic_jump_threshold are non-zero, we test for absolute jumps.
-     Both tests can be combined. If all params are zero, jump detection is disabled.
-     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
-     computed. If any individual joint-space motion delta is larger then this average distance by a factor of
-     \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
-     before the jump.
-
-     @param group The joint model group of the robot state.
-     @param traj The trajectory that should be tested.
-     @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
-     @return The fraction of the trajectory that passed.
-
-     TODO: move to more appropriate location
-  */
-  static Percentage checkJointSpaceJump(const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
-                                        const JumpThreshold& jump_threshold);
-
   /** \brief Tests for relative joint space jumps of the trajectory \e traj.
 
      First, the average distance between adjacent trajectory points is computed. If two adjacent trajectory points
@@ -280,5 +260,23 @@ public:
                                                 double revolute_jump_threshold, double prismatic_jump_threshold);
 };
 
+  /** \brief Tests joint space jumps of a trajectory.
+
+     If \e jump_threshold_factor is non-zero, we test for relative jumps.
+     If \e revolute_jump_threshold  or \e prismatic_jump_threshold are non-zero, we test for absolute jumps.
+     Both tests can be combined. If all params are zero, jump detection is disabled.
+     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
+     computed. If any individual joint-space motion delta is larger then this average distance by a factor of
+     \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
+     before the jump.
+
+     @param group The joint model group of the robot state.
+     @param traj The trajectory that should be tested.
+     @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
+     @return The fraction of the trajectory that passed.
+
+  */
+static Percentage checkJointSpaceJump(const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+                                      const JumpThreshold& jump_threshold);
 }  // end of namespace core
 }  // end of namespace moveit


### PR DESCRIPTION
### Description

Refactored existing implementation of Cartesian Interpolator as a free function. After not any answer back in the pr #2272 about where to move the function, I just moved it outside the class scope but still within the `cartesian_interpolator.h/cartesian_interpolator.cpp` files.

Please let me know if I should move it somewhere else where it would make more sense!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
