### PR TITLE
add rsl depend to moveit_core

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(octomap_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(random_numbers REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rsl REQUIRED)
 find_package(ruckig REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
@@ -150,6 +151,7 @@ ament_export_dependencies(
   pluginlib
   random_numbers
   rclcpp
+  rsl
   ruckig
   sensor_msgs
   shape_msgs

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -47,6 +47,7 @@
   <depend>pybind11_vendor</depend>
   <depend>random_numbers</depend>
   <depend>rclcpp</depend>
+  <depend>rsl</depend>
   <depend>ruckig</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>


### PR DESCRIPTION
### Description

- This should fix #2516
- Several moveit2 packages already depend on rsl
- PR #2482 added a depend in moveit_core

This is only broken when building all of moveit2 deps in one colcon workspace And not using rosdep because colcon uses the package.xml and rsl might not have been built


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
