### PR TITLE
Use offset in POLYLINE pilz planner

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_polyline.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_polyline.cpp
@@ -103,7 +103,8 @@ void TrajectoryGeneratorPolyline::extractMotionPlanInfo(const planning_scene::Pl
   for (const auto& pc : req.path_constraints.position_constraints)
   {
     Eigen::Isometry3d waypoint;
-    tf2::fromMsg(pc.constraint_region.primitive_poses.front(), waypoint);
+    waypoint = getConstraintPose(pc.constraint_region.primitive_poses.front().position,
+                                 pc.constraint_region.primitive_poses.front().orientation, pc.target_point_offset);
     waypoint = scene->getFrameTransform(frame_id) * waypoint;
     info.waypoints.push_back(waypoint);
   }


### PR DESCRIPTION
### Description

use the target_point_offset in POLYLINE pilz planner

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers
