### PR TITLE
Fix error message text about invalid servo parameters

### DIFF
--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -222,7 +222,7 @@ bool Servo::validateParams(const servo::Params& servo_params) const
     RCLCPP_ERROR_STREAM(
         logger_, "When publishing a std_msgs/Float64MultiArray, "
                  "either the parameter 'publish_joint_positions' OR the parameter 'publish_joint_velocities' must "
-                 "be set to true. But both are set to false."
+                 "be set to true. But both are set to true."
                      << check_yaml_string);
     params_valid = false;
   }


### PR DESCRIPTION
### Description

Was debugging something and realized this error message is swapped.

I'll add this later when I'm on a dev computer, but looks like we should also add a check for `  if ((servo_params.command_out_type == "std_msgs/Float64MultiArray") && !servo_params.publish_joint_positions && !servo_params.publish_joint_velocities)`  - The previous check would not trigger that as it is specific to Float64 type.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
