### PR TITLE
fix out-of-bounds memory access with zero-variable joints

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -192,6 +192,33 @@ void RobotState::markEffort()
   }
 }
 
+void RobotState::updateMimicJoint(const JointModel* joint)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  double v = position_[joint->getFirstVariableIndex()];
+  for (const JointModel* jm : joint->getMimicRequests())
+  {
+    position_[jm->getFirstVariableIndex()] = jm->getMimicFactor() * v + jm->getMimicOffset();
+    markDirtyJointTransforms(jm);
+  }
+}
+
+/** \brief Update all mimic joints within group */
+void RobotState::updateMimicJoints(const JointModelGroup* group)
+{
+  for (const JointModel* jm : group->getMimicJointModels())
+  {
+    assert(jm->getVariableCount() != 0);
+    const int fvi = jm->getFirstVariableIndex();
+    position_[fvi] = jm->getMimicFactor() * position_[jm->getMimic()->getFirstVariableIndex()] + jm->getMimicOffset();
+    markDirtyJointTransforms(jm);
+  }
+  markDirtyJointTransforms(group);
+}
+
 void RobotState::zeroVelocities()
 {
   has_velocity_ = false;
@@ -455,11 +482,83 @@ void RobotState::invertVelocity()
   }
 }
 
+void RobotState::setJointPositions(const JointModel* joint, const double* position)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  memcpy(&position_.at(joint->getFirstVariableIndex()), position, joint->getVariableCount() * sizeof(double));
+  markDirtyJointTransforms(joint);
+  updateMimicJoint(joint);
+}
+
+void RobotState::setJointPositions(const JointModel* joint, const Eigen::Isometry3d& transform)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  joint->computeVariablePositions(transform, &position_.at(joint->getFirstVariableIndex()));
+  markDirtyJointTransforms(joint);
+  updateMimicJoint(joint);
+}
+
+void RobotState::setJointVelocities(const JointModel* joint, const double* velocity)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  has_velocity_ = true;
+  memcpy(&velocity_.at(joint->getFirstVariableIndex()), velocity, joint->getVariableCount() * sizeof(double));
+}
+
+const double* RobotState::getJointPositions(const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return nullptr;
+  }
+  return &position_.at(joint->getFirstVariableIndex());
+}
+
+const double* RobotState::getJointVelocities(const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return nullptr;
+  }
+  return &velocity_.at(joint->getFirstVariableIndex());
+}
+
+const double* RobotState::getJointAccelerations(const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return nullptr;
+  }
+  return &effort_or_acceleration_.at(joint->getFirstVariableIndex());
+}
+
+const double* RobotState::getJointEffort(const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return nullptr;
+  }
+  return &effort_or_acceleration_.at(joint->getFirstVariableIndex());
+}
+
 void RobotState::setJointEfforts(const JointModel* joint, const double* effort)
 {
   if (has_acceleration_)
   {
     RCLCPP_ERROR(getLogger(), "Unable to set joint efforts because array is being used for accelerations");
+    return;
+  }
+  if (joint->getVariableCount() == 0)
+  {
     return;
   }
   has_effort_ = true;
@@ -832,6 +931,23 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
   return getRobotModel()->getRigidlyConnectedParentLinkModel(link);
 }
 
+const Eigen::Isometry3d& RobotState::getJointTransform(const JointModel* joint)
+{
+  const int idx = joint->getJointIndex();
+  if (joint->getVariableCount() == 0)
+  {
+    return variable_joint_transforms_[idx];
+  }
+
+  unsigned char& dirty = dirty_joint_transforms_[idx];
+  if (dirty)
+  {
+    joint->computeTransform(&position_.at(joint->getFirstVariableIndex()), variable_joint_transforms_[idx]);
+    dirty = 0;
+  }
+  return variable_joint_transforms_[idx];
+}
+
 bool RobotState::satisfiesBounds(double margin) const
 {
   const std::vector<const JointModel*>& jm = robot_model_->getActiveJointModels();
@@ -868,6 +984,19 @@ void RobotState::enforceBounds(const JointModelGroup* joint_group)
     enforceBounds(joint);
 }
 
+void RobotState::enforcePositionBounds(const JointModel* joint)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  if (joint->enforcePositionBounds(&position_.at(joint->getFirstVariableIndex())))
+  {
+    markDirtyJointTransforms(joint);
+    updateMimicJoint(joint);
+  }
+}
+
 void RobotState::harmonizePositions()
 {
   for (const JointModel* jm : robot_model_->getActiveJointModels())
@@ -878,6 +1007,28 @@ void RobotState::harmonizePositions(const JointModelGroup* joint_group)
 {
   for (const JointModel* jm : joint_group->getActiveJointModels())
     harmonizePosition(jm);
+}
+
+void RobotState::harmonizePosition(const JointModel* joint)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  if (joint->harmonizePosition(&position_.at(joint->getFirstVariableIndex())))
+  {
+    // no need to mark transforms dirty, as the transform hasn't changed
+    updateMimicJoint(joint);
+  }
+}
+
+void RobotState::enforceVelocityBounds(const JointModel* joint)
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+  joint->enforceVelocityBounds(&velocity_.at(joint->getFirstVariableIndex()));
 }
 
 std::pair<double, const JointModel*> RobotState::getMinDistanceToPositionBounds() const
@@ -961,6 +1112,16 @@ double RobotState::distance(const RobotState& other, const JointModelGroup* join
   return d;
 }
 
+double RobotState::distance(const RobotState& other, const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return 0.0;
+  }
+  const int idx = joint->getFirstVariableIndex();
+  return joint->distance(&position_.at(idx), &other.position_.at(idx));
+}
+
 void RobotState::interpolate(const RobotState& to, double t, RobotState& state) const
 {
   checkInterpolationParamBounds(getLogger(), t);
@@ -980,6 +1141,19 @@ void RobotState::interpolate(const RobotState& to, double t, RobotState& state, 
     joint->interpolate(&position_.at(idx), &to.position_.at(idx), t, &state.position_.at(idx));
   }
   state.updateMimicJoints(joint_group);
+}
+
+void RobotState::interpolate(const RobotState& to, double t, RobotState& state, const JointModel* joint) const
+{
+  if (joint->getVariableCount() == 0)
+  {
+    return;
+  }
+
+  const int idx = joint->getFirstVariableIndex();
+  joint->interpolate(&position_.at(idx), &to.position_.at(idx), t, &state.position_.at(idx));
+  state.markDirtyJointTransforms(joint);
+  state.updateMimicJoint(joint);
 }
 
 void RobotState::setAttachedBodyUpdateCallback(const AttachedBodyCallback& callback)

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -1126,7 +1126,7 @@ TEST(getJointPositions, getFixedJointValue)
   ASSERT_TRUE(srdf_model->initString(*urdf_model, robot_srdf));
   const auto robot_model = std::make_shared<moveit::core::RobotModel>(urdf_model, srdf_model);
 
-  // Getting the value of the last fixed joint should return nullptr, since it doesn't have a active variable.
+  // Getting the value of the last fixed joint should return nullptr, since it doesn't have an active variable.
   moveit::core::RobotState state(robot_model);
   state.setToDefaultValues();
   const double* joint_value = state.getJointPositions("joint_c_fixed");


### PR DESCRIPTION
This change updates some methods to avoid an out-of-bounds access after the recent changes to use `std::vector` as the underlying storage in `RobotState` (https://github.com/ros-planning/moveit2/pull/2546).
Before that change, there was nothing stopping us from passing or returning invalid memory addresses. But now that will trigger `range_check` exceptions.
This change fixes an out-of-bounds access that can happen with fixed joint models with a variable count of 0, by special-handling that case where needed. It also moves the implementation of those functions to the source file, to not clutter the header file further.
