### PR TITLE
Allow robot links to have "/" in their names without assuming it belongs to a sub frame (attached object).

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -804,7 +804,10 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
   const moveit::core::LinkModel* link{ nullptr };
 
   size_t idx = 0;
-  if ((idx = frame.find('/')) != std::string::npos)
+  if (getRobotModel()->hasLinkModel(frame)) {
+    link = getLinkModel(frame);
+  } 
+  else if ((idx = frame.find('/')) != std::string::npos)
   {  // resolve sub frame
     std::string object{ frame.substr(0, idx) };
     if (!hasAttachedBody(object))
@@ -818,8 +821,6 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
   {
     link = getAttachedBody(frame)->getAttachedLink();
   }
-  else if (getRobotModel()->hasLinkModel(frame))
-    link = getLinkModel(frame);
 
   return getRobotModel()->getRigidlyConnectedParentLinkModel(link);
 }


### PR DESCRIPTION
### Description
When using multiple robots of different types, it is convenient to prefix their link names with `"${robot_name}/"`. This is done for example by interbotix in their [urdf](https://github.com/Interbotix/interbotix_ros_rovers/blob/humble/interbotix_ros_xslocobots/interbotix_xslocobot_descriptions/urdf/arms/mobile_wx250s.urdf.xacro). Subframes should only be checked if a given frame does **not** refer to a robot link.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
