### PR TITLE
PRBT IkFast patch from robostack

### DIFF
--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -805,12 +805,12 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
     return false;
   }
 
-  IkReal angles[num_joints_];
+  std::vector<IkReal> angles(num_joints_, 0);
   for (unsigned char i = 0; i < num_joints_; i++)
     angles[i] = joint_angles[i];
 
   // IKFast56/61
-  ComputeFk(angles, eetrans, eerot);
+  ComputeFk(angles.data(), eetrans, eerot);
 
   for (int i = 0; i < 3; ++i)
     p_out.p.data[i] = eetrans[i];

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_solver.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_solver.cpp
@@ -26,8 +26,7 @@
 using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
-#define IKFAST_COMPILE_ASSERT(x) extern int __dummy[static_cast<int>(x)]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==0x1000004a);
+static_assert(IKFAST_VERSION==61); // version found in ikfast.h
 
 #include <cmath>
 #include <vector>


### PR DESCRIPTION
### Description

Modified version of this: https://github.com/RoboStack/ros-humble/blob/main/patch/ros-humble-moveit-resources-prbt-ikfast-manipulator-plugin.patch

Quoting @traversaro
> This seems a use of variable length array (that is not supported on MSVC) and hack to implement a static assert that can be substituted with a C++11's static_assert ?

I used a std::vector as we tend to use C++ types to avoid raw new/delete here in MoveIt.

On the version of ikfast changing in that static_assert. I searched for copies of the ikfast.h header, and it is in two places in our repo, and in both places, the version is 61. When I set the version to what it was in that hack, it failed, complaining that the version is 61 so the old test wasn't working anyway, and we've been compiling with version 61.