### PR TITLE
Fix docstring indentation in newly added trajectory Python bindings

### DIFF
--- a/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
@@ -139,7 +139,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("velocity_scaling_factor"), py::arg("acceleration_scaling_factor"), py::kw_only(),
            py::arg("path_tolerance") = 0.1, py::arg("resample_dt") = 0.1, py::arg("min_angle_change") = 0.001,
            R"(
-               Adds time parameterization to the trajectory using the Time-Optimal Trajectory Generation (TOTG) algorithm.
+           Adds time parameterization to the trajectory using the Time-Optimal Trajectory Generation (TOTG) algorithm.
            Args:
                velocity_scaling_factor (float): The velocity scaling factor.
                acceleration_scaling_factor (float): The acceleration scaling factor.
@@ -154,7 +154,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("acceleration_scaling_factor"), py::kw_only(), py::arg("mitigate_overshoot") = false,
            py::arg("overshoot_threshold") = 0.01,
            R"(
-               Applies Ruckig smoothing to the trajectory.
+           Applies Ruckig smoothing to the trajectory.
            Args:
                velocity_scaling_factor (float): The velocity scaling factor.
                acceleration_scaling_factor (float): The acceleration scaling factor.
@@ -168,8 +168,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("joint_filter") = std::vector<std::string>(),
            R"(
            Get the trajectory as a moveit_msgs.msg.RobotTrajectory message.
-
-	   Returns:
+           Returns:
                moveit_msgs.msg.RobotTrajectory: A ROS robot trajectory message.
            )")
       .def("set_robot_trajectory_msg", &moveit_py::bind_robot_trajectory::set_robot_trajectory_msg,


### PR DESCRIPTION
This is weird, but the changes in https://github.com/ros-planning/moveit2/pull/2411 that merged without issue ended up breaking the `moveit2_tutorials` repo with this htmlproofer error:

```
Warning, treated as error:
docstring of moveit.core.robot_trajectory.PyCapsule.apply_ruckig_smoothing:2:Block quote ends without a blank line; unexpected unindent.
Error: Process completed with exit code 2.
```

See https://github.com/ros-planning/moveit2_tutorials/actions/runs/6617124169/job/17972803048?pr=796#step:7:20084

I think it has to do with the indents added to the block quotes in some of the new functionality added in this PR.