### PR TITLE
Add distance to servo collision checker requests

### DIFF
--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -50,6 +50,13 @@ CollisionMonitor::CollisionMonitor(const planning_scene_monitor::PlanningSceneMo
   , planning_scene_monitor_(planning_scene_monitor)
   , collision_velocity_scale_(collision_velocity_scale)
 {
+  scene_collision_request_.distance = true;
+  scene_collision_request_.contacts = true;
+  scene_collision_request_.group_name = servo_params.move_group_name;
+
+  self_collision_request_.distance = true;
+  self_collision_request_.contacts = true;
+  self_collision_request_.group_name = servo_params.move_group_name;
 }
 
 void CollisionMonitor::start()

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -51,11 +51,9 @@ CollisionMonitor::CollisionMonitor(const planning_scene_monitor::PlanningSceneMo
   , collision_velocity_scale_(collision_velocity_scale)
 {
   scene_collision_request_.distance = true;
-  scene_collision_request_.contacts = true;
   scene_collision_request_.group_name = servo_params.move_group_name;
 
   self_collision_request_.distance = true;
-  self_collision_request_.contacts = true;
   self_collision_request_.group_name = servo_params.move_group_name;
 }
 


### PR DESCRIPTION
We found a bug today where the collision distances were not actually being returned by servo's collision checker. So basically, the distance scaling was never working and you could servo right into a binary "is colliding" state.

For reference, these parameters were on before the refactor: https://github.com/ros-planning/moveit2/blob/humble/moveit_ros/moveit_servo/src/collision_check.cpp#L62-L64

@ibrahiminfinite 
