### PR TITLE
Attempt to unbork CI

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/test/test_check_start_state_bounds.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/test/test_check_start_state_bounds.cpp
@@ -50,7 +50,6 @@ class TestCheckStartStateBounds : public testing::Test
 protected:
   void SetUp() override
   {
-    rclcpp::init(0, nullptr);
     node_ = std::make_shared<rclcpp::Node>("test_check_start_state_bounds_adapter", "");
 
     // Load a robot model and place it in a planning scene.
@@ -63,11 +62,6 @@ protected:
         "moveit_core", "planning_interface::PlanningRequestAdapter");
     adapter_ = plugin_loader_->createUniqueInstance("default_planning_request_adapters/CheckStartStateBounds");
     adapter_->initialize(node_, "");
-  }
-
-  void TearDown() override
-  {
-    rclcpp::shutdown();
   }
 
   std::shared_ptr<rclcpp::Node> node_;
@@ -158,6 +152,9 @@ TEST_F(TestCheckStartStateBounds, TestContinuousJointFixedBounds)
 
 int main(int argc, char** argv)
 {
+  rclcpp::init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }


### PR DESCRIPTION
### Description

[This](https://github.com/moveit/moveit2/blob/main/moveit_ros/planning/planning_request_adapter_plugins/test/test_check_start_state_bounds.cpp) lovely set of tests appears to be causing some issues in CI.

Rather than doing `init` and `shutdown` for each test, let's `init` once and `shutdown` once. I'm not a wizard enough to understand why this suddenly started failing, but I think it's a good idea to `init` and `shutdown` like the [other](https://github.com/moveit/moveit2/blob/main/moveit_ros/tests/src/move_group_api_test.cpp#L100-L104) [tests](https://github.com/moveit/moveit2/blob/main/moveit_ros/moveit_servo/tests/test_ros_integration.cpp#L214-L218) [do](https://github.com/moveit/moveit2/blob/main/moveit_ros/planning_interface/test/move_group_ompl_constraints_test.cpp#L182-L187).