### PR TITLE
Finally fix errors building new RobotTrajectory Python bindings docs

### DIFF
--- a/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
@@ -158,7 +158,7 @@ void init_robot_trajectory(py::module& m)
                velocity_scaling_factor (float): The velocity scaling factor.
                acceleration_scaling_factor (float): The acceleration scaling factor.
                mitigate_overshoot (bool): Whether to mitigate overshoot during smoothing (default: false).
-               overshoot_threshold (float): The maximum allowed overshoot during smoothing (default: 0.01
+               overshoot_threshold (float): The maximum allowed overshoot during smoothing (default: 0.01).
            Returns:
                bool: True if the trajectory was successfully retimed, false otherwise.
            )")

--- a/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_trajectory/robot_trajectory.cpp
@@ -140,6 +140,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("path_tolerance") = 0.1, py::arg("resample_dt") = 0.1, py::arg("min_angle_change") = 0.001,
            R"(
            Adds time parameterization to the trajectory using the Time-Optimal Trajectory Generation (TOTG) algorithm.
+
            Args:
                velocity_scaling_factor (float): The velocity scaling factor.
                acceleration_scaling_factor (float): The acceleration scaling factor.
@@ -154,6 +155,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("overshoot_threshold") = 0.01,
            R"(
            Applies Ruckig smoothing to the trajectory.
+
            Args:
                velocity_scaling_factor (float): The velocity scaling factor.
                acceleration_scaling_factor (float): The acceleration scaling factor.
@@ -166,6 +168,7 @@ void init_robot_trajectory(py::module& m)
            py::arg("joint_filter") = std::vector<std::string>(),
            R"(
            Get the trajectory as a moveit_msgs.msg.RobotTrajectory message.
+
            Args:
                joint_filter (list[string]): List of joints to consider in creating the message. If empty, uses all joints.
            Returns:
@@ -175,8 +178,9 @@ void init_robot_trajectory(py::module& m)
            py::arg("robot_state"), py::arg("msg"),
            R"(
            Set the trajectory from a moveit_msgs.msg.RobotTrajectory message.
+
            Args:
-               robot_state (py:class:`moveit_py.core.RobotState`): The reference robot starting state.
+               robot_state (:py:class:`moveit_py.core.RobotState`): The reference robot starting state.
                msg (moveit_msgs.msg.RobotTrajectory): A ROS robot trajectory message.
            )");
   // TODO (peterdavidfagan): support other methods such as appending trajectories


### PR DESCRIPTION
This is the one that will actually fix the `htmlproofer` CI on `moveit2_tutorials`, along with https://github.com/ros-planning/moveit2_tutorials/pull/798... I finally found how to test it locally.