### PR TITLE
Fix Servo singularity scaling unit tests

### DIFF
--- a/moveit_ros/moveit_servo/tests/test_utils.cpp
+++ b/moveit_ros/moveit_servo/tests/test_utils.cpp
@@ -154,7 +154,6 @@ TEST(ServoUtilsUnitTests, ApproachingSingularityScaling)
       robot_state->getJointModelGroup(servo_params.move_group_name);
   robot_state->setToDefaultValues();
 
-  rclcpp::sleep_for(std::chrono::milliseconds(500));
   Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
@@ -183,7 +182,6 @@ TEST(ServoUtilsUnitTests, HaltForSingularityScaling)
       robot_state->getJointModelGroup(servo_params.move_group_name);
   robot_state->setToDefaultValues();
 
-  rclcpp::sleep_for(std::chrono::milliseconds(500));
   Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
   // Home state
@@ -213,8 +211,7 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
       robot_state->getJointModelGroup(servo_params.move_group_name);
   robot_state->setToDefaultValues();
 
-  rclcpp::sleep_for(std::chrono::milliseconds(500));
-  Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  Eigen::Vector<double, 6> cartesian_delta{ -0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
@@ -223,15 +220,7 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
-  // Approach singularity
-  Eigen::Vector<double, 7> state_approaching_singularity{ 0.0, 0.334, 0.0, -1.177, 0.0, 1.510, 0.785 };
-  robot_state->setJointGroupActivePositions(joint_model_group, state_approaching_singularity);
-  robot_state->updateLinkTransforms();
-  scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
-  ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_APPROACHING_SINGULARITY);
-
   // Move away from singularity
-  cartesian_delta(0) *= -1;
   Eigen::Vector<double, 7> state_leaving_singularity{ 0.0, 0.3458, 0.0, -1.1424, 0.0, 1.4865, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_leaving_singularity);
   robot_state->updateLinkTransforms();

--- a/moveit_ros/moveit_servo/tests/test_utils.cpp
+++ b/moveit_ros/moveit_servo/tests/test_utils.cpp
@@ -158,14 +158,12 @@ TEST(ServoUtilsUnitTests, ApproachingSingularityScaling)
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
-  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Approach singularity
   Eigen::Vector<double, 7> state_approaching_singularity{ 0.0, 0.334, 0.0, -1.177, 0.0, 1.510, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_approaching_singularity);
-  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_APPROACHING_SINGULARITY);
 }
@@ -187,14 +185,12 @@ TEST(ServoUtilsUnitTests, HaltForSingularityScaling)
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
-  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Move to singular state.
   Eigen::Vector<double, 7> singular_state{ -0.0001, 0.5690, 0.0005, -0.7782, 0.0, 1.3453, 0.7845 };
   robot_state->setJointGroupActivePositions(joint_model_group, singular_state);
-  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::HALT_FOR_SINGULARITY);
 }
@@ -216,14 +212,12 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
-  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Move away from singularity
   Eigen::Vector<double, 7> state_leaving_singularity{ 0.0, 0.3458, 0.0, -1.1424, 0.0, 1.4865, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_leaving_singularity);
-  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY);
 }

--- a/moveit_ros/moveit_servo/tests/test_utils.cpp
+++ b/moveit_ros/moveit_servo/tests/test_utils.cpp
@@ -152,18 +152,21 @@ TEST(ServoUtilsUnitTests, ApproachingSingularityScaling)
   servo_params.move_group_name = "panda_arm";
   const moveit::core::JointModelGroup* joint_model_group =
       robot_state->getJointModelGroup(servo_params.move_group_name);
+  robot_state->setToDefaultValues();
 
   rclcpp::sleep_for(std::chrono::milliseconds(500));
   Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
+  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Approach singularity
   Eigen::Vector<double, 7> state_approaching_singularity{ 0.0, 0.334, 0.0, -1.177, 0.0, 1.510, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_approaching_singularity);
+  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_APPROACHING_SINGULARITY);
 }
@@ -178,6 +181,7 @@ TEST(ServoUtilsUnitTests, HaltForSingularityScaling)
   servo_params.move_group_name = "panda_arm";
   const moveit::core::JointModelGroup* joint_model_group =
       robot_state->getJointModelGroup(servo_params.move_group_name);
+  robot_state->setToDefaultValues();
 
   rclcpp::sleep_for(std::chrono::milliseconds(500));
   Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -185,12 +189,14 @@ TEST(ServoUtilsUnitTests, HaltForSingularityScaling)
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
+  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Move to singular state.
   Eigen::Vector<double, 7> singular_state{ -0.0001, 0.5690, 0.0005, -0.7782, 0.0, 1.3453, 0.7845 };
   robot_state->setJointGroupActivePositions(joint_model_group, singular_state);
+  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::HALT_FOR_SINGULARITY);
 }
@@ -205,6 +211,7 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
   servo_params.move_group_name = "panda_arm";
   const moveit::core::JointModelGroup* joint_model_group =
       robot_state->getJointModelGroup(servo_params.move_group_name);
+  robot_state->setToDefaultValues();
 
   rclcpp::sleep_for(std::chrono::milliseconds(500));
   Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -212,12 +219,14 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
   // Home state
   Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
+  robot_state->updateLinkTransforms();
   auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
 
   // Approach singularity
   Eigen::Vector<double, 7> state_approaching_singularity{ 0.0, 0.334, 0.0, -1.177, 0.0, 1.510, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_approaching_singularity);
+  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_APPROACHING_SINGULARITY);
 
@@ -225,6 +234,7 @@ TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
   cartesian_delta(0) *= -1;
   Eigen::Vector<double, 7> state_leaving_singularity{ 0.0, 0.3458, 0.0, -1.1424, 0.0, 1.4865, 0.785 };
   robot_state->setJointGroupActivePositions(joint_model_group, state_leaving_singularity);
+  robot_state->updateLinkTransforms();
   scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::DECELERATE_FOR_LEAVING_SINGULARITY);
 }


### PR DESCRIPTION
This PR makes the servo singularity scaling factor unit tests deterministic by initializing the full robot state (not just active positions) to default values before geting the Jacobian.
