### PR TITLE
Add get group urdf capability

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(moveit_move_group_default_capabilities SHARED
   src/default_capabilities/cartesian_path_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
   src/default_capabilities/execute_trajectory_action_capability.cpp
+  src/default_capabilities/get_group_urdf_capability.cpp
   src/default_capabilities/get_planning_scene_service_capability.cpp
   src/default_capabilities/kinematics_service_capability.cpp
   src/default_capabilities/move_action_capability.cpp

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -72,4 +72,10 @@
     </description>
   </class>
 
+  <class name="move_group/GetUrdfService" type="move_group::GetUrdfService" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      TODO
+    </description>
+  </class>
+
 </library>

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -74,7 +74,7 @@
 
   <class name="move_group/GetUrdfService" type="move_group::GetUrdfService" base_class_type="move_group::MoveGroupCapability">
     <description>
-      TODO
+      Provide a capability which creates an URDF string with joints and links of a requested joint model group
     </description>
   </class>
 

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -62,4 +62,6 @@ static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME =
     "apply_planning_scene";  // name of the service that applies a given planning scene
 static const std::string CLEAR_OCTOMAP_SERVICE_NAME =
     "clear_octomap";  // name of the service that can be used to clear the octomap
+static const std::string GET_URDF_SERVICE_NAME =
+    "get_urdf";  // name of the service that can be used to request the urdf of a planning group
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -65,7 +65,7 @@ void GetUrdfService::initialize()
       GET_URDF_SERVICE_NAME,
       [this](const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Request>& req,
              const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Response>& res) {
-        auto const subgroup = context_->moveit_cpp_->getRobotModel()->getJointModelGroup(req->group_name);
+        const auto subgroup = context_->moveit_cpp_->getRobotModel()->getJointModelGroup(req->group_name);
         // Check if group exists in loaded robot model
         if (!subgroup)
         {
@@ -75,7 +75,7 @@ void GetUrdfService::initialize()
           return;
         }
         // Get robot description string
-        auto full_urdf_string = std::string("");
+        std::string full_urdf_string;
         context_->moveit_cpp_->getNode()->get_parameter_or("robot_description", full_urdf_string, std::string(""));
 
         // Check if string is empty
@@ -93,15 +93,15 @@ void GetUrdfService::initialize()
                            std::string("\" xmlns:xacro=\"http://ros.org/wiki/xacro\">");
 
         // Create links
-        auto const link_names = subgroup->getLinkModelNames();
+        const auto& link_names = subgroup->getLinkModelNames();
         for (const auto& link_name : link_names)
         {
-          auto const start = full_urdf_string.find("<link name=\"" + link_name);
+          const auto start = full_urdf_string.find("<link name=\"" + link_name);
           auto substring = full_urdf_string.substr(start, full_urdf_string.size() - start);
           res->urdf_string += substring.substr(0, substring.find(LINK_ELEMENT_CLOSING) + LINK_ELEMENT_CLOSING.size());
         }
         // Create joints
-        auto const joint_names = subgroup->getJointModelNames();
+        const auto& joint_names = subgroup->getJointModelNames();
         for (const auto& joint_name : joint_names)
         {
           auto const start = full_urdf_string.find("<joint name=\"" + joint_name);

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -39,7 +39,7 @@
 #include <moveit/moveit_cpp/moveit_cpp.h>
 #include <moveit/move_group/capability_names.h>
 #include <moveit/utils/logger.hpp>
-#include <tinyxml2.h>
+#include <urdf_parser/urdf_parser.h>
 
 namespace move_group
 {
@@ -85,7 +85,7 @@ void GetUrdfService::initialize()
         if (full_urdf_string.empty())
         {
           const auto error_string =
-              std::string("Couldn't load the urdf from parameter server. Is the /robot_description parameter "
+              std::string("Couldn't load the urdf from parameter server. Is the '/robot_description' parameter "
                           "initialized?");
           RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
@@ -117,13 +117,10 @@ void GetUrdfService::initialize()
         // Create closing
         res->urdf_string += ROBOT_ELEMENT_CLOSING;
 
-        // Validate xml file
-        tinyxml2::XMLDocument group_urdf_xml;
-        group_urdf_xml.Parse(full_urdf_string.c_str());
-        if (group_urdf_xml.Error())
+        // Validate urdf file
+        if (!urdf::parseURDF(full_urdf_string))
         {
-          const std::string error_string = std::string("Failed to create valid urdf. tinyxml returned '") +
-                                           group_urdf_xml.ErrorStr() + std::string("'");
+          const std::string error_string = std::string("Failed to create valid urdf");
           RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
           res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -73,7 +73,7 @@ void GetUrdfService::initialize()
         {
           const auto error_string = std::string("Cannot create URDF because planning group '") + req->group_name +
                                     std::string("' does not exist");
-          RCLCPP_ERROR(getLogger(), error_string.c_str());
+          RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
           res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
           return;
@@ -88,7 +88,7 @@ void GetUrdfService::initialize()
           const auto error_string =
               std::string("Couldn't load the urdf from parameter server. Is the /robot_description parameter "
                           "initialized?");
-          RCLCPP_ERROR(getLogger(), error_string.c_str());
+          RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
           res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
           return;
@@ -125,7 +125,7 @@ void GetUrdfService::initialize()
         {
           const std::string error_string = std::string("Failed to create valid urdf. tinyxml returned '") +
                                            group_urdf_xml.ErrorStr() + std::string("'");
-          RCLCPP_ERROR(getLogger(), error_string.c_str());
+          RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
           res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
           return;

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -46,10 +46,9 @@ namespace move_group
 
 namespace
 {
-const auto LOG_NAME = std::string("GetUrdfService");
 rclcpp::Logger getLogger()
 {
-  return moveit::getLogger(LOG_NAME);
+  return moveit::getLogger("get_urdf_service");
 }
 const auto JOINT_ELEMENT_CLOSING = std::string("</joint>");
 const auto LINK_ELEMENT_CLOSING = std::string("</link>");
@@ -66,7 +65,7 @@ void GetUrdfService::initialize()
       GET_URDF_SERVICE_NAME,
       [this](const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Request>& req,
              const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Response>& res) {
-        res->error_code.source = LOG_NAME;
+        res->error_code.source = std::string("GetUrdfService");
         const auto subgroup = context_->moveit_cpp_->getRobotModel()->getJointModelGroup(req->group_name);
         // Check if group exists in loaded robot model
         if (!subgroup)

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -104,7 +104,7 @@ void GetUrdfService::initialize()
         const auto& joint_names = subgroup->getJointModelNames();
         for (const auto& joint_name : joint_names)
         {
-          auto const start = full_urdf_string.find("<joint name=\"" + joint_name);
+          const auto start = full_urdf_string.find("<joint name=\"" + joint_name);
           auto substring = full_urdf_string.substr(start, full_urdf_string.size() - start);
           res->urdf_string += substring.substr(0, substring.find(JOINT_ELEMENT_CLOSING) + JOINT_ELEMENT_CLOSING.size());
         }

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Sebastian Jahr */
+
+
+#include "get_group_urdf_capability.h"
+
+#include <moveit/moveit_cpp/moveit_cpp.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <moveit/move_group/capability_names.h>
+#include <moveit/utils/logger.hpp>
+
+namespace move_group
+{
+
+namespace
+{
+rclcpp::Logger getLogger()
+{
+  return moveit::getLogger("GetUrdfService");
+}
+}  // namespace
+
+GetUrdfService::GetUrdfService() : MoveGroupCapability("get_group_urdf")
+{
+}
+
+void GetUrdfService::initialize()
+{
+  get_urdf_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetGroupUrdf>(
+      GET_URDF_SERVICE_NAME, [this](const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Request>& req,
+                                   const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Response>& res) {
+        auto const robot_model = context_->moveit_cpp_->getRobotModel();
+        auto const subgroup = robot_model->getJointModelGroup(req->group_name);
+        // Check if group exists in loaded robot model
+        if(!subgroup){
+          RCLCPP_ERROR(getLogger(), "Cannot create URDF because planning group %s does not exist", req->group_name.c_str());
+          res->success = false;
+          return;
+        }
+        // Create header
+        res->urdf_string = std::string("<?xml version=\"1.0\" ?>\n<robot name=\"") + req->group_name + std::string("\" xmlns:xacro=\"http://ros.org/wiki/xacro\">");
+
+        // Create link list
+        auto const link_names = subgroup->getLinkModelNames();
+        // Create joint list
+        auto const joint_names = subgroup->getJointModelNames();
+        // Create closing
+        auto const closing = "</robot>";
+      });
+}
+}  // namespace move_group
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(move_group::GetUrdfService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Sebastian Jahr
+   Desc: TODO */
+
+#pragma once
+
+#include <moveit/move_group/move_group_capability.h>
+#include <moveit_msgs/srv/get_group_urdf.hpp>
+
+namespace move_group
+{
+class GetUrdfService : public MoveGroupCapability
+{
+public:
+  GetUrdfService();
+
+  void initialize() override;
+
+private:
+  rclcpp::Service<moveit_msgs::srv::GetGroupUrdf>::SharedPtr get_urdf_service_;
+};
+}  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
@@ -33,7 +33,7 @@
  *********************************************************************/
 
 /* Author: Sebastian Jahr
-   Desc: TODO */
+   Desc: This capability creates an URDF string with joints and links of a requested joint model group */
 
 #pragma once
 
@@ -42,11 +42,23 @@
 
 namespace move_group
 {
+/**
+ * @brief Move group capability to create an URDF string for a joint model group
+ *
+ */
 class GetUrdfService : public MoveGroupCapability
 {
 public:
+  /**
+   * @brief Constructor
+   *
+   */
   GetUrdfService();
 
+  /**
+   * @brief Initializes service when plugin is loaded
+   *
+   */
   void initialize() override;
 
 private:

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -62,6 +62,7 @@ rclcpp::Logger getLogger()
 // These capabilities are loaded unless listed in disable_capabilities
 // clang-format off
 static const char* const DEFAULT_CAPABILITIES[] = {
+   "move_group/GetUrdfService",
    "move_group/MoveGroupCartesianPathService",
    "move_group/MoveGroupKinematicsService",
    "move_group/MoveGroupExecuteTrajectoryAction",


### PR DESCRIPTION
### Description

Requires: https://github.com/ros-planning/moveit_msgs/pull/174

This PR adds the move_group capability to request a urdf containing links and joints of a specific joint model group


### Testing
1. Launch move_group with the plugin loaded
2. Call service and request urdf of an existing group
```bash
ros2 service call /get_urdf moveit_msgs/srv/GetGroupUrdf group_name:\ \'MY_GROUP\'\
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
