### PR TITLE
Do not overwrite the error code in planWithSinglePipeline

### DIFF
--- a/moveit_ros/planning/planning_pipeline_interfaces/src/planning_pipeline_interfaces.cpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/src/planning_pipeline_interfaces.cpp
@@ -38,6 +38,7 @@
 #include <moveit/utils/logger.hpp>
 
 #include <thread>
+#include <tuple>  // std::ignore.
 
 namespace moveit
 {
@@ -63,10 +64,7 @@ planWithSinglePipeline(const ::planning_interface::MotionPlanRequest& motion_pla
     return motion_plan_response;
   }
   const planning_pipeline::PlanningPipelinePtr pipeline = it->second;
-  if (!pipeline->generatePlan(planning_scene, motion_plan_request, motion_plan_response))
-  {
-    motion_plan_response.error_code = moveit::core::MoveItErrorCode::FAILURE;
-  }
+  std::ignore = pipeline->generatePlan(planning_scene, motion_plan_request, motion_plan_response);
   return motion_plan_response;
 }
 


### PR DESCRIPTION
Return the `MotionPlanResponse` as-is, also in case of error.

### Description

The error code was forced-set to `FAILURE` in case of error, preventing the caller to get the correct information in case of error.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [X] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
