### PR TITLE
Fix threading issue for collision velocity scaling in MoveIt Servo

### DIFF
--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -95,8 +95,8 @@ void CollisionMonitor::checkCollisions()
     const double self_velocity_scale_coefficient{ log_val / servo_params_.self_collision_proximity_threshold };
     const double scene_velocity_scale_coefficient{ log_val / servo_params_.scene_collision_proximity_threshold };
 
-    // Reset the scale on every iteration.
-    collision_velocity_scale_ = 1.0;
+    // Use a local variable to prevent access issues between the collision monitor and the servo loop
+    auto new_collision_velocity_scale = 1.0;
 
     if (servo_params_.check_collisions)
     {
@@ -126,7 +126,7 @@ void CollisionMonitor::checkCollisions()
 
       if (self_collision_result_.collision || scene_collision_result_.collision)
       {
-        collision_velocity_scale_ = 0.0;
+        new_collision_velocity_scale = 0.0;
       }
       else
       {
@@ -151,9 +151,13 @@ void CollisionMonitor::checkCollisions()
         }
 
         // Use the scaling factor with lower value, i.e maximum scale down.
-        collision_velocity_scale_ = std::min(scene_collision_scale, self_collision_scale);
+        new_collision_velocity_scale = std::min(scene_collision_scale, self_collision_scale);
       }
     }
+
+    // Set the shared velocity scale once
+    collision_velocity_scale_ = new_collision_velocity_scale;
+
     rate.sleep();
   }
 }

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -155,7 +155,7 @@ void CollisionMonitor::checkCollisions()
       }
     }
 
-    // Set the shared velocity scale once
+    // Only set the shared variable ONCE to ensure intermediate values are not read by the servo thread.
     collision_velocity_scale_ = new_collision_velocity_scale;
 
     rate.sleep();


### PR DESCRIPTION
### Description

Fixes a thread safety issues in the collision monitor in MoveIt Servo. Basically, the shared atomic double `collision_velocity_scale_` was being reset to `1.0` at the start of each collision check loop, which would sometimes be picked up in the `Servo::getNextJointState`, so the robot ends up moving even though the scene is in collision. E.g.,

```
[component_container_mt-7] ERH TEMP: Servo::getNextJointState, collision_velocity_scale_=1                                                                                                    
[component_container_mt-7] ERH TEMP: CollisionMonitor::checkCollisions, collision_velocity_scale_=1      
```

To fix this, we should use a local variable to compute the new scaling factor, and only set the shared variable at the end of the collision processing loop.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
