### PR TITLE
Use different packages for launch and config packages in generate_demo_launch

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -244,7 +244,7 @@ def generate_move_group_launch(moveit_config):
     return ld
 
 
-def generate_demo_launch(moveit_config):
+def generate_demo_launch(moveit_config, launch_package_path=None):
     """
     Launches a self contained demo
 
@@ -256,6 +256,9 @@ def generate_demo_launch(moveit_config):
      * warehouse_db (optional)
      * ros2_control_node + controller spawners
     """
+    if launch_package_path == None:
+        launch_package_path = moveit_config.package_path
+
     ld = LaunchDescription()
     ld.add_action(
         DeclareBooleanLaunchArg(
@@ -272,11 +275,11 @@ def generate_demo_launch(moveit_config):
         )
     )
     ld.add_action(DeclareBooleanLaunchArg("use_rviz", default_value=True))
-
     # If there are virtual joints, broadcast static tf by including virtual_joints launch
     virtual_joints_launch = (
-        moveit_config.package_path / "launch/static_virtual_joint_tfs.launch.py"
+        launch_package_path / "launch/static_virtual_joint_tfs.launch.py"
     )
+
     if virtual_joints_launch.exists():
         ld.add_action(
             IncludeLaunchDescription(
@@ -288,7 +291,7 @@ def generate_demo_launch(moveit_config):
     ld.add_action(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/rsp.launch.py")
+                str(launch_package_path / "launch/rsp.launch.py")
             ),
         )
     )
@@ -296,7 +299,7 @@ def generate_demo_launch(moveit_config):
     ld.add_action(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/move_group.launch.py")
+                str(launch_package_path / "launch/move_group.launch.py")
             ),
         )
     )
@@ -305,7 +308,7 @@ def generate_demo_launch(moveit_config):
     ld.add_action(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/moveit_rviz.launch.py")
+                str(launch_package_path / "launch/moveit_rviz.launch.py")
             ),
             condition=IfCondition(LaunchConfiguration("use_rviz")),
         )
@@ -315,7 +318,7 @@ def generate_demo_launch(moveit_config):
     ld.add_action(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/warehouse_db.launch.py")
+                str(launch_package_path / "launch/warehouse_db.launch.py")
             ),
             condition=IfCondition(LaunchConfiguration("db")),
         )
@@ -338,7 +341,7 @@ def generate_demo_launch(moveit_config):
     ld.add_action(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/spawn_controllers.launch.py")
+                str(launch_package_path / "launch/spawn_controllers.launch.py")
             ),
         )
     )

--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -248,6 +248,8 @@ def generate_demo_launch(moveit_config, launch_package_path=None):
     """
     Launches a self contained demo
 
+    launch_package_path is optional to use different launch and config packages
+
     Includes
      * static_virtual_joint_tfs
      * robot_state_publisher


### PR DESCRIPTION
### Description

When generating demo launch, allow for separate launch and config packages. If launch_package_path is not provided, default to moveit_config.package_path as previously done. 

This removes the need to have identical duplicate launch files when testing multiple robots.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
