### PR TITLE
Replace all moveit.ros.org to moveit.ai

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,4 +1,4 @@
 # MoveIt Docker Containers
 
 
-For more information see the pages [Continuous Integration and Docker](http://moveit.ros.org/documentation/contributing/continuous_integration.html) and [Using Docker Containers with MoveIt](https://moveit.ros.org/install/docker/).
+For more information see the pages [Continuous Integration and Docker](http://moveit.ai/documentation/contributing/continuous_integration.html) and [Using Docker Containers with MoveIt](https://moveit.ai/install/docker/).

--- a/.docker/gui-docker
+++ b/.docker/gui-docker
@@ -4,7 +4,7 @@
 # All arguments to this script except "-c <container_name>" will be appended to a docker run command.
 # If a container name is specified, and this container already exists, the container is re-entered,
 # which easily allows entering the same persistent container from multiple terminals.
-# See documentation for detailed examples: https://moveit.ros.org/install/docker/
+# See documentation for detailed examples: https://moveit.ai/install/docker/
 
 # Example commands:
 # ./gui-docker --rm -it moveit/moveit:foxy-source /bin/bash     # Run a (randomly named) container that is removed on exit

--- a/.github/ISSUE_TEMPLATE/first_timers_only.md
+++ b/.github/ISSUE_TEMPLATE/first_timers_only.md
@@ -28,7 +28,7 @@ Nothing. This issue is meant to welcome you to Open Source :) We are happy to wa
 
 - [ ] 🙋 **Claim this issue**: Comment below. If someone else has claimed it, ask if they've opened a pull request already and if they're stuck -- maybe you can help them solve a problem or move it along!
 
-- [ ] 🗄️ **Create a local workspace** for making your changes and testing [following these instructions](https://moveit.ros.org/install/source/)
+- [ ] 🗄️ **Create a local workspace** for making your changes and testing [following these instructions](https://moveit.ai/install/source/)
 
 - [ ] 🍴 **Fork the repository** using the handy button at the top of the repository page and **clone** it into `~/ws_moveit/src/moveit`, [here is a guide that you can follow](https://guides.github.com/activities/forking/) (You will have to remove or empty the existing `moveit` folder before cloning your own fork)
 
@@ -58,7 +58,7 @@ $DIFF
 
 Don’t hesitate to ask questions or to get help if you feel like you are getting stuck. For example leave a comment below!
 Furthermore, you find helpful resources here:
-* [MoveIt FAQ](https://moveit.ros.org/documentation/faqs/)
+* [MoveIt FAQ](https://moveit.ai/documentation/faqs/)
 * [MoveIt Tutorials](https://moveit.picknik.ai/main/doc/tutorials/tutorials.html)
 * [MoveIt contribution guide](https://moveit.picknik.ai/main/doc/how_to_contribute/how_to_contribute.html)
 * [ROS Tutorials](https://wiki.ros.org/ROS/Tutorials)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
 Please explain the changes you made, including a reference to the related issue if applicable
 
 ### Checklist
-- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
-- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
+- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ai/documentation/contributing/code)
+- [ ] Extend the tutorials / documentation [reference](http://moveit.ai/documentation/contributing/)
 - [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
 - [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
 - [ ] Include a screenshot if changing a GUI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing to MoveIt
 
 Thanks for getting involved! Information on contributing can be found at
-[http://moveit.ros.org/documentation/contributing/](http://moveit.ros.org/documentation/contributing/)
+[http://moveit.ai/documentation/contributing/](http://moveit.ai/documentation/contributing/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="http://moveit.ros.org/assets/logo/moveit_logo-black.png" alt="MoveIt Logo" width="200"/>
+<img src="http://moveit.ai/assets/logo/moveit_logo-black.png" alt="MoveIt Logo" width="200"/>
 
-The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ros.org).
+The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ai).
 For the ROS 1 repository see [MoveIt 1](https://github.com/moveit/moveit).
 For the commercially supported version see [MoveIt Pro](http://picknik.ai/pro).
 
@@ -18,20 +18,20 @@ See our extensive [Tutorials and Documentation](https://moveit.picknik.ai/).
 
 ## Install
 
-- [Binary Install](https://moveit.ros.org/install-moveit2/binary/)
-- [Source Build](https://moveit.ros.org/install-moveit2/source/)
+- [Binary Install](https://moveit.ai/install-moveit2/binary/)
+- [Source Build](https://moveit.ai/install-moveit2/source/)
 
 ## More Info
 
-- [How to Get Involved](http://moveit.ros.org/about/get_involved/)
-- [Development Roadmap](https://moveit.ros.org/documentation/contributing/roadmap/)
-- [Future Release Dates](https://moveit.ros.org/#release-versions)
+- [How to Get Involved](http://moveit.ai/about/get_involved/)
+- [Development Roadmap](https://moveit.ai/documentation/contributing/roadmap/)
+- [Future Release Dates](https://moveit.ai/#release-versions)
 - [MoveIt 2 Migration Guidelines](doc/MIGRATION_GUIDE.md)
 - [MoveIt 2 Migration Progress](https://docs.google.com/spreadsheets/d/1aPb3hNP213iPHQIYgcnCYh9cGFUlZmi_06E_9iTSsOI/edit?usp=sharing)
 
 ## Supporters
 
-This open source project is maintained by supporters from around the world — see our [MoveIt Maintainers and Core Contributors](https://moveit.ros.org/about/).
+This open source project is maintained by supporters from around the world — see our [MoveIt Maintainers and Core Contributors](https://moveit.ai/about/).
 
 <a href="https://picknik.ai/">
   <img src="https://picknik.ai/assets/images/logo.jpg" width="168">

--- a/moveit/package.xml
+++ b/moveit/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
 

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -12,7 +12,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -13,7 +13,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
 

--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_planners/pilz_industrial_motion_planner/README.md
+++ b/moveit_planners/pilz_industrial_motion_planner/README.md
@@ -1,4 +1,4 @@
-Please consult tutorials and the official [documentation](https://moveit.ros.org/documentation/concepts/).
+Please consult tutorials and the official [documentation](https://moveit.ai/documentation/concepts/).
 
 For details about the blend algorithm please refer to
 ![doc/MotionBlendAlgorithmDescription.pdf](doc/MotionBlendAlgorithmDescription.pdf).

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
@@ -99,7 +99,7 @@ inline bool declareParameters(const std::string& joint_name, const rclcpp::Node:
  *     max_velocity: 4.0
  * \endcode
  *
- * This specification is similar to the one used by <a href="http://moveit.ros.org/wiki/MoveIt!">MoveIt!</a>,
+ * This specification is similar to the one used by <a href="http://moveit.ai/wiki/MoveIt!">MoveIt!</a>,
  * but additionally supports jerk and effort limits.
  *
  * \param[in] joint_name Name of joint whose limits are to be fetched.

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="i.martini@pilz.de">Immanuel Martini</maintainer>
   <license>Apache 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
   <url type="repository">https://github.com/moveit/moveit-resources</url>
 

--- a/moveit_planners/test_configs/prbt_moveit_config/package.xml
+++ b/moveit_planners/test_configs/prbt_moveit_config/package.xml
@@ -16,7 +16,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
   <url type="repository">https://github.com/moveit/moveit-resources</url>
 

--- a/moveit_planners/test_configs/prbt_pg70_support/package.xml
+++ b/moveit_planners/test_configs/prbt_pg70_support/package.xml
@@ -10,7 +10,7 @@
 
   <license>Apache 2.0</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
   <url type="repository">https://github.com/moveit/moveit-resources</url>
 

--- a/moveit_planners/test_configs/prbt_support/package.xml
+++ b/moveit_planners/test_configs/prbt_support/package.xml
@@ -11,7 +11,7 @@
 
   <license>Apache 2.0</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
   <url type="repository">https://github.com/moveit/moveit-resources</url>
 

--- a/moveit_plugins/moveit_plugins/package.xml
+++ b/moveit_plugins/moveit_plugins/package.xml
@@ -12,7 +12,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
 
   <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_py/README.md
+++ b/moveit_py/README.md
@@ -18,7 +18,7 @@ We are continuing to add tutorials for the MoveIt 2 Python library. Of particula
 ## Contribution Guidelines
 Community contributions are welcome.
 
-For detailed contribution guidelines please consult the official [MoveIt contribution guidelines](https://moveit.ros.org/documentation/contributing/).
+For detailed contribution guidelines please consult the official [MoveIt contribution guidelines](https://moveit.ai/documentation/contributing/).
 
 ## Citing the Library
 If you use this library in your work please use the following citation:

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/hybrid_planning/README.md
+++ b/moveit_ros/hybrid_planning/README.md
@@ -1,5 +1,5 @@
 # Hybrid Planning
-A Hybrid Planning architecture. You can find more information in the project's issues[#300](https://github.com/moveit/moveit2/issues/300), [#433](https://github.com/moveit/moveit2/issues/433) and on the [MoveIt 2 roadmap](https://moveit.ros.org/documentation/contributing/roadmap/). Furthermore, there is an extensive tutorial available [here](https://github.com/moveit/moveit2_tutorials/pull/97).
+A Hybrid Planning architecture. You can find more information in the project's issues[#300](https://github.com/moveit/moveit2/issues/300), [#433](https://github.com/moveit/moveit2/issues/433) and on the [MoveIt 2 roadmap](https://moveit.ai/documentation/contributing/roadmap/). Furthermore, there is an extensive tutorial available [here](https://github.com/moveit/moveit2_tutorials/pull/97).
 
 ## Getting started
 To start the demo run:

--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/tests/package.xml
+++ b/moveit_ros/tests/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_runtime/package.xml
+++ b/moveit_runtime/package.xml
@@ -9,7 +9,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="website">http://wiki.ros.org/moveit_runtime</url>
 
   <author email="gm130s@gmail.com">Isaac I. Y. Saito</author>

--- a/moveit_setup_assistant/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/moveit_setup_assistant/package.xml
@@ -12,7 +12,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org</url>
+  <url type="website">http://moveit.ai</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -10,7 +10,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://moveit.ros.org/</url>
+  <url type="website">http://moveit.ai/</url>
   <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
   <url type="repository">https://github.com/moveit/moveit2</url>
 


### PR DESCRIPTION
The ROS.org team is turning of moveit.ros.org, which redirects to moveit.ai currently. We need to find all instances of moveit.ros.org and make PRs to replace them.

@gbiggs is pushing to turn off moveit.ros.rog per this post from a year ago

https://discourse.openrobotics.org/t/move-of-nav2-and-moveit-repositories-at-github/37450
