### PR TITLE
Pass more distance information out from FCL collision check

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -141,41 +141,7 @@ struct CostSource
   }
 };
 
-/** \brief Representation of a collision checking result */
-struct CollisionResult
-{
-  using ContactMap = std::map<std::pair<std::string, std::string>, std::vector<Contact> >;
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  /** \brief Clear a previously stored result */
-  void clear()
-  {
-    collision = false;
-    distance = std::numeric_limits<double>::max();
-    contact_count = 0;
-    contacts.clear();
-    cost_sources.clear();
-  }
-
-  /** \brief Throttled warning printing the first collision pair, if any. All collisions are logged at DEBUG level */
-  void print() const;
-
-  /** \brief True if collision was found, false otherwise */
-  bool collision = false;
-
-  /** \brief Closest distance between two bodies */
-  double distance = std::numeric_limits<double>::max();
-
-  /** \brief Number of contacts returned */
-  std::size_t contact_count = 0;
-
-  /** \brief A map returning the pairs of body ids in contact, plus their contact details */
-  ContactMap contacts;
-
-  /** \brief These are the individual cost sources when costs are computed */
-  std::set<CostSource> cost_sources;
-};
+struct CollisionResult;
 
 /** \brief Representation of a collision checking request */
 struct CollisionRequest
@@ -186,6 +152,9 @@ struct CollisionRequest
 
   /** \brief If true, compute proximity distance */
   bool distance = false;
+
+  /** \brief If true, return detailed distance information. Distance must be set to true as well */
+  bool detailed_distance = false;
 
   /** \brief If true, a collision cost is computed */
   bool cost = false;
@@ -353,5 +322,45 @@ struct DistanceResult
     minimum_distance.clear();
     distances.clear();
   }
+};
+
+/** \brief Representation of a collision checking result */
+struct CollisionResult
+{
+  using ContactMap = std::map<std::pair<std::string, std::string>, std::vector<Contact> >;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /** \brief Clear a previously stored result */
+  void clear()
+  {
+    collision = false;
+    distance = std::numeric_limits<double>::max();
+    distance_result.clear();
+    contact_count = 0;
+    contacts.clear();
+    cost_sources.clear();
+  }
+
+  /** \brief Throttled warning printing the first collision pair, if any. All collisions are logged at DEBUG level */
+  void print() const;
+
+  /** \brief True if collision was found, false otherwise */
+  bool collision = false;
+
+  /** \brief Closest distance between two bodies */
+  double distance = std::numeric_limits<double>::max();
+
+  /** \brief Distance data for each link */
+  DistanceResult distance_result;
+
+  /** \brief Number of contacts returned */
+  std::size_t contact_count = 0;
+
+  /** \brief A map returning the pairs of body ids in contact, plus their contact details */
+  ContactMap contacts;
+
+  /** \brief These are the individual cost sources when costs are computed */
+  std::set<CostSource> cost_sources;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -285,6 +285,10 @@ void CollisionEnvFCL::checkSelfCollisionHelper(const CollisionRequest& req, Coll
     dreq.enableGroup(getRobotModel());
     distanceSelf(dreq, dres, state);
     res.distance = dres.minimum_distance.distance;
+    if (req.detailed_distance)
+    {
+      res.distance_result = dres;
+    }
   }
 }
 
@@ -338,6 +342,10 @@ void CollisionEnvFCL::checkRobotCollisionHelper(const CollisionRequest& req, Col
     dreq.enableGroup(getRobotModel());
     distanceRobot(dreq, dres, state);
     res.distance = dres.minimum_distance.distance;
+    if (req.detailed_distance)
+    {
+      res.distance_result = dres;
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Bring https://github.com/ros-planning/moveit/pull/3531 to MoveIt 2

> The CollisionResult struct doesn't capture some useful information from the FCL collision check. Particularly of interest to us is when calculating the distance to collision (available information today), we'd like to know the two link names that are closest to collision.
> 
> This PR adds the DistanceResult as part of the CollisionResult such that we can access this information, and more.
