### PR TITLE
Update `collision_detection_bullet` install path

### DIFF
--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -47,8 +47,8 @@ target_link_libraries(collision_detector_bullet_plugin
   moveit_planning_scene
 )
 
-install(DIRECTORY include/ DESTINATION include/moveit_core)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_bullet_export.h DESTINATION include/moveit_core)
+install(DIRECTORY include/ DESTINATION include)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_collision_detection_bullet_export.h DESTINATION include)
 
 if(BUILD_TESTING)
   if(WIN32)


### PR DESCRIPTION
### Description

Attempt to fix https://github.com/ros-planning/moveit2/issues/2402.

- `collision_detection_bullet` was the only subfolder whose install path was updated to `include/moveit_core/moveit` in the 2.5.5 release.
- In this update, the `target_include_directories` was not updated accordingly, causing the issue associated with this PR.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
