### PR TITLE
Enable using a subgroup of the move group in servo

### DIFF
--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -49,7 +49,7 @@ servo:
   active_subgroup: {
     type: string,
     default_value: "",
-    description: "This parameter can be used to switch online to actuating a sub-joint group of the move group with servo. \
+    description: "This parameter can be used to switch online to actuating a subgroup of the move group. \
     If it is empty, the full move group is actuated."
   }
 

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -46,8 +46,14 @@ servo:
                   must be passed to the node during launch time."
   }
 
-############################# INCOMING COMMAND SETTINGS ########################
+  active_subgroup: {
+    type: string,
+    default_value: "",
+    description: "This parameter can be used to switch online to actuating a sub-joint group of the move group with servo. \
+    If it is empty, the full move group is actuated."
+  }
 
+############################# INCOMING COMMAND SETTINGS ########################
   pose_command_in_topic: {
     type: string,
     read_only: true,

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -214,6 +214,9 @@ private:
   std::unique_ptr<CollisionMonitor> collision_monitor_;
 
   pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass> smoother_ = nullptr;
+
+  // Map between joint subgroup names and corresponding joint name - move group indices map
+  std::unordered_map<std::string, JointNameToMoveGroupIndexMap> joint_name_to_index_maps_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/command.hpp
@@ -55,7 +55,7 @@ namespace moveit_servo
  * @param command The joint jog command.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
- * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
+ * @param joint_name_group_index_map Mapping between joint subgroup name and move group joint vector position.
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromJointJog(const JointJogCommand& command, const moveit::core::RobotStatePtr& robot_state,
@@ -67,7 +67,7 @@ JointDeltaResult jointDeltaFromJointJog(const JointJogCommand& command, const mo
  * @param command The twist command.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
- * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
+ * @param joint_name_group_index_map Mapping between joint subgroup name and move group joint vector position.
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromTwist(const TwistCommand& command, const moveit::core::RobotStatePtr& robot_state,
@@ -91,7 +91,7 @@ JointDeltaResult jointDeltaFromPose(const PoseCommand& command, const moveit::co
  * @param cartesian_position_delta The change in Cartesian position.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
- * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
+ * @param joint_name_group_index_map Mapping between joint subgroup name and move group joint vector position.
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delta,

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/command.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/command.hpp
@@ -55,39 +55,47 @@ namespace moveit_servo
  * @param command The joint jog command.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
+ * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromJointJog(const JointJogCommand& command, const moveit::core::RobotStatePtr& robot_state,
-                                        const servo::Params& servo_params);
+                                        const servo::Params& servo_params,
+                                        const JointNameToMoveGroupIndexMap& joint_name_group_index_map);
 
 /**
  * \brief Compute the change in joint position for the given twist command.
  * @param command The twist command.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
+ * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromTwist(const TwistCommand& command, const moveit::core::RobotStatePtr& robot_state,
-                                     const servo::Params& servo_params);
+                                     const servo::Params& servo_params,
+                                     const JointNameToMoveGroupIndexMap& joint_name_group_index_map);
 
 /**
  * \brief Compute the change in joint position for the given pose command.
  * @param command The pose command.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
+ * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromPose(const PoseCommand& command, const moveit::core::RobotStatePtr& robot_state,
-                                    const servo::Params& servo_params);
+                                    const servo::Params& servo_params,
+                                    const JointNameToMoveGroupIndexMap& joint_name_group_index_map);
 
 /**
  * \brief Computes the required change in joint angles for given Cartesian change, using the robot's IK solver.
  * @param cartesian_position_delta The change in Cartesian position.
  * @param robot_state_ The current robot state as obtained from PlanningSceneMonitor.
  * @param servo_params The servo parameters.
+ * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
  * @return The status and joint position change required (delta).
  */
 JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delta,
-                                  const moveit::core::RobotStatePtr& robot_state, const servo::Params& servo_params);
+                                  const moveit::core::RobotStatePtr& robot_state, const servo::Params& servo_params,
+                                  const JointNameToMoveGroupIndexMap& joint_name_group_index_map);
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
@@ -129,4 +129,7 @@ struct KinematicState
   }
 };
 
+// Mapping joint names and their position in the move group vector
+typedef std::unordered_map<std::string, std::size_t> JointNameToMoveGroupIndexMap;
+
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -248,7 +248,6 @@ bool Servo::validateParams(const servo::Params& servo_params) const
 bool Servo::updateParams()
 {
   bool params_updated = false;
-  
   if (servo_param_listener_->is_old(servo_params_))
   {
     const auto params = servo_param_listener_->get_params();

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -159,12 +159,13 @@ void Servo::setCollisionChecking(const bool check_collision)
 
 bool Servo::validateParams(const servo::Params& servo_params) const
 {
+  bool params_valid = true;
   auto robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   auto joint_model_group = robot_state->getJointModelGroup(servo_params.move_group_name);
   if (joint_model_group == nullptr)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Invalid move group name: `" << servo_params.move_group_name << '`');
-    return false;
+    params_valid = false;
   }
 
   if (servo_params.hard_stop_singularity_threshold <= servo_params.lower_singularity_threshold)
@@ -172,7 +173,7 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR(LOGGER, "Parameter 'hard_stop_singularity_threshold' "
                          "should be greater than 'lower_singularity_threshold.' "
                          "Check the parameters YAML file used to launch this node.");
-    return false;
+    params_valid = false;
   }
 
   if (!servo_params.publish_joint_positions && !servo_params.publish_joint_velocities &&
@@ -182,7 +183,7 @@ bool Servo::validateParams(const servo::Params& servo_params) const
                          "publish_joint_velocities / "
                          "publish_joint_accelerations must be true. "
                          "Check the parameters YAML file used to launch this node.");
-    return false;
+    params_valid = false;
   }
 
   if ((servo_params.command_out_type == "std_msgs/Float64MultiArray") && servo_params.publish_joint_positions &&
@@ -191,7 +192,7 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR(LOGGER, "When publishing a std_msgs/Float64MultiArray, "
                          "you must select positions OR velocities."
                          "Check the parameters YAML file used to launch this node.");
-    return false;
+    params_valid = false;
   }
 
   if (servo_params.scene_collision_proximity_threshold < servo_params.self_collision_proximity_threshold)
@@ -199,7 +200,7 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR(LOGGER, "Parameter 'self_collision_proximity_threshold' should probably be less "
                          "than or equal to 'scene_collision_proximity_threshold'."
                          "Check the parameters YAML file used to launch this node.");
-    return false;
+    params_valid = false;
   }
 
   if (!servo_params.active_subgroup.empty() && servo_params.active_subgroup != servo_params.move_group_name &&
@@ -208,10 +209,10 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR(LOGGER,
                  "The value '%s' Parameter 'active_subgroup' does not name a valid subgroup of joint group '%s'.",
                  servo_params.active_subgroup.c_str(), servo_params.move_group_name.c_str());
-    return false;
+    params_valid = false;
   }
 
-  return true;
+  return params_valid;
 }
 
 bool Servo::updateParams()

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -159,13 +159,6 @@ void Servo::setCollisionChecking(const bool check_collision)
 
 bool Servo::validateParams(const servo::Params& servo_params) const
 {
-  if (params.move_group_name != servo_params_.move_group_name)
-  {
-    RCLCPP_ERROR_STREAM(LOGGER, "It is not possible to change the move group online from "
-                                    << servo_params_.move_group_name << " to " << params.move_group_name);
-    return false;
-  }
-
   auto robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();
   auto joint_model_group = robot_state->getJointModelGroup(servo_params.move_group_name);
   if (joint_model_group == nullptr)

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -136,7 +136,7 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
     // For each joint name of the subgroup calculate the index in the move group joint vector
     for (const auto& joint_name : subgroup_joint_names)
     {
-      // Find sub group joint name in move group joint names
+      // Find subgroup joint name in move group joint names
       const auto move_group_iterator =
           std::find(move_group_joint_names.cbegin(), move_group_joint_names.cend(), joint_name);
       // Calculate position and add a new mapping of joint name to move group joint vector position
@@ -247,6 +247,8 @@ bool Servo::validateParams(const servo::Params& servo_params) const
 
 bool Servo::updateParams()
 {
+  bool params_updated = false;
+  
   if (servo_param_listener_->is_old(servo_params_))
   {
     const auto params = servo_param_listener_->get_params();
@@ -260,14 +262,14 @@ bool Servo::updateParams()
       }
 
       servo_params_ = params;
-      return true;
+      params_updated = true;
     }
     else
     {
       RCLCPP_WARN_STREAM(LOGGER, "Parameters will not be updated.");
     }
   }
-  return false;
+  return params_updated;
 }
 
 servo::Params& Servo::getParams()

--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -50,7 +50,7 @@ const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.command_processor
  * @param sub_group_deltas Set of command deltas for a subgroup of the move group actuated by servo
  * @param robot_state Current robot state
  * @param servo_params Servo params
- * @param joint_name_group_index_map Mapping between sub group joint name and move group joint vector position
+ * @param joint_name_group_index_map Mapping between joint subgroup name and move group joint vector position.
  * @return Delta vector for the whole move group. The elements that don't belong to the actuated subgroup are zero.
  */
 const Eigen::VectorXd createMoveGroupDelta(const Eigen::VectorXd& sub_group_deltas,

--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -275,7 +275,7 @@ JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delt
 
   if (!servo_params.active_subgroup.empty())
   {
-    // Create full delta vector and add delta theta's at actuated joints
+    // Create full delta vector and add delta theta values only at actuated joints
     const auto& move_group_joint_names =
         robot_state->getJointModelGroup(servo_params.move_group_name)->getActiveJointModelNames();
     const auto& subgroup_joint_names =

--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -243,6 +243,7 @@ JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delt
 
     // setup for IK call
     std::vector<double> solution;
+    solution.reserve(current_joint_positions.size());
     moveit_msgs::msg::MoveItErrorCodes err;
     kinematics::KinematicsQueryOptions opts;
     opts.return_approximate_solution = true;
@@ -252,7 +253,7 @@ JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delt
       // find the difference in joint positions that will get us to the desired pose
       for (size_t i = 0; i < current_joint_positions.size(); ++i)
       {
-        delta_theta[i] = solution[i] - current_joint_positions[i];
+        delta_theta[i] = solution.at(i) - current_joint_positions.at(i);
       }
     }
     else
@@ -273,7 +274,7 @@ JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delt
     delta_theta = pseudo_inverse * cartesian_position_delta;
   }
 
-  if (!servo_params.active_subgroup.empty())
+  if (!servo_params.active_subgroup.empty() && servo_params.active_subgroup != servo_params.move_group_name)
   {
     // Create full delta vector and add delta theta values only at actuated joints
     const auto& move_group_joint_names =

--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -210,7 +210,7 @@ JointDeltaResult jointDeltaFromPose(const PoseCommand& command, const moveit::co
 JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delta,
                                   const moveit::core::RobotStatePtr& robot_state, const servo::Params& servo_params)
 {
-  auto const& group_name =
+  const auto& group_name =
       servo_params.active_subgroup.empty() ? servo_params.move_group_name : servo_params.active_subgroup;
   const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(group_name);
 
@@ -276,15 +276,15 @@ JointDeltaResult jointDeltaFromIK(const Eigen::VectorXd& cartesian_position_delt
   if (!servo_params.active_subgroup.empty())
   {
     // Create full delta vector and add delta theta's at actuated joints
-    auto const& move_group_joint_names =
+    const auto& move_group_joint_names =
         robot_state->getJointModelGroup(servo_params.move_group_name)->getActiveJointModelNames();
-    auto const& subgroup_joint_names =
+    const auto& subgroup_joint_names =
         robot_state->getJointModelGroup(servo_params.active_subgroup)->getActiveJointModelNames();
 
     Eigen::VectorXd move_group_delta_theta = Eigen::VectorXd::Zero(move_group_joint_names.size());
     for (size_t index = 0; index < subgroup_joint_names.size(); index++)
     {
-      auto const move_group_iterator =
+      const auto move_group_iterator =
           find(move_group_joint_names.cbegin(), move_group_joint_names.cend(), subgroup_joint_names.at(index));
       move_group_delta_theta[std::distance(move_group_joint_names.cbegin(), move_group_iterator)] = delta_theta[index];
     }


### PR DESCRIPTION
### Description

This PR enables using a subgroup of the move_group at runtime without the need to stop servo or switch controllers.

- [x] Make subgroup -> move group joint index mapping more efficient
- [x] Disable joint jogging for joints that aren't part of active subgroup

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
