### PR TITLE
stomp: Fix passing different types to std::min in cost_functions.hpp

### DIFF
--- a/moveit_planners/stomp/include/stomp_moveit/cost_functions.hpp
+++ b/moveit_planners/stomp/include/stomp_moveit/cost_functions.hpp
@@ -168,7 +168,7 @@ CostFn getCostFunctionFromStateValidator(const StateValidatorFn& state_validator
       const long kernel_start = mu - static_cast<long>(sigma) * 4;
       const long kernel_end = mu + static_cast<long>(sigma) * 4;
       const long bounded_kernel_start = std::max(0l, kernel_start);
-      const long bounded_kernel_end = std::min(values.cols() - 1, kernel_end);
+      const long bounded_kernel_end = std::min(static_cast<long>(values.cols()) - 1, kernel_end);
       for (auto j = bounded_kernel_start; j <= bounded_kernel_end; ++j)
       {
         costs(j) = std::exp(-std::pow(j - mu, 2) / (2 * std::pow(sigma, 2))) / (sigma * std::sqrt(2 * M_PI));


### PR DESCRIPTION
### Description

`std::min` supports comparing scalar of the same type. Depending on the specific platform or compiler, `values.cols()` return type may not be compatible with `long`, so explicitly casting ensure that `std::min` compiles fine on any platform.

Specifically, I had encountered a compilation problem with this when compiling moveit with MSVC 2019.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
