### PR TITLE
Benchmark robot state

### DIFF
--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -146,14 +146,14 @@ public:
       the state by calling update(true). */
   double* getVariablePositions()
   {
-    return position_;
+    return position_.data();
   }
 
   /** \brief Get a raw pointer to the positions of the variables
       stored in this state. */
   const double* getVariablePositions() const
   {
-    return position_;
+    return position_.data();
   }
 
   /** \brief It is assumed \e positions is an array containing the new
@@ -236,14 +236,14 @@ public:
   double* getVariableVelocities()
   {
     markVelocity();
-    return velocity_;
+    return velocity_.data();
   }
 
   /** \brief Get const access to the velocities of the variables that make up this state. The values are in the same
    * order as reported by getVariableNames() */
   const double* getVariableVelocities() const
   {
-    return velocity_;
+    return velocity_.data();
   }
 
   /** \brief Set all velocities to 0.0 */
@@ -254,7 +254,7 @@ public:
   {
     has_velocity_ = true;
     // assume everything is in order in terms of array lengths (for efficiency reasons)
-    memcpy(velocity_, velocity, robot_model_->getVariableCount() * sizeof(double));
+    memcpy(velocity_.data(), velocity, robot_model_->getVariableCount() * sizeof(double));
   }
 
   /** \brief Given an array with velocity values for all variables, set those values as the velocities in this state */
@@ -428,14 +428,14 @@ public:
   double* getVariableEffort()
   {
     markEffort();
-    return effort_;
+    return effort_.data();
   }
 
   /** \brief Get const raw access to the effort of the variables that make up this state. The values are in the same
    * order as reported by getVariableNames(). */
   const double* getVariableEffort() const
   {
-    return effort_;
+    return effort_.data();
   }
 
   /** \brief Set all effort values to 0.0 */
@@ -447,7 +447,7 @@ public:
     has_effort_ = true;
     has_acceleration_ = false;
     // assume everything is in order in terms of array lengths (for efficiency reasons)
-    memcpy(effort_, effort, robot_model_->getVariableCount() * sizeof(double));
+    memcpy(effort_.data(), effort, robot_model_->getVariableCount() * sizeof(double));
   }
 
   /** \brief Given an array with effort values for all variables, set those values as the effort in this state */
@@ -529,7 +529,7 @@ public:
 
   void setJointPositions(const JointModel* joint, const double* position)
   {
-    memcpy(position_ + joint->getFirstVariableIndex(), position, joint->getVariableCount() * sizeof(double));
+    memcpy(position_.data() + joint->getFirstVariableIndex(), position, joint->getVariableCount() * sizeof(double));
     markDirtyJointTransforms(joint);
     updateMimicJoint(joint);
   }
@@ -541,7 +541,7 @@ public:
 
   void setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
   {
-    joint->computeVariablePositions(transform, position_ + joint->getFirstVariableIndex());
+    joint->computeVariablePositions(transform, position_.data() + joint->getFirstVariableIndex());
     markDirtyJointTransforms(joint);
     updateMimicJoint(joint);
   }
@@ -549,7 +549,7 @@ public:
   void setJointVelocities(const JointModel* joint, const double* velocity)
   {
     has_velocity_ = true;
-    memcpy(velocity_ + joint->getFirstVariableIndex(), velocity, joint->getVariableCount() * sizeof(double));
+    memcpy(velocity_.data() + joint->getFirstVariableIndex(), velocity, joint->getVariableCount() * sizeof(double));
   }
 
   void setJointEfforts(const JointModel* joint, const double* effort);
@@ -561,7 +561,7 @@ public:
 
   const double* getJointPositions(const JointModel* joint) const
   {
-    return position_ + joint->getFirstVariableIndex();
+    return position_.data() + joint->getFirstVariableIndex();
   }
 
   const double* getJointVelocities(const std::string& joint_name) const
@@ -571,7 +571,7 @@ public:
 
   const double* getJointVelocities(const JointModel* joint) const
   {
-    return velocity_ + joint->getFirstVariableIndex();
+    return velocity_.data() + joint->getFirstVariableIndex();
   }
 
   const double* getJointAccelerations(const std::string& joint_name) const
@@ -591,7 +591,7 @@ public:
 
   const double* getJointEffort(const JointModel* joint) const
   {
-    return effort_ + joint->getFirstVariableIndex();
+    return effort_.data() + joint->getFirstVariableIndex();
   }
 
   /** @} */
@@ -1341,7 +1341,7 @@ public:
     unsigned char& dirty = dirty_joint_transforms_[idx];
     if (dirty)
     {
-      joint->computeTransform(position_ + joint->getFirstVariableIndex(), variable_joint_transforms_[idx]);
+      joint->computeTransform(position_.data() + joint->getFirstVariableIndex(), variable_joint_transforms_[idx]);
       dirty = 0;
     }
     return variable_joint_transforms_[idx];
@@ -1388,7 +1388,7 @@ public:
   /** \brief Return the sum of joint distances to "other" state. An L1 norm. Only considers active joints. */
   double distance(const RobotState& other) const
   {
-    return robot_model_->distance(position_, other.getVariablePositions());
+    return robot_model_->distance(position_.data(), other.getVariablePositions());
   }
 
   /** \brief Return the sum of joint distances to "other" state. An L1 norm. Only considers active joints. */
@@ -1398,7 +1398,7 @@ public:
   double distance(const RobotState& other, const JointModel* joint) const
   {
     const int idx = joint->getFirstVariableIndex();
-    return joint->distance(position_ + idx, other.position_ + idx);
+    return joint->distance(position_.data() + idx, other.position_.data() + idx);
   }
 
   /**
@@ -1434,7 +1434,7 @@ public:
   void interpolate(const RobotState& to, double t, RobotState& state, const JointModel* joint) const
   {
     const int idx = joint->getFirstVariableIndex();
-    joint->interpolate(position_ + idx, to.position_ + idx, t, state.position_ + idx);
+    joint->interpolate(position_.data() + idx, to.position_.data() + idx, t, state.position_.data() + idx);
     state.markDirtyJointTransforms(joint);
     state.updateMimicJoint(joint);
   }
@@ -1449,7 +1449,7 @@ public:
   }
   void enforcePositionBounds(const JointModel* joint)
   {
-    if (joint->enforcePositionBounds(position_ + joint->getFirstVariableIndex()))
+    if (joint->enforcePositionBounds(position_.data() + joint->getFirstVariableIndex()))
     {
       markDirtyJointTransforms(joint);
       updateMimicJoint(joint);
@@ -1461,7 +1461,7 @@ public:
   void harmonizePositions(const JointModelGroup* joint_group);
   void harmonizePosition(const JointModel* joint)
   {
-    if (joint->harmonizePosition(position_ + joint->getFirstVariableIndex()))
+    if (joint->harmonizePosition(position_.data() + joint->getFirstVariableIndex()))
     {
       // no need to mark transforms dirty, as the transform hasn't changed
       updateMimicJoint(joint);
@@ -1470,7 +1470,7 @@ public:
 
   void enforceVelocityBounds(const JointModel* joint)
   {
-    joint->enforceVelocityBounds(velocity_ + joint->getFirstVariableIndex());
+    joint->enforceVelocityBounds(velocity_.data() + joint->getFirstVariableIndex());
   }
 
   bool satisfiesBounds(double margin = 0.0) const;
@@ -1792,26 +1792,25 @@ private:
   bool checkCollisionTransforms() const;
 
   RobotModelConstPtr robot_model_;
-  void* memory_;
 
-  double* position_;
-  double* velocity_;
-  double* acceleration_;
-  double* effort_;
+  std::vector<double> position_;
+  std::vector<double> velocity_;
+  double* acceleration_ = nullptr;
+  std::vector<double> effort_;
   bool has_velocity_;
   bool has_acceleration_;
   bool has_effort_;
 
-  const JointModel* dirty_link_transforms_;
-  const JointModel* dirty_collision_body_transforms_;
+  const JointModel* dirty_link_transforms_ = nullptr;
+  const JointModel* dirty_collision_body_transforms_ = nullptr;
 
-  // All the following transform variables point into aligned memory in memory_
+  // All the following transform variables point into aligned memory.
   // They are updated lazily, based on the flags in dirty_joint_transforms_
   // resp. the pointers dirty_link_transforms_ and dirty_collision_body_transforms_
-  Eigen::Isometry3d* variable_joint_transforms_;         ///< Local transforms of all joints
-  Eigen::Isometry3d* global_link_transforms_;            ///< Transforms from model frame to link frame for each link
-  Eigen::Isometry3d* global_collision_body_transforms_;  ///< Transforms from model frame to collision bodies
-  unsigned char* dirty_joint_transforms_;
+  std::vector<Eigen::Isometry3d> variable_joint_transforms_;  ///< Local transforms of all joints
+  std::vector<Eigen::Isometry3d> global_link_transforms_;  ///< Transforms from model frame to link frame for each link
+  std::vector<Eigen::Isometry3d> global_collision_body_transforms_;  ///< Transforms from model frame to collision bodies
+  std::vector<unsigned char> dirty_joint_transforms_;
 
   /** \brief All attached bodies that are part of this state, indexed by their name */
   std::map<std::string, std::unique_ptr<AttachedBody>> attached_body_map_;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -72,68 +72,32 @@ RobotState::RobotState(const RobotModelConstPtr& robot_model)
   }
 
   dirty_link_transforms_ = robot_model_->getRootJoint();
-  allocMemory();
   initTransforms();
 }
 
 RobotState::RobotState(const RobotState& other) : rng_(nullptr)
 {
   robot_model_ = other.robot_model_;
-  allocMemory();
   copyFrom(other);
 }
 
 RobotState::~RobotState()
 {
   clearAttachedBodies();
-  free(memory_);
   if (rng_)
     delete rng_;
 }
 
-void RobotState::allocMemory()
-{
-  static_assert((sizeof(Eigen::Isometry3d) / EIGEN_MAX_ALIGN_BYTES) * EIGEN_MAX_ALIGN_BYTES == sizeof(Eigen::Isometry3d),
-                "sizeof(Eigen::Isometry3d) should be a multiple of EIGEN_MAX_ALIGN_BYTES");
-
-  constexpr unsigned int extra_alignment_bytes = EIGEN_MAX_ALIGN_BYTES - 1;
-  // memory for the dirty joint transforms
-  const int nr_doubles_for_dirty_joint_transforms =
-      1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
-  const size_t bytes =
-      sizeof(Eigen::Isometry3d) * (robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
-                                   robot_model_->getLinkGeometryCount()) +
-      sizeof(double) * (robot_model_->getVariableCount() * 3 + nr_doubles_for_dirty_joint_transforms) +
-      extra_alignment_bytes;
-  memory_ = malloc(bytes);
-
-  // make the memory for transforms align at EIGEN_MAX_ALIGN_BYTES
-  // https://eigen.tuxfamily.org/dox/classEigen_1_1aligned__allocator.html
-  // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  variable_joint_transforms_ = reinterpret_cast<Eigen::Isometry3d*>(
-      (reinterpret_cast<uintptr_t>(memory_) + extra_alignment_bytes) & ~static_cast<uintptr_t>(extra_alignment_bytes));
-  global_link_transforms_ = variable_joint_transforms_ + robot_model_->getJointModelCount();
-  global_collision_body_transforms_ = global_link_transforms_ + robot_model_->getLinkModelCount();
-  dirty_joint_transforms_ =
-      reinterpret_cast<unsigned char*>(global_collision_body_transforms_ + robot_model_->getLinkGeometryCount());
-  position_ = reinterpret_cast<double*>(dirty_joint_transforms_) + nr_doubles_for_dirty_joint_transforms;
-  velocity_ = position_ + robot_model_->getVariableCount();
-  // acceleration and effort share the memory (not both can be specified)
-  effort_ = acceleration_ = velocity_ + robot_model_->getVariableCount();
-}
-
 void RobotState::initTransforms()
 {
-  // mark all transforms as dirty
-  const int nr_doubles_for_dirty_joint_transforms =
-      1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
-  memset(dirty_joint_transforms_, 1, sizeof(double) * nr_doubles_for_dirty_joint_transforms);
-
-  // initialize last row of transformation matrices, which will not be modified by transform updates anymore
-  for (size_t i = 0, end = robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
-                           robot_model_->getLinkGeometryCount();
-       i != end; ++i)
-    variable_joint_transforms_[i].makeAffine();
+  variable_joint_transforms_.resize(robot_model_->getJointModelCount(), Eigen::Isometry3d::Identity());
+  global_link_transforms_.resize(robot_model_->getLinkModelCount(), Eigen::Isometry3d::Identity());
+  global_collision_body_transforms_.resize(robot_model_->getLinkModelCount(), Eigen::Isometry3d::Identity());
+  dirty_joint_transforms_.resize(robot_model_->getJointModelCount(), 1);
+  position_.resize(robot_model_->getVariableCount());
+  velocity_.resize(robot_model_->getVariableCount());
+  effort_.resize(robot_model_->getVariableCount());
+  acceleration_ = effort_.data();
 }
 
 RobotState& RobotState::operator=(const RobotState& other)
@@ -154,26 +118,26 @@ void RobotState::copyFrom(const RobotState& other)
 
   if (dirty_link_transforms_ == robot_model_->getRootJoint())
   {
-    // everything is dirty; no point in copying transforms; copy positions, potentially velocity & acceleration
-    memcpy(position_, other.position_,
-           robot_model_->getVariableCount() * sizeof(double) *
-               (1 + (has_velocity_ ? 1 : 0) + ((has_acceleration_ || has_effort_) ? 1 : 0)));
-    // and just initialize transforms
-    initTransforms();
+    variable_joint_transforms_.resize(robot_model_->getJointModelCount(), Eigen::Isometry3d::Identity());
+    global_link_transforms_.resize(robot_model_->getLinkModelCount(), Eigen::Isometry3d::Identity());
+    global_collision_body_transforms_.resize(robot_model_->getLinkModelCount(), Eigen::Isometry3d::Identity());
+    dirty_joint_transforms_.resize(robot_model_->getJointModelCount(), 1);
+    position_ = other.position_;
+    velocity_.resize(robot_model_->getVariableCount());
+    effort_.resize(robot_model_->getVariableCount());
+    acceleration_ = effort_.data();
   }
   else
   {
     // copy all the memory; maybe avoid copying velocity and acceleration if possible
-    const int nr_doubles_for_dirty_joint_transforms =
-        1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
-    const size_t bytes =
-        sizeof(Eigen::Isometry3d) * (robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
-                                     robot_model_->getLinkGeometryCount()) +
-        sizeof(double) *
-            (robot_model_->getVariableCount() * (1 + ((has_velocity_ || has_acceleration_ || has_effort_) ? 1 : 0) +
-                                                 ((has_acceleration_ || has_effort_) ? 1 : 0)) +
-             nr_doubles_for_dirty_joint_transforms);
-    memcpy(static_cast<void*>(variable_joint_transforms_), other.variable_joint_transforms_, bytes);
+    variable_joint_transforms_ = other.variable_joint_transforms_;
+    global_link_transforms_ = other.global_link_transforms_;
+    global_collision_body_transforms_ = other.global_collision_body_transforms_;
+    dirty_joint_transforms_ = other.dirty_joint_transforms_;
+    position_ = other.position_;
+    velocity_ = other.velocity_;
+    effort_ = other.effort_;
+    acceleration_ = effort_.data();
   }
 
   // copy attached bodies
@@ -217,7 +181,7 @@ void RobotState::markVelocity()
   if (!has_velocity_)
   {
     has_velocity_ = true;
-    memset(velocity_, 0, sizeof(double) * robot_model_->getVariableCount());
+    memset(velocity_.data(), 0, sizeof(double) * robot_model_->getVariableCount());
   }
 }
 
@@ -237,7 +201,7 @@ void RobotState::markEffort()
   {
     has_acceleration_ = false;
     has_effort_ = true;
-    memset(effort_, 0, sizeof(double) * robot_model_->getVariableCount());
+    memset(effort_.data(), 0, sizeof(double) * robot_model_->getVariableCount());
   }
 }
 
@@ -285,7 +249,7 @@ void RobotState::setToRandomPositions()
 {
   random_numbers::RandomNumberGenerator& rng = getRandomNumberGenerator();
   robot_model_->getVariableRandomPositions(rng, position_);
-  memset(dirty_joint_transforms_, 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
+  memset(dirty_joint_transforms_.data(), 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
   dirty_link_transforms_ = robot_model_->getRootJoint();
   // mimic values are correctly set in RobotModel
 }
@@ -301,7 +265,7 @@ void RobotState::setToRandomPositions(const JointModelGroup* group, random_numbe
 {
   const std::vector<const JointModel*>& joints = group->getActiveJointModels();
   for (const JointModel* joint : joints)
-    joint->getVariableRandomPositions(rng, position_ + joint->getFirstVariableIndex());
+    joint->getVariableRandomPositions(rng, position_.data() + joint->getFirstVariableIndex());
   updateMimicJoints(group);
 }
 
@@ -323,8 +287,8 @@ void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const 
   for (std::size_t i = 0; i < joints.size(); ++i)
   {
     const int idx = joints[i]->getFirstVariableIndex();
-    joints[i]->getVariableRandomPositionsNearBy(rng, position_ + joints[i]->getFirstVariableIndex(),
-                                                seed.position_ + idx, distances[i]);
+    joints[i]->getVariableRandomPositionsNearBy(rng, position_.data() + joints[i]->getFirstVariableIndex(),
+                                                seed.position_.data() + idx, distances[i]);
   }
   updateMimicJoints(group);
 }
@@ -344,8 +308,8 @@ void RobotState::setToRandomPositionsNearBy(const JointModelGroup* group, const 
   for (const JointModel* joint : joints)
   {
     const int idx = joint->getFirstVariableIndex();
-    joint->getVariableRandomPositionsNearBy(rng, position_ + joint->getFirstVariableIndex(), seed.position_ + idx,
-                                            distance);
+    joint->getVariableRandomPositionsNearBy(rng, position_.data() + joint->getFirstVariableIndex(),
+                                            seed.position_.data() + idx, distance);
   }
   updateMimicJoints(group);
 }
@@ -362,20 +326,20 @@ void RobotState::setToDefaultValues()
 {
   robot_model_->getVariableDefaultPositions(position_);  // mimic values are updated
   // set velocity & acceleration to 0
-  memset(velocity_, 0, sizeof(double) * 2 * robot_model_->getVariableCount());
-  memset(dirty_joint_transforms_, 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
+  memset(velocity_.data(), 0, sizeof(double) * robot_model_->getVariableCount());
+  memset(dirty_joint_transforms_.data(), 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
   dirty_link_transforms_ = robot_model_->getRootJoint();
 }
 
 void RobotState::setVariablePositions(const double* position)
 {
   // assume everything is in order in terms of array lengths (for efficiency reasons)
-  memcpy(position_, position, robot_model_->getVariableCount() * sizeof(double));
+  memcpy(position_.data(), position, robot_model_->getVariableCount() * sizeof(double));
 
   // the full state includes mimic joint values, so no need to update mimic here
 
   // Since all joint values have potentially changed, we will need to recompute all transforms
-  memset(dirty_joint_transforms_, 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
+  memset(dirty_joint_transforms_.data(), 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
   dirty_link_transforms_ = robot_model_->getRootJoint();
 }
 
@@ -513,7 +477,7 @@ void RobotState::setJointEfforts(const JointModel* joint, const double* effort)
   }
   has_effort_ = true;
 
-  memcpy(effort_ + joint->getFirstVariableIndex(), effort, joint->getVariableCount() * sizeof(double));
+  memcpy(effort_.data() + joint->getFirstVariableIndex(), effort, joint->getVariableCount() * sizeof(double));
 }
 
 void RobotState::setJointGroupPositions(const JointModelGroup* group, const double* gstate)
@@ -521,7 +485,7 @@ void RobotState::setJointGroupPositions(const JointModelGroup* group, const doub
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
   {
-    memcpy(position_ + il[0], gstate, group->getVariableCount() * sizeof(double));
+    memcpy(position_.data() + il[0], gstate, group->getVariableCount() * sizeof(double));
   }
   else
   {
@@ -568,7 +532,7 @@ void RobotState::copyJointGroupPositions(const JointModelGroup* group, double* g
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
   {
-    memcpy(gstate, position_ + il[0], group->getVariableCount() * sizeof(double));
+    memcpy(gstate, position_.data() + il[0], group->getVariableCount() * sizeof(double));
   }
   else
   {
@@ -591,7 +555,7 @@ void RobotState::setJointGroupVelocities(const JointModelGroup* group, const dou
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
   {
-    memcpy(velocity_ + il[0], gstate, group->getVariableCount() * sizeof(double));
+    memcpy(velocity_.data() + il[0], gstate, group->getVariableCount() * sizeof(double));
   }
   else
   {
@@ -613,7 +577,7 @@ void RobotState::copyJointGroupVelocities(const JointModelGroup* group, double* 
   const std::vector<int>& il = group->getVariableIndexList();
   if (group->isContiguousWithinState())
   {
-    memcpy(gstate, velocity_ + il[0], group->getVariableCount() * sizeof(double));
+    memcpy(gstate, velocity_.data() + il[0], group->getVariableCount() * sizeof(double));
   }
   else
   {
@@ -680,7 +644,7 @@ void RobotState::update(bool force)
   // make sure we do everything from scratch if needed
   if (force)
   {
-    memset(dirty_joint_transforms_, 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
+    memset(dirty_joint_transforms_.data(), 1, robot_model_->getJointModelCount() * sizeof(unsigned char));
     dirty_link_transforms_ = robot_model_->getRootJoint();
   }
 
@@ -982,7 +946,8 @@ bool RobotState::isValidVelocityMove(const RobotState& other, const JointModelGr
     // Check velocity for each joint variable
     for (std::size_t var_id = 0; var_id < joint_id->getVariableCount(); ++var_id)
     {
-      const double dtheta = std::abs(*(position_ + idx + var_id) - *(other.getVariablePositions() + idx + var_id));
+      const double dtheta =
+          std::abs(*(position_.data() + idx + var_id) - *(other.getVariablePositions() + idx + var_id));
 
       if (dtheta > dt * bounds[var_id].max_velocity_)
         return false;
@@ -998,7 +963,7 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
   for (const JointModel* joint : jm)
   {
     const int idx = joint->getFirstVariableIndex();
-    d += joint->getDistanceFactor() * joint->distance(position_ + idx, other.position_ + idx);
+    d += joint->getDistanceFactor() * joint->distance(position_.data() + idx, other.position_.data() + idx);
   }
   return d;
 }
@@ -1008,7 +973,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state) 
   checkInterpolationParamBounds(LOGGER, t);
   robot_model_->interpolate(getVariablePositions(), to.getVariablePositions(), t, state.getVariablePositions());
 
-  memset(state.dirty_joint_transforms_, 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
+  memset(state.dirty_joint_transforms_.data(), 1, state.robot_model_->getJointModelCount() * sizeof(unsigned char));
   state.dirty_link_transforms_ = state.robot_model_->getRootJoint();
 }
 
@@ -1019,7 +984,7 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state, 
   for (const JointModel* joint : jm)
   {
     const int idx = joint->getFirstVariableIndex();
-    joint->interpolate(position_ + idx, to.position_ + idx, t, state.position_ + idx);
+    joint->interpolate(position_.data() + idx, to.position_.data() + idx, t, state.position_.data() + idx);
   }
   state.updateMimicJoints(joint_group);
 }
@@ -2206,7 +2171,7 @@ void RobotState::printStateInfo(std::ostream& out) const
   out << "Robot State @" << this << '\n';
 
   std::size_t n = robot_model_->getVariableCount();
-  if (position_)
+  if (!position_.empty())
   {
     out << "  * Position: ";
     for (std::size_t i = 0; i < n; ++i)
@@ -2216,7 +2181,7 @@ void RobotState::printStateInfo(std::ostream& out) const
   else
     out << "  * Position: NULL\n";
 
-  if (velocity_)
+  if (!velocity_.empty())
   {
     out << "  * Velocity: ";
     for (std::size_t i = 0; i < n; ++i)
@@ -2263,7 +2228,7 @@ void RobotState::printTransform(const Eigen::Isometry3d& transform, std::ostream
 
 void RobotState::printTransforms(std::ostream& out) const
 {
-  if (!variable_joint_transforms_)
+  if (variable_joint_transforms_.empty())
   {
     out << "No transforms computed\n";
     return;
@@ -2334,7 +2299,7 @@ void RobotState::getStateTreeJointString(std::ostream& ss, const JointModel* jm,
 
   ss << pfx << "Link: " << link_model->getName() << '\n';
   getPoseString(ss, link_model->getJointOriginTransform(), pfx + "joint_origin:");
-  if (variable_joint_transforms_)
+  if (!variable_joint_transforms_.empty())
   {
     getPoseString(ss, variable_joint_transforms_[jm->getJointIndex()], pfx + "joint_variable:");
     getPoseString(ss, global_link_transforms_[link_model->getLinkIndex()], pfx + "link_global:");


### PR DESCRIPTION
### Description

This change simplifies memory management in `RobotState`, at the expense slower copy/construct operations.
Instead of having a `void *memory_` chunk of memory with crafted pointers pointing inside, this change updates the pointer variables to be what they really are: `std::vector`. 
Construction is more expensive because now it has to do multiple allocation/initialization, instead of a single one. On the positive side, the code is more readable, maintainable and less error-prone. This change actually fixes at least a couple of memory issues with the existing code.

On the performance check, these are the `RobotState` benchmark results for the related test cases:
```
With this PR:
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
robotStateConstruct/100                     0.020 ms        0.020 ms        35180
robotStateConstruct/1000                    0.197 ms        0.197 ms         3650
robotStateConstruct/10000                    1.95 ms         1.95 ms          348
robotStateCopy/100                          0.024 ms        0.024 ms        32654
robotStateCopy/1000                         0.197 ms        0.197 ms         3160
robotStateCopy/10000                         2.09 ms         2.09 ms          318
robotStateUpdate/10                         0.029 ms        0.029 ms        22723
robotStateUpdate/100                        0.282 ms        0.282 ms         2464
robotStateUpdate/1000                        2.72 ms         2.72 ms          252
robotStateForwardKinematics/10              0.025 ms        0.025 ms        28880
robotStateForwardKinematics/100             0.245 ms        0.245 ms         2902
robotStateForwardKinematics/1000             2.48 ms         2.48 ms          285

Without this change (i.e. at HEAD):
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
robotStateConstruct/100                     0.006 ms        0.006 ms       121103
robotStateConstruct/1000                    0.057 ms        0.057 ms        12037
robotStateConstruct/10000                   0.584 ms        0.584 ms         1240
robotStateCopy/100                          0.007 ms        0.007 ms       107305
robotStateCopy/1000                         0.062 ms        0.062 ms        11115
robotStateCopy/10000                        0.628 ms        0.628 ms         1133
robotStateUpdate/10                         0.028 ms        0.028 ms        25451
robotStateUpdate/100                        0.277 ms        0.277 ms         2450
robotStateUpdate/1000                        2.78 ms         2.78 ms          254
robotStateForwardKinematics/10              0.024 ms        0.024 ms        29117
robotStateForwardKinematics/100             0.242 ms        0.242 ms         2847
robotStateForwardKinematics/1000             2.41 ms         2.41 ms          288

```

So, state updates and FK are the same. Copy and construction are around 4x slower, e.g. copying 10.000 states changes from 0.6ms to ~2ms.

Regarding trajectories:
```
With RS Change:
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
robotTrajectoryCreate/10          0.008 ms        0.008 ms        91556
robotTrajectoryCreate/100         0.089 ms        0.089 ms         7889
robotTrajectoryCreate/1000         1.11 ms         1.11 ms          620
robotTrajectoryCreate/10000        22.2 ms         22.2 ms           32
robotTrajectoryCreate/100000        244 ms          244 ms            3
robotTrajectoryTiming/10          0.022 ms        0.022 ms        29042
robotTrajectoryTiming/100         0.070 ms        0.070 ms         9982
robotTrajectoryTiming/1000        0.322 ms        0.322 ms         2161
robotTrajectoryTiming/10000        1.22 ms         1.22 ms          440
robotTrajectoryTiming/20000        1123 ms         1123 ms            1

Without this change (i.e. at HEAD):
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
robotTrajectoryCreate/10          0.005 ms        0.005 ms       100000
robotTrajectoryCreate/100         0.050 ms        0.050 ms        13940
robotTrajectoryCreate/1000         1.10 ms         1.10 ms          609
robotTrajectoryCreate/10000        16.1 ms         16.1 ms           43
robotTrajectoryCreate/100000        190 ms          190 ms            4
robotTrajectoryTiming/10          0.020 ms        0.020 ms        34208
robotTrajectoryTiming/100         0.063 ms        0.063 ms        10910
robotTrajectoryTiming/1000        0.298 ms        0.298 ms         2342
robotTrajectoryTiming/10000       0.975 ms        0.975 ms          554
robotTrajectoryTiming/20000        1057 ms         1057 ms            1
```

Creating a trajectory with 100.000 states goes from 190ms to 244ms.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
