### PR TITLE
Map ompl's APPROXIMATE_SOLUTION -> TIMED_OUT / PLANNING_FAILED

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -860,7 +860,7 @@ const moveit_msgs::msg::MoveItErrorCodes ompl_interface::ModelBasedPlanningConte
     RCLCPP_DEBUG(LOGGER, "%s: Solving the planning problem once...", name_.c_str());
     ob::PlannerTerminationCondition ptc = constructPlannerTerminationCondition(timeout, start);
     registerTerminationCondition(ptc);
-    result.val = ompl_simple_setup_->solve(ptc) == ompl::base::PlannerStatus::EXACT_SOLUTION;
+    std::ignore = ompl_simple_setup_->solve(ptc);
     last_plan_time_ = ompl_simple_setup_->getLastPlanComputationTime();
     unregisterTerminationCondition();
     // fill the result status code

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -996,14 +996,16 @@ int32_t ompl_interface::ModelBasedPlanningContext::logPlannerStatus(const og::Si
       result = moveit_msgs::msg::MoveItErrorCodes::UNRECOGNIZED_GOAL_TYPE;
       break;
     case ompl::base::PlannerStatus::TIMEOUT:
-      RCLCPP_WARN(LOGGER, "Timed out");
+      RCLCPP_WARN(LOGGER, "Timed out: %.1fs ≥ %.1fs", ompl_simple_setup->getLastPlanComputationTime(),
+                  request_.allowed_planning_time);
       result = moveit_msgs::msg::MoveItErrorCodes::TIMED_OUT;
       break;
     case ompl::base::PlannerStatus::APPROXIMATE_SOLUTION:
       // timeout is a common reason for APPROXIMATE_SOLUTION
       if (ompl_simple_setup->getLastPlanComputationTime() > request_.allowed_planning_time)
       {
-        RCLCPP_WARN(LOGGER, "Planning timed out");
+        RCLCPP_WARN(LOGGER, "Planning timed out: %.1fs ≥ %.1fs", ompl_simple_setup->getLastPlanComputationTime(),
+                    request_.allowed_planning_time);
         result = moveit_msgs::msg::MoveItErrorCodes::TIMED_OUT;
       }
       else


### PR DESCRIPTION
ompl's `APPROXIMATE_SOLUTION` is not suitable for actual execution. It just states that we [got closer to the goal](https://ompl.kavrakilab.org/classompl_1_1base_1_1ProblemDefinition.html#a612902cacc3b1a2bcc367a9e82739132):

> If the top found solution is approximate, does not actually reach the desired goal, but hopefully is closer to it

As the most prominent reason for an approximate solution is a timeout, also checking for this case.

Fixes https://github.com/ros-planning/moveit_task_constructor/issues/485


