### PR TITLE
Fix #1971 - MSA RViz Panel can pan/zoom

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp
@@ -38,6 +38,7 @@
 #include <moveit_setup_framework/data/srdf_config.hpp>
 #include <QApplication>
 #include <rviz_rendering/render_window.hpp>
+#include <rviz_common/tool_manager.hpp>
 
 namespace moveit_setup
 {
@@ -73,6 +74,9 @@ void RVizPanel::initialize()
   rviz_render_panel_->initialize(rviz_manager_);
   rviz_manager_->initialize();
   rviz_manager_->startUpdate();
+
+  auto tm = rviz_manager_->getToolManager();
+  tm->addTool("rviz_default_plugins/MoveCamera");
 
   // Create the MoveIt Rviz Plugin and attach to display
   robot_state_display_ = new moveit_rviz_plugin::RobotStateDisplay();


### PR DESCRIPTION
### Description
MSA was crashing under certain conditions (#1971) when attempting to interact with the RViz Panel. 

[It seems like the `rviz_common::VisualizationManager`'s `ToolManager` assumes there is at least one tool.](https://github.com/ros2/rviz/blob/59c1485398238551645cf047e93e888995171309/rviz_common/src/rviz_common/tool_manager.cpp#L146), and when none are defined, it will attempt to pass a keypress to a null pointer. 

This PR adds a `MoveCamera` tool, which removes the crash AND means you can pan/zoom the rviz panel to look at the model. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
