### PR TITLE
(moveit_py) remove unused applyPlanningScene

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
@@ -79,17 +79,6 @@ void LockedPlanningSceneContextManagerRW::lockedPlanningSceneRwExit(const py::ob
   ls_rw_.reset();
 }
 
-// TODO: simplify with typecaster
-void applyPlanningScene(std::shared_ptr<planning_scene_monitor::PlanningSceneMonitor>& planning_scene_monitor,
-                        const moveit_msgs::msg::PlanningScene& planning_scene)
-{
-  // lock planning scene
-  {
-    planning_scene_monitor::LockedPlanningSceneRW scene(planning_scene_monitor);
-    scene->usePlanningSceneMsg(planning_scene);
-  }
-}
-
 void initPlanningSceneMonitor(py::module& m)
 {
   py::class_<planning_scene_monitor::PlanningSceneMonitor, planning_scene_monitor::PlanningSceneMonitorPtr>(

--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.h
@@ -90,14 +90,6 @@ readWrite(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_
 LockedPlanningSceneContextManagerRO
 readOnly(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
-// const planning_scene::PlanningScenePtr& locked_planning_scene_enter_(LockedPlanningSceneContextManager& context_manager);
-
-// void locked_planning_scene_exit_(LockedPlanningSceneContextManager& context_manager, const py::object& type,
-//                                  const py::object& value, const py::object& traceback);
-
-void applyPlanningScene(std::shared_ptr<planning_scene_monitor::PlanningSceneMonitor>& planning_scene_monitor,
-                        const moveit_msgs::msg::PlanningScene& planning_scene);
-
 void initPlanningSceneMonitor(py::module& m);
 
 void initContextManagers(py::module& m);


### PR DESCRIPTION
### Description

Removed unused `applyPlanningScene` function.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
