### PR TITLE
Fix launch parameters in Servo demos

### DIFF
--- a/moveit_ros/moveit_servo/README.md
+++ b/moveit_ros/moveit_servo/README.md
@@ -1,3 +1,3 @@
-# Moveit Servo
+# MoveIt Servo
 
 See the [Realtime Arm Servoing Tutorial](https://moveit.picknik.ai/main/doc/examples/realtime_servo/realtime_servo_tutorial.html) for installation instructions, quick-start guide, an overview about `moveit_servo`, and to learn how to set it up on your robot.

--- a/moveit_ros/moveit_servo/launch/demo_joint_jog.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_joint_jog.launch.py
@@ -22,8 +22,9 @@ def generate_launch_description():
         .to_dict()
     }
 
-    # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
-    low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
+    # This sets the update rate and planning group name for the acceleration limiting filter.
+    acceleration_filter_update_period = {"update_period": 0.01}
+    planning_group_name = {"planning_group_name": "panda_arm"}
 
     # RViz
     rviz_config_file = (
@@ -104,7 +105,8 @@ def generate_launch_description():
         executable="demo_joint_jog",
         parameters=[
             servo_params,
-            low_pass_filter_coeff,
+            acceleration_filter_update_period,
+            planning_group_name,
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,

--- a/moveit_ros/moveit_servo/launch/demo_pose.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_pose.launch.py
@@ -22,8 +22,9 @@ def generate_launch_description():
         .to_dict()
     }
 
-    # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
-    low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
+    # This sets the update rate and planning group name for the acceleration limiting filter.
+    acceleration_filter_update_period = {"update_period": 0.01}
+    planning_group_name = {"planning_group_name": "panda_arm"}
 
     # RViz
     rviz_config_file = (
@@ -104,7 +105,8 @@ def generate_launch_description():
         executable="demo_pose",
         parameters=[
             servo_params,
-            low_pass_filter_coeff,
+            acceleration_filter_update_period,
+            planning_group_name,
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,

--- a/moveit_ros/moveit_servo/launch/demo_ros_api.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_ros_api.launch.py
@@ -31,6 +31,7 @@ def generate_launch_description():
     # This sets the update rate and planning group name for the acceleration limiting filter.
     acceleration_filter_update_period = {"update_period": 0.01}
     planning_group_name = {"planning_group_name": "panda_arm"}
+
     # RViz
     rviz_config_file = (
         get_package_share_directory("moveit_servo")

--- a/moveit_ros/moveit_servo/launch/demo_twist.launch.py
+++ b/moveit_ros/moveit_servo/launch/demo_twist.launch.py
@@ -22,8 +22,9 @@ def generate_launch_description():
         .to_dict()
     }
 
-    # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
-    low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
+    # This sets the update rate and planning group name for the acceleration limiting filter.
+    acceleration_filter_update_period = {"update_period": 0.01}
+    planning_group_name = {"planning_group_name": "panda_arm"}
 
     # RViz
     rviz_config_file = (
@@ -104,7 +105,8 @@ def generate_launch_description():
         executable="demo_twist",
         parameters=[
             servo_params,
-            low_pass_filter_coeff,
+            acceleration_filter_update_period,
+            planning_group_name,
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,


### PR DESCRIPTION
### Description

This PR fixes the launch parameters of all the MoveIt Servo demos to be consistent with the new acceleration limited smoothing plugin.

Note this also requires https://github.com/ros-planning/moveit_resources/pull/198.

Closes https://github.com/ros-planning/moveit2/issues/2733.

cc @ibrahiminfinite 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
