### PR TITLE
Update ros2_control usage

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -327,8 +327,10 @@ def generate_demo_launch(moveit_config):
             package="controller_manager",
             executable="ros2_control_node",
             parameters=[
-                moveit_config.robot_description,
                 str(moveit_config.package_path / "config/ros2_controllers.yaml"),
+            ],
+            remappings=[
+                ("/controller_manager/robot_description", "/robot_description"),
             ],
         )
     )

--- a/moveit_planners/test_configs/prbt_moveit_config/launch/demo.launch.py
+++ b/moveit_planners/test_configs/prbt_moveit_config/launch/demo.launch.py
@@ -189,7 +189,10 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_planners/test_configs/prbt_support/urdf/prbt.ros2_control.xacro
+++ b/moveit_planners/test_configs/prbt_support/urdf/prbt.ros2_control.xacro
@@ -21,9 +21,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_1']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 			<joint name="${prefix}joint_2">
@@ -35,9 +41,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_2']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 			<joint name="${prefix}joint_3">
@@ -49,9 +61,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_3']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 			<joint name="${prefix}joint_4">
@@ -63,9 +81,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_4']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 			<joint name="${prefix}joint_5">
@@ -77,9 +101,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_5']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 			<joint name="${prefix}joint_6">
@@ -91,9 +121,15 @@
 					<param name="min">-3.15</param>
 					<param name="max">3.15</param>
 				</command_interface>
-				<state_interface name="position"/>
-				<state_interface name="velocity"/>
-				<state_interface name="effort"/>
+				<state_interface name="position">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="velocity">
+					<param name="initial_value">0.0</param>
+				</state_interface>
+				<state_interface name="effort">
+					<param name="initial_value">0.0</param>
+				</state_interface>
 				<param name="initial_position">${initial_positions['joint_6']}</param>  <!-- initial position for the FakeSystem -->
 			</joint>
 		</ros2_control>

--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning_common.py
@@ -198,7 +198,10 @@ def generate_common_hybrid_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/launch/demo_joint_jog.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_joint_jog.launch.py
@@ -48,7 +48,10 @@ def generate_launch_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/launch/demo_pose.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_pose.launch.py
@@ -48,7 +48,10 @@ def generate_launch_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/launch/demo_ros_api.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_ros_api.launch.py
@@ -56,7 +56,10 @@ def generate_launch_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/launch/demo_twist.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_twist.launch.py
@@ -48,7 +48,10 @@ def generate_launch_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
@@ -34,7 +34,10 @@ def generate_test_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
@@ -41,7 +41,10 @@ def generate_test_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/moveit_servo/tests/launch/servo_utils.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_utils.test.py
@@ -34,7 +34,10 @@ def generate_test_description():
     ros2_control_node = launch_ros.actions.Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -60,7 +60,10 @@ def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsTyp
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 


### PR DESCRIPTION
### Description

Address ros2_control deprecation warnings. More info here: https://github.com/ros-controls/ros2_control/blob/89c8658a3419e4d23aea37eda7b17a0d1eecb840/controller_manager/src/controller_manager.cpp#L276

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
