### PR TITLE
Depend on `rsl::rsl` as a non-ament dependency

### DIFF
--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -8,7 +8,8 @@ target_include_directories(moveit_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/moveit_core>
 )
-ament_target_dependencies(moveit_utils Boost moveit_msgs rclcpp rsl fmt)
+ament_target_dependencies(moveit_utils Boost moveit_msgs rclcpp fmt)
+target_link_libraries(moveit_utils rsl::rsl)
 set_target_properties(moveit_utils PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)
@@ -20,7 +21,7 @@ target_include_directories(moveit_test_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/moveit_core>
 )
-target_link_libraries(moveit_test_utils moveit_robot_model moveit_kinematics_base)
+target_link_libraries(moveit_test_utils moveit_robot_model moveit_kinematics_base rsl::rsl)
 ament_target_dependencies(moveit_test_utils
   ament_index_cpp
   Boost
@@ -30,7 +31,6 @@ ament_target_dependencies(moveit_test_utils
   urdfdom
   urdfdom_headers
   rclcpp
-  rsl
   fmt
 )
 set_target_properties(moveit_test_utils PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")


### PR DESCRIPTION
### Description

`ament_target_dependencies` apparently does not work if the target it depends on is it not itself built using ament CMake macros as is the case with RSL as of version 1.0. Because of this API break in the build interface of RSL we have to switch to a vanilla `target_link_libraries` call to use `rsl::rsl`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
