### PR TITLE
Do not switch object and shape poses of attached objects with subframes

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1817,7 +1817,7 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
   shape_poses.reserve(num_shapes);
 
   bool switch_object_pose_and_shape_pose = false;
-  if (num_shapes == 1 && (!object.subframe_poses.size()) && moveit::core::isEmpty(object.pose))
+  if (num_shapes == 1 && object.subframe_poses.empty() && moveit::core::isEmpty(object.pose))
   {
     // If the object pose is not set but the shape pose is, use the shape's pose as the object pose.
     switch_object_pose_and_shape_pose = true;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1817,7 +1817,7 @@ bool PlanningScene::shapesAndPosesFromCollisionObjectMessage(const moveit_msgs::
   shape_poses.reserve(num_shapes);
 
   bool switch_object_pose_and_shape_pose = false;
-  if (num_shapes == 1 && moveit::core::isEmpty(object.pose))
+  if (num_shapes == 1 && (!object.subframe_poses.size()) && moveit::core::isEmpty(object.pose))
   {
     // If the object pose is not set but the shape pose is, use the shape's pose as the object pose.
     switch_object_pose_and_shape_pose = true;


### PR DESCRIPTION
### Description

https://github.com/moveit/moveit/pull/2816#issuecomment-906094021 said
> If the object consists of a single shape, the object pose should be set to that shape's pose, and the primitive pose to identity. Otherwise, there is a regression for scenes that were built in a scene-graph-like manner by referring to previously placed objects.
>
> It also looks nicer when you visualize the object pose in TF.

Namely, if an attached object has exactly one shape (primitive or mesh) and the pose of the attached object is "empty" (that is, the origin of the attached object coincides with the origin of the link it is attached to), then the code would "swap" the poses, moving the origin of the attached object to the origin of the shape/mesh. 

Unfortunately this change had some IMHO very unfortunate side-effects. In my use case, the pose is not "empty", it is correctly set to identity, as the URDF was intentionally structured to have the origin of the robot link and attached object coincide, to make the whole thing simpler to set up. Whereas in my case the mesh origin is a completely "random" location (the URDF is created by exporting from Fusion using https://github.com/jaredgonzales/fusion360descriptor/ and Fusion has all meshes originate at global origin of the design, regardless of the local origin of the specific bodies). The issue is than two-fold:
- This changes the location of the attached object origin to some "random" place 
- This fails to change the pose of the subframes, so the subframe locations end up equally wrong.
This means that using the attached object or its subframe as a frame id or tip name in IK/motion planning results in things failing in completely unpredictable and seemingly incomprehensible ways (I just happened to have the scene returned by move_group's get_planning_scene logged and happened to see that the mesh origin was 0, which clued me to where to look in source code, otherwise I would have likely spent hours trying to understand why things work correctly for some attached objects, and completely bogus for others).

I see the following options:

1. If swapping, update the subframe poses so that they are unchanged.
2. Do not swap when subframes are present.
3. Never swap, and fix whatever incorrectly relies on the swapping behavior.
4. Add an extra boolean field yes_this_is_the_real_pose_even_if_its_an_identity_and_do_not_mess_with_it to the message type (obviously silly, but IMHO not more so than the current implementation).

IMHO option 3 is the right way, but I do not have bandwidth or understanding to implement it, and I do not know how much may be relying on the current behavior by now. This PR implements option 2 - it is the simplest fix for my use case and although I would expect to leave plenty of opportunities to trip people, it would hopefully avoid the worst side-effects.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
