### PR TITLE
Factor out path joint-space jump check

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -232,15 +232,15 @@ public:
                                         const JumpThreshold& jump_threshold);
 };
 
-/** \brief Checks if a joint-space path has jumps larger than the given threshold.
+/** \brief Checks if a joint-space path has a jump larger than the given threshold.
 
    This function computes the distance between every pair of adjacent waypoints (for the given group) and checks if that
    distance is larger than the threshold defined by `jump_threshold`. If so, it is considered that the path has a
    jump, and the path index where the jump happens is returned as output.
    Otherwise the function returns a nullopt. */
-std::optional<int> hasJointSpaceJumps(const std::vector<moveit::core::RobotStatePtr>& waypoints,
-                                      const moveit::core::JointModelGroup& group,
-                                      const moveit::core::JumpThreshold& jump_threshold);
+std::optional<int> hasJointSpaceJump(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                     const moveit::core::JointModelGroup& group,
+                                     const moveit::core::JumpThreshold& jump_threshold);
 
 }  // end of namespace core
 }  // end of namespace moveit

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -44,10 +44,9 @@ namespace moveit
 {
 namespace core
 {
-/** \brief Class with options for defining joint-space jump thresholds. */
-class JumpThreshold
+/** \brief Struct with options for defining joint-space jump thresholds. */
+struct JumpThreshold
 {
-public:
   JumpThreshold() = default;  // default is equivalent to disabled().
 
   /** \brief Do not define any jump threshold, i.e., disable joint-space jump detection. */
@@ -154,7 +153,7 @@ public:
      Cartesian space between consecutive points on the resulting path is specified in the \e MaxEEFStep struct which
      provides two fields: translation and rotation. If a \e validCallback is specified, this is passed to the internal
      call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to
-     the distance that was achieved and for which corresponding states were added to the path.  At the end of the
+     the distance that was achieved and for which corresponding states were added to the path. At the end of the
      function call, the state of the group corresponds to the last attempted Cartesian pose.
 
      During the computation of the path, it is usually preferred if consecutive joint values do not 'jump' by a
@@ -240,7 +239,7 @@ public:
    jump, and the path index where the jump happens is returned as output.
    Otherwise the function returns a nullopt. */
 std::optional<int> hasJointSpaceJumps(const std::vector<moveit::core::RobotStatePtr>& waypoints,
-                                      const moveit::core::JointModelGroup* group,
+                                      const moveit::core::JointModelGroup& group,
                                       const moveit::core::JumpThreshold& jump_threshold);
 
 }  // end of namespace core

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -51,14 +51,15 @@ namespace core
     thresholds for detecting joint space jumps. */
 struct JumpThreshold
 {
-  double factor;
-  double revolute;   // Radians
-  double prismatic;  // Meters
+  double factor = 0.0;
+  double revolute = 0.0;   // Radians
+  double prismatic = 0.0;  // Meters
 
-  explicit JumpThreshold() : factor(0.0), revolute(0.0), prismatic(0.0)
-  {
-  }
+  explicit JumpThreshold() = default;
 
+  // For relative jump detection, the average joint-space distance between consecutive points in the path is
+  // computed. If any individual joint-space motion delta is larger than this average distance by a factor of
+  // \e jt_factor, it is considered the path has a jump.
   explicit JumpThreshold(double jt_factor) : JumpThreshold()
   {
     factor = jt_factor;
@@ -145,14 +146,14 @@ public:
      The Cartesian path to be followed is specified as a \e translation vector to be followed by the robot \e link.
      This vector is assumed to be specified either in the global reference frame or in the local
      reference frame of the link (\e global_reference_frame is false).
-     The resulting joint values are stored in the vector \e traj, one by one. The maximum distance in
+     The resulting joint values are stored in the vector \e path, one by one. The maximum distance in
      Cartesian space between consecutive points on the resulting path is specified in the \e MaxEEFStep struct which
      provides two fields: translation and rotation. If a \e validCallback is specified, this is passed to the internal
      call to setFromIK(). In case of IK failure, the computation of the path stops and the value returned corresponds to
      the distance that was achieved and for which corresponding states were added to the path.  At the end of the
      function call, the state of the group corresponds to the last attempted Cartesian pose.
 
-     During the computation of the trajectory, it is usually preferred if consecutive joint values do not 'jump' by a
+     During the computation of the path, it is usually preferred if consecutive joint values do not 'jump' by a
      large amount in joint space, even if the Cartesian distance between the corresponding points is small as expected.
      To account for this, the \e jump_threshold struct is provided, which comprises three fields:
      \e jump_threshold_factor, \e revolute_jump_threshold and \e prismatic_jump_threshold.
@@ -160,7 +161,7 @@ public:
      If \e jump_threshold_factor is non-zero, we test for relative jumps. Otherwise (all params are zero), jump
      detection is disabled.
 
-     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
+     For relative jump detection, the average joint-space distance between consecutive points in the path is
      computed. If any individual joint-space motion delta is larger then this average distance by a factor of
      \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
      before the jump.
@@ -169,9 +170,10 @@ public:
      for revolute joints or \e prismatic_jump_threshold for prismatic joints then this step is considered a failure and
      the returned path is truncated up to just before the jump.
 
-     Kinematics solvers may use cost functions to prioritize certain solutions, which may be specified with \e cost_function. */
+     Kinematics solvers may use cost functions to prioritize certain solutions, which may be specified with \e
+     cost_function. */
   static Distance computeCartesianPath(
-      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& path,
       const LinkModel* link, const Eigen::Vector3d& translation, bool global_reference_frame,
       const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
@@ -183,14 +185,14 @@ public:
      In contrast to the previous function, the translation vector is specified as a (unit) direction vector and
      a distance. */
   static Distance computeCartesianPath(
-      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& path,
       const LinkModel* link, const Eigen::Vector3d& direction, bool global_reference_frame, double distance,
       const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
       const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
       const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn())
   {
-    return computeCartesianPath(start_state, group, traj, link, distance * direction, global_reference_frame, max_step,
+    return computeCartesianPath(start_state, group, path, link, distance * direction, global_reference_frame, max_step,
                                 jump_threshold, validCallback, options, cost_function);
   }
 
@@ -202,7 +204,7 @@ public:
      (\e global_reference_frame is false). This function returns the percentage (0..1) of the path that was achieved.
      All other comments from the previous function apply. */
   static Percentage computeCartesianPath(
-      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& path,
       const LinkModel* link, const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
       const JumpThreshold& jump_threshold,
       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
@@ -213,11 +215,11 @@ public:
   /** \brief Compute the sequence of joint values that perform a general Cartesian path.
 
      In contrast to the previous functions, the Cartesian path is specified as a set of \e waypoints to be sequentially
-     reached by the virtual frame attached to the robot \e link. The waypoints are transforms given either w.r.t. the global
-     reference frame or the virtual frame at the immediately preceding waypoint. The virtual frame needs
-     to move in a straight line between two consecutive waypoints. All other comments apply. */
+     reached by the virtual frame attached to the robot \e link. The waypoints are transforms given either w.r.t. the
+     global reference frame or the virtual frame at the immediately preceding waypoint. The virtual frame needs to move
+     in a straight line between two consecutive waypoints. All other comments apply. */
   static Percentage computeCartesianPath(
-      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+      RobotState* start_state, const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& path,
       const LinkModel* link, const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame,
       const MaxEEFStep& max_step, const JumpThreshold& jump_threshold,
       const GroupStateValidityCallbackFn& validCallback = GroupStateValidityCallbackFn(),
@@ -225,60 +227,30 @@ public:
       const kinematics::KinematicsBase::IKCostFn& cost_function = kinematics::KinematicsBase::IKCostFn(),
       const Eigen::Isometry3d& link_offset = Eigen::Isometry3d::Identity());
 
-  /** \brief Tests joint space jumps of a trajectory.
+  /** \brief Checks if a path has a joint-space jump, and truncates the path at the jump.
 
-     If \e jump_threshold_factor is non-zero, we test for relative jumps.
-     If \e revolute_jump_threshold  or \e prismatic_jump_threshold are non-zero, we test for absolute jumps.
-     Both tests can be combined. If all params are zero, jump detection is disabled.
-     For relative jump detection, the average joint-space distance between consecutive points in the trajectory is
-     computed. If any individual joint-space motion delta is larger then this average distance by a factor of
-     \e jump_threshold_factor, this step is considered a failure and the returned path is truncated up to just
-     before the jump.
+     Checks if a path has a jump larger than `jump_threshold` and truncates the path to the waypoint right before the
+     jump. Returns the percentage of the path that doesn't have jumps.
 
      @param group The joint model group of the robot state.
-     @param traj The trajectory that should be tested.
+     @param path The path that should be tested.
      @param jump_threshold The struct holding jump thresholds to determine if a joint space jump has occurred.
-     @return The fraction of the trajectory that passed.
-
-     TODO: move to more appropriate location
+     @return The fraction of the path that passed.
   */
-  static Percentage checkJointSpaceJump(const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& traj,
+  static Percentage checkJointSpaceJump(const JointModelGroup* group, std::vector<std::shared_ptr<RobotState>>& path,
                                         const JumpThreshold& jump_threshold);
-
-  /** \brief Tests for relative joint space jumps of the trajectory \e traj.
-
-     First, the average distance between adjacent trajectory points is computed. If two adjacent trajectory points
-     have distance > \e jump_threshold_factor * average, the trajectory is truncated at this point.
-
-     @param group The joint model group of the robot state.
-     @param traj The trajectory that should be tested.
-     @param jump_threshold_factor The threshold to determine if a joint space jump has occurred .
-     @return The fraction of the trajectory that passed.
-
-     TODO: move to more appropriate location
-   */
-  static Percentage checkRelativeJointSpaceJump(const JointModelGroup* group,
-                                                std::vector<std::shared_ptr<RobotState>>& traj,
-                                                double jump_threshold_factor);
-
-  /** \brief Tests for absolute joint space jumps of the trajectory \e traj.
-
-     The joint-space difference between consecutive waypoints is computed for each active joint and compared to the
-     absolute thresholds \e revolute_jump_threshold for revolute joints and \e prismatic_jump_threshold for prismatic
-     joints. If these thresholds are exceeded, the trajectory is truncated.
-
-     @param group The joint model group of the robot state.
-     @param traj The trajectory that should be tested.
-     @param revolute_jump_threshold Absolute joint-space threshold for revolute joints.
-     @param prismatic_jump_threshold Absolute joint-space threshold for prismatic joints.
-     @return The fraction of the trajectory that passed.
-
-     TODO: move to more appropriate location
-  */
-  static Percentage checkAbsoluteJointSpaceJump(const JointModelGroup* group,
-                                                std::vector<std::shared_ptr<RobotState>>& traj,
-                                                double revolute_jump_threshold, double prismatic_jump_threshold);
 };
+
+/** \brief Checks if a joint-space path has jumps larger than the given threshold.
+ *
+ * This function computes the distance between every pair of adjacent waypoints (for the given group) and checks if that
+ * distance is larger than the threshold defined by `jump_threshold`. If so, it is considered that the path has a
+ * jump, and the path index where the jump happens is returned as output.
+ * Otherwise the function returns a nullopt.
+ */
+std::optional<int> hasJointSpaceJumps(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                      const moveit::core::JointModelGroup* group,
+                                      const moveit::core::JumpThreshold& jump_threshold);
 
 }  // end of namespace core
 }  // end of namespace moveit

--- a/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/cartesian_interpolator.h
@@ -48,6 +48,8 @@ namespace core
 class JumpThreshold
 {
 public:
+  JumpThreshold() = default;  // default is equivalent to disabled().
+
   /** \brief Do not define any jump threshold, i.e., disable joint-space jump detection. */
   static JumpThreshold disabled();
 
@@ -69,11 +71,9 @@ public:
   double revolute = 0.0;   // Radians
   double prismatic = 0.0;  // Meters
 
-private:
-  // Private constructors. Construct using builder methods in the public interface.
-  JumpThreshold() = default;
-  JumpThreshold(double relative_factor);
-  JumpThreshold(double revolute, double prismatic);
+  // Deprecated constructors. Construct using the builder methods above.
+  [[deprecated("Use JumpThreshold::relative() instead.")]] JumpThreshold(double relative_factor);
+  [[deprecated("Use JumpThreshold::absolute() instead.")]] JumpThreshold(double revolute, double prismatic);
 };
 
 /** \brief Struct for containing max_step for computeCartesianPath

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -42,11 +42,10 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
-namespace moveit
+namespace moveit::core
 {
-namespace core
-{
-/** \brief It is recommended that there are at least 10 steps per trajectory
+
+/** \brief It is recommended that there are at least 10 steps per path
  * for testing jump thresholds with computeCartesianPath. With less than 10 steps
  * it is difficult to choose a jump_threshold parameter that effectively separates
  * valid paths from paths with large joint space jumps. */
@@ -54,8 +53,85 @@ static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_state.cartesian_interpolator");
 
+namespace
+{
+std::optional<int> hasRelativeJointSpaceJump(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                             const moveit::core::JointModelGroup* group, double jump_threshold_factor)
+{
+  if (waypoints.size() < MIN_STEPS_FOR_JUMP_THRESH)
+  {
+    RCLCPP_WARN(LOGGER,
+                "The computed path is too short to detect jumps in joint-space. "
+                "Need at least %zu steps, only got %zu. Try a lower max_step.",
+                MIN_STEPS_FOR_JUMP_THRESH, waypoints.size());
+  }
+
+  std::vector<double> dist_vector;
+  dist_vector.reserve(waypoints.size() - 1);
+  double total_dist = 0.0;
+  for (std::size_t i = 1; i < waypoints.size(); ++i)
+  {
+    double dist_prev_point = waypoints[i]->distance(*waypoints[i - 1], group);
+    dist_vector.push_back(dist_prev_point);
+    total_dist += dist_prev_point;
+  }
+
+  // compute the average distance between the states we looked at.
+  double thres = jump_threshold_factor * (total_dist / static_cast<double>(dist_vector.size()));
+  for (std::size_t i = 0; i < dist_vector.size(); ++i)
+  {
+    if (dist_vector[i] > thres)
+    {
+      return i + 1;
+    }
+  }
+
+  return std::nullopt;
+}
+
+std::optional<int> hasAbsoluteJointSpaceJump(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                             const moveit::core::JointModelGroup* group, double revolute_threshold,
+                                             double prismatic_threshold)
+{
+  const bool check_revolute = revolute_threshold > 0.0;
+  const bool check_prismatic = prismatic_threshold > 0.0;
+
+  const std::vector<const moveit::core::JointModel*>& joints = group->getActiveJointModels();
+  for (std::size_t i = 1; i < waypoints.size(); ++i)
+  {
+    for (const auto& joint : joints)
+    {
+      const double distance = waypoints[i]->distance(*waypoints[i - 1], joint);
+      switch (joint->getType())
+      {
+        case moveit::core::JointModel::REVOLUTE:
+          if (check_revolute && distance > revolute_threshold)
+          {
+            return i;
+          }
+          break;
+        case moveit::core::JointModel::PRISMATIC:
+          if (check_prismatic && distance > prismatic_threshold)
+          {
+            return i;
+          }
+          break;
+        default:
+          RCLCPP_WARN(LOGGER,
+                      "Joint %s has not supported type %s. \n"
+                      "hasAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
+                      joint->getName().c_str(), joint->getTypeName().c_str());
+          continue;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+}  // namespace
+
 CartesianInterpolator::Distance CartesianInterpolator::computeCartesianPath(
-    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& path, const LinkModel* link,
     const Eigen::Vector3d& translation, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
     const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function)
@@ -68,13 +144,13 @@ CartesianInterpolator::Distance CartesianInterpolator::computeCartesianPath(
   pose.translation() += global_reference_frame ? translation : pose.linear() * translation;
 
   // call computeCartesianPath for the computed target pose in the global reference frame
-  return CartesianInterpolator::Distance(distance) * computeCartesianPath(start_state, group, traj, link, pose, true,
+  return CartesianInterpolator::Distance(distance) * computeCartesianPath(start_state, group, path, link, pose, true,
                                                                           max_step, jump_threshold, validCallback,
                                                                           options, cost_function);
 }
 
 CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
-    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& path, const LinkModel* link,
     const Eigen::Isometry3d& target, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
     const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function,
@@ -110,7 +186,7 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
   double rotation_distance = start_quaternion.angularDistance(target_quaternion);
   double translation_distance = (rotated_target.translation() - start_pose.translation()).norm();
 
-  // decide how many steps we will need for this trajectory
+  // decide how many steps we will need for this path
   std::size_t translation_steps = 0;
   if (max_step.translation > 0.0)
     translation_steps = floor(translation_distance / max_step.translation);
@@ -148,8 +224,8 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     }
   }
 
-  traj.clear();
-  traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
+  path.clear();
+  path.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
 
   double last_valid_percentage = 0.0;
   for (std::size_t i = 1; i <= steps; ++i)
@@ -159,12 +235,12 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     Eigen::Isometry3d pose(start_quaternion.slerp(percentage, target_quaternion));
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
-    // Explicitly use a single IK attempt only: We want a smooth trajectory.
+    // Explicitly use a single IK attempt only: We want a smooth path.
     // Random seeding (of additional attempts) would probably create IK jumps.
     if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options,
                                cost_function))
     {
-      traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
+      path.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
     }
     else
     {
@@ -174,13 +250,13 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     last_valid_percentage = percentage;
   }
 
-  last_valid_percentage *= checkJointSpaceJump(group, traj, jump_threshold);
+  last_valid_percentage *= checkJointSpaceJump(group, path, jump_threshold);
 
   return CartesianInterpolator::Percentage(last_valid_percentage);
 }
 
 CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
-    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& traj, const LinkModel* link,
+    RobotState* start_state, const JointModelGroup* group, std::vector<RobotStatePtr>& path, const LinkModel* link,
     const EigenSTL::vector_Isometry3d& waypoints, bool global_reference_frame, const MaxEEFStep& max_step,
     const JumpThreshold& jump_threshold, const GroupStateValidityCallbackFn& validCallback,
     const kinematics::KinematicsQueryOptions& options, const kinematics::KinematicsBase::IKCostFn& cost_function,
@@ -189,147 +265,73 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
   double percentage_solved = 0.0;
   for (std::size_t i = 0; i < waypoints.size(); ++i)
   {
-    // Don't test joint space jumps for every waypoint, test them later on the whole trajectory.
+    // Don't test joint space jumps for every waypoint, test them later on the whole path.
     static const JumpThreshold NO_JOINT_SPACE_JUMP_TEST;
-    std::vector<RobotStatePtr> waypoint_traj;
+    std::vector<RobotStatePtr> waypoint_path;
     double wp_percentage_solved =
-        computeCartesianPath(start_state, group, waypoint_traj, link, waypoints[i], global_reference_frame, max_step,
+        computeCartesianPath(start_state, group, waypoint_path, link, waypoints[i], global_reference_frame, max_step,
                              NO_JOINT_SPACE_JUMP_TEST, validCallback, options, cost_function, link_offset);
     if (fabs(wp_percentage_solved - 1.0) < std::numeric_limits<double>::epsilon())
     {
       percentage_solved = static_cast<double>((i + 1)) / static_cast<double>(waypoints.size());
-      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
-      if (i > 0 && !waypoint_traj.empty())
+      std::vector<RobotStatePtr>::iterator start = waypoint_path.begin();
+      if (i > 0 && !waypoint_path.empty())
         std::advance(start, 1);
-      traj.insert(traj.end(), start, waypoint_traj.end());
+      path.insert(path.end(), start, waypoint_path.end());
     }
     else
     {
       percentage_solved += wp_percentage_solved / static_cast<double>(waypoints.size());
-      std::vector<RobotStatePtr>::iterator start = waypoint_traj.begin();
-      if (i > 0 && !waypoint_traj.empty())
+      std::vector<RobotStatePtr>::iterator start = waypoint_path.begin();
+      if (i > 0 && !waypoint_path.empty())
         std::advance(start, 1);
-      traj.insert(traj.end(), start, waypoint_traj.end());
+      path.insert(path.end(), start, waypoint_path.end());
       break;
     }
   }
 
-  percentage_solved *= checkJointSpaceJump(group, traj, jump_threshold);
+  percentage_solved *= checkJointSpaceJump(group, path, jump_threshold);
 
   return CartesianInterpolator::Percentage(percentage_solved);
 }
 
 CartesianInterpolator::Percentage CartesianInterpolator::checkJointSpaceJump(const JointModelGroup* group,
-                                                                             std::vector<RobotStatePtr>& traj,
+                                                                             std::vector<RobotStatePtr>& path,
                                                                              const JumpThreshold& jump_threshold)
 {
+  std::optional<int> jump_index = hasJointSpaceJumps(path, group, jump_threshold);
+
   double percentage_solved = 1.0;
-  if (traj.size() <= 1)
-    return percentage_solved;
-
-  if (jump_threshold.factor > 0.0)
-    percentage_solved *= checkRelativeJointSpaceJump(group, traj, jump_threshold.factor);
-
-  if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
-    percentage_solved *= checkAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+  if (jump_index)
+  {
+    percentage_solved = static_cast<double>(*jump_index) / static_cast<double>(path.size());
+    // Truncate the path at the index right before the jump.
+    path.resize(*jump_index);
+  }
 
   return CartesianInterpolator::Percentage(percentage_solved);
 }
 
-CartesianInterpolator::Percentage CartesianInterpolator::checkRelativeJointSpaceJump(const JointModelGroup* group,
-                                                                                     std::vector<RobotStatePtr>& traj,
-                                                                                     double jump_threshold_factor)
+std::optional<int> hasJointSpaceJumps(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                      const moveit::core::JointModelGroup* group,
+                                      const moveit::core::JumpThreshold& jump_threshold)
 {
-  if (traj.size() < MIN_STEPS_FOR_JUMP_THRESH)
+  if (waypoints.size() <= 1)
   {
-    RCLCPP_WARN(LOGGER,
-                "The computed trajectory is too short to detect jumps in joint-space "
-                "Need at least %zu steps, only got %zu. Try a lower max_step.",
-                MIN_STEPS_FOR_JUMP_THRESH, traj.size());
+    return std::nullopt;
   }
 
-  std::vector<double> dist_vector;
-  dist_vector.reserve(traj.size() - 1);
-  double total_dist = 0.0;
-  for (std::size_t i = 1; i < traj.size(); ++i)
+  if (jump_threshold.factor > 0.0)
   {
-    double dist_prev_point = traj[i]->distance(*traj[i - 1], group);
-    dist_vector.push_back(dist_prev_point);
-    total_dist += dist_prev_point;
+    return hasRelativeJointSpaceJump(waypoints, group, jump_threshold.factor);
   }
 
-  double percentage = 1.0;
-  // compute the average distance between the states we looked at
-  double thres = jump_threshold_factor * (total_dist / static_cast<double>(dist_vector.size()));
-  for (std::size_t i = 0; i < dist_vector.size(); ++i)
+  if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
   {
-    if (dist_vector[i] > thres)
-    {
-      RCLCPP_DEBUG(LOGGER, "Truncating Cartesian path due to detected jump in joint-space distance");
-      percentage = static_cast<double>(i + 1) / static_cast<double>(traj.size());
-      traj.resize(i + 1);
-      break;
-    }
+    return hasAbsoluteJointSpaceJump(waypoints, group, jump_threshold.revolute, jump_threshold.prismatic);
   }
 
-  return CartesianInterpolator::Percentage(percentage);
+  return std::nullopt;
 }
 
-CartesianInterpolator::Percentage CartesianInterpolator::checkAbsoluteJointSpaceJump(const JointModelGroup* group,
-                                                                                     std::vector<RobotStatePtr>& traj,
-                                                                                     double revolute_threshold,
-                                                                                     double prismatic_threshold)
-{
-  bool check_revolute = revolute_threshold > 0.0;
-  bool check_prismatic = prismatic_threshold > 0.0;
-
-  double joint_threshold;
-  bool check_joint;
-  bool still_valid = true;
-  const std::vector<const JointModel*>& joints = group->getActiveJointModels();
-  for (std::size_t traj_ix = 0, ix_end = traj.size() - 1; traj_ix != ix_end; ++traj_ix)
-  {
-    for (auto& joint : joints)
-    {
-      switch (joint->getType())
-      {
-        case JointModel::REVOLUTE:
-          check_joint = check_revolute;
-          joint_threshold = revolute_threshold;
-          break;
-        case JointModel::PRISMATIC:
-          check_joint = check_prismatic;
-          joint_threshold = prismatic_threshold;
-          break;
-        default:
-          RCLCPP_WARN(LOGGER,
-                      "Joint %s has not supported type %s. \n"
-                      "checkAbsoluteJointSpaceJump only supports prismatic and revolute joints.",
-                      joint->getName().c_str(), joint->getTypeName().c_str());
-          continue;
-      }
-      if (check_joint)
-      {
-        double distance = traj[traj_ix]->distance(*traj[traj_ix + 1], joint);
-        if (distance > joint_threshold)
-        {
-          RCLCPP_DEBUG(LOGGER, "Truncating Cartesian path due to detected jump of %.4f > %.4f in joint %s", distance,
-                       joint_threshold, joint->getName().c_str());
-          still_valid = false;
-          break;
-        }
-      }
-    }
-
-    if (!still_valid)
-    {
-      double percent_valid = static_cast<double>(traj_ix + 1) / static_cast<double>(traj.size());
-      traj.resize(traj_ix + 1);
-      return CartesianInterpolator::Percentage(percent_valid);
-    }
-  }
-  return CartesianInterpolator::Percentage(1.0);
-}
-
-}  // end of namespace core
-}  // end of namespace moveit
+}  // end of namespace moveit::core

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -137,12 +137,17 @@ JumpThreshold JumpThreshold::disabled()
 
 JumpThreshold JumpThreshold::relative(double relative_factor)
 {
-  return JumpThreshold(relative_factor);
+  JumpThreshold threshold;
+  threshold.relative_factor = relative_factor;
+  return threshold;
 }
 
 JumpThreshold JumpThreshold::absolute(double revolute, double prismatic)
 {
-  return JumpThreshold(revolute, prismatic);
+  JumpThreshold threshold;
+  threshold.revolute = revolute;
+  threshold.prismatic = prismatic;
+  return threshold;
 }
 
 JumpThreshold::JumpThreshold(double relative_factor)

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -45,10 +45,9 @@
 namespace moveit::core
 {
 
-/** \brief It is recommended that there are at least 10 steps per path
- * for testing jump thresholds with computeCartesianPath. With less than 10 steps
- * it is difficult to choose a jump_threshold parameter that effectively separates
- * valid paths from paths with large joint space jumps. */
+// Minimum amount of path waypoints recommended to reliably compute a joint-space increment average.
+// If relative jump detection is selected and the path is shorter than `MIN_STEPS_FOR_JUMP_THRESH`, a warning message
+// will be printed out.
 static const std::size_t MIN_STEPS_FOR_JUMP_THRESH = 10;
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_robot_state.cartesian_interpolator");
@@ -335,7 +334,7 @@ CartesianInterpolator::Percentage CartesianInterpolator::checkJointSpaceJump(con
                                                                              std::vector<RobotStatePtr>& path,
                                                                              const JumpThreshold& jump_threshold)
 {
-  std::optional<int> jump_index = hasJointSpaceJumps(path, *group, jump_threshold);
+  std::optional<int> jump_index = hasJointSpaceJump(path, *group, jump_threshold);
 
   double percentage_solved = 1.0;
   if (jump_index)
@@ -348,9 +347,9 @@ CartesianInterpolator::Percentage CartesianInterpolator::checkJointSpaceJump(con
   return CartesianInterpolator::Percentage(percentage_solved);
 }
 
-std::optional<int> hasJointSpaceJumps(const std::vector<moveit::core::RobotStatePtr>& waypoints,
-                                      const moveit::core::JointModelGroup& group,
-                                      const moveit::core::JumpThreshold& jump_threshold)
+std::optional<int> hasJointSpaceJump(const std::vector<moveit::core::RobotStatePtr>& waypoints,
+                                     const moveit::core::JointModelGroup& group,
+                                     const moveit::core::JumpThreshold& jump_threshold)
 {
   if (waypoints.size() <= 1)
   {

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -141,12 +141,7 @@ TEST_F(SimpleRobot, checkAbsoluteJointSpaceJump)
   // Container for results
   double fraction;
 
-  // Direct call of absolute version
-  fraction = CartesianInterpolator::checkAbsoluteJointSpaceJump(joint_model_group, traj, 1.0, 1.0);
-  EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut
-  EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
-
-  // Indirect call using checkJointSpaceJumps
+  // Revolute and prismatic joints.
   generateTestTraj(traj, robot_model_);
   fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(1.0, 1.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
@@ -185,14 +180,9 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
       static_cast<double>(expected_relative_jump_traj_len) / static_cast<double>(full_traj_len);
 
   // Container for results
-  double fraction;
+  double fraction = 0.0;
 
-  // Direct call of relative version: 1.01 > 2.97 * (0.01 * 2 + 1.01 * 2)/6.
-  fraction = CartesianInterpolator::checkRelativeJointSpaceJump(joint_model_group, traj, 2.97);
-  EXPECT_EQ(expected_relative_jump_traj_len, traj.size());  // traj should be cut before the first jump of 1.01
-  EXPECT_NEAR(expected_relative_jump_fraction, fraction, 0.01);
-
-  // Indirect call of relative version using checkJointSpaceJumps
+  // Call of relative version: 1.01 > 2.97 * (0.01 * 2 + 1.01 * 2)/6.
   generateTestTraj(traj, robot_model_);
   fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(2.97));
   EXPECT_EQ(expected_relative_jump_traj_len, traj.size());  // traj should be cut before the first jump of 1.01

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -143,25 +143,25 @@ TEST_F(SimpleRobot, checkAbsoluteJointSpaceJump)
 
   // Revolute and prismatic joints.
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(1.0, 1.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(1.0, 1.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Test revolute joints
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(1.0, 0.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(1.0, 0.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Test prismatic joints
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(0.0, 1.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.0, 1.0));
   EXPECT_EQ(expected_prismatic_jump_traj_len, traj.size());  // traj should be cut before the prismatic jump
   EXPECT_NEAR(expected_prismatic_jump_fraction, fraction, 0.01);
 
   // Ignore all absolute jumps
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(0.0, 0.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.0, 0.0));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
 }
@@ -184,13 +184,13 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
 
   // Call of relative version: 1.01 > 2.97 * (0.01 * 2 + 1.01 * 2)/6.
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(2.97));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::relative(2.97));
   EXPECT_EQ(expected_relative_jump_traj_len, traj.size());  // traj should be cut before the first jump of 1.01
   EXPECT_NEAR(expected_relative_jump_fraction, fraction, 0.01);
 
   // Trajectory should not be cut: 1.01 < 2.98 * (0.01 * 2 + 1.01 * 2)/6.
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold(2.98));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::relative(2.98));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
 }
@@ -225,7 +225,8 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
 //                               bool global)
 //   {
 //     return CartesianInterpolator::computeCartesianPath(start_state.get(), jmg, result, link, translation, global,
-//                                                        MaxEEFStep(0.1), JumpThreshold(), GroupStateValidityCallbackFn(),
+//                                                        MaxEEFStep(0.1), JumpThreshold::Disabled(),
+//                                                        GroupStateValidityCallbackFn(),
 //                                                        kinematics::KinematicsQueryOptions());
 //   }
 //
@@ -233,7 +234,8 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
 //                               bool global, const Eigen::Isometry3d& offset = Eigen::Isometry3d::Identity())
 //   {
 //     return CartesianInterpolator::computeCartesianPath(start_state.get(), jmg, result, link, target, global,
-//                                                        MaxEEFStep(0.1), JumpThreshold(), GroupStateValidityCallbackFn(),
+//                                                        MaxEEFStep(0.1), JumpThreshold::Disabled(),
+//                                                        GroupStateValidityCallbackFn(),
 //                                                        kinematics::KinematicsQueryOptions(),
 //                                                        kinematics::KinematicsBase::IKCostFn(), offset);
 //   }
@@ -325,7 +327,8 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
 // TEST_F(PandaRobot, testRotationOffset)
 // {
 //   // define offset to virtual center frame
-//   Eigen::Isometry3d offset = Eigen::Translation3d(0, 0, 0.2) * Eigen::AngleAxisd(-M_PI / 4, Eigen::Vector3d::UnitZ());
+//   Eigen::Isometry3d offset = Eigen::Translation3d(0, 0, 0.2) * Eigen::AngleAxisd(-M_PI / 4,
+//   Eigen::Vector3d::UnitZ());
 //   // 45° rotation about center's x-axis
 //   Eigen::Isometry3d rot(Eigen::AngleAxisd(M_PI / 4, Eigen::Vector3d::UnitX()));
 //   Eigen::Isometry3d goal = start_pose * offset * rot;

--- a/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/test/test_cartesian_interpolator.cpp
@@ -149,21 +149,21 @@ TEST_F(SimpleRobot, checkAbsoluteJointSpaceJump)
 
   // Test revolute joints
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(1.0, 0.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.01, 10.0));
   EXPECT_EQ(expected_revolute_jump_traj_len, traj.size());  // traj should be cut before the revolute jump
   EXPECT_NEAR(expected_revolute_jump_fraction, fraction, 0.01);
 
   // Test prismatic joints
   generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.0, 1.0));
+  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(10.0, 0.01));
   EXPECT_EQ(expected_prismatic_jump_traj_len, traj.size());  // traj should be cut before the prismatic jump
   EXPECT_NEAR(expected_prismatic_jump_fraction, fraction, 0.01);
 
-  // Ignore all absolute jumps
-  generateTestTraj(traj, robot_model_);
-  fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.0, 0.0));
-  EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
-  EXPECT_NEAR(1.0, fraction, 0.01);
+  // Pre-condition checks.
+  EXPECT_ANY_THROW(
+      CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.0, 0.01)));
+  EXPECT_ANY_THROW(
+      CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::absolute(0.01, 0.0)));
 }
 
 TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
@@ -193,6 +193,9 @@ TEST_F(SimpleRobot, checkRelativeJointSpaceJump)
   fraction = CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::relative(2.98));
   EXPECT_EQ(full_traj_len, traj.size());  // traj should not be cut
   EXPECT_NEAR(1.0, fraction, 0.01);
+
+  // Pre-condition checks.
+  EXPECT_ANY_THROW(CartesianInterpolator::checkJointSpaceJump(joint_model_group, traj, JumpThreshold::relative(0.0)));
 }
 
 // TODO - The tests below fail since no kinematic plugins are found. Move the tests to IK plugin package.

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -171,7 +171,8 @@ bool MoveGroupCartesianPathService::computeService(
           std::vector<moveit::core::RobotStatePtr> traj;
           res->fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
               &start_state, jmg, traj, start_state.getLinkModel(link_name), waypoints, global_frame,
-              moveit::core::MaxEEFStep(req->max_step), moveit::core::JumpThreshold(req->jump_threshold), constraint_fn);
+              moveit::core::MaxEEFStep(req->max_step), moveit::core::JumpThreshold::relative(req->jump_threshold),
+              constraint_fn);
           moveit::core::robotStateToRobotStateMsg(start_state, res->start_state);
 
           robot_trajectory::RobotTrajectory rt(context_->planning_scene_monitor_->getRobotModel(), req->group_name);


### PR DESCRIPTION
### Description

This change factors out the path joint-space jump detector of `CartesianInterpolator` into a separate function called `hasJointSpaceJumps()`, so that it can be used in a different context.

The new function returns an `std::optional<int>` with the path index where the jump happens, or nothing if there are no jumps.
The `CartesianInterpolator::checkJointSpaceJump` function is then updated to use the free function underneath, and truncate the path, etc, i.e., it keeps the same behavior.

In addition to this, there's two API-breaking changes:
1) Remove the public `CartesianInterpolator::checkRelativeJointSpaceJump` and `CartesianInterpolator::checkAbsoluteJointSpaceJump`, since these can be easily achieved with the more general `CartesianInterpolator::checkJointSpaceJump`, therefore exposing a smaller API footprint.
2) Update the `JumpThreshold` struct with named builder methods (`disabled()`, `relative()` and `absolute()`) instead of public constructors. This should be more readable and less error-prone.

Migrating old code to the new API should be straight-forward:
* `JumpThreshold()` -> `JumpThreshold::disabled()`
* `JumpThreshold(2.0)` -> `JumpThreshold::relative(2.0)` 
* `JumpThreshold(1.0, 2.0)` -> `JumpThreshold::absolute(1.0, 2.0)` 

Finally, there's a few cosmetic changes in documentation and a semantic rename `traj` -> `path`, since these methods operate on paths (sequence of `RobotState`, as opposed to `RobotTrajectory`, which should take timing into account).

Closes https://github.com/ros-planning/moveit2/issues/2272.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
