### PR TITLE
Change default topic name for display contacts

### DIFF
--- a/moveit_ros/planning/planning_response_adapter_plugins/res/default_response_adapter_params.yaml
+++ b/moveit_ros/planning/planning_response_adapter_plugins/res/default_response_adapter_params.yaml
@@ -24,5 +24,5 @@ default_response_adapter_parameters:
   display_contacts_topic: {
     type: string,
     description: "If contacts are found in the solution path, they can be published as markers to this topic (visualization_msgs::MarkerArray). An empty string disables the publisher.",
-    default_value: "display_planned_path",
+    default_value: "display_contacts",
   }


### PR DESCRIPTION
The default topics for `display_path` and `display_contacts` are the same. This will create a problem since they both construct publishers using the same topic name with different msg types which will produce a segfault.

```
[move_group-4] [INFO] [1701373538.471684625] [move_group]: Try loading adapter 'default_planning_response_adapters/DisplayMotionPath'
    [move_group-4] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
    [move_group-4]   what():  could not create publisher: create_publisher() called for existing topic name rt/display_planned_path with incompatible type moveit_msgs::msg::dds_::DisplayTrajectory_, at ./src/publisher.cpp:145, at ./src/rcl/publisher.c:117
    [move_group-4] Stack trace (most recent call last):
    [move_group-4] #22   Object "", at 0xffffffffffffffff, in 
    [move_group-4] #21   Object "/root/ws_moveit/install/moveit_ros_move_group/lib/moveit_ros_move_group/move_group", at 0x55cf20c60f04, in _start
    [move_group-4] #20   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7fa28d4e9e3f, in __libc_start_main
    [move_group-4] #19   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7fa28d4e9d8f, in 
    [move_group-4] #18   Object "/root/ws_moveit/install/moveit_ros_move_group/lib/moveit_ros_move_group/move_group", at 0x55cf20c600d3, in main
    [move_group-4] #17   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_cpp.so.2.8.0", at 0x7fa28de30676, in moveit_cpp::MoveItCpp::MoveItCpp(std::shared_ptr<rclcpp::Node> const&, moveit_cpp::MoveItCpp::Options const&)
    [move_group-4] #16   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_cpp.so.2.8.0", at 0x7fa28de2f5db, in moveit_cpp::MoveItCpp::loadPlanningPipelines(moveit_cpp::MoveItCpp::PlanningPipelineOptions const&)
    [move_group-4] #15   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_planning_pipeline_interfaces.so.2.8.0", at 0x7fa28d277e8f, in moveit::planning_pipeline_interfaces::createPlanningPipelineMap(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::shared_ptr<moveit::core::RobotModel const> const&, std::shared_ptr<rclcpp::Node> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    [move_group-4] #14   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_planning_pipeline.so.2.8.0", at 0x7fa28d110b16, in planning_pipeline::PlanningPipeline::PlanningPipeline(std::shared_ptr<moveit::core::RobotModel const> const&, std::shared_ptr<rclcpp::Node> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    [move_group-4] #13   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_planning_pipeline.so.2.8.0", at 0x7fa28d140676, in void planning_pipeline::loadPluginVector<planning_interface::PlanningResponseAdapter>(std::shared_ptr<rclcpp::Node> const&, std::unique_ptr<pluginlib::ClassLoader<planning_interface::PlanningResponseAdapter>, std::default_delete<pluginlib::ClassLoader<planning_interface::PlanningResponseAdapter> > > const&, std::vector<std::shared_ptr<planning_interface::PlanningResponseAdapter const>, std::allocator<std::shared_ptr<planning_interface::PlanningResponseAdapter const> > >&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    [move_group-4] #12   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_default_planning_response_adapter_plugins.so.2.8.0", at 0x7fa27c0e9e1d, in default_planning_response_adapters::DisplayMotionPath::initialize(std::shared_ptr<rclcpp::Node> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    [move_group-4] #11   Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_default_planning_response_adapter_plugins.so.2.8.0", at 0x7fa27c0e62bd, in std::shared_ptr<rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory_<std::allocator<void> >, std::allocator<void> > > rclcpp::detail::create_publisher<moveit_msgs::msg::DisplayTrajectory_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory_<std::allocator<void> >, std::allocator<void> >, rclcpp::Node, rclcpp::Node>(rclcpp::Node&, rclcpp::Node&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&, rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)
    [move_group-4] #10   Object "/opt/ros/rolling/lib/librclcpp.so", at 0x7fa28dab9b5b, in rclcpp::node_interfaces::NodeTopics::create_publisher(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::PublisherFactory const&, rclcpp::QoS const&)
    [move_group-4] #9    Object "/root/ws_moveit/install/moveit_ros_planning/lib/libmoveit_default_planning_response_adapter_plugins.so.2.8.0", at 0x7fa27c0e59ee, in std::_Function_handler<std::shared_ptr<rclcpp::PublisherBase> (rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&), rclcpp::create_publisher_factory<moveit_msgs::msg::DisplayTrajectory_<std::allocator<void> >, std::allocator<void>, rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory_<std::allocator<void> >, std::allocator<void> > >(rclcpp::PublisherOptionsWithAllocator<std::allocator<void> > const&)::{lambda(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)#1}>::_M_invoke(std::_Any_data const&, rclcpp::node_interfaces::NodeBaseInterface*&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rclcpp::QoS const&)
    [move_group-4] #8    Object "/opt/ros/rolling/lib/librclcpp.so", at 0x7fa28db05b1b, in rclcpp::PublisherBase::PublisherBase(rclcpp::node_interfaces::NodeBaseInterface*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rosidl_message_type_support_t const&, rcl_publisher_options_s const&, rclcpp::PublisherEventCallbacks const&, bool)
    [move_group-4] #7    Object "/opt/ros/rolling/lib/librclcpp.so", at 0x7fa28da6b7b8, in rclcpp::exceptions::throw_from_rcl_error(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rcutils_error_state_s const*, void (*)())
    [move_group-4] #6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fa28d7b81fd, in std::rethrow_exception(std::__exception_ptr::exception_ptr)
    [move_group-4] #5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fa28d7b8276, in std::terminate()
    [move_group-4] #4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fa28d7b820b, in 
    [move_group-4] #3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fa28d7acb9d, in 
    [move_group-4] #2    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7fa28d4e87f2, in abort
    [move_group-4] #1    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7fa28d502475, in raise
    [move_group-4] #0    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7fa28d5569fc, in pthread_kill
    [move_group-4] Aborted (Signal sent by tkill() 12326 0)
```
