### PR TITLE
(core) Install collision_detector_fcl_plugin

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -68,6 +68,7 @@ add_subdirectory(version)
 
 install(
   TARGETS collision_detector_bullet_plugin
+          collision_detector_fcl_plugin
           moveit_acceleration_filter
           moveit_acceleration_filter_parameters
           moveit_butterworth_filter


### PR DESCRIPTION
### Description

FCL version of acda563
Make sure the collision_detector_fcl_plugin library is installed.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
