### PR TITLE
[moveit_py] add missing constructor of CollisionResult

### DIFF
--- a/moveit_py/src/moveit/moveit_core/collision_detection/collision_common.cpp
+++ b/moveit_py/src/moveit/moveit_core/collision_detection/collision_common.cpp
@@ -103,6 +103,9 @@ void initCollisionResult(py::module& m)
   py::class_<collision_detection::CollisionResult>(collision_detection, "CollisionResult", R"(
       Representation of a collision checking result.
       )")
+
+      .def(py::init<>())
+
       .def_readwrite("collision", &collision_detection::CollisionResult::collision,
                      R"(
                      bool: True if collision was found, false otherwise.


### PR DESCRIPTION
### Description

the constructor of `CollisionResult` is missing, so we can't use it in python.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
