### PR TITLE
Adding planning_frame and ee_frame to panda_simulated_config.yaml

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -37,6 +37,8 @@ is_primary_planning_scene_monitor: true
 
 ## MoveIt properties
 move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+planning_frame: world # Frame in which to plan
+ee_frame: panda_hand # Frame to move
 
 ## Configure handling of singularities and joint limits
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)


### PR DESCRIPTION
When implementing moveit servo for my own robot. The servo node crashed because planning_frame and ee_frame were not defined. This was a bit of a pain to debug because the error did not show up in the terminal log when the servo node was started as a node component (this may also be fixed).

Disclaimer: I have not had time to test if this works with the example provided. So either wait until I do, or test it on your machine before approving.