### PR TITLE
[PSM] Get the parameter values of the main node when declaring them in the private node.

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -661,15 +661,11 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
   }
   if (publish_planning_scene)
   {
-    RCLCPP_INFO(LOGGER, "Publishing maintained planning scene on '%s'", planning_scene_publisher_->get_topic_name());
     setPlanningScenePublishingFrequency(publish_planning_scene_hz);
     startPublishingPlanningScene(event);
   }
   else
-  {
-    RCLCPP_INFO(LOGGER, "STOPPED Publishing maintained planning scene on");
     stopPublishingPlanningScene();
-  }
 }
 
 void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::ConstSharedPtr& scene)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -224,7 +224,8 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
   private_executor_thread_ = std::thread([this]() { private_executor_->spin(); });
 
   auto declare_parameter = [this](const std::string& param_name, auto default_val,
-                                  const std::string& description) -> auto {
+                                  const std::string& description) -> auto 
+  {
     rcl_interfaces::msg::ParameterDescriptor desc;
     desc.set__description(description);
     return pnode_->declare_parameter(param_name, default_val, desc);
@@ -280,7 +281,8 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     return;
   }
 
-  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto {
+  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto 
+  {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -233,17 +233,43 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
 
   try
   {
+    bool publish_planning_scene = false;
+    bool publish_geometry_updates = false;
+    bool publish_state_updates = false;
+    bool publish_transform_updates = false;
+    double publish_planning_scene_hz = 4.0;
+    if(node_->has_parameter("publish_planning_scene"))
+    {
+      publish_planning_scene = node_->get_parameter("publish_planning_scene").as_bool();
+    }
+    if(node_->has_parameter("publish_geometry_updates"))
+    {
+      publish_geometry_updates = node_->get_parameter("publish_geometry_updates").as_bool();
+    }
+    if(node_->has_parameter("publish_state_updates"))
+    {
+      publish_state_updates = node_->get_parameter("publish_state_updates").as_bool();
+    }
+    if(node_->has_parameter("publish_transforms_updates"))
+    {
+      publish_transform_updates = node_->get_parameter("publish_transforms_updates").as_bool();
+    }
+    if(node_->has_parameter("publish_planning_scene_hz"))
+    {
+      publish_planning_scene_hz = node_->get_parameter("publish_planning_scene_hz").as_double();
+    }
+
     // Set up publishing parameters
-    bool publish_planning_scene =
-        declare_parameter("publish_planning_scene", false, "Set to True to publish Planning Scenes");
-    bool publish_geometry_updates = declare_parameter("publish_geometry_updates", false,
+    publish_planning_scene =
+        declare_parameter("publish_planning_scene", publish_planning_scene, "Set to True to publish Planning Scenes");
+    publish_geometry_updates = declare_parameter("publish_geometry_updates", publish_geometry_updates,
                                                       "Set to True to publish geometry updates of the planning scene");
-    bool publish_state_updates =
-        declare_parameter("publish_state_updates", false, "Set to True to publish state updates of the planning scene");
-    bool publish_transform_updates = declare_parameter(
-        "publish_transforms_updates", false, "Set to True to publish transform updates of the planning scene");
-    double publish_planning_scene_hz = declare_parameter(
-        "publish_planning_scene_hz", 4.0, "Set the maximum frequency at which planning scene updates are published");
+    publish_state_updates =
+        declare_parameter("publish_state_updates", publish_state_updates, "Set to True to publish state updates of the planning scene");
+    publish_transform_updates = declare_parameter(
+        "publish_transforms_updates", publish_transform_updates, "Set to True to publish transform updates of the planning scene");
+    publish_planning_scene_hz = declare_parameter(
+        "publish_planning_scene_hz", publish_planning_scene_hz, "Set the maximum frequency at which planning scene updates are published");
     updatePublishSettings(publish_geometry_updates, publish_state_updates, publish_transform_updates,
                           publish_planning_scene, publish_planning_scene_hz);
   }
@@ -636,11 +662,14 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
   }
   if (publish_planning_scene)
   {
+    RCLCPP_INFO(LOGGER, "Publishing maintained planning scene on '%s'", planning_scene_publisher_->get_topic_name());
     setPlanningScenePublishingFrequency(publish_planning_scene_hz);
     startPublishingPlanningScene(event);
   }
-  else
+  else {
+      RCLCPP_INFO(LOGGER, "STOPPED Publishing maintained planning scene on");
     stopPublishingPlanningScene();
+  }
 }
 
 void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::msg::PlanningScene::ConstSharedPtr& scene)

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -224,7 +224,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
   private_executor_thread_ = std::thread([this]() { private_executor_->spin(); });
 
   auto declare_parameter = [this](const std::string& param_name, auto default_val,
-                                  const std::string& description) -> auto 
+                                  const std::string& description) -> auto
   {
     rcl_interfaces::msg::ParameterDescriptor desc;
     desc.set__description(description);
@@ -281,7 +281,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     return;
   }
 
-  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto 
+  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto
   {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -224,8 +224,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
   private_executor_thread_ = std::thread([this]() { private_executor_->spin(); });
 
   auto declare_parameter = [this](const std::string& param_name, auto default_val,
-                                  const std::string& description) -> auto
-  {
+                                  const std::string& description) -> auto {
     rcl_interfaces::msg::ParameterDescriptor desc;
     desc.set__description(description);
     return pnode_->declare_parameter(param_name, default_val, desc);
@@ -238,23 +237,23 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     bool publish_state_updates = false;
     bool publish_transform_updates = false;
     double publish_planning_scene_hz = 4.0;
-    if(node_->has_parameter("publish_planning_scene"))
+    if (node_->has_parameter("publish_planning_scene"))
     {
       publish_planning_scene = node_->get_parameter("publish_planning_scene").as_bool();
     }
-    if(node_->has_parameter("publish_geometry_updates"))
+    if (node_->has_parameter("publish_geometry_updates"))
     {
       publish_geometry_updates = node_->get_parameter("publish_geometry_updates").as_bool();
     }
-    if(node_->has_parameter("publish_state_updates"))
+    if (node_->has_parameter("publish_state_updates"))
     {
       publish_state_updates = node_->get_parameter("publish_state_updates").as_bool();
     }
-    if(node_->has_parameter("publish_transforms_updates"))
+    if (node_->has_parameter("publish_transforms_updates"))
     {
       publish_transform_updates = node_->get_parameter("publish_transforms_updates").as_bool();
     }
-    if(node_->has_parameter("publish_planning_scene_hz"))
+    if (node_->has_parameter("publish_planning_scene_hz"))
     {
       publish_planning_scene_hz = node_->get_parameter("publish_planning_scene_hz").as_double();
     }
@@ -263,13 +262,14 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     publish_planning_scene =
         declare_parameter("publish_planning_scene", publish_planning_scene, "Set to True to publish Planning Scenes");
     publish_geometry_updates = declare_parameter("publish_geometry_updates", publish_geometry_updates,
-                                                      "Set to True to publish geometry updates of the planning scene");
-    publish_state_updates =
-        declare_parameter("publish_state_updates", publish_state_updates, "Set to True to publish state updates of the planning scene");
-    publish_transform_updates = declare_parameter(
-        "publish_transforms_updates", publish_transform_updates, "Set to True to publish transform updates of the planning scene");
-    publish_planning_scene_hz = declare_parameter(
-        "publish_planning_scene_hz", publish_planning_scene_hz, "Set the maximum frequency at which planning scene updates are published");
+                                                 "Set to True to publish geometry updates of the planning scene");
+    publish_state_updates = declare_parameter("publish_state_updates", publish_state_updates,
+                                              "Set to True to publish state updates of the planning scene");
+    publish_transform_updates = declare_parameter("publish_transforms_updates", publish_transform_updates,
+                                                  "Set to True to publish transform updates of the planning scene");
+    publish_planning_scene_hz =
+        declare_parameter("publish_planning_scene_hz", publish_planning_scene_hz,
+                          "Set the maximum frequency at which planning scene updates are published");
     updatePublishSettings(publish_geometry_updates, publish_state_updates, publish_transform_updates,
                           publish_planning_scene, publish_planning_scene_hz);
   }
@@ -280,8 +280,7 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
     return;
   }
 
-  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto
-  {
+  auto psm_parameter_set_callback = [this](const std::vector<rclcpp::Parameter>& parameters) -> auto {
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 
@@ -666,8 +665,9 @@ void PlanningSceneMonitor::updatePublishSettings(bool publish_geom_updates, bool
     setPlanningScenePublishingFrequency(publish_planning_scene_hz);
     startPublishingPlanningScene(event);
   }
-  else {
-      RCLCPP_INFO(LOGGER, "STOPPED Publishing maintained planning scene on");
+  else
+  {
+    RCLCPP_INFO(LOGGER, "STOPPED Publishing maintained planning scene on");
     stopPublishingPlanningScene();
   }
 }


### PR DESCRIPTION
### Description

When creating the PlanningSceneMonitor a private node is created. (This was done here: #266)
This however doesn't use the declared parameters in the main node. 

I added a check if the parameters exist and updated the default value of the parameter in the private node to this value.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
