### PR TITLE
Fix getLinkModelNamesWithCollisionGeometry to include the base link

### DIFF
--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -229,6 +229,13 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
   {
     link_model_map_[link_model->getName()] = link_model;
     link_model_name_vector_.push_back(link_model->getName());
+    // if this is the first link of the group with geometry (for example `base_link`) it should included
+    if(link_model_with_geometry_vector_.empty() && !link_model->getParentLinkModel()->getShapes().empty())
+    {        
+      link_model_with_geometry_vector_.push_back(link_model->getParentLinkModel());
+      link_model_with_geometry_name_vector_.push_back(link_model->getParentLinkModel()->getName());
+    }
+    // all child links with collision geometry should also be included
     if (!link_model->getShapes().empty())
     {
       link_model_with_geometry_vector_.push_back(link_model);

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -230,8 +230,8 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
     link_model_map_[link_model->getName()] = link_model;
     link_model_name_vector_.push_back(link_model->getName());
     // if this is the first link of the group with geometry (for example `base_link`) it should included
-    if(link_model_with_geometry_vector_.empty() && !link_model->getParentLinkModel()->getShapes().empty())
-    {        
+    if (link_model_with_geometry_vector_.empty() && !link_model->getParentLinkModel()->getShapes().empty())
+    {
       link_model_with_geometry_vector_.push_back(link_model->getParentLinkModel());
       link_model_with_geometry_name_vector_.push_back(link_model->getParentLinkModel()->getName());
     }

--- a/moveit_core/robot_model/src/joint_model_group.cpp
+++ b/moveit_core/robot_model/src/joint_model_group.cpp
@@ -229,8 +229,9 @@ JointModelGroup::JointModelGroup(const std::string& group_name, const srdf::Mode
   {
     link_model_map_[link_model->getName()] = link_model;
     link_model_name_vector_.push_back(link_model->getName());
-    // if this is the first link of the group with geometry (for example `base_link`) it should included
-    if (link_model_with_geometry_vector_.empty() && !link_model->getParentLinkModel()->getShapes().empty())
+    // if this is the first link of the group with a valid parent and includes geometry (for example `base_link`) it should included
+    if (link_model_with_geometry_vector_.empty() && link_model->getParentLinkModel() &&
+        !link_model->getParentLinkModel()->getShapes().empty())
     {
       link_model_with_geometry_vector_.push_back(link_model->getParentLinkModel());
       link_model_with_geometry_name_vector_.push_back(link_model->getParentLinkModel()->getName());


### PR DESCRIPTION
### Description
I was working on an MTC task a while ago where I was manually modifying the planning scene. In my program I was calling  `getLinkModelNamesWithCollisionGeometry()` on the `JointModelGroup` to get the links of the manipulator that had collision geometry and noticed that the base link of the group is never included. This caused planning problems like this while I was debugging...
![collision_issue](https://user-images.githubusercontent.com/25058794/226439198-498defc0-f9fe-4ea1-9997-b338800f123f.gif)

To test this change out I modified the moveit2_tutorial `Robot Model and Robot State` where I asked it to print the results of `getLinkModelNamesWithCollisionGeometry` and with this new change it now includes `panda_link0` :1st_place_medal: 
```
RCLCPP_INFO(LOGGER, "Joint model group `panda_arm` collision links:");
std::vector<std::string> collision_link_model_names = joint_model_group->getLinkModelNamesWithCollisionGeometry();
for (const auto& name : collision_link_model_names)
{
    RCLCPP_INFO(LOGGER, "Link with collision: %s", name.c_str());
}

Output:
Joint model group `panda_arm` collision links:
  Link with collision: panda_link0
  Link with collision: panda_link1
  Link with collision: panda_link2
  Link with collision: panda_link3
  Link with collision: panda_link4
  Link with collision: panda_link5
  Link with collision: panda_link6
  Link with collision: panda_link7
```

Very small nitpick but I have also noticed that in Rviz the base link is not highlighted for the goal pose which shows that it is not include in the group when using the motion planning widget.
![image](https://github.com/ros-planning/moveit2/assets/25058794/6a65b220-dbc1-4845-b4b6-3f7b4d540ad4)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
