### PR TITLE
CI job for building docker images for tutorial on main

### DIFF
--- a/.docker/tutorial-source/Dockerfile
+++ b/.docker/tutorial-source/Dockerfile
@@ -1,0 +1,42 @@
+# syntax = docker/dockerfile:1.3
+
+# ghcr.io/ros-planning/moveit2:main-tutorial-${ROS_DISTRO}
+# Source build of the repos file from the tutorail site
+
+ARG ROS_DISTRO=rolling
+FROM moveit/moveit2:${ROS_DISTRO}-ci
+LABEL maintainer Tyler Weaver tyler@picknik.ai
+
+# Export ROS_UNDERLAY for downstream docker containers
+ENV ROS_UNDERLAY /root/ws_moveit/install
+WORKDIR $ROS_UNDERLAY/..
+
+# Copy MoveIt sources from docker context
+COPY . src/moveit2
+
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
+RUN --mount=type=cache,target=/root/.ccache/,sharing=locked \
+        # Enable ccache
+        PATH=/usr/lib/ccache:$PATH && \
+        # Checkout the tutorial repo
+        git clone https://github.com/ros-planning/moveit2_tutorials src/moveit2_tutorials && \
+        # Fetch required upstream sources for building
+        vcs import --skip-existing src < src/moveit2_tutorials/moveit2_tutorials.repos && \
+        # Source ROS install
+        . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
+        # Install dependencies from rosdep
+        apt-get -q update && \
+        rosdep update && \
+        DEBIAN_FRONTEND=noninteractive \
+        rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+        rm -rf /var/lib/apt/lists/* && \
+        # Build the workspace
+        colcon build \
+        --cmake-args "-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli" \
+        --ament-cmake-args -DCMAKE_BUILD_TYPE=Release \
+        --event-handlers desktop_notification- status- && \
+        ccache -s && \
+        #
+        # Update /ros_entrypoint.sh to source our new workspace
+        sed -i "s#/opt/ros/\$ROS_DISTRO/setup.bash#$ROS_UNDERLAY/setup.sh#g" /ros_entrypoint.sh

--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -1,0 +1,94 @@
+name: "Tutorial Docker Images"
+
+on:
+  schedule:
+    # 5 PM UTC every Sunday
+    - cron:  '0 17 * * 6'
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tutorial-source:
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [rolling, humble, iron]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    env:
+      GH_IMAGE: ghcr.io/ros-planning/moveit2:main-tutorial-${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      DH_IMAGE: moveit/moveit2:main-tutorial-${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Github Container Registry
+        if: env.PUSH == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to DockerHub
+        if: env.PUSH == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: "Remove .dockerignore"
+        run: rm .dockerignore  # enforce full source context
+      - name: Cache ccache
+        uses: actions/cache@v3
+        with:
+          path: .ccache
+          key: docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-${{ hashFiles( '.docker/tutorial-source/Dockerfile' ) }}
+      - name: inject ccache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: .ccache
+          cache-target: /root/.ccache/
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .docker/${{ github.job }}/Dockerfile
+          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+          push: ${{ env.PUSH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.GH_IMAGE }}
+            ${{ env.DH_IMAGE }}
+
+  delete_untagged:
+    runs-on: ubuntu-latest
+    needs:
+      - tutorial-source
+    steps:
+      - name: Delete Untagged Images
+        if: (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2')
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          script: |
+            const response = await github.request("GET /orgs/${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions", {
+                per_page: ${{ env.PER_PAGE }}
+              });
+            for(version of response.data) {
+                if (version.metadata.container.tags.length == 0) {
+                    console.log("delete " + version.id)
+                    const deleteResponse = await github.request("DELETE /orgs/${{ env.OWNER }}/packages/container/${{ env.PACKAGE_NAME }}/versions/" + version.id, { });
+                    console.log("status " + deleteResponse.status)
+                }
+            }
+        env:
+          OWNER: ros-planning
+          PACKAGE_NAME: moveit2
+          PER_PAGE: 100


### PR DESCRIPTION
### Description

Here is the docker job we talked about yesterday. This should build a docker image on the main branch in CI for rolling, humble, and iron and push to the github container registry on pushes to main. The docker tag will be `ghcr.io/ros-planning/moveit2:main-tutorial-${ROS_DISTRO}`. I made it a separate workflow from the docker one because I want this to also run in PRs as a CI job and separate from the normal CI one because I only want it to run on pushes to the main branch.