### PR TITLE
Fix parameter passing in generate_state_database.cpp

### DIFF
--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -54,8 +54,8 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 static const std::string CONSTRAINT_PARAMETER = "constraints";
 
-static bool getUintParameterOr(const rclcpp::Node::SharedPtr& node, const std::string& param_name,
-                               size_t&& result_value, const size_t default_value)
+static bool get_uint_parameter_or(const rclcpp::Node::SharedPtr& node, const std::string& param_name,
+                                  unsigned int& result_value, const size_t default_value)
 {
   int param_value;
   if (node->get_parameter(param_name, param_value))
@@ -75,6 +75,7 @@ static bool getUintParameterOr(const rclcpp::Node::SharedPtr& node, const std::s
   result_value = default_value;
   return true;
 }
+
 
 struct GenerateStateDatabaseParameters
 {

--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -54,7 +54,7 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 
 static const std::string CONSTRAINT_PARAMETER = "constraints";
 
-static bool get_uint_parameter_or(const rclcpp::Node::SharedPtr& node, const std::string& param_name,
+static bool getUintParameterOr(const rclcpp::Node::SharedPtr& node, const std::string& param_name,
                                   unsigned int& result_value, const unsigned int default_value)
 {
   int param_value;

--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -55,7 +55,7 @@ static const std::string ROBOT_DESCRIPTION = "robot_description";
 static const std::string CONSTRAINT_PARAMETER = "constraints";
 
 static bool get_uint_parameter_or(const rclcpp::Node::SharedPtr& node, const std::string& param_name,
-                                  unsigned int& result_value, const size_t default_value)
+                                  unsigned int& result_value, const unsigned int default_value)
 {
   int param_value;
   if (node->get_parameter(param_name, param_value))


### PR DESCRIPTION
**Background**
MoveIt 2 provides the “Planning with Approximated Constraint Manifolds” feature to accelerate constrained motion planning. The generate_state_database.cpp file is responsible for building the constraint state database, but due to the parameter-retrieval function’s signature using an rvalue reference, both options.samples and options.edges_per_sample remain at their default value of 0. As a result, the sampling and connection loops never execute.
**Problem**
In the original implementation, the parameter-retrieval function is declared as:
static bool get_uint_parameter_or(
    const rclcpp::Node::SharedPtr& node,
    const std::string& param_name,
    size_t&& result_value,
    const size_t default_value)
{ … }
Passing result_value as a size_t&& rvalue reference prevents the retrieved parameter value from being written back to the caller’s variable.
Consequently, both options.samples and options.edges_per_sample stay at 0, causing the state database generation to fail with:
[INFO] […] Generated 0 states in 0.000005 seconds
[ERROR] […] No StateStoragePtr found – implement better solution here.
**Solution**
Change the function signature to use an lvalue reference of type unsigned int&, ensuring that the retrieved parameter is correctly assigned:
-static bool get_uint_parameter_or(
-    const rclcpp::Node::SharedPtr& node,
-    const std::string& param_name,
-    size_t&& result_value,
-    const size_t default_value)
+static bool get_uint_parameter_or(
+    const rclcpp::Node::SharedPtr& node,
+    const std::string& param_name,
+    unsigned int& result_value,
+    const size_t default_value)
{
    int param_value;
    if (node->get_parameter(param_name, param_value))
    {
        if (param_value >= 0)
        {
-           result_value = static_cast<size_t>(param_value);
+           result_value = static_cast<unsigned int>(param_value);
            return true;
        }
        RCLCPP_WARN_STREAM(...);
    }
    result_value = default_value;
    return true;
}
Key Changes
Changed parameter type from size_t&& to unsigned int&.
Cast the retrieved int to unsigned int instead of size_t.
Preserved the original default-value fallback and warning logic.
Verification
After rebuilding and running the generation script locally, you can now observe proper sampling and connection progress:
[INFO] […] 90% complete
[INFO] […] Computed possible connexions in 14.77 seconds. Added 2373 connexions
[INFO] […] Spent 202.56 seconds constructing the database
The Constraint Approximation Database is successfully created and saved to the specified path.
Related Work
There is an existing community PR (see #1412) addressing issues with generate_state_database, but that effort focuses on different aspects. This fix targets only the parameter-retrieval signature, so the two can be merged independently.