### PR TITLE
Add command queue to servo to account for latency

### DIFF
--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -23,6 +23,16 @@ servo:
     }
   }
 
+  latency: {
+    type: double,
+    read_only: true,
+    default_value: 0.1,
+    description: " max expected latency between generating a servo command and the controller receiving it [seconds]",
+    validation: {
+      gt<>: 0.0
+    }
+  }
+
   move_group_name: {
     type: string,
     read_only: true,

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -54,6 +54,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <variant>
 #include <rclcpp/logger.hpp>
+#include <queue>
 
 namespace moveit_servo
 {
@@ -78,6 +79,13 @@ public:
    * @return The required joint state.
    */
   KinematicState getNextJointState(const ServoInput& command);
+
+  /**
+   * \brief Create a trajectory message.
+   * @return The trajectory message.
+   */
+  trajectory_msgs::msg::JointTrajectory createTrajectoryMessage();
+
 
   /**
    * \brief Set the type of incoming servo command.
@@ -180,11 +188,6 @@ private:
   Eigen::VectorXd jointDeltaFromCommand(const ServoInput& command, const moveit::core::RobotStatePtr& robot_state);
 
   /**
-   * \brief Updates data depending on joint model group
-   */
-  void updateJointModelGroup();
-
-  /**
    * \brief Validate the servo parameters
    * @param servo_params The servo parameters
    * @return True if parameters are valid, else False
@@ -232,6 +235,10 @@ private:
 
   // Map between joint subgroup names and corresponding joint name - move group indices map
   std::unordered_map<std::string, JointNameToMoveGroupIndexMap> joint_name_to_index_maps_;
+
+  // keep track of previously generated joint commands for constructing trajectory messages
+  std::deque<KinematicState> committed_commands_;
+
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
@@ -115,13 +115,14 @@ struct KinematicState
 {
   std::vector<std::string> joint_names;
   Eigen::VectorXd positions, velocities, accelerations;
+  rclcpp::Time time;
 
   KinematicState(const int num_joints)
   {
     joint_names.resize(num_joints);
-    positions.resize(num_joints);
-    velocities.resize(num_joints);
-    accelerations.resize(num_joints);
+    positions = Eigen::VectorXd::Zero(num_joints);
+    velocities = Eigen::VectorXd::Zero(num_joints);
+    accelerations = Eigen::VectorXd::Zero(num_joints);
   }
 
   KinematicState()

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -100,6 +100,7 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
   }
 
   // Create the collision checker and start collision checking.
+  // TODO if servo_params_.check_collisions == false, should CollisionMonitor even be created?
   collision_monitor_ =
       std::make_unique<CollisionMonitor>(planning_scene_monitor_, servo_params_, std::ref(collision_velocity_scale_));
   collision_monitor_->start();
@@ -244,6 +245,14 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR(logger_,
                  "The value '%s' Parameter 'active_subgroup' does not name a valid subgroup of joint group '%s'.",
                  servo_params.active_subgroup.c_str(), servo_params.move_group_name.c_str());
+    params_valid = false;
+  }
+
+  if (servo_params.latency < servo_params.publish_period)
+  {
+    RCLCPP_ERROR(logger_,
+                 "The publish period (%f sec) parameter must be less than latency parameter (%f sec).",
+                 servo_params.publish_period, servo_params.latency);
     params_valid = false;
   }
 
@@ -392,7 +401,7 @@ Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command, const mo
     }
     else if (expected_type == CommandType::POSE)
     {
-      // Transform the twist command to the planning frame, which is the base frame of the active subgroup's IK solver,
+      // Transform the pose command to the planning frame, which is the base frame of the active subgroup's IK solver,
       // before applying it. The end effector frame is also extracted as the tip frame of the IK solver.
       // Additionally verify there is an IK solver, and that the transformation is successful.
       const auto planning_frame_maybe = getIKSolverBaseFrame(robot_state, active_subgroup_name);
@@ -456,9 +465,22 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
   KinematicState current_state(num_joints), target_state(num_joints);
   target_state.joint_names = joint_names;
 
-  // Copy current kinematic data from RobotState.
-  robot_state->copyJointGroupPositions(joint_model_group, current_state.positions);
-  robot_state->copyJointGroupVelocities(joint_model_group, current_state.velocities);
+  // remove commands not yet committed
+  auto cur_time = node_->now();
+  while (!committed_commands_.empty() && committed_commands_.back().time > (cur_time + rclcpp::Duration::from_seconds(servo_params_.latency))){
+    committed_commands_.pop_back();
+  }
+  if (!committed_commands_.empty()){
+    current_state = committed_commands_.back();
+  } else {
+    // Copy current kinematic data from RobotState.
+      robot_state->copyJointGroupPositions(joint_model_group, current_state.positions);
+      robot_state->copyJointGroupVelocities(joint_model_group, current_state.velocities);
+      current_state.joint_names = joint_names;
+      current_state.time = cur_time;
+      committed_commands_.push_back(current_state);
+  }
+
 
   // Compute the change in joint position due to the incoming command
   Eigen::VectorXd joint_position_delta = jointDeltaFromCommand(command, robot_state);
@@ -513,8 +535,64 @@ KinematicState Servo::getNextJointState(const ServoInput& command)
     }
   }
 
+  // remove old commands
+  cur_time = node_->now();
+  while (!committed_commands_.empty() && committed_commands_.front().time < (cur_time - rclcpp::Duration::from_seconds(2*servo_params_.latency))){
+    committed_commands_.pop_front();
+  }
+
+  // add next committed command
+  target_state.time = node_->now() + rclcpp::Duration::from_seconds(servo_params_.latency);
+  committed_commands_.push_back(target_state);
+
+  // add end command stop point in case of large delay
+  auto dt = 2*(servo_params_.latency);
+  auto end_state = target_state;
+  for (auto i = 0ul; i < num_joints; i++) {
+    end_state.positions[i] = target_state.positions[i] + target_state.velocities[i]*dt;
+    end_state.velocities[i] = 0;
+    end_state.accelerations[i] = 0;
+    end_state.time = target_state.time + rclcpp::Duration::from_seconds(dt);
+    }
+  committed_commands_.push_back(end_state);
+
   return target_state;
 }
+
+trajectory_msgs::msg::JointTrajectory Servo::createTrajectoryMessage() {
+  // TODO should have realtime capabilities
+  trajectory_msgs::msg::JointTrajectory joint_trajectory;
+
+  // remove old commands
+  auto cur_time = node_->now();
+  while (!committed_commands_.empty() && committed_commands_.front().time < (cur_time-rclcpp::Duration::from_seconds(2*servo_params_.latency))){
+    committed_commands_.pop_front();
+  }
+  if (committed_commands_.empty()) {
+    RCLCPP_ERROR(node_->get_logger(), "Command queue is empty when creating trajectory, the newest command is already in the past!");
+    return joint_trajectory;
+  }
+  joint_trajectory.joint_names = committed_commands_.front().joint_names;
+  joint_trajectory.points.reserve(committed_commands_.size());
+  joint_trajectory.header.stamp = committed_commands_.front().time;
+  for (const auto& state : committed_commands_) {
+    trajectory_msgs::msg::JointTrajectoryPoint point;
+    size_t num_joints = state.positions.size();
+    point.positions.reserve(num_joints);
+    point.velocities.reserve(num_joints);
+    for (const auto& pos : state.positions) {
+      point.positions.emplace_back(pos);
+    }
+    for (const auto& vel : state.velocities) {
+      point.velocities.emplace_back(vel);
+    }
+    point.time_from_start = state.time - joint_trajectory.header.stamp;
+    joint_trajectory.points.emplace_back(point);
+  }
+
+  return joint_trajectory;
+}
+
 
 std::optional<Eigen::Isometry3d> Servo::getPlanningToCommandFrameTransform(const std::string& command_frame,
                                                                            const std::string& planning_frame) const

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -332,7 +332,7 @@ void ServoNode::servoLoop()
     {
       if (servo_params_.command_out_type == "trajectory_msgs/JointTrajectory")
       {
-        trajectory_publisher_->publish(composeTrajectoryMessage(servo_->getParams(), next_joint_state.value()));
+        trajectory_publisher_->publish(servo_->createTrajectoryMessage());
       }
       else if (servo_params_.command_out_type == "std_msgs/Float64MultiArray")
       {


### PR DESCRIPTION
There is an issue where some robots experience non-smooth and noisy servo performance https://github.com/ros-planning/moveit2/issues/2275. Currently, servo sends trajectory messages to the ros2_control JTC one waypoint at a time. However, This causes issues because when the JTC receives a new message, it replaces the old one entirely. My proposal to solve this issue is to send more than one waypoint at a time and make sure everything is time-synchronized. Below is an example diagram.   

![buffer](https://github.com/ros-planning/moveit2/assets/28868750/4837a19e-7c42-4550-a9a6-765d581e0faf)

When messages are sent from servo to the JTC, there is an inherent noisy delay that should be accounted for. One strategy is to use a buffer that contains all generated servo commands from the current time to the current time plus the maximum expected latency. This range is shown in red. Any commands that are put in the buffer are considered "committed", meaning they will be executed by the JTC. For any time after the red region, there is still an opportunity to change commands. This is illustrated with the green trajectory.        
 
I recorded and plotted the commands received by the JTC with the current servo implementation (left) vs. this PR (right) using the 'demo_pose.cpp' example in the servo package.     

![image](https://github.com/ros-planning/moveit2/assets/28868750/8942ff99-6a86-42ac-a0b1-d7c32411776a)
