### PR TITLE
Add `allow_nonzero_velocity_at_trajectory_end` parameter to exported `ros2_controllers` config file

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
@@ -206,6 +206,7 @@ bool ROS2ControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitter&
           const ControlInterfaces interfaces = parent_.getControlInterfaces(ci.joints_);
           emitter << YAML::Key << "command_interfaces" << YAML::Value << interfaces.command_interfaces;
           emitter << YAML::Key << "state_interfaces" << YAML::Value << interfaces.state_interfaces;
+          emitter << YAML::Key << "allow_nonzero_velocity_at_trajectory_end" << YAML::Value << true;
         }
       }
       emitter << YAML::EndMap;


### PR DESCRIPTION
### Description

With the addition of https://github.com/ros-planning/moveit_resources/pull/198/, the YAML equivalence tests in the `moveit_setup_controllers` package was failing. So this adds that line to the exported configs, which is probably a good default if we want users to use MoveIt Servo easily.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
