### PR TITLE
Fix ERROR stream + check only active controllers for multiple chained controllers

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -567,10 +567,10 @@ public:
     dependency_map_reverse_.clear();
     for (auto& controller : result->controller)
     {
-      if (controller.chain_connections.size() > 1)
+      if (isActive(controller) && controller.chain_connections.size() > 1)
       {
-        RCLCPP_ERROR_STREAM(LOGGER, "Controller with name %s chains to more than one controller. Chaining to more than "
-                                    "one controller is not supported.");
+        RCLCPP_ERROR_STREAM(LOGGER, "Controller with name " <<  controller.name << " chains to more than one controller. "
+                                    "Chaining to more than one controller is not supported.");
         return false;
       }
       for (const auto& chained_controller : controller.chain_connections)


### PR DESCRIPTION
### Description

Hello Moveit Team,

When trying to control TIAGo Pro using moveit in Rviz I got this error:
```
[move_group-1] [ERROR] [1755075355.583941867] [moveit.plugins.ros_control_interface]: Controller with name %s chains to more than one controller. Chaining to more than one controller is not supported.
[move_group-1] [ERROR] [1755075355.584044598] [moveit_ros.trajectory_execution_manager]: Unable to identify any set of controllers that can actuate the specified joints: [ arm_left_1_joint arm_left_2_joint arm_left_3_joint arm_left_4_joint arm_left_5_joint arm_left_6_joint arm_left_7_joint ]
[move_group-1] [ERROR] [1755075355.584057241] [moveit_ros.trajectory_execution_manager]: Known controllers and their joints:
[move_group-1] 
```
This was due to a controller that is expected to be chained to several other controllers to be able to work, however this controller is not active when I did the test, it is just spawned by default in inactive

My change is to check chained controller only for active controllers and to fix the error message

Would this work or you prefer this to be fixed differently ?