### PR TITLE
Add generate_parameter_library source build 0.37 until latest release is fixed

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -8,3 +8,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_resources.git
     version: ros2
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version: 0.3.7


### PR DESCRIPTION
This PR adds generate_parameter_library as a source build to fix the current build failure. This will be needed until the latest release is fixed. 