### PR TITLE
Ensure to reset the smoothing plugin when resuming Servo

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -125,7 +125,19 @@ public:
    * @param The last commanded joint states.
    * @return The next state stepping towards the required halting state.
    */
-  std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state) const;
+  std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state);
+
+  /**
+   * \brief Updates the smoother, if one exists, by filtering with a new state.
+   * @param state The state used to update the smoothing plugin.
+   */
+  void updateSmoother(KinematicState& state);
+
+  /**
+   * \brief Resets the smoother, if one exists, to a specified state.
+   * @param state The desired state to reset the smoother to.
+   */
+  void resetSmoother(const KinematicState& state);
 
 private:
   /**
@@ -215,6 +227,7 @@ private:
   std::atomic<double> collision_velocity_scale_ = 1.0;
   std::unique_ptr<CollisionMonitor> collision_monitor_;
 
+  // Pointer to the (optional) smoothing plugin.
   pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass> smoother_ = nullptr;
 
   // Map between joint subgroup names and corresponding joint name - move group indices map

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -128,16 +128,16 @@ public:
   std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state);
 
   /**
-   * \brief Updates the smoother, if one exists, by filtering with a new state.
-   * @param state The state used to update the smoothing plugin.
+   * \brief Applies smoothing to an input state, if a smoothing plugin is set.
+   * @param state The state to be updated by the smoothing plugin.
    */
-  void updateSmoother(KinematicState& state);
+  void doSmoothing(KinematicState& state);
 
   /**
-   * \brief Resets the smoother, if one exists, to a specified state.
-   * @param state The desired state to reset the smoother to.
+   * \brief Resets the smoothing plugin, if set, to a specified state.
+   * @param state The desired state to reset the smoothing plugin to.
    */
-  void resetSmoother(const KinematicState& state);
+  void resetSmoothing(const KinematicState& state);
 
 private:
   /**

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -168,10 +168,10 @@ void Servo::setSmoothingPlugin()
     RCLCPP_ERROR(logger_, "Smoothing plugin could not be initialized");
     std::exit(EXIT_FAILURE);
   }
-  resetSmoother(getCurrentRobotState());
+  resetSmoothing(getCurrentRobotState());
 }
 
-void Servo::updateSmoother(KinematicState& state)
+void Servo::doSmoothing(KinematicState& state)
 {
   if (smoother_)
   {
@@ -179,7 +179,7 @@ void Servo::updateSmoother(KinematicState& state)
   }
 }
 
-void Servo::resetSmoother(const KinematicState& state)
+void Servo::resetSmoothing(const KinematicState& state)
 {
   if (smoother_)
   {
@@ -483,7 +483,7 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
     target_state.positions = current_state.positions + joint_position_delta;
 
     // Apply smoothing to the positions if a smoother was provided.
-    updateSmoother(target_state);
+    doSmoothing(target_state);
 
     // Compute velocities based on smoothed joint positions
     target_state.velocities = (target_state.positions - current_state.positions) / servo_params_.publish_period;
@@ -640,7 +640,7 @@ std::pair<bool, KinematicState> Servo::smoothHalt(const KinematicState& halt_sta
         (target_state.velocities[i] - current_state.velocities[i]) / servo_params_.publish_period;
   }
 
-  updateSmoother(target_state);
+  doSmoothing(target_state);
 
   // If all velocities are near zero, robot has decelerated to a stop.
   stopped =

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -168,8 +168,25 @@ void Servo::setSmoothingPlugin()
     RCLCPP_ERROR(logger_, "Smoothing plugin could not be initialized");
     std::exit(EXIT_FAILURE);
   }
-  const KinematicState current_state = getCurrentRobotState();
-  smoother_->reset(current_state.positions, current_state.velocities, current_state.accelerations);
+  resetSmoother(getCurrentRobotState());
+}
+
+void Servo::updateSmoother(KinematicState& state)
+{
+  if (smoother_)
+  {
+    smoother_->doSmoothing(state.positions, state.velocities, state.accelerations);
+  }
+}
+
+void Servo::resetSmoother(const KinematicState& state)
+{
+  RCLCPP_ERROR(logger_, "TRYING TO RESET SMOOTHER");
+  if (smoother_)
+  {
+    RCLCPP_ERROR(logger_, "RESET SMOOTHER TO CURRENT STATE");
+    smoother_->reset(state.positions, state.velocities, state.accelerations);
+  }
 }
 
 void Servo::setCollisionChecking(const bool check_collision)
@@ -467,13 +484,8 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
     // Compute the next joint positions based on the joint position deltas
     target_state.positions = current_state.positions + joint_position_delta;
 
-    // TODO : apply filtering to the velocity instead of position
     // Apply smoothing to the positions if a smoother was provided.
-    // Update filter state and apply filtering in position domain
-    if (smoother_)
-    {
-      smoother_->doSmoothing(target_state.positions, target_state.velocities, target_state.accelerations);
-    }
+    updateSmoother(target_state);
 
     // Compute velocities based on smoothed joint positions
     target_state.velocities = (target_state.positions - current_state.positions) / servo_params_.publish_period;
@@ -615,7 +627,7 @@ KinematicState Servo::getCurrentRobotState() const
   return current_state;
 }
 
-std::pair<bool, KinematicState> Servo::smoothHalt(const KinematicState& halt_state) const
+std::pair<bool, KinematicState> Servo::smoothHalt(const KinematicState& halt_state)
 {
   bool stopped = false;
   auto target_state = halt_state;
@@ -630,15 +642,11 @@ std::pair<bool, KinematicState> Servo::smoothHalt(const KinematicState& halt_sta
         (target_state.velocities[i] - current_state.velocities[i]) / servo_params_.publish_period;
   }
 
+  updateSmoother(target_state);
+
   // If all velocities are near zero, robot has decelerated to a stop.
   stopped =
       (std::accumulate(target_state.velocities.begin(), target_state.velocities.end(), 0.0) <= STOPPED_VELOCITY_EPS);
-
-  if (smoother_)
-  {
-    smoother_->reset(current_state.positions, current_state.velocities, current_state.accelerations);
-    smoother_->doSmoothing(target_state.positions, target_state.velocities, target_state.accelerations);
-  }
 
   return std::make_pair(stopped, target_state);
 }

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -181,10 +181,8 @@ void Servo::updateSmoother(KinematicState& state)
 
 void Servo::resetSmoother(const KinematicState& state)
 {
-  RCLCPP_ERROR(logger_, "TRYING TO RESET SMOOTHER");
   if (smoother_)
   {
-    RCLCPP_ERROR(logger_, "RESET SMOOTHER TO CURRENT STATE");
     smoother_->reset(state.positions, state.velocities, state.accelerations);
   }
 }

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -162,6 +162,9 @@ void ServoNode::pauseServo(const std::shared_ptr<std_srvs::srv::SetBool::Request
   }
   else
   {
+    // Reset the smoother with the robot's current state in case the robot moved between pausing and unpausing.
+    servo_->resetSmoother(servo_->getCurrentRobotState());
+
     servo_->setCollisionChecking(true);
     response->message = "Servoing enabled";
   }

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -162,8 +162,8 @@ void ServoNode::pauseServo(const std::shared_ptr<std_srvs::srv::SetBool::Request
   }
   else
   {
-    // Reset the smoother with the robot's current state in case the robot moved between pausing and unpausing.
-    servo_->resetSmoother(servo_->getCurrentRobotState());
+    // Reset the smoothing plugin with the robot's current state in case the robot moved between pausing and unpausing.
+    servo_->resetSmoothing(servo_->getCurrentRobotState());
 
     servo_->setCollisionChecking(true);
     response->message = "Servoing enabled";


### PR DESCRIPTION
This fixes another Servo issue we found when resuming Servo after moving through another means, e.g., by running the motion planner to move to a completely different waypoint.

With this fix, the robot shouldn't teleport in these situations.

@ibrahiminfinite 