### PR TITLE
Fix angular distance calculation in floating joint model

### DIFF
--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -36,6 +36,7 @@
 /* Author: Ioan Sucan */
 
 #include <cmath>
+#include <Eigen/Geometry>
 #include <geometric_shapes/check_isometry.h>
 #include <limits>
 #include <moveit/robot_model/floating_joint_model.h>
@@ -121,16 +122,10 @@ double FloatingJointModel::distanceTranslation(const double* values1, const doub
 
 double FloatingJointModel::distanceRotation(const double* values1, const double* values2) const
 {
-  double dq =
-      fabs(values1[3] * values2[3] + values1[4] * values2[4] + values1[5] * values2[5] + values1[6] * values2[6]);
-  if (dq + std::numeric_limits<double>::epsilon() >= 1.0)
-  {
-    return 0.0;
-  }
-  else
-  {
-    return acos(dq);
-  }
+  // The values are in "xyzw" order but Eigen expects "wxyz".
+  const auto q1 = Eigen::Quaterniond(values1[6], values1[3], values1[4], values1[5]);
+  const auto q2 = Eigen::Quaterniond(values2[6], values2[3], values2[4], values2[5]);
+  return q2.angularDistance(q1);
 }
 
 void FloatingJointModel::interpolate(const double* from, const double* to, const double t, double* state) const

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -123,8 +123,8 @@ double FloatingJointModel::distanceTranslation(const double* values1, const doub
 double FloatingJointModel::distanceRotation(const double* values1, const double* values2) const
 {
   // The values are in "xyzw" order but Eigen expects "wxyz".
-  const auto q1 = Eigen::Quaterniond(values1[6], values1[3], values1[4], values1[5]);
-  const auto q2 = Eigen::Quaterniond(values2[6], values2[3], values2[4], values2[5]);
+  const auto q1 = Eigen::Quaterniond(values1[6], values1[3], values1[4], values1[5]).normalized();
+  const auto q2 = Eigen::Quaterniond(values2[6], values2[3], values2[4], values2[5]).normalized();
   return q2.angularDistance(q1);
 }
 

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -528,7 +528,7 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectoryLength)
 {
   robot_trajectory::RobotTrajectoryPtr trajectory;
   initTestTrajectory(trajectory);
-  EXPECT_GT(robot_trajectory::pathLength(*trajectory), 0.0);
+  EXPECT_FLOAT_EQ(robot_trajectory::pathLength(*trajectory), 0.0);
 }
 
 TEST_F(RobotTrajectoryTestFixture, RobotTrajectorySmoothness)
@@ -538,7 +538,7 @@ TEST_F(RobotTrajectoryTestFixture, RobotTrajectorySmoothness)
 
   const auto smoothness = robot_trajectory::smoothness(*trajectory);
   ASSERT_TRUE(smoothness.has_value());
-  EXPECT_GT(smoothness.value(), 0.0);
+  EXPECT_FLOAT_EQ(smoothness.value(), 0.0);
 
   // Check for empty trajectory
   trajectory->clear();

--- a/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/test/test_robot_trajectory.cpp
@@ -55,7 +55,7 @@ protected:
   {
     robot_model_ = moveit::core::loadTestingRobotModel(robot_model_name_);
     robot_state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
-    robot_state_->setToDefaultValues(arm_jmg_name_, arm_state_name_);
+    robot_state_->setToDefaultValues();
     robot_state_->setVariableVelocity(/*index*/ 0, /*value*/ 1.0);
     robot_state_->setVariableAcceleration(/*index*/ 0, /*value*/ -0.1);
     robot_state_->update();


### PR DESCRIPTION
From debugging some strange trajectory tests, we found a bug in the angular distance calculation of floating joints. Eigen to the rescue!