### PR TITLE
Make getJacobian simpler and faster

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1143,7 +1143,7 @@ public:
    * \param group The group to compute the Jacobian for
    * \param link The link model to compute the Jacobian for
    * \param reference_point_position The reference point position (with respect to the link specified in link)
-   * \param jacobian The resultant jacobian
+   * \param jacobian The resultant jacobian, with the origin at the group root link.
    * \param use_quaternion_representation Flag indicating if the Jacobian should use a quaternion representation
    * (default is false)
    * \return True if jacobian was successfully computed, false otherwise
@@ -1155,7 +1155,7 @@ public:
    * \param group The group to compute the Jacobian for
    * \param link The link model to compute the Jacobian for
    * \param reference_point_position The reference point position (with respect to the link specified in link)
-   * \param jacobian The resultant jacobian
+   * \param jacobian The resultant jacobian, with the origin at the group root link.
    * \param use_quaternion_representation Flag indicating if the Jacobian should use a quaternion representation
    * (default is false)
    * \return True if jacobian was successfully computed, false otherwise
@@ -1168,8 +1168,8 @@ public:
                                                              use_quaternion_representation);
   }
 
-  /** \brief Compute the Jacobian with reference to the last link of a specified group. If the group is not a chain, an
-   * exception is thrown.
+  /** \brief Compute the Jacobian with reference to the last link of a specified group, and origin at the group root
+   * link. If the group is not a chain, an exception is thrown.
    * \param group The group to compute the Jacobian for
    * \param reference_point_position The reference point position (with respect to the link specified in link_name)
    * \return The computed Jacobian.
@@ -1177,8 +1177,8 @@ public:
   Eigen::MatrixXd getJacobian(const JointModelGroup* group,
                               const Eigen::Vector3d& reference_point_position = Eigen::Vector3d(0.0, 0.0, 0.0)) const;
 
-  /** \brief Compute the Jacobian with reference to the last link of a specified group. If the group is not a chain, an
-   * exception is thrown.
+  /** \brief Compute the Jacobian with reference to the last link of a specified group, and origin at the group root
+   * link. If the group is not a chain, an exception is thrown.
    * \param group The group to compute the Jacobian for
    * \param reference_point_position The reference point position (with respect to the link specified in link_name)
    * \return The computed Jacobian.

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -851,7 +851,7 @@ void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isome
 
 const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::string& frame) const
 {
-  const moveit::core::LinkModel* link{ nullptr };
+  const LinkModel* link{ nullptr };
 
   size_t idx = 0;
   if ((idx = frame.find('/')) != std::string::npos)
@@ -1005,7 +1005,7 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
-  moveit::core::checkInterpolationParamBounds(LOGGER, t);
+  checkInterpolationParamBounds(LOGGER, t);
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
   memset(state.dirty_joint_transforms_, 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
@@ -1014,7 +1014,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
 
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state, const JointModelGroup* joint_group) const
 {
-  moveit::core::checkInterpolationParamBounds(LOGGER, t);
+  checkInterpolationParamBounds(LOGGER, t);
   const std::vector<const JointModel*>& jm = joint_group->getActiveJointModels();
   for (const JointModel* joint : jm)
   {
@@ -1066,7 +1066,7 @@ void RobotState::attachBody(const std::string& id, const Eigen::Isometry3d& pose
                             const std::vector<shapes::ShapeConstPtr>& shapes,
                             const EigenSTL::vector_Isometry3d& shape_poses, const std::set<std::string>& touch_links,
                             const std::string& link, const trajectory_msgs::msg::JointTrajectory& detach_posture,
-                            const moveit::core::FixedTransformsMap& subframe_poses)
+                            const FixedTransformsMap& subframe_poses)
 {
   attachBody(std::make_unique<AttachedBody>(robot_model_->getLinkModel(link), id, pose, shapes, shape_poses,
                                             touch_links, detach_posture, subframe_poses));
@@ -1349,11 +1349,9 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
                              const Eigen::Vector3d& reference_point_position, Eigen::MatrixXd& jacobian,
                              bool use_quaternion_representation) const
 {
-  using LinkModel = moveit::core::LinkModel;
-  using JointModel = moveit::core::JointModel;
-
   assert(checkLinkTransforms());
 
+  // Check that the group is a chain, contains 'link' and has joint models.
   if (!group->isChain())
   {
     RCLCPP_ERROR(LOGGER, "The group '%s' is not a chain. Cannot compute Jacobian.", group->getName().c_str());
@@ -1368,54 +1366,61 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     return false;
   }
 
-  const std::vector<const moveit::core::JointModel*>& joint_models = group->getActiveJointModels();
+  const std::vector<const JointModel*>& joint_models = group->getActiveJointModels();
   if (joint_models.empty())
   {
     RCLCPP_ERROR(LOGGER, "The group '%s' doesn't contain any joint models. Cannot compute Jacobian.",
                  group->getName().c_str());
     return false;
   }
+
+  // Get the link model of the group root link, and it's inverted pose with respect to the RobotModel (URDF) root,
+  // 'root_pose_world'.
   const JointModel* root_joint_model = group->getJointModels().front();
   const LinkModel* root_link_model = root_joint_model->getParentLinkModel();
-
   const Eigen::Isometry3d root_pose_world =
       root_link_model ? getGlobalLinkTransform(root_link_model).inverse() : Eigen::Isometry3d::Identity();
   const int rows = use_quaternion_representation ? 7 : 6;
   const int columns = group->getVariableCount();
   jacobian.resize(rows, columns);
 
+  // Get the tip pose with respect to the group root link. Append the user-requested offset 'reference_point_position'.
   const Eigen::Isometry3d root_pose_tip = root_pose_world * getGlobalLinkTransform(link);
   const Eigen::Vector3d tip_point = root_pose_tip * reference_point_position;
 
+  // Here we iterate over all the group active joints, and compute how much each of them contribute to the Cartesian
+  // displacement at the tip. So we build the Jacobian incrementally joint by joint.
   std::size_t active_joints = group->getActiveJointModels().size();
   int i = 0;
   for (std::size_t joint = 0; joint < active_joints; ++joint)
   {
+    // Get the child link for the current joint, and its pose with respect to the group root link.
     const JointModel* joint_model = joint_models[joint];
     const LinkModel* child_link_model = joint_model->getChildLinkModel();
-    const Eigen::Isometry3d& origin_pose_link = getGlobalLinkTransform(child_link_model);
+    const Eigen::Isometry3d& root_pose_link = root_pose_world * getGlobalLinkTransform(child_link_model);
 
+    // Compute the Jacobian for the specific joint model, given with respect to the group root link.
     if (joint_model->getType() == JointModel::REVOLUTE)
     {
       const Eigen::Vector3d axis_wrt_origin =
-          origin_pose_link.linear() * static_cast<const moveit::core::RevoluteJointModel*>(joint_model)->getAxis();
-      jacobian.block<3, 1>(0, i) = axis_wrt_origin.cross(tip_point - origin_pose_link.translation());
+          root_pose_link.linear() * static_cast<const RevoluteJointModel*>(joint_model)->getAxis();
+      jacobian.block<3, 1>(0, i) = axis_wrt_origin.cross(tip_point - root_pose_link.translation());
       jacobian.block<3, 1>(3, i) = axis_wrt_origin;
     }
     else if (joint_model->getType() == JointModel::PRISMATIC)
     {
       const Eigen::Vector3d axis_wrt_origin =
-          origin_pose_link.linear() * static_cast<const moveit::core::PrismaticJointModel*>(joint_model)->getAxis();
+          root_pose_link.linear() * static_cast<const PrismaticJointModel*>(joint_model)->getAxis();
       jacobian.block<3, 1>(0, i) = axis_wrt_origin;
       jacobian.block<3, 1>(3, i) = Eigen::Vector3d::Zero();
     }
     else if (joint_model->getType() == JointModel::PLANAR)
     {
-      jacobian.block<3, 1>(0, i) = origin_pose_link.linear() * Eigen::Vector3d(1.0, 0.0, 0.0);
-      jacobian.block<3, 1>(0, i + 1) = origin_pose_link.linear() * Eigen::Vector3d(0.0, 1.0, 0.0);
+      jacobian.block<3, 1>(0, i) = root_pose_link.linear() * Eigen::Vector3d(1.0, 0.0, 0.0);
+      jacobian.block<3, 1>(0, i + 1) = root_pose_link.linear() * Eigen::Vector3d(0.0, 1.0, 0.0);
       jacobian.block<3, 1>(0, i + 2) =
-          (origin_pose_link.linear() * Eigen::Vector3d(0.0, 0.0, 1.0)).cross(tip_point - origin_pose_link.translation());
-      jacobian.block<3, 1>(3, i + 2) = origin_pose_link.linear() * Eigen::Vector3d(0.0, 0.0, 1.0);
+          (root_pose_link.linear() * Eigen::Vector3d(0.0, 0.0, 1.0)).cross(tip_point - root_pose_link.translation());
+      jacobian.block<3, 1>(3, i + 2) = root_pose_link.linear() * Eigen::Vector3d(0.0, 0.0, 1.0);
     }
     else
     {
@@ -1760,13 +1765,13 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
         }
         if (pose_frame != solver_tip_frame)
         {
-          const moveit::core::LinkModel* link_model = getLinkModel(pose_frame);
+          const LinkModel* link_model = getLinkModel(pose_frame);
           if (!link_model)
           {
             RCLCPP_ERROR(LOGGER, "The following Pose Frame does not exist: %s", pose_frame.c_str());
             return false;
           }
-          const moveit::core::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
+          const LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
           for (const std::pair<const LinkModel* const, Eigen::Isometry3d>& fixed_link : fixed_links)
           {
             if (Transforms::sameFrame(fixed_link.first->getName(), solver_tip_frame))
@@ -1974,11 +1979,11 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
       }
       if (pose_frame != solver_tip_frame)
       {
-        const moveit::core::LinkModel* link_model = getLinkModel(pose_frame);
+        const LinkModel* link_model = getLinkModel(pose_frame);
         if (!link_model)
           return false;
         // getAssociatedFixedTransforms() returns valid isometries by contract
-        const moveit::core::LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
+        const LinkTransformMap& fixed_links = link_model->getAssociatedFixedTransforms();
         for (const std::pair<const LinkModel* const, Eigen::Isometry3d>& fixed_link : fixed_links)
         {
           if (fixed_link.first->getName() == solver_tip_frame)
@@ -2168,12 +2173,12 @@ void RobotState::printStatePositions(std::ostream& out) const
     out << nm[i] << '=' << position_[i] << '\n';
 }
 
-void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointModelGroup* jmg, std::ostream& out) const
+void RobotState::printStatePositionsWithJointLimits(const JointModelGroup* jmg, std::ostream& out) const
 {
   // TODO(davetcoleman): support joints with multiple variables / multiple DOFs such as floating joints
   // TODO(davetcoleman): support unbounded joints
 
-  const std::vector<const moveit::core::JointModel*>& joints = jmg->getActiveJointModels();
+  const std::vector<const JointModel*>& joints = jmg->getActiveJointModels();
 
   // Loop through joints
   for (const JointModel* joint : joints)
@@ -2187,7 +2192,7 @@ void RobotState::printStatePositionsWithJointLimits(const moveit::core::JointMod
     // check if joint is beyond limits
     bool out_of_bounds = !satisfiesBounds(joint);
 
-    const moveit::core::VariableBounds& bound = joint->getVariableBounds()[0];
+    const VariableBounds& bound = joint->getVariableBounds()[0];
 
     if (out_of_bounds)
       out << MOVEIT_CONSOLE_COLOR_RED;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1374,7 +1374,7 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
     return false;
   }
 
-  // Get the link model of the group root link, and it's inverted pose with respect to the RobotModel (URDF) root,
+  // Get the link model of the group root link, and its inverted pose with respect to the RobotModel (URDF) root,
   // 'root_pose_world'.
   const JointModel* root_joint_model = group->getJointModels().front();
   const LinkModel* root_link_model = root_joint_model->getParentLinkModel();


### PR DESCRIPTION
### Description

This change makes `getJacobian` a little bit more readable (hopefully!), while also making it 2x faster, by removing string comparisons where possible and other little optimizations.
The jacobian benchmark shows a ~2x improvement with respect to HEAD (>500ns), and ~4x with respect to the KDL Jacobian, for the panda robot:

```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_MoveItJacobian        248 ns          249 ns      2867707
BM_KDLJacobian          1099 ns         1100 ns       634762
```

The recently added Jacobian tests for the different types of joints are also passing.
Also manually tested this with Servo, which I know uses the MoveIt! Jacobian.

Note: `a_pose_b` is a notation I have used in the past to denote a transformation matrix to convert points in `b` to points in `a`, e.g:  `point_a = a_pose_b * point_b`. Not sure if there's another established notation if MoveIt!. Happy to change to whatever makes more sense.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
