### PR TITLE
Fix Trajectory template usage for `checkOvershoot` with StandardVector

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.hpp
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.hpp
@@ -159,8 +159,8 @@ private:
                                        robot_trajectory::RobotTrajectory& trajectory);
 
   /** \brief Check if a trajectory out of Ruckig overshoots the target state */
-  static bool checkOvershoot(ruckig::Trajectory<ruckig::DynamicDOFs, ruckig::StandardVector>& ruckig_trajectory,
-                             const size_t num_dof, ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input,
+  static bool checkOvershoot(ruckig::Trajectory<ruckig::DynamicDOFs>& ruckig_trajectory, const size_t num_dof,
+                             ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input,
                              const double overshoot_threshold);
 };
 }  // namespace trajectory_processing

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -422,8 +422,8 @@ void RuckigSmoothing::getNextRuckigInput(const moveit::core::RobotStateConstPtr&
   }
 }
 
-bool RuckigSmoothing::checkOvershoot(ruckig::Trajectory<ruckig::DynamicDOFs, ruckig::StandardVector>& ruckig_trajectory,
-                                     const size_t num_dof, ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input,
+bool RuckigSmoothing::checkOvershoot(ruckig::Trajectory<ruckig::DynamicDOFs>& ruckig_trajectory, const size_t num_dof,
+                                     ruckig::InputParameter<ruckig::DynamicDOFs>& ruckig_input,
                                      const double overshoot_threshold)
 {
   // For every timestep


### PR DESCRIPTION
# PR Description
## Compilation was failing on macOS/Clang for code using:

```cpp
ruckig::Trajectory<ruckig::DynamicDOFs, ruckig::StandardVector>& ruckig_trajectory
```

The explicit use of StandardVector caused template resolution issues. The Trajectory class template already defines a default CustomVector type, which handles dynamic DOFs correctly. Explicitly specifying StandardVector was redundant and incompatible with some compilers.

## Fix:

```cpp
ruckig::Trajectory<ruckig::DynamicDOFs>& ruckig_trajectory
```

This lets the template use its default CustomVector alias internally. The change:

- Fixes compilation errors on macOS/Clang.

- Preserves all trajectory logic and runtime behavior.

- Simplifies template usage by relying on defaults.

## Impact:

Purely a type-level correction; no functional changes. Compilation now works across platforms.