### PR TITLE
Fix overriding binary install #1928

### DIFF
--- a/moveit_planners/stomp/CMakeLists.txt
+++ b/moveit_planners/stomp/CMakeLists.txt
@@ -39,7 +39,7 @@ install(TARGETS stomp_moveit_plugin stomp_moveit_parameters
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION include/moveit_planners_stomp
 )
 
 ament_export_targets(moveit_planners_stompTargets HAS_LIBRARY_TARGET)


### PR DESCRIPTION
### Description

Missing Destination Path at movieit_planners/stomp/CmakeLists.txt #1928

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
