### PR TITLE
Allow planning_scene_options to be set trough node parameters.

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.hpp
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.hpp
@@ -79,13 +79,21 @@ public:
       node->get_parameter_or(ns + ".name", name, std::string("planning_scene_monitor"));
       node->get_parameter_or(ns + ".robot_description", robot_description, std::string("robot_description"));
       node->get_parameter_or(ns + ".wait_for_initial_state_timeout", wait_for_initial_state_timeout, 0.0);
+      node->get_parameter_or(ns + ".joint_state_topic", joint_state_topic,
+                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC);
+      node->get_parameter_or(ns + ".attached_collision_object_topic", attached_collision_object_topic,
+                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC);
+      node->get_parameter_or(ns + ".monitored_planning_scene_topic", monitored_planning_scene_topic,
+                             planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC);
+      node->get_parameter_or(ns + ".publish_planning_scene_topic", publish_planning_scene_topic,
+                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
     }
     std::string name;
     std::string robot_description;
-    const std::string joint_state_topic;
-    const std::string attached_collision_object_topic;
-    const std::string monitored_planning_scene_topic;
-    const std::string publish_planning_scene_topic;
+    std::string joint_state_topic;
+    std::string attached_collision_object_topic;
+    std::string monitored_planning_scene_topic;
+    std::string publish_planning_scene_topic;
     double wait_for_initial_state_timeout;
   };
 


### PR DESCRIPTION
### Description

When using moveit_py, in the documentation we find the following:
[moveit_py documentation](https://moveit.picknik.ai/main/doc/examples/motion_planning_python_api/motion_planning_python_api_tutorial.html)

```yaml
planning_scene_monitor_options:
        name: "planning_scene_monitor"
        robot_description: "robot_description"
        joint_state_topic: "/joint_states"
        attached_collision_object_topic: "/moveit_cpp/planning_scene_monitor"
        publish_planning_scene_topic: "/moveit_cpp/publish_planning_scene"
        monitored_planning_scene_topic: "/moveit_cpp/monitored_planning_scene"
        wait_for_initial_state_timeout: 10.0
```

However, `joint_state_topic`, `attached_collision_object_topic`, `publish_planning_scene_topic`, `monitored_planning_scene_topic` can't be set this way because it always loads the defaults.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
