### PR TITLE
[Servo] Fix collision checking with attached objects

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_monitor.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_monitor.hpp
@@ -67,8 +67,9 @@ private:
   // Variables
 
   const servo::Params& servo_params_;
-  moveit::core::RobotStatePtr robot_state_;
+
   const planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+  moveit::core::RobotState robot_state_;
 
   // The collision monitor thread.
   std::thread monitor_thread_;

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -108,9 +108,6 @@ void CollisionMonitor::checkCollisions()
       // Fetch latest robot state.
       robot_state_ = planning_scene_monitor_->getPlanningScene()->getCurrentState();
       // This must be called before doing collision checking.
-      std::vector<const moveit::core::AttachedBody*> bodies;
-      robot_state_.getAttachedBodies(bodies);
-      RCLCPP_ERROR(getLogger(), "SCASTRO Servo Attached bodies: %ld", bodies.size());
       robot_state_.updateCollisionBodyTransforms();
 
       // Get a read-only copy of planning scene.

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -55,6 +55,7 @@ CollisionMonitor::CollisionMonitor(const planning_scene_monitor::PlanningSceneMo
                                    const servo::Params& servo_params, std::atomic<double>& collision_velocity_scale)
   : servo_params_(servo_params)
   , planning_scene_monitor_(planning_scene_monitor)
+  , robot_state_(planning_scene_monitor->getPlanningScene()->getCurrentState())
   , collision_velocity_scale_(collision_velocity_scale)
 {
   scene_collision_request_.distance = true;
@@ -105,9 +106,12 @@ void CollisionMonitor::checkCollisions()
     if (servo_params_.check_collisions)
     {
       // Fetch latest robot state.
-      robot_state_ = planning_scene_monitor_->getStateMonitor()->getCurrentState();
+      robot_state_ = planning_scene_monitor_->getPlanningScene()->getCurrentState();
       // This must be called before doing collision checking.
-      robot_state_->updateCollisionBodyTransforms();
+      std::vector<const moveit::core::AttachedBody*> bodies;
+      robot_state_.getAttachedBodies(bodies);
+      RCLCPP_ERROR(getLogger(), "SCASTRO Servo Attached bodies: %ld", bodies.size());
+      robot_state_.updateCollisionBodyTransforms();
 
       // Get a read-only copy of planning scene.
       planning_scene_monitor::LockedPlanningSceneRO locked_scene(planning_scene_monitor_);
@@ -115,12 +119,12 @@ void CollisionMonitor::checkCollisions()
       // Check collision with environment.
       scene_collision_result_.clear();
       locked_scene->getCollisionEnv()->checkRobotCollision(scene_collision_request_, scene_collision_result_,
-                                                           *robot_state_, locked_scene->getAllowedCollisionMatrix());
+                                                           robot_state_, locked_scene->getAllowedCollisionMatrix());
 
       // Check robot self collision.
       self_collision_result_.clear();
       locked_scene->getCollisionEnvUnpadded()->checkSelfCollision(
-          self_collision_request_, self_collision_result_, *robot_state_, locked_scene->getAllowedCollisionMatrix());
+          self_collision_request_, self_collision_result_, robot_state_, locked_scene->getAllowedCollisionMatrix());
 
       // If collision detected scale velocity to 0, else start decelerating exponentially.
       // velocity_scale = e ^ k * (collision_distance - threshold)

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -105,7 +105,8 @@ void CollisionMonitor::checkCollisions()
 
     if (servo_params_.check_collisions)
     {
-      // Fetch latest robot state.
+      // Fetch latest robot state using planning scene instead of state monitor due to
+      // https://github.com/ros-planning/moveit2/issues/2748
       robot_state_ = planning_scene_monitor_->getPlanningScene()->getCurrentState();
       // This must be called before doing collision checking.
       robot_state_.updateCollisionBodyTransforms();


### PR DESCRIPTION
### Description

This PR introduces a slight fix to the MoveIt Servo collision checker to make it work with attached objects.

Turns out Current State Monitor has some issues, but Planning Scene Monitor works fine: https://github.com/ros-planning/moveit2/issues/2748

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
