### PR TITLE
Remove boost lexical cast

### DIFF
--- a/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
+++ b/moveit_core/planning_interface/include/moveit/planning_interface/planning_interface.h
@@ -42,6 +42,7 @@
 #include <rclcpp/node.hpp>
 #include <string>
 #include <map>
+#include <any>
 #include <rclcpp/rclcpp.hpp>
 
 namespace planning_scene
@@ -69,7 +70,7 @@ struct PlannerConfigurationSettings
   std::string name;
 
   /** \brief Key-value pairs of settings that get passed to the planning algorithm */
-  std::map<std::string, std::string> config;
+  std::map<std::string, std::any> config;
 };
 
 /** \brief Map from PlannerConfigurationSettings.name to PlannerConfigurationSettings */

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -46,6 +46,8 @@
 #include <ompl/base/StateStorage.h>
 #include <ompl/base/spaces/constraint/ConstrainedStateSpace.h>
 
+#include <any>
+
 namespace ompl_interface
 {
 namespace ob = ompl::base;
@@ -63,7 +65,7 @@ typedef std::function<ConfiguredPlannerAllocator(const std::string& planner_type
 
 struct ModelBasedPlanningContextSpecification
 {
-  std::map<std::string, std::string> config_;
+  std::map<std::string, std::any> config_;
   ConfiguredPlannerSelector planner_selector_;
   constraint_samplers::ConstraintSamplerManagerPtr constraint_sampler_manager_;
 
@@ -109,7 +111,7 @@ public:
     return spec_.config_;
   }
 
-  void setSpecificationConfig(const std::map<std::string, std::string>& config)
+  void setSpecificationConfig(const std::map<std::string, std::any>& config)
   {
     spec_.config_ = config;
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -106,7 +106,7 @@ public:
     return spec_;
   }
 
-  const std::map<std::string, std::string>& getSpecificationConfig() const
+  const std::map<std::string, std::any>& getSpecificationConfig() const
   {
     return spec_.config_;
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/ompl_interface.h
@@ -45,6 +45,7 @@
 #include <rclcpp/node.hpp>
 #include <string>
 #include <map>
+#include <any>
 
 /** \brief The MoveIt interface to OMPL */
 namespace ompl_interface
@@ -122,7 +123,7 @@ public:
 protected:
   /** @brief Load planner configurations for specified group into planner_config */
   bool loadPlannerConfiguration(const std::string& group_name, const std::string& planner_id,
-                                const std::map<std::string, std::string>& group_params,
+                                const std::map<std::string, std::any>& group_params,
                                 planning_interface::PlannerConfigurationSettings& planner_config);
 
   /** @brief Configure the planners*/

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -37,7 +37,6 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <moveit/ompl_interface/model_based_planning_context.h>
 #include <moveit/ompl_interface/detail/state_validity_checker.h>
@@ -280,10 +279,10 @@ ompl_interface::ModelBasedPlanningContext::allocPathConstrainedSampler(const omp
 
 void ompl_interface::ModelBasedPlanningContext::useConfig()
 {
-  const std::map<std::string, std::string>& config = spec_.config_;
+  const std::map<std::string, std::any>& config = spec_.config_;
   if (config.empty())
     return;
-  std::map<std::string, std::string> cfg = config;
+  std::map<std::string, std::any> cfg = config;
 
   // set the distance between waypoints when interpolating and collision checking.
   auto it = cfg.find("longest_valid_segment_fraction");
@@ -292,7 +291,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   {
     // clang-format off
     double longest_valid_segment_fraction_config = (it != cfg.end())
-      ? moveit::core::toDouble(it->second)  // value from config file if there
+      ? moveit::core::toDouble(std::any_cast<double>(it->second))  // value from config file if there
       : 0.01;  // default value in OMPL.
     double longest_valid_segment_fraction_final = longest_valid_segment_fraction_config;
     if (max_solution_segment_length_ > 0.0)
@@ -370,14 +369,14 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   it = cfg.find("multi_query_planning_enabled");
   if (it != cfg.end())
   {
-    multi_query_planning_enabled_ = boost::lexical_cast<bool>(it->second);
+    multi_query_planning_enabled_ = std::any_cast<bool>(it->second);
   }
 
   // check whether the path returned by the planner should be interpolated
   it = cfg.find("interpolate");
   if (it != cfg.end())
   {
-    interpolate_ = boost::lexical_cast<bool>(it->second);
+    interpolate_ = std::any_cast<bool>(it->second);
     cfg.erase(it);
   }
 
@@ -385,7 +384,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   it = cfg.find("simplify_solutions");
   if (it != cfg.end())
   {
-    simplify_solutions_ = boost::lexical_cast<bool>(it->second);
+    simplify_solutions_ = std::any_cast<bool>(it->second);
     cfg.erase(it);
   }
 
@@ -393,7 +392,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   it = cfg.find("hybridize");
   if (it != cfg.end())
   {
-    hybridize_ = boost::lexical_cast<bool>(it->second);
+    hybridize_ = std::any_cast<bool>(it->second);
     cfg.erase(it);
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -291,7 +291,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   {
     // clang-format off
     double longest_valid_segment_fraction_config = (it != cfg.end())
-      ? moveit::core::toDouble(std::any_cast<double>(it->second))  // value from config file if there
+      ? std::any_cast<double>(it->second)  // value from config file if there
       : 0.01;  // default value in OMPL.
     double longest_valid_segment_fraction_final = longest_valid_segment_fraction_config;
     if (max_solution_segment_length_ > 0.0)
@@ -313,7 +313,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   it = cfg.find("projection_evaluator");
   if (it != cfg.end())
   {
-    setProjectionEvaluator(boost::trim_copy(it->second));
+    setProjectionEvaluator(boost::trim_copy(std::any_cast<std::string>(it->second)));
     cfg.erase(it);
   }
 
@@ -327,7 +327,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   it = cfg.find("optimization_objective");
   if (it != cfg.end())
   {
-    optimizer = it->second;
+    optimizer = std::any_cast<std::string>(it->second);
     cfg.erase(it);
 
     if (optimizer == "PathLengthOptimizationObjective")
@@ -405,7 +405,7 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
   }
   else
   {
-    std::string type = it->second;
+    std::string type = std::any_cast<std::string>(it->second);
     cfg.erase(it);
     const std::string planner_name = getGroupName() + "/" + name_;
     ompl_simple_setup_->setPlannerAllocator(
@@ -553,7 +553,7 @@ ompl_interface::ModelBasedPlanningContext::constructPlannerTerminationCondition(
     return ob::timedPlannerTerminationCondition(timeout - ompl::time::seconds(ompl::time::now() - start));
   }
 
-  std::string termination_string = it->second;
+  std::string termination_string = std::any_cast<std::string>(it->second);
   std::vector<std::string> termination_and_params;
   boost::split(termination_and_params, termination_string, boost::is_any_of("[ ,]"));
 

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -39,6 +39,7 @@
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/utils/lexical_casts.h>
 #include <fstream>
+#include <any>
 
 namespace ompl_interface
 {
@@ -119,7 +120,7 @@ void OMPLInterface::loadConstraintSamplers()
 }
 
 bool OMPLInterface::loadPlannerConfiguration(const std::string& group_name, const std::string& planner_id,
-                                             const std::map<std::string, std::string>& group_params,
+                                             const std::map<std::string, std::any>& group_params,
                                              planning_interface::PlannerConfigurationSettings& planner_config)
 {
   rcl_interfaces::msg::ListParametersResult planner_params_result =
@@ -168,7 +169,7 @@ void OMPLInterface::loadPlannerConfigurations()
     const std::string group_name_param = parameter_namespace_ + "." + group_name;
 
     // get parameters specific for the robot planning group
-    std::map<std::string, std::string> specific_group_params;
+    std::map<std::string, std::any> specific_group_params;
     for (const auto& [name, type] : KNOWN_GROUP_PARAMS)
     {
       std::string param_name{ group_name_param };
@@ -190,15 +191,15 @@ void OMPLInterface::loadPlannerConfigurations()
         }
         else if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
         {
-          specific_group_params[name] = moveit::core::toString(parameter.as_double());
+          specific_group_params[name] = parameter.as_double();
         }
         else if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
         {
-          specific_group_params[name] = std::to_string(parameter.as_int());
+          specific_group_params[name] = parameter.as_int();
         }
         else if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
         {
-          specific_group_params[name] = std::to_string(parameter.as_bool());
+          specific_group_params[name] = parameter.as_bool();
         }
       }
     }
@@ -245,7 +246,7 @@ void OMPLInterface::loadPlannerConfigurations()
 
     for (const auto& [param_name, param_value] : config_settings.config)
     {
-      RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << param_value);
+      RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << moveit::core::toString(param_value));
     }
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/ompl_interface.cpp
@@ -246,7 +246,22 @@ void OMPLInterface::loadPlannerConfigurations()
 
     for (const auto& [param_name, param_value] : config_settings.config)
     {
-      RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << moveit::core::toString(param_value));
+      if (param_value.type() == typeid(std::string()))
+      {
+        RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << std::any_cast<std::string>(param_value));
+      }
+      else if (param_value.type() == typeid(double))
+      {
+        RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << std::any_cast<double>(param_value));
+      }
+      else if (param_value.type() == typeid(int))
+      {
+        RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << std::any_cast<int>(param_value));
+      }
+      else if (param_value.type() == typeid(bool))
+      {
+        RCLCPP_DEBUG_STREAM(LOGGER, " - " << param_name << " = " << std::any_cast<bool>(param_value));
+      }
     }
   }
 

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -113,7 +113,7 @@ ompl::base::PlannerPtr MultiQueryPlannerAllocator::allocatePlanner(const ob::Spa
   bool multi_query_planning_enabled = false;
   if (it != cfg.end())
   {
-    multi_query_planning_enabled = boost::lexical_cast<bool>(it->second);
+    multi_query_planning_enabled = std::any_cast<bool>(it->second);
     cfg.erase(it);
   }
   if (multi_query_planning_enabled)
@@ -140,14 +140,14 @@ ompl::base::PlannerPtr MultiQueryPlannerAllocator::allocatePlanner(const ob::Spa
     bool load_planner_data = false;
     if (it != cfg.end())
     {
-      load_planner_data = boost::lexical_cast<bool>(it->second);
+      load_planner_data = std::any_cast<bool>(it->second);
       cfg.erase(it);
     }
     it = cfg.find("store_planner_data");
     bool store_planner_data = false;
     if (it != cfg.end())
     {
-      store_planner_data = boost::lexical_cast<bool>(it->second);
+      store_planner_data = std::any_cast<bool>(it->second);
       cfg.erase(it);
     }
     it = cfg.find("planner_data_path");
@@ -548,14 +548,14 @@ ModelBasedPlanningContextPtr PlanningContextManager::getPlanningContext(
 
   // Use ConstrainedPlanningStateSpace if there is exactly one position constraint and/or one orientation constraint
   if (constrained_planning_iterator != pc->second.config.end() &&
-      boost::lexical_cast<bool>(constrained_planning_iterator->second) &&
+      std::any_cast<bool>(constrained_planning_iterator->second) &&
       ((req.path_constraints.position_constraints.size() == 1) ||
        (req.path_constraints.orientation_constraints.size() == 1)))
   {
     factory = getStateSpaceFactory(ConstrainedPlanningStateSpace::PARAMETERIZATION_TYPE);
   }
   else if (joint_space_planning_iterator != pc->second.config.end() &&
-           boost::lexical_cast<bool>(joint_space_planning_iterator->second))
+           std::any_cast<bool>(joint_space_planning_iterator->second))
   {
     factory = getStateSpaceFactory(JointModelStateSpace::PARAMETERIZATION_TYPE);
   }

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -154,7 +154,7 @@ ompl::base::PlannerPtr MultiQueryPlannerAllocator::allocatePlanner(const ob::Spa
     std::string planner_data_path;
     if (it != cfg.end())
     {
-      planner_data_path = it->second;
+      planner_data_path = std::any_cast<std::string>(it->second);
       cfg.erase(it);
     }
     // Store planner instance for multi-query use


### PR DESCRIPTION
### Description

Used std::any as data type in std::map to store different params without casting to string to avoid using lexical_cast.
Fixes #2088 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
