### PR TITLE
Fix joint limits crash

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -300,7 +300,21 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_velocity";
-    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_velocity_), fabs(b.min_velocity_)));
+
+    // To Solve Putting integer Values like 100 as 100.0 in YAML
+    double val = std::min(fabs(b.max_velocity_), fabs(b.min_velocity_));
+
+    // Check if val is a full integer (within floating-point tolerance)
+    bool is_integer = std::fabs(val - std::round(val)) < 1e-9;
+
+    // Format value as string
+    std::ostringstream oss;
+    if (is_integer)
+      oss << std::fixed << std::setprecision(1) << val;  // e.g. 100.0
+    else
+      oss << val;  // e.g. 99.75
+
+    emitter << YAML::Value << oss.str();
 
     // Output property
     emitter << YAML::Key << "has_acceleration_limits";
@@ -315,7 +329,21 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_acceleration";
-    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_)));
+
+    // To Solve Putting integer Values like 100 as 100.0 in YAML
+    val = std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_));
+
+    // Check if val is a full integer (within floating-point tolerance)
+    is_integer = std::fabs(val - std::round(val)) < 1e-9;
+
+    // Format value as string
+    oss.str("");  // Clear the stringstream
+    if (is_integer)
+      oss << std::fixed << std::setprecision(1) << val;  // e.g. 100.0
+    else
+      oss << val;  // e.g. 99.75
+
+    emitter << YAML::Value << oss.str();
 
     emitter << YAML::EndMap;
   }


### PR DESCRIPTION
review: 

### Description

When I put max velocity of joint to number with zero fraction part (100.0) the setup_assistance put it in the joint_limits.yaml
as 100 then
```yaml
j5:
    has_velocity_limits: true
    max_velocity: 100.0
    has_acceleration_limits: true
    max_acceleration: 10.0
  j6:
    has_velocity_limits: true
    max_velocity: 100
    has_acceleration_limits: true
    max_acceleration: 10
```

 if I use it (for example with moveit_servo) I get:

```bash
[manual_control-5] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
[manual_control-5]   what():  parameter 'robot_description_planning.joint_limits.j6.max_velocity' has invalid type: Wrong parameter type, parameter {robot_description_planning.joint_limits.j6.max_velocity} is of type {double}, setting it to {integer} is not allowed.
. 
.
.
[ERROR] [manual_control-5]: process has died [pid 53938, exit code -6, cmd '/home/aymanhadair/ROS2/ProjectController/install/manual_control/lib/manual_control/manual_control --ros-args --params-file /tmp/launch_params_2bxo_2iu --params-file /tmp/launch_params_gpgmeah0 --params-file /tmp/launch_params_6cgfm0fw --params-file /tmp/launch_params_r_lfeaqi --params-file /tmp/launch_params_fijlhhaz --params-file /tmp/launch_params__key9xja --params-file /tmp/launch_params_zj2opjrh'].
```

I solve it just by adding ".0" if the value is pure integer:
```cpp
// To Solve Putting integer Values like 100 as 100.0 in YAML
double val = std::min(fabs(b.max_velocity_), fabs(b.min_velocity_));

// Check if val is a full integer (within floating-point tolerance)
bool is_integer = std::fabs(val - std::round(val)) < 1e-9;

// Format value as string
std::ostringstream oss;
if (is_integer)
  oss << std::fixed << std::setprecision(1) << val;  // e.g. 100.0
else
  oss << val;  // e.g. 99.75

emitter << YAML::Value << oss.str();
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"