### PR TITLE
[Experimental] Fix CI

### DIFF
--- a/moveit2_humble.repos
+++ b/moveit2_humble.repos
@@ -1,0 +1,9 @@
+repositories:
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: humble
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: humble


### PR DESCRIPTION
I was not able to recreate the segfault locally. I had the latest binaries of `ros2_control` and `ros2_controllers`
```
abishalini@abishalini:~/ws_moveit_humble$ apt-cache show ros-humble-hardware-interface
Package: ros-humble-hardware-interface
Version: 2.36.0-1jammy.20231212.174340

abishalini@abishalini:~/ws_moveit_humble/src/moveit2(pr-fix-ci)$ apt-cache show ros-humble-joint-trajectory-controller
Package: ros-humble-joint-trajectory-controller
Version: 2.29.0-1jammy.20231212.183151
```

Maybe the humble CI docker didn't have the latest binaries? Not sure how I can check that
I tried source building `ros2_control` and `ros2_controllers` for Humble to fix the segfault in CI 