### PR TITLE
Using std types instead of boost for Gaussian sampling

### DIFF
--- a/moveit_planners/stomp/CMakeLists.txt
+++ b/moveit_planners/stomp/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(std_msgs REQUIRED)
 find_package(stomp REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
+find_package(rsl REQUIRED)
 
 generate_parameter_library(stomp_moveit_parameters res/stomp_moveit.yaml)
 
@@ -29,6 +30,7 @@ ament_target_dependencies(stomp_moveit_plugin
   std_msgs
   tf2_eigen
   visualization_msgs
+  rsl
 )
 target_link_libraries(stomp_moveit_plugin stomp::stomp stomp_moveit_parameters)
 

--- a/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
@@ -42,7 +42,7 @@
 #include <Eigen/Core>
 #include <Eigen/Cholesky>
 
-#include <random>
+#include <rsl/random.hpp>
 #include <cstdlib>
 
 namespace stomp_moveit
@@ -75,8 +75,6 @@ private:
   Eigen::MatrixXd covariance_cholesky_; /**< Cholesky decomposition (LL^T) of the covariance */
 
   int size_;
-  std::mt19937 rng_;
-  std::random_device rd_{};
   std::normal_distribution<double> normal_dist_;
 };
 
@@ -87,7 +85,6 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
                                            const Eigen::MatrixBase<Derived2>& covariance)
   : mean_(mean), covariance_(covariance), covariance_cholesky_(covariance_.llt().matrixL()), normal_dist_(0.0, 1.0)
 {
-  rng_.seed(rd_());
   size_ = mean.rows();
 }
 
@@ -95,7 +92,7 @@ template <typename Derived>
 void MultivariateGaussian::sample(Eigen::MatrixBase<Derived>& output, bool use_covariance)
 {
   for (int i = 0; i < size_; ++i)
-    output(i) = normal_dist_(rng_);
+    output(i) = normal_dist_(rsl::rng());
 
   if (use_covariance)
   {

--- a/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
@@ -76,6 +76,7 @@ private:
 
   int size_;
   std::mt19937 rng_;
+  std::random_device rd_{};
   std::normal_distribution<double> normal_dist_;
 };
 
@@ -86,7 +87,7 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
                                            const Eigen::MatrixBase<Derived2>& covariance)
   : mean_(mean), covariance_(covariance), covariance_cholesky_(covariance_.llt().matrixL()), normal_dist_(0.0, 1.0)
 {
-  rng_.seed(rand());
+  rng_.seed(rd_());
   size_ = mean.rows();
 }
 

--- a/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
@@ -80,9 +80,9 @@ private:
   int size_;
   std::mt19937 rng_;
   std::normal_distribution<double> normal_dist_;
-  std::shared_ptr<boost::variate_generator<
-      std::mt19937, STD_MSGS__MSG__DETAIL__COLOR_RGBA__TYPE_SUPPORT_HPP_::std::normal_distribution<>>>
-      gaussian_;
+  // std::shared_ptr<boost::variate_generator<
+  //     std::mt19937, STD_MSGS__MSG__DETAIL__COLOR_RGBA__TYPE_SUPPORT_HPP_::std::normal_distribution<>>>
+  //     gaussian_;
 };
 
 //////////////////////// template function definitions follow //////////////////////////////
@@ -94,14 +94,14 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
 {
   rng_.seed(rand());
   size_ = mean.rows();
-  gaussian_.reset(new boost::variate_generator<std::mt19937, std::normal_distribution<double>>(rng_, normal_dist_));
+  // gaussian_.reset(new boost::variate_generator<std::mt19937, std::normal_distribution<double>>(rng_, normal_dist_));
 }
 
 template <typename Derived>
 void MultivariateGaussian::sample(Eigen::MatrixBase<Derived>& output, bool use_covariance)
 {
   for (int i = 0; i < size_; ++i)
-    output(i) = (*gaussian_)();
+    output(i) = normal_dist_(rng_);
 
   if (use_covariance)
   {

--- a/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
@@ -42,9 +42,6 @@
 #include <Eigen/Core>
 #include <Eigen/Cholesky>
 
-// TODO(#2166): Replace with std types
-#include <boost/random/variate_generator.hpp>
-
 #include <random>
 #include <cstdlib>
 
@@ -80,9 +77,6 @@ private:
   int size_;
   std::mt19937 rng_;
   std::normal_distribution<double> normal_dist_;
-  // std::shared_ptr<boost::variate_generator<
-  //     std::mt19937, STD_MSGS__MSG__DETAIL__COLOR_RGBA__TYPE_SUPPORT_HPP_::std::normal_distribution<>>>
-  //     gaussian_;
 };
 
 //////////////////////// template function definitions follow //////////////////////////////
@@ -94,7 +88,6 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
 {
   rng_.seed(rand());
   size_ = mean.rows();
-  // gaussian_.reset(new boost::variate_generator<std::mt19937, std::normal_distribution<double>>(rng_, normal_dist_));
 }
 
 template <typename Derived>

--- a/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/math/multivariate_gaussian.hpp
@@ -44,9 +44,8 @@
 
 // TODO(#2166): Replace with std types
 #include <boost/random/variate_generator.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/shared_ptr.hpp>
+
+#include <random>
 #include <cstdlib>
 
 namespace stomp_moveit
@@ -79,9 +78,11 @@ private:
   Eigen::MatrixXd covariance_cholesky_; /**< Cholesky decomposition (LL^T) of the covariance */
 
   int size_;
-  boost::mt19937 rng_;
-  boost::normal_distribution<> normal_dist_;
-  std::shared_ptr<boost::variate_generator<boost::mt19937, boost::normal_distribution<> > > gaussian_;
+  std::mt19937 rng_;
+  std::normal_distribution<double> normal_dist_;
+  std::shared_ptr<boost::variate_generator<
+      std::mt19937, STD_MSGS__MSG__DETAIL__COLOR_RGBA__TYPE_SUPPORT_HPP_::std::normal_distribution<>>>
+      gaussian_;
 };
 
 //////////////////////// template function definitions follow //////////////////////////////
@@ -93,7 +94,7 @@ MultivariateGaussian::MultivariateGaussian(const Eigen::MatrixBase<Derived1>& me
 {
   rng_.seed(rand());
   size_ = mean.rows();
-  gaussian_.reset(new boost::variate_generator<boost::mt19937, boost::normal_distribution<> >(rng_, normal_dist_));
+  gaussian_.reset(new boost::variate_generator<std::mt19937, std::normal_distribution<double>>(rng_, normal_dist_));
 }
 
 template <typename Derived>

--- a/moveit_planners/stomp/package.xml
+++ b/moveit_planners/stomp/package.xml
@@ -21,6 +21,7 @@
   <depend>std_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>visualization_msgs</depend>
+  <depend>rsl</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
### Description

Getting rid of boost for sampling from a gaussian distribution and instead using standard library functions, wherever available.

Fixes #2166 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
