### PR TITLE
[Servo] Improve support for switching planning group

### DIFF
--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
+    servo.updateParams();  // This can be skipped if your application will not be updating parameters.
     const KinematicState joint_state = servo.getNextJointState(joint_jog);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
+    servo.updateParams();  // Update will be processed only when servo is paused.
     const KinematicState joint_state = servo.getNextJointState(joint_jog);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_joint_jog.cpp
@@ -93,7 +93,6 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
-    servo.updateParams();  // Update will be processed only when servo is paused.
     const KinematicState joint_state = servo.getNextJointState(joint_jog);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
@@ -100,6 +100,7 @@ int main(int argc, char* argv[])
     rclcpp::WallRate tracking_rate(1 / servo_params.publish_period);
     while (!stop_tracking && rclcpp::ok())
     {
+      servo.updateParams();  // Update will be processed only when servo is paused.
       {
         std::lock_guard<std::mutex> pguard(pose_guard);
         joint_state = servo.getNextJointState(target_pose);

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
@@ -100,6 +100,7 @@ int main(int argc, char* argv[])
     rclcpp::WallRate tracking_rate(1 / servo_params.publish_period);
     while (!stop_tracking && rclcpp::ok())
     {
+      servo.updateParams();  // This can be skipped if your application will not be updating parameters.
       {
         std::lock_guard<std::mutex> pguard(pose_guard);
         joint_state = servo.getNextJointState(target_pose);

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_pose.cpp
@@ -100,7 +100,6 @@ int main(int argc, char* argv[])
     rclcpp::WallRate tracking_rate(1 / servo_params.publish_period);
     while (!stop_tracking && rclcpp::ok())
     {
-      servo.updateParams();  // Update will be processed only when servo is paused.
       {
         std::lock_guard<std::mutex> pguard(pose_guard);
         joint_state = servo.getNextJointState(target_pose);

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
@@ -97,6 +97,7 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
+    servo.updateParams();  // Update will be processed only when servo is paused.
     const KinematicState joint_state = servo.getNextJointState(target_twist);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
@@ -97,7 +97,6 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
-    servo.updateParams();  // Update will be processed only when servo is paused.
     const KinematicState joint_state = servo.getNextJointState(target_twist);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
+++ b/moveit_ros/moveit_servo/demos/cpp_interface/demo_twist.cpp
@@ -97,6 +97,7 @@ int main(int argc, char* argv[])
   RCLCPP_INFO_STREAM(LOGGER, servo.getStatusMessage());
   while (rclcpp::ok())
   {
+    servo.updateParams();  // This can be skipped if your application will not be updating parameters.
     const KinematicState joint_state = servo.getNextJointState(target_twist);
     const StatusCode status = servo.getStatus();
 

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -97,6 +97,12 @@ public:
   StatusCode getStatus() const;
 
   /**
+   * \brief Set the current status of servo to the provided status.
+   * @param status The new status of servo.
+   */
+  void setStatus(const StatusCode status);
+
+  /**
    * \brief Get the message associated with the current servo status.
    * @return The status message.
    */

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -128,14 +128,14 @@ public:
    * \brief Get the current state of the robot as given by planning scene monitor.
    * @return The current state of the robot.
    */
-  KinematicState getCurrentRobotState() const;
+  KinematicState getCurrentRobotState();
 
   /**
    * \brief Smoothly halt at a commanded state when command goes stale.
    * @param The last commanded joint states.
    * @return The next state stepping towards the required halting state.
    */
-  std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state) const;
+  std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state);
 
   /**
    * \brief Updates the servo parameters and performs validations.
@@ -150,7 +150,7 @@ private:
    * @param command_frame The command frame name.
    * @return The transformation between planning frame and command frame.
    */
-  Eigen::Isometry3d getPlanningToCommandFrameTransform(const std::string& command_frame) const;
+  Eigen::Isometry3d getPlanningToCommandFrameTransform(const std::string& command_frame);
 
   /**
    * \brief Convert a given twist command to planning frame,
@@ -161,21 +161,21 @@ private:
    * @param command The twist command to be converted.
    * @return The transformed twist command.
    */
-  TwistCommand toPlanningFrame(const TwistCommand& command) const;
+  TwistCommand toPlanningFrame(const TwistCommand& command);
 
   /**
    * \brief Convert a given pose command to planning frame
    * @param command The pose command to be converted
    * @return The transformed pose command
    */
-  PoseCommand toPlanningFrame(const PoseCommand& command) const;
+  PoseCommand toPlanningFrame(const PoseCommand& command);
 
   /**
    * \brief Compute the change in joint position required to follow the received command.
    * @param command The incoming servo command.
    * @return The joint position change required (delta).
    */
-  Eigen::VectorXd jointDeltaFromCommand(const ServoInput& command, const moveit::core::RobotStatePtr& robot_state);
+  Eigen::VectorXd jointDeltaFromCommand(const ServoInput& command);
 
   /**
    * \brief Updates data depending on joint model group
@@ -220,6 +220,8 @@ private:
   std::unique_ptr<CollisionMonitor> collision_monitor_;
 
   pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass> smoother_ = nullptr;
+
+  moveit::core::RobotStatePtr robot_state_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -223,6 +223,7 @@ private:
 
   moveit::core::RobotStatePtr robot_state_;
   const moveit::core::JointModelGroup* joint_model_group_;
+  std::vector<std::string> joint_names_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -222,6 +222,7 @@ private:
   pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass> smoother_ = nullptr;
 
   moveit::core::RobotStatePtr robot_state_;
+  const moveit::core::JointModelGroup* joint_model_group_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -137,6 +137,11 @@ public:
    */
   std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state) const;
 
+  /**
+   * \brief Updates the servo parameters and performs validations.
+   */
+  bool updateParams();
+
 private:
   /**
    * \brief Finds the transform from the planning frame to a specified command frame.
@@ -183,11 +188,6 @@ private:
    * @return True if parameters are valid, else False
    */
   bool validateParams(const servo::Params& servo_params) const;
-
-  /**
-   * \brief Updates the servo parameters and performs validations.
-   */
-  bool updateParams();
 
   /**
    * \brief Create and initialize the smoothing plugin to be used by servo.

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -224,6 +224,8 @@ private:
   moveit::core::RobotStatePtr robot_state_;
   const moveit::core::JointModelGroup* joint_model_group_;
   std::vector<std::string> joint_names_;
+
+  bool invalid_parameter_update_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
@@ -57,7 +57,8 @@ enum class StatusCode : int8_t
   DECELERATE_FOR_LEAVING_SINGULARITY = 3,
   DECELERATE_FOR_COLLISION = 4,
   HALT_FOR_COLLISION = 5,
-  JOINT_BOUND = 6
+  JOINT_BOUND = 6,
+  PAUSED = 7
 };
 
 const std::unordered_map<StatusCode, std::string> SERVO_STATUS_CODE_MAP(
@@ -68,7 +69,8 @@ const std::unordered_map<StatusCode, std::string> SERVO_STATUS_CODE_MAP(
       { StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY, "Moving away from a singularity, decelerating" },
       { StatusCode::DECELERATE_FOR_COLLISION, "Close to a collision, decelerating" },
       { StatusCode::HALT_FOR_COLLISION, "Collision detected, emergency stop" },
-      { StatusCode::JOINT_BOUND, "Close to a joint bound (position or velocity), halting" } });
+      { StatusCode::JOINT_BOUND, "Close to a joint bound (position or velocity), halting" },
+      { StatusCode::PAUSED, "Servo paused" } });
 
 // The datatype that specifies the type of command that servo should expect.
 enum class CommandType : int8_t

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -105,14 +105,7 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
   else
   {
     // Load the smoothing plugin
-    if (servo_params_.use_smoothing)
-    {
-      setSmoothingPlugin();
-    }
-    else
-    {
-      RCLCPP_WARN(LOGGER, "No smoothing plugin loaded");
-    }
+    setSmoothingPlugin();
 
     // Create the collision checker and start collision checking.
     collision_monitor_ =
@@ -426,7 +419,7 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
     // TODO : apply filtering to the velocity instead of position
     // Apply smoothing to the positions if a smoother was provided.
     // Update filter state and apply filtering in position domain
-    if (smoother_)
+    if (servo_params_.use_smoothing)
     {
       smoother_->reset(current_state.positions);
       smoother_->doSmoothing(target_state.positions);

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -145,9 +145,7 @@ void Servo::setSmoothingPlugin()
   }
 
   // Initialize the smoothing plugin
-  const int num_joints =
-      robot_state_->getJointModelGroup(servo_params_.move_group_name)->getActiveJointModelNames().size();
-  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), num_joints))
+  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), joint_names_.size()))
   {
     RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
     std::exit(EXIT_FAILURE);
@@ -308,9 +306,7 @@ KinematicState Servo::haltJoints(const std::vector<int>& joints_to_halt, const K
 
 Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command)
 {
-  const int num_joints =
-      robot_state_->getJointModelGroup(servo_params_.move_group_name)->getActiveJointModelNames().size();
-  Eigen::VectorXd joint_position_deltas(num_joints);
+  Eigen::VectorXd joint_position_deltas(joint_names_.size());
   joint_position_deltas.setZero();
 
   JointDeltaResult delta_result;
@@ -544,8 +540,7 @@ std::pair<bool, KinematicState> Servo::smoothHalt(const KinematicState& halt_sta
   auto target_state = halt_state;
   const auto current_state = getCurrentRobotState();
 
-  const size_t num_joints = joint_names_.size();
-  for (size_t i = 0; i < num_joints; i++)
+  for (size_t i = 0; i < joint_names_.size(); i++)
   {
     const double vel = (target_state.positions[i] - current_state.positions[i]) / servo_params_.publish_period;
     target_state.velocities[i] = (vel > STOPPED_VELOCITY_EPS) ? vel : 0.0;

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -90,6 +90,7 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
   robot_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   joint_model_group_ = robot_state_->getJointModelGroup(servo_params_.move_group_name);
   joint_names_ = joint_model_group_->getActiveJointModelNames();
+
   // Check if the transforms to planning frame and end effector frame exist.
   if (!robot_state_->knowsFrameTransform(servo_params_.planning_frame))
   {
@@ -130,7 +131,6 @@ Servo::~Servo()
 
 void Servo::setSmoothingPlugin()
 {
-  // Load the smoothing plugin
   try
   {
     pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader(
@@ -219,6 +219,18 @@ bool Servo::updateParams()
       {
         RCLCPP_INFO_STREAM(LOGGER, "Move group changed from " << servo_params_.move_group_name << " to "
                                                               << params.move_group_name);
+
+        robot_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
+        auto joint_model_group = robot_state_->getJointModelGroup(servo_params_.move_group_name);
+        if (joint_model_group == nullptr)
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "Group with name: " << params.move_group_name << " not found.");
+        }
+        else
+        {
+          joint_model_group_ = robot_state_->getJointModelGroup(servo_params_.move_group_name);
+          joint_names_ = joint_model_group_->getActiveJointModelNames();
+        }
       }
 
       servo_params_ = params;

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -129,18 +129,18 @@ void Servo::setSmoothingPlugin()
     pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader(
         "moveit_core", "online_signal_smoothing::SmoothingBaseClass");
     smoother_ = smoothing_loader.createUniqueInstance(servo_params_.smoothing_filter_plugin_name);
+
+    // Initialize the smoothing plugin
+    if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), joint_names_.size()))
+    {
+      RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
+      std::exit(EXIT_FAILURE);
+    }
   }
   catch (pluginlib::PluginlibException& ex)
   {
     RCLCPP_ERROR(LOGGER, "Exception while loading the smoothing plugin '%s': '%s'",
                  servo_params_.smoothing_filter_plugin_name.c_str(), ex.what());
-    std::exit(EXIT_FAILURE);
-  }
-
-  // Initialize the smoothing plugin
-  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), joint_names_.size()))
-  {
-    RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
     std::exit(EXIT_FAILURE);
   }
 }

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -230,6 +230,7 @@ bool Servo::updateParams()
         {
           joint_model_group_ = robot_state_->getJointModelGroup(servo_params_.move_group_name);
           joint_names_ = joint_model_group_->getActiveJointModelNames();
+          setSmoothingPlugin();
         }
       }
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -212,7 +212,7 @@ bool Servo::updateParams()
 {
   bool params_updated = false;
 
-  if (servo_param_listener_->is_old(servo_params_))
+  if (servo_param_listener_->is_old(servo_params_) && servo_status_ == StatusCode::PAUSED)
   {
     auto params = servo_param_listener_->get_params();
 
@@ -377,9 +377,6 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
 {
   // Set status to clear
   setStatus(StatusCode::NO_WARNING);
-
-  // Update the parameters
-  updateParams();
 
   // Get the robot state and joint model group info.
   moveit::core::RobotStatePtr robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -298,6 +298,8 @@ void ServoNode::servoLoop()
 
   while (rclcpp::ok() && !stop_servo_)
   {
+    servo_->updateParams();
+
     // Skip processing commands if servoing is disabled.
     if (servo_->getStatus() == StatusCode::PAUSED)
     {

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -157,11 +157,13 @@ void ServoNode::pauseServo(const std::shared_ptr<std_srvs::srv::SetBool::Request
   if (servo_paused_)
   {
     servo_->setCollisionChecking(false);
+    servo_->setStatus(StatusCode::PAUSED);
     response->message = "Servoing disabled";
   }
   else
   {
     servo_->setCollisionChecking(true);
+    servo_->setStatus(StatusCode::NO_WARNING);
     response->message = "Servoing enabled";
   }
 }
@@ -297,7 +299,7 @@ void ServoNode::servoLoop()
   while (rclcpp::ok() && !stop_servo_)
   {
     // Skip processing commands if servoing is disabled, but allow parameter updates.
-    if (servo_paused_)
+    if (servo_->getStatus() == StatusCode::PAUSED)
     {
       servo_->updateParams();
       continue;
@@ -320,6 +322,7 @@ void ServoNode::servoLoop()
     }
     else if (new_joint_jog_msg_ || new_twist_msg_ || new_pose_msg_)
     {
+      servo_->setStatus(StatusCode::INVALID);
       new_joint_jog_msg_ = new_twist_msg_ = new_pose_msg_ = false;
       RCLCPP_WARN_STREAM(LOGGER, "Command type has not been set, cannot accept input");
     }

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -296,9 +296,12 @@ void ServoNode::servoLoop()
 
   while (rclcpp::ok() && !stop_servo_)
   {
-    // Skip processing if servoing is disabled.
+    // Skip processing commands if servoing is disabled, but allow parameter updates.
     if (servo_paused_)
+    {
+      servo_->updateParams();
       continue;
+    }
 
     next_joint_state = std::nullopt;
     const CommandType expected_type = servo_->getCommandType();

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -298,10 +298,9 @@ void ServoNode::servoLoop()
 
   while (rclcpp::ok() && !stop_servo_)
   {
-    // Skip processing commands if servoing is disabled, but allow parameter updates.
+    // Skip processing commands if servoing is disabled.
     if (servo_->getStatus() == StatusCode::PAUSED)
     {
-      servo_->updateParams();
       continue;
     }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit2/issues/2332

This PR adds improved support for changing the planning group used by Servo by following  [approach 3](https://github.com/ros-planning/moveit2/issues/2332#issuecomment-1702845344) mentioned in the issue.
