### PR TITLE
CI: Allow non-interactive installation of rmw-connextdds

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -6,6 +6,8 @@ FROM ros:${ROS_DISTRO}-ros-base
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 ENV TERM xterm
+# Allow non-interactive installation of ros-humble-rmw-connextdds
+ENV RTI_NC_LICENSE_ACCEPTED yes
 
 # Setup (temporary) ROS workspace
 WORKDIR /root/ws_moveit

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -5,6 +5,9 @@ ARG ROS_DISTRO=rolling
 FROM ros:${ROS_DISTRO}-ros-base
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
+# Allow non-interactive installation of ros-humble-rmw-connextdds
+ENV RTI_NC_LICENSE_ACCEPTED yes
+
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 RUN apt-get update -q && \
     apt-get upgrade -q -y && \


### PR DESCRIPTION
When installing `rmw-connextdds` within a humble docker image, e.g. via rosdep, this fails, because interactive acceptance of the license is required despite common flags like `--yes`:
https://github.com/ros-planning/moveit_task_constructor/issues/558
https://github.com/ros-planning/moveit_task_constructor/actions/runs/8680352798/job/23800710624#step:4:177

Declaring the environment variable `RTI_NC_LICENSE_ACCEPTED=yes` resolves that issue:
https://github.com/ros-planning/moveit_task_constructor/actions/runs/8680352798