### PR TITLE
Fix for already declared deceleration parameters when using Pilz

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
@@ -67,7 +67,7 @@ inline bool getJointLimits(const std::string& joint_name, const std::string& par
   {
     // Deceleration limits
     const std::string param_base_name = (param_ns.empty() ? "" : param_ns + ".") + "joint_limits." + joint_name;
-    if(node->has_parameter(param_base_name + ".has_deceleration_limits"))
+    if (node->has_parameter(param_base_name + ".has_deceleration_limits"))
     {
       limits.has_deceleration_limits = node->get_parameter(param_base_name + ".has_deceleration_limits").as_bool();
     }
@@ -83,7 +83,7 @@ inline bool getJointLimits(const std::string& joint_name, const std::string& par
       }
       else
       {
-        limits.max_deceleration = 
+        limits.max_deceleration =
             node->declare_parameter(param_base_name + ".max_deceleration", std::numeric_limits<double>::quiet_NaN());
       }
     }

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
@@ -67,9 +67,12 @@ inline bool getJointLimits(const std::string& joint_name, const std::string& par
   {
     // Deceleration limits
     const std::string param_base_name = (param_ns.empty() ? "" : param_ns + ".") + "joint_limits." + joint_name;
-    if(node->has_parameter(param_base_name + ".has_deceleration_limits")) {
+    if(node->has_parameter(param_base_name + ".has_deceleration_limits"))
+    {
       limits.has_deceleration_limits = node->get_parameter(param_base_name + ".has_deceleration_limits").as_bool();
-    } else {
+    }
+    else
+    {
       limits.has_deceleration_limits = node->declare_parameter(param_base_name + ".has_deceleration_limits", false);
     }
     if (limits.has_deceleration_limits)
@@ -80,7 +83,8 @@ inline bool getJointLimits(const std::string& joint_name, const std::string& par
       }
       else
       {
-        limits.max_deceleration = node->declare_parameter(param_base_name + ".max_deceleration", std::numeric_limits<double>::quiet_NaN());
+        limits.max_deceleration = 
+            node->declare_parameter(param_base_name + ".max_deceleration", std::numeric_limits<double>::quiet_NaN());
       }
     }
   }

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/joint_limits_interface_extension.h
@@ -67,12 +67,21 @@ inline bool getJointLimits(const std::string& joint_name, const std::string& par
   {
     // Deceleration limits
     const std::string param_base_name = (param_ns.empty() ? "" : param_ns + ".") + "joint_limits." + joint_name;
-
-    limits.has_deceleration_limits = node->declare_parameter(param_base_name + ".has_deceleration_limits", false);
+    if(node->has_parameter(param_base_name + ".has_deceleration_limits")) {
+      limits.has_deceleration_limits = node->get_parameter(param_base_name + ".has_deceleration_limits").as_bool();
+    } else {
+      limits.has_deceleration_limits = node->declare_parameter(param_base_name + ".has_deceleration_limits", false);
+    }
     if (limits.has_deceleration_limits)
     {
-      limits.max_deceleration =
-          node->declare_parameter(param_base_name + ".max_deceleration", std::numeric_limits<double>::quiet_NaN());
+      if (node->has_parameter(param_base_name + ".max_deceleration"))
+      {
+        limits.max_deceleration = node->get_parameter(param_base_name + ".max_deceleration").as_double();
+      }
+      else
+      {
+        limits.max_deceleration = node->declare_parameter(param_base_name + ".max_deceleration", std::numeric_limits<double>::quiet_NaN());
+      }
     }
   }
   catch (const std::exception& ex)


### PR DESCRIPTION
### Description

When using the Pilz motion planner, the following message is printend multiple times:
`Failed loading deceleration limits`

This is due to redeclaration of these parameters.
I check if the parameter is already decalared, and if so, the value is get. Otherwise we declare the parameters.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
