### PR TITLE
Avoid calling static node's destructor.

### DIFF
--- a/moveit_core/utils/src/logger.cpp
+++ b/moveit_core/utils/src/logger.cpp
@@ -70,7 +70,7 @@ rclcpp::Logger& getGlobalLoggerRef()
     auto name = fmt::format("moveit_{}", rsl::rng()());
     try
     {
-      static auto moveit_node = std::make_shared<rclcpp::Node>(name);
+      static auto* moveit_node = new rclcpp::Node(name);
       return moveit_node->get_logger();
     }
     catch (const std::exception& ex)


### PR DESCRIPTION
### Description

This PR replaces the global logger's static node with a static pointer to the node, thus avoiding the call to the node's destructor, which was making [tests fail at tear-down](https://github.com/PickNikRobotics/moveit_studio/actions/runs/6778903261/job/18425874838?pr=5195#step:9:65).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
