### PR TITLE
[Servo] Update Smoothing plugin API

### DIFF
--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -15,6 +15,7 @@ set_target_properties(moveit_smoothing_base PROPERTIES VERSION
 )
 ament_target_dependencies(moveit_smoothing_base
   rclcpp
+  tf2_eigen
 )
 
 # Plugin implementations

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
@@ -114,7 +114,8 @@ public:
    * @param joint_positions reset the filters to these joint positions
    * @return True if reset was successful
    */
-  bool reset(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) override;
+  bool reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+             const Eigen::VectorXd& accelerations) override;
 
 private:
   rclcpp::Node::SharedPtr node_;

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/butterworth_filter.h
@@ -107,14 +107,14 @@ public:
    * @param position_vector array of joint position commands
    * @return True if initialization was successful
    */
-  bool doSmoothing(std::vector<double>& position_vector) override;
+  bool doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) override;
 
   /**
    * Reset to a given joint state
    * @param joint_positions reset the filters to these joint positions
    * @return True if reset was successful
    */
-  bool reset(const std::vector<double>& joint_positions) override;
+  bool reset(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) override;
 
 private:
   rclcpp::Node::SharedPtr node_;

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
@@ -83,7 +83,8 @@ public:
    * @param joint_positions reset the filters to these joint positions
    * @return True if reset was successful
    */
-  virtual bool reset(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) = 0;
+  virtual bool reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+                     const Eigen::VectorXd& accelerations) = 0;
   ;
 };
 }  // namespace online_signal_smoothing

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
@@ -43,7 +43,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit_smoothing_base_export.h>
 
-#include <tf2_eigen/tf2_eigen.hpp>
+#include <Eigen/Dense>
 
 namespace moveit
 {

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
@@ -38,12 +38,12 @@
 
 #pragma once
 
-#include <optional>
-
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
+
 #include <moveit/macros/class_forward.h>
 #include <moveit_smoothing_base_export.h>
+
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit
 {

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/smoothing_base_class.h
@@ -38,9 +38,11 @@
 
 #pragma once
 
-#include <rclcpp/rclcpp.hpp>
-#include <moveit/macros/class_forward.h>
+#include <optional>
 
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <moveit/macros/class_forward.h>
 #include <moveit_smoothing_base_export.h>
 
 namespace moveit
@@ -74,13 +76,14 @@ public:
    * @param position_vector array of joint position commands
    * @return True if initialization was successful
    */
-  virtual bool doSmoothing(std::vector<double>& position_vector) = 0;
+  virtual bool doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) = 0;
 
   /**
    * Reset to a given joint state
    * @param joint_positions reset the filters to these joint positions
    * @return True if reset was successful
    */
-  virtual bool reset(const std::vector<double>& joint_positions) = 0;
+  virtual bool reset(Eigen::VectorXd& positions, Eigen::VectorXd& velocities, Eigen::VectorXd& accelerations) = 0;
+  ;
 };
 }  // namespace online_signal_smoothing

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -117,13 +117,14 @@ bool ButterworthFilterPlugin::initialize(rclcpp::Node::SharedPtr node, moveit::c
 bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& /* unused */,
                                           Eigen::VectorXd& /* unused */)
 {
-  if (positions.size() != position_filters_.size())
+  const size_t num_positions = positions.size();
+  if (num_positions != position_filters_.size())
   {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
                           "Position vector to be smoothed does not have the right length.");
     return false;
   }
-  for (size_t i = 0; i < positions.size(); ++i)
+  for (size_t i = 0; i < num_positions; ++i)
   {
     // Lowpass filter the position command
     positions[i] = position_filters_.at(i).filter(positions[i]);
@@ -134,13 +135,14 @@ bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::Vec
 bool ButterworthFilterPlugin::reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& /* unused */,
                                     const Eigen::VectorXd& /* unused */)
 {
-  if (positions.size() != position_filters_.size())
+  const size_t num_positions = positions.size();
+  if (num_positions != position_filters_.size())
   {
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
                           "Position vector to be reset does not have the right length.");
     return false;
   }
-  for (size_t joint_idx = 0; joint_idx < positions.size(); ++joint_idx)
+  for (size_t joint_idx = 0; joint_idx < num_positions; ++joint_idx)
   {
     position_filters_.at(joint_idx).reset(positions[joint_idx]);
   }

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -131,8 +131,8 @@ bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::Vec
   return true;
 };
 
-bool ButterworthFilterPlugin::reset(Eigen::VectorXd& positions, Eigen::VectorXd& velocities,
-                                    Eigen::VectorXd& accelerations)
+bool ButterworthFilterPlugin::reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+                                    const Eigen::VectorXd& accelerations)
 {
   if (positions.size() != position_filters_.size())
   {

--- a/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/butterworth_filter.cpp
@@ -114,8 +114,8 @@ bool ButterworthFilterPlugin::initialize(rclcpp::Node::SharedPtr node, moveit::c
   return true;
 };
 
-bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& velocities,
-                                          Eigen::VectorXd& accelerations)
+bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& /* unused */,
+                                          Eigen::VectorXd& /* unused */)
 {
   if (positions.size() != position_filters_.size())
   {
@@ -131,8 +131,8 @@ bool ButterworthFilterPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::Vec
   return true;
 };
 
-bool ButterworthFilterPlugin::reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
-                                    const Eigen::VectorXd& accelerations)
+bool ButterworthFilterPlugin::reset(const Eigen::VectorXd& positions, const Eigen::VectorXd& /* unused */,
+                                    const Eigen::VectorXd& /* unused */)
 {
   if (positions.size() != position_filters_.size())
   {

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
@@ -114,7 +114,7 @@ typedef std::variant<JointJogCommand, TwistCommand, PoseCommand> ServoInput;
 struct KinematicState
 {
   std::vector<std::string> joint_names;
-  std::vector<double> positions, velocities, accelerations;
+  Eigen::VectorXd positions, velocities, accelerations;
 
   KinematicState(const int num_joints)
   {

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -103,7 +103,8 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
     // Load the smoothing plugin
     if (servo_params_.use_smoothing)
     {
-      setSmoothingPlugin();
+      // setSmoothingPlugin();
+      RCLCPP_WARN(LOGGER, "smoothing plugin loaded");
     }
     else
     {
@@ -155,32 +156,32 @@ Servo::~Servo()
   setCollisionChecking(false);
 }
 
-void Servo::setSmoothingPlugin()
-{
-  // Load the smoothing plugin
-  try
-  {
-    pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader(
-        "moveit_core", "online_signal_smoothing::SmoothingBaseClass");
-    smoother_ = smoothing_loader.createUniqueInstance(servo_params_.smoothing_filter_plugin_name);
-  }
-  catch (pluginlib::PluginlibException& ex)
-  {
-    RCLCPP_ERROR(LOGGER, "Exception while loading the smoothing plugin '%s': '%s'",
-                 servo_params_.smoothing_filter_plugin_name.c_str(), ex.what());
-    std::exit(EXIT_FAILURE);
-  }
+// void Servo::setSmoothingPlugin()
+// {
+//   // Load the smoothing plugin
+//   try
+//   {
+//     pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader(
+//         "moveit_core", "online_signal_smoothing::SmoothingBaseClass");
+//     smoother_ = smoothing_loader.createUniqueInstance(servo_params_.smoothing_filter_plugin_name);
+//   }
+//   catch (pluginlib::PluginlibException& ex)
+//   {
+//     RCLCPP_ERROR(LOGGER, "Exception while loading the smoothing plugin '%s': '%s'",
+//                  servo_params_.smoothing_filter_plugin_name.c_str(), ex.what());
+//     std::exit(EXIT_FAILURE);
+//   }
 
-  // Initialize the smoothing plugin
-  moveit::core::RobotStatePtr robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();
-  const int num_joints =
-      robot_state->getJointModelGroup(servo_params_.move_group_name)->getActiveJointModelNames().size();
-  if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), num_joints))
-  {
-    RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
-    std::exit(EXIT_FAILURE);
-  }
-}
+//   // Initialize the smoothing plugin
+//   moveit::core::RobotStatePtr robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();
+//   const int num_joints =
+//       robot_state->getJointModelGroup(servo_params_.move_group_name)->getActiveJointModelNames().size();
+//   if (!smoother_->initialize(node_, planning_scene_monitor_->getRobotModel(), num_joints))
+//   {
+//     RCLCPP_ERROR(LOGGER, "Smoothing plugin could not be initialized");
+//     std::exit(EXIT_FAILURE);
+//   }
+// }
 
 void Servo::setCollisionChecking(const bool check_collision)
 {

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -121,13 +121,36 @@ trajectory_msgs::msg::JointTrajectory composeTrajectoryMessage(const servo::Para
 
   trajectory_msgs::msg::JointTrajectoryPoint point;
   point.time_from_start = rclcpp::Duration::from_seconds(servo_params.publish_period);
+  const size_t num_joints = joint_state.joint_names.size();
+  point.positions.resize(num_joints);
+  point.velocities.resize(num_joints);
+  point.accelerations.resize(num_joints);
 
   // Set the fields of trajectory point based on which fields are requested.
   // Some controllers check that acceleration data is non-empty, even if accelerations are not used
   // Send all zeros (joint_state.accelerations is a vector of all zeros).
-  point.positions = servo_params.publish_joint_positions ? joint_state.positions : point.positions;
-  point.velocities = servo_params.publish_joint_velocities ? joint_state.velocities : point.velocities;
-  point.accelerations = servo_params.publish_joint_accelerations ? joint_state.accelerations : point.accelerations;
+
+  if (servo_params.publish_joint_positions)
+  {
+    for (size_t i = 0; i < num_joints; i++)
+    {
+      point.positions[i] = joint_state.positions[i];
+    }
+  }
+  if (servo_params.publish_joint_velocities)
+  {
+    for (size_t i = 0; i < num_joints; i++)
+    {
+      point.velocities[i] = joint_state.velocities[i];
+    }
+  }
+  if (servo_params.publish_joint_accelerations)
+  {
+    for (size_t i = 0; i < num_joints; i++)
+    {
+      point.accelerations[i] = joint_state.accelerations[i];
+    }
+  }
 
   joint_trajectory.points.push_back(point);
   return joint_trajectory;
@@ -137,13 +160,21 @@ std_msgs::msg::Float64MultiArray composeMultiArrayMessage(const servo::Params& s
                                                           const KinematicState& joint_state)
 {
   std_msgs::msg::Float64MultiArray multi_array;
+  const size_t num_joints = joint_state.joint_names.size();
+  multi_array.data.resize(num_joints);
   if (servo_params.publish_joint_positions)
   {
-    multi_array.data = joint_state.positions;
+    for (size_t i = 0; i < num_joints; i++)
+    {
+      multi_array.data[i] = joint_state.positions[i];
+    }
   }
   else if (servo_params.publish_joint_velocities)
   {
-    multi_array.data = joint_state.velocities;
+    for (size_t i = 0; i < num_joints; i++)
+    {
+      multi_array.data[i] = joint_state.velocities[i];
+    }
   }
 
   return multi_array;

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -119,7 +119,7 @@ trajectory_msgs::msg::JointTrajectory composeTrajectoryMessage(const servo::Para
   joint_trajectory.header.frame_id = servo_params.planning_frame;
   joint_trajectory.joint_names = joint_state.joint_names;
 
-  trajectory_msgs::msg::JointTrajectoryPoint point;
+  static trajectory_msgs::msg::JointTrajectoryPoint point;
   point.time_from_start = rclcpp::Duration::from_seconds(servo_params.publish_period);
   const size_t num_joints = joint_state.joint_names.size();
   point.positions.resize(num_joints);


### PR DESCRIPTION
### Description

This PR updates the smoothing plugins to accept `Eigen` vectors instead of `std` vectors and lets us avoid having to create `Eigen::Map`s.  The only reason `moveit_servo::KinematicState` used `std::vector` was due to the smoothing plugin.
Additionally the API of the smoothing plugins has been updated in preparation for the `Ruckig` smoothing plugin.