### PR TITLE
Fix penalty calculation in constraints cost function in STOMP

### DIFF
--- a/moveit_planners/stomp/include/stomp_moveit/cost_functions.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/cost_functions.hpp
@@ -212,7 +212,8 @@ CostFn getConstraintsCostFunction(const std::shared_ptr<const planning_scene::Pl
     setJointPositions(positions, joints, state);
     state.update();
 
-    return constraints.decide(state).distance * cost_scale;
+    const auto& result = constraints.decide(state);
+    return result.satisfied ? 0.0 : result.distance * cost_scale;
   };
 
   return getCostFunctionFromStateValidator(constraints_validator_fn, CONSTRAINT_CHECK_DISTANCE);


### PR DESCRIPTION
### Description

@henningkayser 
I mentioned this issue here: https://github.com/ros-planning/moveit2/issues/2554#issuecomment-1866178090
I can't plan in STOMP with joint constrants.

I think the penalty result for constraints cost function should be `0.0` when `ConstraintEvaluationResult.satisfied` is `true`


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
