### PR TITLE
[Backport of #2222]: Skip joints not belonging to RobotModel

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -337,7 +337,7 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState:
       {
         continue;
       }
-      
+
       const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
       if (!jm)
         continue;


### PR DESCRIPTION
Add check to skip joints not in RobotModel

### Description

I backported the changes of #2222 to humble. This prevents printing error messages when the robot_model contains more joints than just the robot arm.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
