### PR TITLE
Small planning pipeline class fixes

### DIFF
--- a/moveit_ros/planning/planning_pipeline/res/planning_pipeline_parameters.yaml
+++ b/moveit_ros/planning/planning_pipeline/res/planning_pipeline_parameters.yaml
@@ -7,5 +7,5 @@ planning_pipeline_parameters:
   request_adapters: {
     type: string,
     description: "Names of the planning request adapter plugins (plugin names separated by space).",
-    default_value: "UNKNOWN",
+    default_value: "",
   }

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -107,10 +107,10 @@ void planning_pipeline::PlanningPipeline::configure()
     throw;
   }
 
-  if (planner_plugin_name_.empty())
+  if (planner_plugin_name_.empty() || planner_plugin_name_ == "UNKNOWN")
   {
     std::string classes_str = fmt::format("{}", fmt::join(planner_plugin_loader_->getDeclaredClasses(), ", "));
-    throw std::runtime_error("Planning plugin name is empty. Please choose one of the available plugins: " +
+    throw std::runtime_error("Planning plugin name is empty or not defined in namespace '" + parameter_namespace_ + "'. Please choose one of the available plugins: " +
                              classes_str);
   }
 

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -110,8 +110,8 @@ void planning_pipeline::PlanningPipeline::configure()
   if (planner_plugin_name_.empty() || planner_plugin_name_ == "UNKNOWN")
   {
     std::string classes_str = fmt::format("{}", fmt::join(planner_plugin_loader_->getDeclaredClasses(), ", "));
-    throw std::runtime_error("Planning plugin name is empty or not defined in namespace '" + parameter_namespace_ + "'. Please choose one of the available plugins: " +
-                             classes_str);
+    throw std::runtime_error("Planning plugin name is empty or not defined in namespace '" + parameter_namespace_ +
+                             "'. Please choose one of the available plugins: " + classes_str);
   }
 
   try


### PR DESCRIPTION
### Description

Two small patches for the PlanningPipeline class
 - Improve error logging in constructor
 - Change default value of request adapter parameter to empty so that a minimal valid pipeline config just requires a planner plugin

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
