### PR TITLE
Change KDL IK plugin joint weight parameters specification

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_parameters.yaml
@@ -5,15 +5,16 @@ kdl_kinematics:
     description: "Joints names to assign weights",
   }
 
-  __map_joints:
-    weight: {
-      type: double,
-      default_value: 1.0,
-      description: "Joint weight",
-      validation: {
-        gt<>: [ 0.0 ]
+  weights:
+    __map_joints:
+      value: {
+        type: double,
+        default_value: 1.0,
+        description: "Joint weight",
+        validation: {
+          gt<>: [ 0.0 ]
+        }
       }
-    }
 
   max_solver_iterations: {
     type: int,

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -95,11 +95,10 @@ void KDLKinematicsPlugin::getJointWeights()
   joint_weights_ = std::vector<double>(joint_names.size(), 1.0);
 
   // Check if joint weight is assigned in kinematics YAML
-  // Loop through map (key: joint name and value: Struct with a weight member variable)
-  for (const auto& joint_weight : params_.joints_map)
+  // Loop through map (key: joint name and weight: struct with a value member variable)
+  for (const auto& [joint_name, weight] : params_.weights.joints_map)
   {
     // Check if joint is an active joint in the group
-    const auto joint_name = joint_weight.first;
     auto it = std::find(joint_names.begin(), joint_names.end(), joint_name);
     if (it == joint_names.cend())
     {
@@ -109,7 +108,7 @@ void KDLKinematicsPlugin::getJointWeights()
     }
 
     // Find index of the joint name and assign weight to the coressponding index
-    joint_weights_.at(it - joint_names.begin()) = joint_weight.second.weight;
+    joint_weights_.at(it - joint_names.begin()) = weight.value;
   }
 
   RCLCPP_INFO_STREAM(

--- a/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
@@ -206,6 +206,7 @@ bool ROS2ControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitter&
           const ControlInterfaces interfaces = parent_.getControlInterfaces(ci.joints_);
           emitter << YAML::Key << "command_interfaces" << YAML::Value << interfaces.command_interfaces;
           emitter << YAML::Key << "state_interfaces" << YAML::Value << interfaces.state_interfaces;
+          emitter << YAML::Key << "allow_nonzero_velocity_at_trajectory_end" << YAML::Value << true;
         }
       }
       emitter << YAML::EndMap;


### PR DESCRIPTION
### Description

This is a potential fix for #2749.

It changes the KDL parameters introduced in https://github.com/ros-planning/moveit2/pull/1671 from:

```yaml
panda_arm:
  kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
  kinematics_solver_search_resolution: 0.005
  kinematics_solver_timeout: 0.05

  joints: ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]
  # Default weight for joints is 1.0 
  joint1:
    weight: 2.0
  joint5:
    weight: 1.5
```

to 

```yaml
panda_arm:
  kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
  kinematics_solver_search_resolution: 0.005
  kinematics_solver_timeout: 0.05

  joints: ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]
  # Default weight for joints is 1.0 
  weights:
    joint1:
      value: 2.0
    joint5:
      value: 1.5
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
