### PR TITLE
Get robot description from topic in GetUrdfService

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -63,7 +63,7 @@ GetUrdfService::GetUrdfService() : MoveGroupCapability("get_group_urdf")
 void GetUrdfService::initialize()
 {
   robot_description_subscriber_ = context_->moveit_cpp_->getNode()->create_subscription<std_msgs::msg::String>(
-      "robot_description", rclcpp::SystemDefaultsQoS(),
+      "robot_description", rclcpp::QoS(1).transient_local().reliable(),
       [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return robotDescriptionSubscriberCallback(msg); });
 
   get_urdf_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetGroupUrdf>(

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -87,8 +87,7 @@ void GetUrdfService::initialize()
         if (full_urdf_string_.empty())
         {
           const auto error_string =
-              std::string("Couldn't load the urdf from parameter server. Is the '/robot_description' parameter "
-                          "initialized?");
+              std::string("Couldn't get the robot description string from '/robot_description' topic");
           RCLCPP_ERROR(getLogger(), "%s", error_string.c_str());
           res->error_code.message = error_string;
           res->error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -59,7 +59,7 @@ const auto GENERAL_ELEMENT_CLOSING = std::string("/>");
 GetUrdfService::GetUrdfService()
   : MoveGroupCapability("get_group_urdf")
   , robot_description_subscriber_{ context_->moveit_cpp_->getNode()->create_subscription<std_msgs::msg::String>(
-        "robot_description", rclcpp::SystemDefaultsQoS(),
+        "robot_description", rclcpp::QoS(1).transient_local().reliable(),
         [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return robotDescriptionSubscriberCallback(msg); }) }
 {
 }

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -41,16 +41,11 @@
 #include <moveit/utils/logger.hpp>
 #include <urdf_parser/urdf_parser.h>
 
-#include "rclcpp/wait_for_message.hpp"
-
 namespace move_group
 {
 
 namespace
 {
-
-using namespace std::chrono_literals;
-
 rclcpp::Logger getLogger()
 {
   return moveit::getLogger("get_urdf_service");

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -56,16 +56,16 @@ const auto ROBOT_ELEMENT_CLOSING = std::string("</robot>");
 const auto GENERAL_ELEMENT_CLOSING = std::string("/>");
 }  // namespace
 
-GetUrdfService::GetUrdfService()
-  : MoveGroupCapability("get_group_urdf")
-  , robot_description_subscriber_{ context_->moveit_cpp_->getNode()->create_subscription<std_msgs::msg::String>(
-        "robot_description", rclcpp::QoS(1).transient_local().reliable(),
-        [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return robotDescriptionSubscriberCallback(msg); }) }
+GetUrdfService::GetUrdfService() : MoveGroupCapability("get_group_urdf")
 {
 }
 
 void GetUrdfService::initialize()
 {
+  robot_description_subscriber_ = context_->moveit_cpp_->getNode()->create_subscription<std_msgs::msg::String>(
+      "robot_description", rclcpp::SystemDefaultsQoS(),
+      [this](const std_msgs::msg::String::ConstSharedPtr& msg) { return robotDescriptionSubscriberCallback(msg); });
+
   get_urdf_service_ = context_->moveit_cpp_->getNode()->create_service<moveit_msgs::srv::GetGroupUrdf>(
       GET_URDF_SERVICE_NAME,
       [this](const std::shared_ptr<moveit_msgs::srv::GetGroupUrdf::Request>& req,

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
@@ -40,8 +40,6 @@
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit_msgs/srv/get_group_urdf.hpp>
 
-#include <std_msgs/msg/string.hpp>
-
 namespace move_group
 {
 /**

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
@@ -40,6 +40,8 @@
 #include <moveit/move_group/move_group_capability.h>
 #include <moveit_msgs/srv/get_group_urdf.hpp>
 
+#include <std_msgs/msg/string.hpp>
+
 namespace move_group
 {
 /**
@@ -62,6 +64,10 @@ public:
   void initialize() override;
 
 private:
+  std::string full_urdf_string_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr robot_description_subscriber_;
   rclcpp::Service<moveit_msgs::srv::GetGroupUrdf>::SharedPtr get_urdf_service_;
+
+  void robotDescriptionSubscriberCallback(const std_msgs::msg::String::ConstSharedPtr& msg);
 };
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.h
@@ -64,10 +64,6 @@ public:
   void initialize() override;
 
 private:
-  std::string full_urdf_string_;
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr robot_description_subscriber_;
   rclcpp::Service<moveit_msgs::srv::GetGroupUrdf>::SharedPtr get_urdf_service_;
-
-  void robotDescriptionSubscriberCallback(const std_msgs::msg::String::ConstSharedPtr& msg);
 };
 }  // namespace move_group

--- a/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
+++ b/moveit_ros/planning/rdf_loader/include/moveit/rdf_loader/rdf_loader.h
@@ -81,6 +81,12 @@ public:
     return ros_name_;
   }
 
+  /** @brief Get the URDF string*/
+  const std::string& getURDFString() const
+  {
+    return urdf_string_;
+  }
+
   /** @brief Get the parsed URDF model*/
   const urdf::ModelInterfaceSharedPtr& getURDF() const
   {


### PR DESCRIPTION
### Description

If robot description is not passed as a parameter to the move_group node, this service will fail.
The robot description will now be acquired from the `robot_description` topic
