### PR TITLE
[PSM] Process collision object color when adding object trough the planning scene monitor

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
@@ -43,11 +43,12 @@ namespace bind_planning_scene_monitor
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_py.bind_planning_scene_monitor");
 
 bool processCollisionObject(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
-                            moveit_msgs::msg::CollisionObject& collision_object_msg)
+                            moveit_msgs::msg::CollisionObject& collision_object_msg,
+                            std::optional<moveit_msgs::msg::ObjectColor> color_msg)
 {
   moveit_msgs::msg::CollisionObject::ConstSharedPtr const_ptr =
       std::make_shared<const moveit_msgs::msg::CollisionObject>(collision_object_msg);
-  return planning_scene_monitor->processCollisionObjectMsg(const_ptr);
+  return planning_scene_monitor->processCollisionObjectMsg(const_ptr, color_msg);
 }
 
 bool processAttachedCollisionObjectMsg(const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
@@ -154,7 +155,7 @@ void initPlanningSceneMonitor(py::module& m)
            Clears the octomap.
            )")
       .def("process_collision_object", &moveit_py::bind_planning_scene_monitor::processCollisionObject,
-           py::arg("collision_object_msg"),  // py::arg("color_msg") = nullptr,
+           py::arg("collision_object_msg"), py::arg("color_msg") = nullptr,
            R"(
            Apply a collision object to the planning scene.
 

--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <moveit_py/moveit_py_utils/copy_ros_msg.h>
 #include <moveit_py/moveit_py_utils/ros_msg_typecasters.h>
 #include <rclcpp/rclcpp.hpp>

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -393,7 +393,8 @@ public:
   bool newPlanningSceneMessage(const moveit_msgs::msg::PlanningScene& scene);
 
   // Called to update a collision object in the planning scene.
-  bool processCollisionObjectMsg(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& collision_object_msg);
+  bool processCollisionObjectMsg(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& collision_object_msg,
+                                 const std::optional<moveit_msgs::msg::ObjectColor> color_msg = std::nullopt);
 
   // Called to update an attached collision object in the planning scene.
   bool processAttachedCollisionObjectMsg(

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -780,7 +780,8 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
   return result;
 }
 
-bool PlanningSceneMonitor::processCollisionObjectMsg(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& object)
+bool PlanningSceneMonitor::processCollisionObjectMsg(const moveit_msgs::msg::CollisionObject::ConstSharedPtr& object,
+                                                     const std::optional<moveit_msgs::msg::ObjectColor> color_msg)
 {
   if (!scene_)
     return false;
@@ -791,6 +792,8 @@ bool PlanningSceneMonitor::processCollisionObjectMsg(const moveit_msgs::msg::Col
     last_update_time_ = rclcpp::Clock().now();
     if (!scene_->processCollisionObjectMsg(*object))
       return false;
+    if (color_msg.has_value())
+      scene_->setObjectColor(color_msg.value().id, color_msg.value().color);
   }
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);
   RCLCPP_INFO(logger_, "Published update collision object");


### PR DESCRIPTION
Added an optional collision object color object to the processCollisionObjectMsg call. This allows will apply the color to the planning scene and make sure this is also synced when publishing a diff planning scene.

### Description

Added an optional color_msg to the processCollisionObjectMsg in the Planning scene monitor.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
