### PR TITLE
fix fmt deprecation

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -85,7 +85,7 @@ void URDFConfig::loadFromPath(const std::filesystem::path& urdf_file_path, const
 {
   urdf_path_ = urdf_file_path;
   xacro_args_vec_ = xacro_args;
-  xacro_args_ = fmt::format("{}", fmt::join(xacro_args_vec_, " "));
+  xacro_args_ = fmt::format("{}", rcpputils::join(xacro_args_vec_, " "));
   setPackageName();
   load();
 }


### PR DESCRIPTION

### Description

fix error: ‘join’ is not a member of ‘fmt’. Migrate to rcpputils


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
