### PR TITLE
[Servo] Correct for drift by using previously commanded state instead of current state

### DIFF
--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -126,7 +126,6 @@ servo:
       description: "Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic."
     }
 
-
   apply_twist_commands_about_ee_frame: {
     type: bool,
     default_value: true,

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -33,7 +33,7 @@ servo:
   status_topic: {
     type: string,
     default_value: "~/status",
-    description: "The topic to which the status will be published"
+    description: "The topic to which the status will be published."
   }
 
   command_out_topic: {
@@ -46,7 +46,7 @@ servo:
   command_out_type: {
     type: string,
     default_value: "trajectory_msgs/JointTrajectory",
-    description: "The type of command that servo will publish",
+    description: "The type of command to publish.",
     validation: {
       one_of<>: [["trajectory_msgs/JointTrajectory", "std_msgs/Float64MultiArray"]]
     }
@@ -57,19 +57,19 @@ servo:
   pose_command_in_topic: {
     type: string,
     default_value: "~/pose_target_cmds",
-    description: "The topic on which servo will receive the pose commands"
+    description: "The topic on which to receive pose commands."
   }
 
   cartesian_command_in_topic: {
     type: string,
     default_value: "~/delta_twist_cmds",
-    description: "The topic on which servo will receive the twist commands"
+    description: "The topic on which to receive twist commands."
   }
 
   joint_command_in_topic: {
     type: string,
     default_value: "~/delta_joint_cmds",
-    description: "The topic on which servo will receive the joint jog commands"
+    description: "The topic on which to receive joint jog commands."
   }
 
   command_in_type: {
@@ -86,7 +86,7 @@ servo:
   joint_topic: {
     type: string,
     default_value: "/joint_states",
-    description: "The topic on which joint states can be monitored"
+    description: "The topic on which joint states can be monitored."
   }
 
 ################################ GENERAL CONFIG #############################
@@ -105,8 +105,8 @@ servo:
   incoming_command_timeout: {
     type: double,
     default_value: 0.1,
-    description: "Commands will be discarded if it is older than the timeout.\
-                   Important because ROS may drop some messages."
+    description: "Commands will be discarded if it is older than the timeout. \
+                  Important because ROS may drop some messages."
   }
 
   scale:
@@ -138,13 +138,13 @@ servo:
   override_velocity_scaling_factor: {
     type: double,
     default_value: 0.0,
-    description: "Scaling factor when servo overrides the velocity (eg: near singularities)"
+    description: "Scaling factor when overriding the velocity scaling, e.g., near singularities)"
   }
 
   publish_period: {
     type: double,
     default_value: 0.034,
-    description: " 1 / (Nominal publish rate) [seconds]",
+    description: "1 / (Nominal publish rate) [seconds]",
     validation: {
       gt<>: 0.0
     }
@@ -153,32 +153,37 @@ servo:
   publish_joint_positions: {
     type: bool,
     default_value: true,
-    description: "If true servo will publish joint positions in the output command"
+    description: "If true, publish joint positions in the output command."
   }
 
   publish_joint_velocities: {
     type: bool,
     default_value: true,
-    description: "If true servo will publish joint velocities in the output command"
+    description: "If true, publish joint velocities in the output command."
   }
 
   publish_joint_accelerations: {
     type: bool,
     default_value: false,
-    description: "If true servo will publish joint accelerations in the output command"
+    description: "If true, publish joint accelerations in the output command."
   }
 
+  apply_anti_drift: {
+    type: bool,
+    default_value: false,
+    description: "If true, uses the previous commanded state instead of current state to correct for joint drift."
+  }
 
   use_smoothing: {
     type: bool,
     default_value: true,
-    description: "Enables the use of smoothing plugins for joint trajectory smoothing"
+    description: "Enables the use of smoothing plugins for joint trajectory smoothing."
   }
 
   smoothing_filter_plugin_name: {
     type: string,
     default_value: "online_signal_smoothing::ButterworthFilterPlugin",
-    description: "The name of the smoothing plugin to be used"
+    description: "The name of the smoothing plugin to be used."
   }
 
   is_primary_planning_scene_monitor: {
@@ -188,25 +193,25 @@ servo:
                   the Servo server's PlanningScene advertises the /get_planning_scene service, \
                   which other nodes can use to get information about the planning environment. \
                   If a different node in your system will be publishing the planning scene, \
-                  this should be set to false"
+                  this should be set to false."
   }
 
   halt_all_joints_in_joint_mode: {
     type: bool,
     default_value: true,
-    description: "Halt all joints in joint mode"
+    description: "Halt all joints in joint mode."
   }
 
   halt_all_joints_in_cartesian_mode: {
     type: bool,
     default_value: true,
-    description: "Halt all joints in cartesian mode"
+    description: "Halt all joints in cartesian mode."
   }
 
   lower_singularity_threshold: {
     type: double,
     default_value: 17.0,
-    description: "Start decelerating when the condition number hits this (close to singularity)",
+    description: "Start decelerating when the condition number hits this (close to singularity).",
     validation: {
       gt<>: 0.0
     }
@@ -215,7 +220,7 @@ servo:
   hard_stop_singularity_threshold: {
     type: double,
     default_value: 30.0,
-    description: "Stop when the condition number hits this",
+    description: "Stop when the condition number reaches this value.",
     validation: {
       gt<>: 0.0,
     }
@@ -226,7 +231,7 @@ servo:
     default_value: 2.0,
     description: "When 'lower_singularity_threshold' is triggered, \
                   but we are moving away from singularity, move this many times faster \
-                  than if we were moving further into singularity",
+                  than if we were moving further into singularity.",
     validation: {
       gt<>: 0.0
     }
@@ -235,7 +240,7 @@ servo:
   singularity_step_scale: {
     type: double,
     default_value: 0.01,
-    description: "The vector towards singularity is scaled by this factor during singularity check",
+    description: "The vector towards singularity is scaled by this factor during singularity check.",
     validation: {
       gt<>: 0.0
     }
@@ -253,7 +258,7 @@ servo:
   check_collisions: {
     type: bool,
     default_value: true,
-    description: "If true, servo will check for collision using the planning scene monitor."
+    description: "If true, check for collisions using the planning scene monitor."
   }
 
   collision_check_rate: {
@@ -269,7 +274,7 @@ servo:
   self_collision_proximity_threshold: {
     type: double,
     default_value: 0.01,
-    description: "Start decelerating when a self-collision is this far [m]",
+    description: "Start decelerating when a self-collision is this far [m].",
     validation: {
       gt<>: 0.0
     }
@@ -278,7 +283,7 @@ servo:
   scene_collision_proximity_threshold: {
     type: double,
     default_value: 0.02,
-    description: "Start decelerating when a collision is this far [m]",
+    description: "Start decelerating when a collision is this far [m].",
     validation: {
       gt<>: 0.0
     }

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -74,9 +74,12 @@ public:
   /**
    * \brief Computes the joint state required to follow the given command.
    * @param command The command to follow, std::variant type, can handle JointJog, Twist and Pose.
+   * @param previous_state_maybe A std::optional containing the previous commanded state. If this value is set, it
+   * is used to calculate an error between the current state and the previous commanded state for anti-drift correction.
    * @return The required joint state.
    */
-  KinematicState getNextJointState(const ServoInput& command);
+  KinematicState getNextJointState(const ServoInput& command,
+                                   const std::optional<KinematicState>& previous_state_maybe = std::nullopt);
 
   /**
    * \brief Set the type of incoming servo command.
@@ -126,10 +129,10 @@ public:
 
   /**
    * \brief Smoothly halt at a commanded state when command goes stale.
-   * @param The last commanded joint states.
+   * @param halt_state_maybe A std::optional containing the last commanded joint states, if available.
    * @return The next state stepping towards the required halting state.
    */
-  std::pair<bool, KinematicState> smoothHalt(KinematicState halt_state);
+  std::pair<bool, KinematicState> smoothHalt(std::optional<KinematicState>& halt_state_maybe);
 
 private:
   /**

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -74,12 +74,10 @@ public:
   /**
    * \brief Computes the joint state required to follow the given command.
    * @param command The command to follow, std::variant type, can handle JointJog, Twist and Pose.
-   * @param previous_state_maybe A std::optional containing the previous commanded state. If this value is set, it
    * is used to calculate an error between the current state and the previous commanded state for anti-drift correction.
    * @return The required joint state.
    */
-  KinematicState getNextJointState(const ServoInput& command,
-                                   const std::optional<KinematicState>& previous_state_maybe = std::nullopt);
+  KinematicState getNextJointState(const ServoInput& command);
 
   /**
    * \brief Set the type of incoming servo command.
@@ -132,7 +130,14 @@ public:
    * @param halt_state_maybe A std::optional containing the last commanded joint states, if available.
    * @return The next state stepping towards the required halting state.
    */
-  std::pair<bool, KinematicState> smoothHalt(std::optional<KinematicState>& halt_state_maybe);
+  std::pair<bool, KinematicState> smoothHalt();
+
+  /**
+   * TODO
+   */
+  std::optional<KinematicState> getLastCommandedState();
+
+  void resetLastCommandedState();
 
 private:
   /**
@@ -202,6 +207,8 @@ private:
   const rclcpp::Node::SharedPtr node_;
   std::shared_ptr<const servo::ParamListener> servo_param_listener_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+
+  std::optional<KinematicState> last_commanded_state_;
 
   // This value will be updated by CollisionMonitor in a separate thread.
   std::atomic<double> collision_velocity_scale_ = 1.0;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -133,10 +133,14 @@ public:
   std::pair<bool, KinematicState> smoothHalt();
 
   /**
-   * TODO
+   * \brief Returns the last commanded state.
+   * @return The last commanded state.
    */
   std::optional<KinematicState> getLastCommandedState();
 
+  /**
+   * \brief Resets the last commanded state to std::nullopt.
+   */
   void resetLastCommandedState();
 
 private:

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
@@ -110,7 +110,7 @@ private:
   servo::Params servo_params_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
-  KinematicState last_commanded_state_;  // Used when commands go stale;
+  std::optional<KinematicState> last_commanded_state_;  // Used when commands go stale or to correct for drift;
   control_msgs::msg::JointJog latest_joint_jog_;
   geometry_msgs::msg::TwistStamped latest_twist_;
   geometry_msgs::msg::PoseStamped latest_pose_;

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
@@ -110,7 +110,6 @@ private:
   servo::Params servo_params_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
-  std::optional<KinematicState> last_commanded_state_;  // Used when commands go stale or to correct for drift;
   control_msgs::msg::JointJog latest_joint_jog_;
   geometry_msgs::msg::TwistStamped latest_twist_;
   geometry_msgs::msg::PoseStamped latest_pose_;

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -394,12 +394,10 @@ KinematicState Servo::getNextJointState(const ServoInput& command,
   KinematicState current_state(num_joints), target_state(num_joints);
   target_state.joint_names = joint_names;
 
-  // If we provide a previous state for drift correction, set that as the robot state.
+  // If we provide a previous state for drift correction, set the robot position to that.
   if (previous_state_maybe)
   {
-    const auto& previous_state = previous_state_maybe.value();
-    robot_state->setJointGroupPositions(joint_model_group, previous_state.positions);
-    robot_state->setJointGroupVelocities(joint_model_group, previous_state.velocities);
+    robot_state->setJointGroupPositions(joint_model_group, previous_state_maybe.value().positions);
   }
 
   // Copy current kinematic data from RobotState.

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -338,6 +338,10 @@ void ServoNode::servoLoop()
       }
       last_commanded_state_ = next_joint_state;
     }
+    else
+    {
+      last_commanded_state_ = std::nullopt;
+    }
 
     status_msg.code = static_cast<int8_t>(servo_->getStatus());
     status_msg.message = servo_->getStatusMessage();

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -223,10 +223,6 @@ std::optional<KinematicState> ServoNode::processJointJogCommand()
       next_joint_state = result.second;
       RCLCPP_DEBUG_STREAM(LOGGER, "Joint jog command timed out. Halting to a stop.");
     }
-    else
-    {
-      new_joint_jog_msg_ = false;
-    }
   }
 
   return next_joint_state;
@@ -260,10 +256,6 @@ std::optional<KinematicState> ServoNode::processTwistCommand()
       next_joint_state = result.second;
       RCLCPP_INFO_STREAM(LOGGER, "Twist command timed out. Halting to a stop.");
     }
-    else
-    {
-      new_twist_msg_ = false;
-    }
   }
 
   return next_joint_state;
@@ -293,10 +285,6 @@ std::optional<KinematicState> ServoNode::processPoseCommand()
     {
       next_joint_state = result.second;
       RCLCPP_DEBUG_STREAM(LOGGER, "Pose command timed out. Halting to a stop.");
-    }
-    else
-    {
-      new_pose_msg_ = false;
     }
   }
 

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -211,12 +211,11 @@ std::optional<KinematicState> ServoNode::processJointJogCommand()
   if (!command_stale)
   {
     JointJogCommand command{ latest_joint_jog_.joint_names, latest_joint_jog_.velocities };
-    next_joint_state =
-        servo_->getNextJointState(command, servo_params_.apply_anti_drift ? last_commanded_state_ : std::nullopt);
+    next_joint_state = servo_->getNextJointState(command);
   }
   else
   {
-    auto result = servo_->smoothHalt(last_commanded_state_);
+    auto result = servo_->smoothHalt();
     new_joint_jog_msg_ = result.first;
     if (new_joint_jog_msg_)
     {
@@ -244,12 +243,11 @@ std::optional<KinematicState> ServoNode::processTwistCommand()
                                                latest_twist_.twist.linear.z,  latest_twist_.twist.angular.x,
                                                latest_twist_.twist.angular.y, latest_twist_.twist.angular.z };
     const TwistCommand command{ latest_twist_.header.frame_id, velocities };
-    next_joint_state =
-        servo_->getNextJointState(command, servo_params_.apply_anti_drift ? last_commanded_state_ : std::nullopt);
+    next_joint_state = servo_->getNextJointState(command);
   }
   else
   {
-    auto result = servo_->smoothHalt(last_commanded_state_);
+    auto result = servo_->smoothHalt();
     new_twist_msg_ = result.first;
     if (new_twist_msg_)
     {
@@ -274,12 +272,11 @@ std::optional<KinematicState> ServoNode::processPoseCommand()
   if (!command_stale)
   {
     const PoseCommand command = poseFromPoseStamped(latest_pose_);
-    next_joint_state =
-        servo_->getNextJointState(command, servo_params_.apply_anti_drift ? last_commanded_state_ : std::nullopt);
+    next_joint_state = servo_->getNextJointState(command);
   }
   else
   {
-    auto result = servo_->smoothHalt(last_commanded_state_);
+    auto result = servo_->smoothHalt();
     new_pose_msg_ = result.first;
     if (new_pose_msg_)
     {
@@ -336,11 +333,10 @@ void ServoNode::servoLoop()
       {
         multi_array_publisher_->publish(composeMultiArrayMessage(servo_->getParams(), next_joint_state.value()));
       }
-      last_commanded_state_ = next_joint_state;
     }
     else
     {
-      last_commanded_state_ = std::nullopt;
+      servo_->resetLastCommandedState();
     }
 
     status_msg.code = static_cast<int8_t>(servo_->getStatus());


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/ros-planning/moveit2/issues/1857#issuecomment-1506581979 to try correct drift for robots without great joint tracking control (like the MoveIt Studio Gazebo simulation).

This adds an `apply_anti_drift` parameter to MoveIt Servo, which when enabled will use the previously commanded joint state instead of the current state to compute joint deltas.