### PR TITLE
[Servo] Make listening to octomap updates optional

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -11,6 +11,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_core
   moveit_msgs
   moveit_ros_planning
+  moveit_ros_planning_interface
   pluginlib
   rclcpp
   rclcpp_components

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -33,8 +33,8 @@ smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
 # which other nodes can use as a source for information about the planning environment.
 # NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
 # then is_primary_planning_scene_monitor needs to be set to false.
-check_octomap_collisions: false
 is_primary_planning_scene_monitor: true
+check_octomap_collisions: false  # Check collision against the octomap (if a 3D sensor plugin is available)
 
 ## MoveIt properties
 move_group_name:  panda_arm  # Often 'manipulator' or 'arm'

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -3,16 +3,16 @@
 ###############################################
 
 # Optionally override Servo's internal velocity scaling when near singularity or collision (0.0 = use internal velocity scaling)
-# override_velocity_scaling_factor = 0.0 # valid range [0.0:1.0]
+# override_velocity_scaling_factor = 0.0  # valid range [0.0:1.0]
 
 ## Properties of outgoing commands
 publish_period: 0.034  # 1/Nominal publish rate [seconds]
 
-command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
+command_in_type: "speed_units"  # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
   linear:  0.4  # Max linear velocity. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.8 # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
+  rotational:  0.8  # Max angular velocity. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Only used for joint commands on joint_command_in_topic.
   joint: 0.5
 
@@ -33,6 +33,7 @@ smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
 # which other nodes can use as a source for information about the planning environment.
 # NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
 # then is_primary_planning_scene_monitor needs to be set to false.
+check_octomap_collisions: false
 is_primary_planning_scene_monitor: true
 
 ## MoveIt properties
@@ -40,19 +41,19 @@ move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
 
 ## Configure handling of singularities and joint limits
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)
-hard_stop_singularity_threshold: 30.0 # Stop when the condition number hits this
+hard_stop_singularity_threshold: 30.0  # Stop when the condition number hits this
 joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]  # added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
-leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
+leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands
-joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
-joint_topic: /joint_states
-status_topic: ~/status # Publish status to this topic
-command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing commands here
+joint_command_in_topic: ~/delta_joint_cmds  # Topic for incoming joint angle commands
+joint_topic: /joint_states  # Get joint states from this tpoic
+status_topic: ~/status  # Publish status to this topic
+command_out_topic: /panda_arm_controller/joint_trajectory  # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
-check_collisions: true # Check collisions?
-collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
-self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
-scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
+check_collisions: true  # Check collisions?
+collision_check_rate: 10.0  # [Hz] Collision-checking can easily bog down a CPU if done too often.
+self_collision_proximity_threshold: 0.01  # Start decelerating when a self-collision is this far [m]
+scene_collision_proximity_threshold: 0.02  # Start decelerating when a scene collision is this far [m]

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -189,6 +189,13 @@ servo:
     description: "The topic on which joint states can be monitored"
   }
 
+  check_octomap_collisions: {
+    type: bool,
+    read_only: true,
+    default_value: false,
+    description: "If true, the planning scene monitor also listens to octomap updates for collision checking."
+  }
+
   is_primary_planning_scene_monitor: {
     type: bool,
     read_only: true,

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -28,6 +28,7 @@
   <depend>geometry_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_msgs</depend>
+  <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>pluginlib</depend>
   <depend>realtime_tools</depend>

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -77,16 +77,6 @@ Servo::Servo(const rclcpp::Node::SharedPtr& node, std::shared_ptr<const servo::P
     std::exit(EXIT_FAILURE);
   }
 
-  // Planning scene monitor is passed in.
-  if (servo_params_.is_primary_planning_scene_monitor)
-  {
-    planning_scene_monitor_->providePlanningSceneService();
-  }
-  else
-  {
-    planning_scene_monitor_->requestPlanningSceneState();
-  }
-
   moveit::core::RobotStatePtr robot_state = planning_scene_monitor_->getStateMonitor()->getCurrentState();
 
   // Load the smoothing plugin

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -42,7 +42,10 @@
 namespace
 {
 // The threshold above which `override_velocity_scaling_factor` will be used instead of computing the scaling from joint bounds.
-const double SCALING_OVERRIDE_THRESHOLD = 0.01;
+constexpr double SCALING_OVERRIDE_THRESHOLD = 0.01;
+
+// The publishing frequency for the planning scene monitor, in Hz.
+constexpr double PLANNING_SCENE_PUBLISHING_FREQUENCY = 25.0;
 }  // namespace
 
 namespace moveit_servo
@@ -390,18 +393,31 @@ PoseCommand poseFromPoseStamped(const geometry_msgs::msg::PoseStamped& msg)
 planning_scene_monitor::PlanningSceneMonitorPtr createPlanningSceneMonitor(const rclcpp::Node::SharedPtr& node,
                                                                            const servo::Params& servo_params)
 {
-  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor;
   // Can set robot_description name from parameters
   std::string robot_description_name = "robot_description";
   node->get_parameter_or("robot_description_name", robot_description_name, robot_description_name);
+
   // Set up planning_scene_monitor
-  planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(node, robot_description_name,
-                                                                                          "planning_scene_monitor");
+  auto planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(
+      node, robot_description_name, "planning_scene_monitor");
 
   planning_scene_monitor->startStateMonitor(servo_params.joint_topic);
   planning_scene_monitor->startSceneMonitor(servo_params.monitored_planning_scene_topic);
-  planning_scene_monitor->startWorldGeometryMonitor();
-  planning_scene_monitor->setPlanningScenePublishingFrequency(25);
+  planning_scene_monitor->startWorldGeometryMonitor(
+      planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC,
+      planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
+      servo_params.check_octomap_collisions);
+
+  if (servo_params.is_primary_planning_scene_monitor)
+  {
+    planning_scene_monitor->providePlanningSceneService();
+  }
+  else
+  {
+    planning_scene_monitor->requestPlanningSceneState();
+  }
+
+  planning_scene_monitor->setPlanningScenePublishingFrequency(PLANNING_SCENE_PUBLISHING_FREQUENCY);
   planning_scene_monitor->getStateMonitor()->enableCopyDynamics(true);
   planning_scene_monitor->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE,
                                                        std::string(node->get_fully_qualified_name()) +

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1278,7 +1278,7 @@ void PlanningSceneMonitor::startWorldGeometryMonitor(const std::string& collisio
     RCLCPP_INFO(logger_, "Listening to '%s' for planning scene world geometry", planning_scene_world_topic.c_str());
   }
 
-  // Ocotomap monitor is optional
+  // Octomap monitor is optional
   if (load_octomap_monitor)
   {
     if (!octomap_monitor_)


### PR DESCRIPTION
Following from https://github.com/ros-planning/moveit2/pull/2601, the [`RCLCPP_ERROR` log message when no 3D sensor plugins are available](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor_middleware_handle.cpp#L91) has been loud -- so I put this addition behind a new boolean parameter called `check_octomap_collisions`.

@amalnanavati sharing with you since you made this original PR and would appreciate your input behind this change.

In the process, I also cleaned up a few things I saw.
