### PR TITLE
Remove extraneous error message from URDF service

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/get_group_urdf_capability.cpp
@@ -134,7 +134,6 @@ void GetUrdfService::initialize()
           const auto start = full_urdf_string.find("<joint name=\"" + joint_name + "\" type");
           auto substring = full_urdf_string.substr(start, full_urdf_string.size() - start);
           res->urdf_string += substring.substr(0, substring.find(JOINT_ELEMENT_CLOSING) + JOINT_ELEMENT_CLOSING.size());
-          RCLCPP_ERROR(getLogger(), "%s", joint_name.c_str());
 
           // If parent link model is not part of the joint group, add it
           const auto parent_link_element = subgroup->getJointModel(joint_name)->getParentLinkModel()->getName();


### PR DESCRIPTION
### Description

Gets rid of an RCLCPP_ERROR invocation that doesn't have any clear benefit and is making my terminal fill up with the names of joints.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
