### PR TITLE
Re-add low_latency_mode parameter to Servo

### DIFF
--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -286,8 +286,8 @@ servo:
   low_latency_mode: {
     type: bool,
     default_value: false,
-    description: "If true, publish commands as fast as possible. \
-                  Useful for controlling robots that have significant drift."
+    description: "If true, publish commands as quickly as possible. \
+                  Useful workaround for controlling robots with significant joint drift."
   }
 
 ########################### POSE TRACKING #######################################

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -168,7 +168,6 @@ servo:
     description: "If true servo will publish joint accelerations in the output command"
   }
 
-
   use_smoothing: {
     type: bool,
     default_value: true,
@@ -284,6 +283,12 @@ servo:
     }
   }
 
+  low_latency_mode: {
+    type: bool,
+    default_value: false,
+    description: "If true, publish commands as fast as possible. \
+                  Useful for controlling robots that have significant drift."
+  }
 
 ########################### POSE TRACKING #######################################
 

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -202,6 +202,8 @@ void ServoNode::poseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedP
 
 std::optional<KinematicState> ServoNode::processJointJogCommand()
 {
+  std::optional<KinematicState> next_joint_state = std::nullopt;
+
   const bool command_stale = (node_->now() - latest_joint_jog_.header.stamp) >=
                              rclcpp::Duration::from_seconds(servo_params_.incoming_command_timeout);
   if (!command_stale)

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -338,7 +338,10 @@ void ServoNode::servoLoop()
     status_msg.message = servo_->getStatusMessage();
     status_publisher_->publish(status_msg);
 
-    servo_frequency.sleep();
+    if (!servo_params_.low_latency_mode)
+    {
+      servo_frequency.sleep();
+    }
   }
 }
 


### PR DESCRIPTION
This PR re-adds the `low_latency_mode` workaround to servo, but also fixes a bug I found in doing this where the `new_X_msg_` flags were not being unset correctly.