### PR TITLE
Fix wrong rename of set_start_state in 63e0c3a

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/planning_component.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/planning_component.cpp
@@ -290,7 +290,7 @@ void initPlanningComponent(py::module& m)
            Set the start state of the plan to the current state of the robot.
            )")
 
-      .def("set_goal_state", &moveit_py::bind_planning_component::setStartState,
+      .def("set_start_state", &moveit_py::bind_planning_component::setStartState,
            py::arg("configuration_name") = nullptr, py::arg("robot_state") = nullptr,
            R"(
            Set the start state of the plan to the given robot state.


### PR DESCRIPTION
### Description

In 63e0c3a the name of set_start_state was changed to set_goal_state.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
