### PR TITLE
[OMPL] also check constraints in StateValidityCallback

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/constrained_goal_sampler.cpp
@@ -89,7 +89,8 @@ bool ConstrainedGoalSampler::stateValidityCallback(ob::State* new_goal, const mo
   moveit::core::RobotState solution_state(*state);
   solution_state.setJointGroupPositions(jmg, jpos);
   solution_state.update();
-  return checkStateValidity(new_goal, solution_state, verbose);
+  return checkStateValidity(new_goal, solution_state, verbose) &&
+         kinematic_constraint_set_->decide(solution_state, verbose).satisfied;
 }
 
 bool ConstrainedGoalSampler::sampleUsingConstraintSampler(const ob::GoalLazySamples* gls, ob::State* new_goal)


### PR DESCRIPTION
This allows the IK solver to continue finding a valid solution, which also satisfies the kinematic constraints.

In the old situation the IK solver would return a solution, which it thinks is valid, but it is not. The sampler will keep calling the IK solver. Though for IK solvers, which are not that random. There is a high chance of returning the same solution over and over. Which keeps failing the constraints.

By checking the constraints in the callback the IK solver will continue and return a valid solution.

Please backport to Jazzy and others

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
