### PR TITLE
Add collision_detection dependency on pluginlib

### DIFF
--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -17,6 +17,7 @@ include(GenerateExportHeader)
 generate_export_header(moveit_collision_detection)
 
 ament_target_dependencies(moveit_collision_detection
+  pluginlib
   rclcpp
   rmw_implementation
   urdf


### PR DESCRIPTION
It is included by src/collision_plugin_cache.cpp, so it should be set as a dependency.

### Description

Add a target_dependency from collision_detection to pluginlib, which is required for building.  This should fix the build on Rolling: https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__moveit_core__ubuntu_jammy_amd64__binary/166/

### Checklist
- [N/A] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [N/A] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [N/A] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [N/A] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [N/A] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"