### PR TITLE
Return all colliding links from getCollidingLinks function in Planning Scene

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -511,10 +511,8 @@ void PlanningScene::getCollidingLinks(std::vector<std::string>& links, const mov
   {
     for (const collision_detection::Contact& contact : it->second)
     {
-      if (contact.body_type_1 == collision_detection::BodyTypes::ROBOT_LINK)
-        links.push_back(contact.body_name_1);
-      if (contact.body_type_2 == collision_detection::BodyTypes::ROBOT_LINK)
-        links.push_back(contact.body_name_2);
+      links.push_back(contact.body_name_1);
+      links.push_back(contact.body_name_2);
     }
   }
 }


### PR DESCRIPTION
### Description

Currently, this function only returns robot links in collision. If the robot is in collision with another link in the environment, it would be helpful to get the environment link as part of this function. 

TODO
- [ ] Is it better for this function to return `std::vector<std::pair<std::string, std::string>>` instead of `std::vector<std::string>`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
