### PR TITLE
Fix MeshShape::clear() for safer mesh removal

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -140,7 +140,11 @@ void MeshShape::clear()
   if (entity_)
   {
     entity_->detachFromParent();
-    Ogre::MeshManager::getSingleton().remove(entity_->getMesh()->getName());
+    const auto& mesh_name = entity_->getMesh()->getName();
+    if (Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().getByName(mesh_name))
+    {
+      Ogre::MeshManager::getSingleton().remove(mesh);
+    }
     scene_manager_->destroyEntity(entity_);
     entity_ = nullptr;
   }


### PR DESCRIPTION

### Description
To address https://github.com/moveit/moveit2/issues/3162#issuecomment-2541905304, I add a check to retrieve the mesh by name before attempting to remove it.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
