### PR TITLE
[Humble] Remove ros2_control 2.13 source build

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -9,7 +9,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_resources.git
     version: humble
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 2.13.0


### PR DESCRIPTION
Turns out we were cloning a pretty old version of `ros2_control` here -- 2.13 when it's now at 2.36.

Maybe this will be the thing to fix the `humble_ci` job on `main` which uses the generated Docker image from this branch since https://github.com/ros-planning/moveit2/pull/2284?