### PR TITLE
Update moveit::core::error_msg_to_string in Humble

### DIFF
--- a/moveit_core/utils/include/moveit/utils/moveit_error_code.h
+++ b/moveit_core/utils/include/moveit/utils/moveit_error_code.h
@@ -47,11 +47,7 @@ namespace core
 class MoveItErrorCode : public moveit_msgs::msg::MoveItErrorCodes
 {
 public:
-  MoveItErrorCode()
-  {
-    val = 0;
-  }
-  MoveItErrorCode(int code)
+  MoveItErrorCode(int code = 0)
   {
     val = code;
   }
@@ -104,12 +100,18 @@ inline std::string error_code_to_string(MoveItErrorCode error_code)
       return std::string("START_STATE_IN_COLLISION");
     case moveit::core::MoveItErrorCode::START_STATE_VIOLATES_PATH_CONSTRAINTS:
       return std::string("START_STATE_VIOLATES_PATH_CONSTRAINTS");
+    case moveit::core::MoveItErrorCode::START_STATE_INVALID:
+      return std::string("START_STATE_INVALID");
     case moveit::core::MoveItErrorCode::GOAL_IN_COLLISION:
       return std::string("GOAL_IN_COLLISION");
     case moveit::core::MoveItErrorCode::GOAL_VIOLATES_PATH_CONSTRAINTS:
       return std::string("GOAL_VIOLATES_PATH_CONSTRAINTS");
     case moveit::core::MoveItErrorCode::GOAL_CONSTRAINTS_VIOLATED:
       return std::string("GOAL_CONSTRAINTS_VIOLATED");
+    case moveit::core::MoveItErrorCode::GOAL_STATE_INVALID:
+      return std::string("GOAL_STATE_INVALID");
+    case moveit::core::MoveItErrorCode::UNRECOGNIZED_GOAL_TYPE:
+      return std::string("UNRECOGNIZED_GOAL_TYPE");
     case moveit::core::MoveItErrorCode::INVALID_GROUP_NAME:
       return std::string("INVALID_GROUP_NAME");
     case moveit::core::MoveItErrorCode::INVALID_GOAL_CONSTRAINTS:
@@ -130,9 +132,14 @@ inline std::string error_code_to_string(MoveItErrorCode error_code)
       return std::string("SENSOR_INFO_STALE");
     case moveit::core::MoveItErrorCode::COMMUNICATION_FAILURE:
       return std::string("COMMUNICATION_FAILURE");
+    case moveit::core::MoveItErrorCode::CRASH:
+      return std::string("CRASH");
+    case moveit::core::MoveItErrorCode::ABORT:
+      return std::string("ABORT");
     case moveit::core::MoveItErrorCode::NO_IK_SOLUTION:
       return std::string("NO_IK_SOLUTION");
   }
+  return std::string("Unrecognized MoveItErrorCode. This should never happen!");
 }
 
 }  // namespace core


### PR DESCRIPTION
### Description

Update moveit::core::error_msg_to_string to match updates to moveit_msgs/msg/MoveItErrorCodes.msg. Simply pulled down the file from Iron.

Fixes #2688 

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
