### PR TITLE
Re-enable waiting for current state in MoveItCpp

### DIFF
--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -114,12 +114,11 @@ bool MoveItCpp::loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& opti
   }
 
   // Wait for complete state to be received
-  // TODO(henningkayser): Fix segfault in waitForCurrentState()
-  // if (options.wait_for_initial_state_timeout > 0.0)
-  // {
-  //   return planning_scene_monitor_->getStateMonitor()->waitForCurrentState(node_->now(),
-  //                                                                          options.wait_for_initial_state_timeout);
-  // }
+  if (options.wait_for_initial_state_timeout > 0.0)
+  {
+    return planning_scene_monitor_->getStateMonitor()->waitForCurrentState(node_->now(),
+                                                                           options.wait_for_initial_state_timeout);
+  }
 
   return true;
 }


### PR DESCRIPTION
I don't recall why exactly this has been commented out, but this is ancient and there have been several related fixes to the CSM. I tested this and didn't run into any issues, works as intended.