### PR TITLE
Fix trajectory execution manager comments for docs builds

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
+++ b/moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
@@ -64,7 +64,7 @@ void initTrajectoryExecutionManager(py::module& m)
            R"(
            Make sure the active controllers are such that trajectories that actuate joints in the specified group can be executed.
 
-           If manage_controllers_ is false and the controllers that happen to be active do not cover the joints in the group to be actuated, this function fails.
+           If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active do not cover the joints in the group to be actuated, this function fails.
            )")
 
       .def("ensure_active_controllers_for_joints",
@@ -73,7 +73,7 @@ void initTrajectoryExecutionManager(py::module& m)
            R"(
            Make sure the active controllers are such that trajectories that actuate joints in the specified set can be executed.
 
-           If manage_controllers_ is false and the controllers that happen to be active do not cover the joints to be actuated, this function fails.
+           If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active do not cover the joints to be actuated, this function fails.
            )")
 
       .def("ensure_active_controller",
@@ -81,7 +81,7 @@ void initTrajectoryExecutionManager(py::module& m)
            R"(
            Make sure a particular controller is active.
 
-           If manage_controllers_ is false and the controllers that happen to be active to not include the one specified as argument, this function fails.
+           If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active to not include the one specified as argument, this function fails.
            )")
 
       .def("ensure_active_controllers",
@@ -89,7 +89,7 @@ void initTrajectoryExecutionManager(py::module& m)
            R"(
            Make sure a particular set of controllers are active.
 
-           If manage_controllers_ is false and the controllers that happen to be active to not include the ones specified as argument, this function fails.
+           If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active to not include the ones specified as argument, this function fails.
           )")
 
       .def("is_controller_active", &trajectory_execution_manager::TrajectoryExecutionManager::isControllerActive,
@@ -101,7 +101,7 @@ void initTrajectoryExecutionManager(py::module& m)
       .def("are_controllers_active", &trajectory_execution_manager::TrajectoryExecutionManager::areControllersActive,
            py::arg("controllers"),
            R"(
-           Check if a set of controllers are active
+           Check if a set of controllers are active.
            )")
 
       .def("push",

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -105,30 +105,30 @@ public:
 
   /** \brief Make sure the active controllers are such that trajectories that actuate joints in the specified group can
      be executed.
-      \note If manage_controllers_ is false and the controllers that happen to be active do not cover the joints in the
-     group to be actuated, this function fails. */
+      \note If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active do not
+     cover the joints in the group to be actuated, this function fails. */
   bool ensureActiveControllersForGroup(const std::string& group);
 
   /** \brief Make sure the active controllers are such that trajectories that actuate joints in the specified set can be
      executed.
-      \note If manage_controllers_ is false and the controllers that happen to be active do not cover the joints to be
-     actuated, this function fails. */
+      \note If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active do not
+     cover the joints to be actuated, this function fails. */
   bool ensureActiveControllersForJoints(const std::vector<std::string>& joints);
 
   /** \brief Make sure a particular controller is active.
-      \note If manage_controllers_ is false and the controllers that happen to be active to not include the one
-     specified as argument, this function fails. */
+      \note If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active to not
+     include the one specified as argument, this function fails. */
   bool ensureActiveController(const std::string& controller);
 
   /** \brief Make sure a particular set of controllers are active.
-      \note If manage_controllers_ is false and the controllers that happen to be active to not include the ones
-     specified as argument, this function fails. */
+      \note If the 'moveit_manage_controllers' parameter is false and the controllers that happen to be active to not
+     include the ones specified as argument, this function fails. */
   bool ensureActiveControllers(const std::vector<std::string>& controllers);
 
-  /** \brief Check if a controller is active */
+  /** \brief Check if a controller is active. */
   bool isControllerActive(const std::string& controller);
 
-  /** \brief Check if a set of controllers are active */
+  /** \brief Check if a set of controllers are active. */
   bool areControllersActive(const std::vector<std::string>& controllers);
 
   /// Add a trajectory for future execution. Optionally specify a controller to use for the trajectory. If no controller


### PR DESCRIPTION
Some of the new additions to the `moveit_py` package in https://github.com/ros-planning/moveit2/pull/2406 caused docs build failures because it's not happy with underscores.

Anyways, the original comments shouldn't point to a private member variable, but rather the ROS parameter that it is set from.

Confirmed this fixes docs builds on my end.