### PR TITLE
MoveItPy Bug Fix: Perform Logging after RCLCPP Initialization

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -87,7 +87,6 @@ void initMoveitPy(py::module& m)
              // Initialize ROS, pass launch arguments with rclcpp::init()
              if (!rclcpp::ok())
              {
-               RCLCPP_INFO(getLogger(), "Initialize rclcpp");
                std::vector<const char*> chars;
                chars.reserve(launch_arguments.size());
                for (const auto& arg : launch_arguments)
@@ -96,6 +95,7 @@ void initMoveitPy(py::module& m)
                }
 
                rclcpp::init(launch_arguments.size(), chars.data());
+               RCLCPP_INFO(getLogger(), "Initialize rclcpp");
              }
 
              // Build NodeOptions


### PR DESCRIPTION
### Description

There is currently a bug in the init method of the `MoveItPy` class as outlined [here](https://github.com/ros-planning/moveit2/issues/2626#event-11720300010).

This change moves logging to after `rclcpp::init` has been called to prevent this bug. 

Thanks to @TomCC7 for identifying this bug. 