### PR TITLE
(moveit_py) Allow editing allowed collision matrix in python + fix get_entry function

### DIFF
--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -291,8 +291,12 @@ public:
   {
     return acm_ ? *acm_ : parent_->getAllowedCollisionMatrix();
   }
+
   /** \brief Get the allowed collision matrix */
   collision_detection::AllowedCollisionMatrix& getAllowedCollisionMatrixNonConst();
+
+  /** \brief Set the allowed collision matrix */
+  void setAllowedCollisionMatrix(const collision_detection::AllowedCollisionMatrix& acm);
 
   /**@}*/
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -558,6 +558,11 @@ collision_detection::AllowedCollisionMatrix& PlanningScene::getAllowedCollisionM
   return *acm_;
 }
 
+void PlanningScene::setAllowedCollisionMatrix(const collision_detection::AllowedCollisionMatrix& acm)
+{
+  getAllowedCollisionMatrixNonConst() = acm;
+}
+
 const moveit::core::Transforms& PlanningScene::getTransforms()
 {
   // Trigger an update of the robot transforms

--- a/moveit_py/src/moveit/moveit_core/collision_detection/collision_matrix.cpp
+++ b/moveit_py/src/moveit/moveit_core/collision_detection/collision_matrix.cpp
@@ -40,16 +40,34 @@ namespace moveit_py
 {
 namespace bind_collision_detection
 {
-std::pair<bool, collision_detection::AllowedCollision::Type>
-getEntry(const std::shared_ptr<collision_detection::AllowedCollisionMatrix>& acm, const std::string& name1,
-         const std::string& name2)
+// TODO: Create a custom typecaster/revise the current implementation to return std::pair<bool,
+// collision_detection::AllowedCollision::Type>
+std::pair<bool, std::string> getEntry(const collision_detection::AllowedCollisionMatrix& acm, const std::string& name1,
+                                      const std::string& name2)
 {
   // check acm for collision
   collision_detection::AllowedCollision::Type type;
-  bool collision_allowed = acm->getEntry(name1, name2, type);
+  bool collision_allowed = acm.getEntry(name1, name2, type);
+  std::string type_str;
+  if (type == collision_detection::AllowedCollision::Type::NEVER)
+  {
+    type_str = "NEVER";
+  }
+  else if (type == collision_detection::AllowedCollision::Type::ALWAYS)
+  {
+    type_str = "ALWAYS";
+  }
+  else if (type == collision_detection::AllowedCollision::Type::CONDITIONAL)
+  {
+    type_str = "CONDITIONAL";
+  }
+  else
+  {
+    type_str = "UNKNOWN";
+  }
 
   // should return a tuple true/false and the allowed collision type
-  std::pair<bool, collision_detection::AllowedCollision::Type> result = std::make_pair(collision_allowed, type);
+  std::pair<bool, std::string> result = std::make_pair(collision_allowed, type_str);
   return result;
 }
 

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -111,8 +111,9 @@ void initPlanningScene(py::module& m)
                     py::return_value_policy::move)
 
       .def_property("transforms", py::overload_cast<>(&planning_scene::PlanningScene::getTransforms), nullptr)
-      .def_property("allowed_collision_matrix", &planning_scene::PlanningScene::getAllowedCollisionMatrix, nullptr,
-                    py::return_value_policy::move)
+      .def_property("allowed_collision_matrix", &planning_scene::PlanningScene::getAllowedCollisionMatrix,
+                    &planning_scene::PlanningScene::setAllowedCollisionMatrix,
+                    py::return_value_policy::reference_internal)
       // methods
       .def("__copy__",
            [](const planning_scene::PlanningScene* self) {


### PR DESCRIPTION
Allow editing allowed collision matrix in python + fix get_entry function

### Description

Added a setter + changed from move to reference_internal to allow changes when using inside of a context.
Also added some changes to allow the call of the get_entry function. Currently there is no custom typecaster for collision_detection::AllowedCollision::Type. Added a basic str return for now.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
