### PR TITLE
Print links in collision

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/src/check_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/check_start_state_collision.cpp
@@ -78,9 +78,6 @@ public:
     // TODO(sjahr): Would verbose make sense?
     planning_scene->checkCollision(creq, cres, start_state);
 
-    collision_detection::CollisionResult::ContactMap contacts;
-    planning_scene->getCollidingPairs(contacts);
-
     auto status = moveit::core::MoveItErrorCode();
     if (!cres.collision)
     {

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/check_start_state_collision.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/check_start_state_collision.cpp
@@ -78,6 +78,9 @@ public:
     // TODO(sjahr): Would verbose make sense?
     planning_scene->checkCollision(creq, cres, start_state);
 
+    collision_detection::CollisionResult::ContactMap contacts;
+    planning_scene->getCollidingPairs(contacts);
+
     auto status = moveit::core::MoveItErrorCode();
     if (!cres.collision)
     {
@@ -85,8 +88,18 @@ public:
     }
     else
     {
+      collision_detection::CollisionResult::ContactMap contacts;
+      planning_scene->getCollidingPairs(contacts);
+
+      std::string contact_information = std::to_string(contacts.size()) + " contact(s) detected : ";
+
+      for (const auto& [contact_pair, contact_info] : contacts)
+      {
+        contact_information.append(contact_pair.first + " - " + contact_pair.second + ", ");
+      }
+
       status.val = moveit_msgs::msg::MoveItErrorCodes::START_STATE_IN_COLLISION;
-      status.message = std::string("Start state in collision.");
+      status.message = std::string(contact_information);
     }
     status.source = getDescription();
     return status;


### PR DESCRIPTION
### Description

The CheckStartStateCollision adapter does return failure when links are in collision but it currently does not say which links are in collision. This PR adds the links in collision to the MoveItErrorCode message so it can help with debugging.

