### PR TITLE
Enable running parallel or single pipeline benchmarks

### DIFF
--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -170,8 +170,7 @@ bool BenchmarkOptions::readPlannerConfigs(const rclcpp::Node::SharedPtr& node)
   std::vector<std::string> pipelines;
   if (!node->get_parameter(ns + ".pipelines", pipelines))
   {
-    RCLCPP_ERROR(LOGGER, "Fail to get the parameter in `%s` namespace.", (ns + ".pipelines").c_str());
-    return false;
+    RCLCPP_ERROR(LOGGER, "No single planning pipeline namespace `%s` configured.", (ns + ".pipelines").c_str());
   }
 
   for (const std::string& pipeline : pipelines)
@@ -210,8 +209,8 @@ bool BenchmarkOptions::readPlannerConfigs(const rclcpp::Node::SharedPtr& node)
   std::vector<std::string> parallel_pipelines;
   if (!node->get_parameter(ns + ".parallel_pipelines", parallel_pipelines))
   {
-    RCLCPP_ERROR(LOGGER, "Fail to get the parameter in `%s` namespace.", (ns + ".parallel_pipelines").c_str());
-    return false;
+    RCLCPP_WARN(LOGGER, "No parallel planning pipeline namespace `%s` configured.",
+                (ns + ".parallel_pipelines").c_str());
   }
 
   for (const std::string& parallel_pipeline : parallel_pipelines)
@@ -250,7 +249,7 @@ bool BenchmarkOptions::readPlannerConfigs(const rclcpp::Node::SharedPtr& node)
       std::vector<std::pair<std::string, std::string>> pipeline_planner_id_pairs;
       for (size_t i = 0; i < pipelines.size(); ++i)
       {
-        pipeline_planner_id_pairs.push_back(std::pair<std::string, std::string>(pipelines[i], planner_ids[i]));
+        pipeline_planner_id_pairs.push_back(std::pair<std::string, std::string>(pipelines.at(i), planner_ids.at(i)));
       }
 
       parallel_planning_pipelines[parallel_pipeline] = pipeline_planner_id_pairs;
@@ -264,6 +263,11 @@ bool BenchmarkOptions::readPlannerConfigs(const rclcpp::Node::SharedPtr& node)
         }
       }
     }
+  }
+  if (pipelines.empty() && parallel_pipelines.empty())
+  {
+    RCLCPP_ERROR(LOGGER, "No single or parallel planning pipelines configured for benchmarking.");
+    return false;
   }
   return true;
 }

--- a/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkOptions.cpp
@@ -170,7 +170,7 @@ bool BenchmarkOptions::readPlannerConfigs(const rclcpp::Node::SharedPtr& node)
   std::vector<std::string> pipelines;
   if (!node->get_parameter(ns + ".pipelines", pipelines))
   {
-    RCLCPP_ERROR(LOGGER, "No single planning pipeline namespace `%s` configured.", (ns + ".pipelines").c_str());
+    RCLCPP_WARN(LOGGER, "No single planning pipeline namespace `%s` configured.", (ns + ".pipelines").c_str());
   }
 
   for (const std::string& pipeline : pipelines)


### PR DESCRIPTION
### Description

Small fix to disable the need to always configure single and parallel planning pipelines for benchmarks.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
