### PR TITLE
Set `planner_id` in reponses with OMPL interface

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -771,6 +771,7 @@ void ModelBasedPlanningContext::postSolve()
 
 void ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 {
+  res.planner_id = request_.planner_id;
   res.error_code = solve(request_.allowed_planning_time, request_.num_planning_attempts);
   if (res.error_code.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
   {
@@ -800,6 +801,7 @@ void ModelBasedPlanningContext::solve(planning_interface::MotionPlanResponse& re
 
 void ModelBasedPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& res)
 {
+  res.planner_id = request_.planner_id;
   moveit_msgs::msg::MoveItErrorCodes moveit_result =
       solve(request_.allowed_planning_time, request_.num_planning_attempts);
   if (moveit_result.val != moveit_msgs::msg::MoveItErrorCodes::SUCCESS)


### PR DESCRIPTION
### Description

This avoids a warning `PlanningPipeline::generatePlan()` that `res.planner_id` is not set.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [X] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [X] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
