### PR TITLE
Fix logging levels in servo logs

### DIFF
--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -66,7 +66,7 @@ void CollisionMonitor::start()
   }
   else
   {
-    RCLCPP_INFO_STREAM(LOGGER, "Collision monitor could not be started");
+    RCLCPP_ERROR_STREAM(LOGGER, "Collision monitor could not be started");
   }
 }
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -401,7 +401,7 @@ Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command, const mo
   else
   {
     servo_status_ = StatusCode::INVALID;
-    RCLCPP_WARN_STREAM(LOGGER, "SERVO : Incoming command type does not match expected command type.");
+    RCLCPP_WARN_STREAM(LOGGER, "Incoming servo command type does not match known command types.");
   }
 
   return joint_position_deltas;
@@ -477,7 +477,9 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
     const double joint_limit_scale = jointLimitVelocityScalingFactor(target_joint_velocities, joint_bounds,
                                                                      servo_params_.override_velocity_scaling_factor);
     if (joint_limit_scale < 1.0)  // 1.0 means no scaling.
-      RCLCPP_WARN_STREAM(LOGGER, "Joint velocity limit scaling applied by a factor of " << joint_limit_scale);
+    {
+      RCLCPP_DEBUG_STREAM(LOGGER, "Joint velocity limit scaling applied by a factor of " << joint_limit_scale);
+    }
 
     target_joint_velocities *= joint_limit_scale;
 

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -252,7 +252,7 @@ std::optional<KinematicState> ServoNode::processTwistCommand()
     if (new_twist_msg_)
     {
       next_joint_state = result.second;
-      RCLCPP_INFO_STREAM(LOGGER, "Twist command timed out. Halting to a stop.");
+      RCLCPP_DEBUG_STREAM(LOGGER, "Twist command timed out. Halting to a stop.");
     }
   }
 

--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -198,7 +198,7 @@ JointDeltaResult jointDeltaFromTwist(const TwistCommand& command, const moveit::
     if (!is_planning_frame)
     {
       RCLCPP_WARN_STREAM(LOGGER,
-                         "Command frame is: " << command.frame_id << " expected: " << servo_params.planning_frame);
+                         "Command frame is: " << command.frame_id << ", expected: " << servo_params.planning_frame);
     }
   }
   return std::make_pair(status, joint_position_delta);


### PR DESCRIPTION
We were getting spammed by the servo velocity scaling factor because something was using `RCLCPP_WARN` instead of `RCLCPP_DEBUG`.

Decided to comb through the Servo code and change other possible logging levels that.