### PR TITLE
Fix penalty-based cost function in STOMP

### DIFF
--- a/moveit_planners/stomp/CMakeLists.txt
+++ b/moveit_planners/stomp/CMakeLists.txt
@@ -29,9 +29,12 @@ ament_target_dependencies(stomp_moveit_plugin
   std_msgs
   tf2_eigen
   visualization_msgs
-  rsl
 )
-target_link_libraries(stomp_moveit_plugin stomp::stomp stomp_moveit_parameters)
+target_link_libraries(stomp_moveit_plugin
+  stomp::stomp
+  stomp_moveit_parameters
+  rsl::rsl
+)
 
 pluginlib_export_plugin_description_file(moveit_core stomp_moveit_plugin_description.xml)
 
@@ -57,6 +60,8 @@ if(BUILD_TESTING)
   set(ament_cmake_lint_cmake_FOUND TRUE)
 
   ament_lint_auto_find_test_dependencies()
+
+  add_subdirectory(test)
 endif()
 
 ament_package()

--- a/moveit_planners/stomp/test/CMakeLists.txt
+++ b/moveit_planners/stomp/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+find_package(ament_cmake_gtest REQUIRED)
+ament_add_gtest(test_noise_generator test_noise_generator.cpp)
+ament_target_dependencies(test_noise_generator
+  tf2_eigen
+)
+target_link_libraries(test_noise_generator
+  rsl::rsl
+)
+
+ament_add_gtest(test_cost_functions test_cost_functions.cpp)
+ament_target_dependencies(test_cost_functions
+  moveit_core
+)
+target_link_libraries(test_cost_functions
+  rsl::rsl
+)

--- a/moveit_planners/stomp/test/test_cost_functions.cpp
+++ b/moveit_planners/stomp/test/test_cost_functions.cpp
@@ -1,0 +1,114 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/** @file
+ * @author Henning Kayser
+ */
+
+#include <gtest/gtest.h>
+#include <stomp_moveit/cost_functions.hpp>
+
+constexpr size_t TIMESTEPS = 100;
+constexpr size_t VARIABLES = 6;
+constexpr double PENALTY = 1.0;
+
+TEST(NoiseGeneratorTest, testGetCostFunctionAllValidStates)
+{
+  // State validator that
+  auto state_validator_fn = [](const Eigen::VectorXd& /* state_positions */) { return 0.0; };
+
+  auto cost_fn =
+      stomp_moveit::costs::getCostFunctionFromStateValidator(state_validator_fn, 0.1 /* interpolation_step_size */);
+
+  // Build trajectory with TIMESTEPS states, interpolating from 0.0 to 1.0 joint values
+  Eigen::MatrixXd values = Eigen::MatrixXd::Zero(VARIABLES, TIMESTEPS);
+  const int last_timestep = values.cols() - 1;
+  for (int timestep = 0; timestep <= last_timestep; ++timestep)
+  {
+    values.col(timestep).fill(1.0 * timestep / last_timestep);
+  }
+
+  Eigen::VectorXd costs(TIMESTEPS);
+  bool validity;
+
+  ASSERT_TRUE(cost_fn(values, costs, validity));
+  EXPECT_TRUE(validity);
+  EXPECT_EQ(costs.sum(), 0.0);
+}
+
+TEST(NoiseGeneratorTest, testGetCostFunctionInvalidStates)
+{
+  // We are simulating a state validator by tagging specific timesteps as invalid.
+  // The state validation function is called once per timestep since interpolation is disabled.
+  // These assumptions are tested
+  static const std::set<int> INVALID_TIMESTEPS(
+      { 0, 10, 11, 12, 25, 26, 27, 46, 63, 64, 65, 66, 67, 68, 69, 97, 98, 99 });
+  size_t timestep_counter = 0;
+  auto state_validator_fn = [&](const Eigen::VectorXd& /* state_positions */) {
+    return PENALTY * INVALID_TIMESTEPS.count(timestep_counter++);
+  };
+
+  auto cost_fn =
+      stomp_moveit::costs::getCostFunctionFromStateValidator(state_validator_fn, 0.0 /* interpolation disabled */);
+
+  // Build trajectory with TIMESTEPS states, interpolating from 0.0 to 1.0 joint values
+  Eigen::MatrixXd values = Eigen::MatrixXd::Zero(VARIABLES, TIMESTEPS);
+  const int last_timestep = values.cols() - 1;
+  for (int timestep = 0; timestep <= last_timestep; ++timestep)
+  {
+    values.col(timestep).fill(1.0 * timestep / last_timestep);
+  }
+
+  // Test boundary assumptions about cost function outputs, costs and validity
+  Eigen::VectorXd costs(TIMESTEPS);
+  bool validity;
+  ASSERT_TRUE(cost_fn(values, costs, validity));
+  EXPECT_EQ(timestep_counter, 100u);     // 100 timesteps checked without interpolation
+  EXPECT_FALSE(validity);                // invalid states must result in an invalid trajectory
+  EXPECT_LE(costs.maxCoeff(), PENALTY);  // the highest cost must not be higher than the configured penalty
+  EXPECT_GE(costs.minCoeff(), 0.0);      // no negative cost values should be computed
+
+  // The total cost must equal the sum of penalties produced by all invalid timesteps
+  EXPECT_DOUBLE_EQ(costs.sum(), PENALTY * INVALID_TIMESTEPS.size());
+  // Invalid timesteps should account for the majority of the total cost.
+  // We expect that invalid windows cover at least 2*sigma (=68.1%) of each cost distribution.
+  const std::vector<int> invalid_timesteps_vec(INVALID_TIMESTEPS.begin(), INVALID_TIMESTEPS.end());
+  EXPECT_GE(costs(invalid_timesteps_vec).sum(), 0.681 * PENALTY);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_planners/stomp/test/test_noise_generator.cpp
+++ b/moveit_planners/stomp/test/test_noise_generator.cpp
@@ -1,0 +1,76 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/** @file
+ * @author Henning Kayser
+ */
+
+#include <gtest/gtest.h>
+#include <stomp_moveit/noise_generators.hpp>
+
+constexpr size_t TIMESTEPS = 100;
+constexpr size_t VARIABLES = 6;
+static const std::vector<double> STDDEV(VARIABLES, 0.2);
+static const Eigen::MatrixXd VALUES = Eigen::MatrixXd::Constant(VARIABLES, TIMESTEPS, 1.0);
+static const Eigen::MatrixXd NOISY_VALUES = Eigen::MatrixXd::Constant(VARIABLES, TIMESTEPS, 0.0);
+static const Eigen::MatrixXd NOISE = Eigen::MatrixXd::Constant(VARIABLES, TIMESTEPS, 0.0);
+
+TEST(NoiseGeneratorTest, testStartEndUnchanged)
+{
+  auto noise_gen = stomp_moveit::noise::getNormalDistributionGenerator(TIMESTEPS, STDDEV);
+
+  auto noise = NOISE;
+  auto noisy_values = NOISY_VALUES;
+
+  noise_gen(VALUES, noisy_values, noise);
+
+  // Test that noise creates output unlike the input
+  EXPECT_NE(noise, NOISE);
+  EXPECT_NE(noisy_values, NOISY_VALUES);
+  EXPECT_NE(VALUES, noisy_values);
+
+  // Test that the dimensions of the output matches the input
+  EXPECT_EQ(noise.size(), NOISE.size());
+  EXPECT_EQ(noisy_values.size(), NOISY_VALUES.size());
+
+  // Test that start and end columns (=states) are not modified
+  EXPECT_EQ(VALUES.col(0), noisy_values.col(0));
+  EXPECT_EQ(VALUES.col(TIMESTEPS - 1), noisy_values.col(TIMESTEPS - 1));
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This adds several test cases for STOMP's noise generation and cost functions, and provides the following fixes:

* out-of-bounds vector access when tail states of trajectory are invalid
* smoothed costs overriding values of previous invalid groups
* missing validity check of last state in trajectory
* inability to disable cost function interpolation steps
* total cost of trajectory not summing up to sum of state penalties
* bug in Gaussian producing infinite values with invalid start states

Fixes #2462, #2554