### PR TITLE
Get tip frames from joint model group in kinematics plugin loader

### DIFF
--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -88,13 +88,17 @@ public:
   std::vector<std::string> chooseTipFrames(const moveit::core::JointModelGroup* jmg)
   {
     std::vector<std::string> tips;
-    // get the last link in the chain
-    RCLCPP_DEBUG(logger_,
-                 "Choosing tip frame of kinematic solver for group %s"
-                 "based on last link in chain",
-                 jmg->getName().c_str());
 
-    tips.push_back(jmg->getLinkModels().back()->getName());
+    // try to retrieve the tip frames from the joint model group
+    if (!jmg->getEndEffectorTips(tips))
+    {
+      // get the last link in the chain as fallback
+      RCLCPP_DEBUG(logger_,
+                  "Choosing tip frame of kinematic solver for group %s"
+                  "based on last link in chain",
+                  jmg->getName().c_str());
+      tips.push_back(jmg->getLinkModels().back()->getName());
+    }
 
     // Error check
     if (tips.empty())


### PR DESCRIPTION
The current implementation of the kinematics plugin loader assumes that the joint model group is a chain and just passes the last link to the kinematics plugin. When trying to create a kinematics plugin for groups with multiple end effectors, it therefore incorrectly only gets one of the end effectors in its initialize method.

I changed the chooseTipFrames method to instead call getEndEffectorTips on the joint model group, which handles groups with multiple end effectors. I kept the old method as a fallback.