### PR TITLE
Support Docker siblings in IKFast plugin script

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/auto_create_ikfast_moveit_plugin.sh
@@ -148,8 +148,15 @@ function create_dae_file {
       echo "Failed. Converting urdf to Collada (in docker)"
       build_docker_image
       cp "$INPUT" "$TMP_DIR/robot.urdf"
-      run_quiet docker run --rm --user $(id -u):$(id -g) -v $TMP_DIR:/input --workdir /input -e HOME=/input \
-             fixed-openrave:latest rosrun collada_urdf urdf_to_collada robot.urdf robot.dae
+      run_quiet docker create \
+        --workdir /input \
+        -e HOME=/input \
+        --cidfile="$TMP_DIR/docker-collada.cid" \
+        fixed-openrave:latest rosrun collada_urdf urdf_to_collada robot.urdf robot.dae && \
+      docker cp "$TMP_DIR/." "$(cat $TMP_DIR/docker-collada.cid)":/input && \
+      docker start -ai "$(cat $TMP_DIR/docker-collada.cid)" && \
+      docker cp "$(cat $TMP_DIR/docker-collada.cid)":/input/. "$TMP_DIR" ; \
+      docker rm "$(cat $TMP_DIR/docker-collada.cid)"
    fi
 }
 
@@ -171,9 +178,15 @@ EOF
    echo "Running $cmd"
 
    # run $cmd in docker as current user, outputting files to $TMP_DIR/.openrave
-   run_quiet docker run --rm --user $(id -u):$(id -g) \
-      -v $TMP_DIR:/input --workdir /input -e HOME=/input \
-      fixed-openrave:latest $cmd
+   run_quiet docker create \
+           --workdir /input \
+           -e HOME=/input \
+           --cidfile="$TMP_DIR/docker-solver.cid" \
+           fixed-openrave:latest $cmd && \
+         docker cp "$TMP_DIR/." "$(cat $TMP_DIR/docker-solver.cid)":/input && \
+         docker start -ai "$(cat $TMP_DIR/docker-solver.cid)" && \
+         docker cp "$(cat $TMP_DIR/docker-solver.cid)":/input/. "$TMP_DIR" ; \
+         docker rm "$(cat $TMP_DIR/docker-solver.cid)"
 
    # update INPUT to generated .cpp
    INPUT=$(ls -1 $TMP_DIR/.openrave/*/*.cpp 2> /dev/null)


### PR DESCRIPTION
### Description

Adds support for running the IKFast plugin creation script `auto_create_ikfast_moveit_plugin.sh` from within a Docker container.

The script uses Docker containers itself, and was attempting to share files with the spawned containers using bind mounts. If you create your main container with a bind mount to the Docker socket (`/var/run/docker.sock`) then you are able to create sibling containers from inside, and thus would expect the script to execute correctly. The problem is that bind mounts always refer to the host-machine's paths, so if you try to run the script from inside a Docker container the mounts do not resolve correctly.

I solved this by switching to explicit `docker create` and `docker start` commands, and used `docker cp` to copy files in and out, since `docker cp` supports being run from inside a container. This works in-place and does not require any changes to documentation or processes.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
