### PR TITLE
Protect against zero frequency in TrajectoryMonitorMiddlewareHandler

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
@@ -39,17 +39,23 @@
 namespace planning_scene_monitor
 {
 planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::TrajectoryMonitorMiddlewareHandle(double sampling_frequency)
-  : rate_{ std::make_unique<rclcpp::Rate>(sampling_frequency) }
 {
+  setRate(sampling_frequency);
 }
 
 void planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::setRate(double sampling_frequency)
 {
-  rate_ = std::make_unique<rclcpp::Rate>(sampling_frequency);
+  if (sampling_frequency > 0.0)
+  {
+    rate_ = std::make_unique<rclcpp::Rate>(sampling_frequency);
+  }
 }
 
 void planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::sleep()
 {
-  rate_->sleep();
+  if (rate_)
+  {
+    rate_->sleep();
+  }
 }
 }  // namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
@@ -35,6 +35,7 @@
 /* Author: Abishalini Sivaraman */
 
 #include <moveit/planning_scene_monitor/trajectory_monitor_middleware_handle.hpp>
+#include <limits>
 
 namespace planning_scene_monitor
 {
@@ -45,7 +46,7 @@ planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::TrajectoryMonitorMidd
 
 void planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::setRate(double sampling_frequency)
 {
-  if (sampling_frequency > 0.0)
+  if (sampling_frequency > std::numeric_limits<double>::epsilon())
   {
     rate_ = std::make_unique<rclcpp::Rate>(sampling_frequency);
   }


### PR DESCRIPTION
I was seeing a stack trace in the tutorials on rolling when trying to execute a motion with the Kinova Gen3 robot.

Turns out the issue was trying to construct an `rclcpp::Rate` with zero frequency in the `TrajectoryMonitorMiddlewareHandle` class, so this PR fixes that.