### PR TITLE
fix: remove deprecated ament target dependencies

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -68,8 +68,34 @@ add_subdirectory(transforms)
 add_subdirectory(utils)
 add_subdirectory(version)
 
+add_library(moveit_core INTERFACE)
+target_link_libraries(
+  moveit_core
+  INTERFACE moveit_collision_detection
+            moveit_collision_detection_bullet
+            moveit_collision_detection_fcl
+            moveit_collision_distance_field
+            moveit_constraint_samplers
+            moveit_distance_field
+            moveit_dynamics_solver
+            moveit_exceptions
+            moveit_kinematic_constraints
+            moveit_kinematics_base
+            moveit_kinematics_metrics
+            moveit_macros
+            moveit_planning_interface
+            moveit_planning_scene
+            moveit_robot_model
+            moveit_robot_state
+            moveit_robot_trajectory
+            moveit_smoothing_base
+            moveit_trajectory_processing
+            moveit_transforms
+            moveit_utils)
+
 install(
-  TARGETS moveit_collision_detection
+  TARGETS moveit_core
+          moveit_collision_detection
           moveit_collision_detection_bullet
           moveit_collision_detection_fcl
           moveit_collision_distance_field

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -24,8 +24,6 @@ set_target_properties(
   moveit_ros_control_interface_plugin
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_plugin PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_trajectory_plugin SHARED
             src/joint_trajectory_controller_plugin.cpp)
@@ -34,8 +32,6 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_trajectory_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_trajectory_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_gripper_plugin SHARED
             src/gripper_command_controller_plugin.cpp)
@@ -44,8 +40,6 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_gripper_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_gripper_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_parallel_gripper_plugin SHARED
             src/parallel_gripper_command_controller_plugin.cpp)
@@ -54,8 +48,6 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_parallel_gripper_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_parallel_gripper_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_empty_plugin SHARED
             src/empty_controller_plugin.cpp)
@@ -64,8 +56,25 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_empty_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_empty_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+
+set(TARGET_LIBRARIES
+    moveit_ros_control_interface_plugin
+    moveit_ros_control_interface_trajectory_plugin
+    moveit_ros_control_interface_gripper_plugin
+    moveit_ros_control_interface_parallel_gripper_plugin
+    moveit_ros_control_interface_empty_plugin)
+
+foreach(target ${TARGET_LIBRARIES})
+  target_link_libraries(
+    ${target}
+    PUBLIC moveit_core::moveit_core
+           ${moveit_simple_controller_manager_TARGETS}
+           pluginlib::pluginlib
+           rclcpp_action::rclcpp_action
+           ${controller_manager_msgs_TARGETS}
+           ${trajectory_msgs_TARGETS}
+           ${Boost_LIBRARIES})
+endforeach()
 
 if(BUILD_TESTING)
   add_subdirectory(test)
@@ -74,13 +83,6 @@ endif()
 # ##############################################################################
 # Install ##
 # ##############################################################################
-
-set(TARGET_LIBRARIES
-    moveit_ros_control_interface_plugin
-    moveit_ros_control_interface_trajectory_plugin
-    moveit_ros_control_interface_gripper_plugin
-    moveit_ros_control_interface_parallel_gripper_plugin
-    moveit_ros_control_interface_empty_plugin)
 
 # Mark executables and/or libraries for installation
 install(

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -29,8 +29,14 @@ set_target_properties(
   moveit_simple_controller_manager
   PROPERTIES VERSION "${moveit_simple_controller_manager_VERSION}")
 
-ament_target_dependencies(moveit_simple_controller_manager
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(
+  moveit_simple_controller_manager
+  PUBLIC moveit_core::moveit_core
+         pluginlib::pluginlib
+         rclcpp::rclcpp
+         rclcpp_action::rclcpp_action
+         ${control_msgs_TARGETS}
+         ${Boost_LIBRARIES})
 
 install(
   TARGETS moveit_simple_controller_manager

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -30,6 +30,25 @@ endforeach()
 
 include_directories(include)
 
+add_library(moveit_servo_dependency_targets INTERFACE)
+target_link_libraries(
+  moveit_servo_dependency_targets
+  INTERFACE ${control_msgs_TARGETS}
+            ${geometry_msgs_TARGETS}
+            moveit_core::moveit_core
+            ${moveit_msgs_TARGETS}
+            ${moveit_ros_planning_TARGETS}
+            ${moveit_ros_planning_interface_TARGETS}
+            pluginlib::pluginlib
+            rclcpp::rclcpp
+            rclcpp_components::component
+            realtime_tools::realtime_tools
+            ${sensor_msgs_TARGETS}
+            ${std_msgs_TARGETS}
+            ${std_srvs_TARGETS}
+            tf2_eigen::tf2_eigen
+            ${trajectory_msgs_TARGETS})
+
 # ##############################################################################
 # C++ Libraries ##
 # ##############################################################################
@@ -45,14 +64,18 @@ add_library(
                               src/utils/common.cpp src/utils/command.cpp)
 set_target_properties(moveit_servo_lib_cpp PROPERTIES VERSION
                                                       "${moveit_servo_VERSION}")
-target_link_libraries(moveit_servo_lib_cpp moveit_servo_lib_parameters)
-ament_target_dependencies(moveit_servo_lib_cpp ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(
+  moveit_servo_lib_cpp
+  PUBLIC moveit_servo_dependency_targets
+         moveit_servo_lib_parameters)
 
 add_library(moveit_servo_lib_ros SHARED src/servo_node.cpp)
 set_target_properties(moveit_servo_lib_ros PROPERTIES VERSION
                                                       "${moveit_servo_VERSION}")
-target_link_libraries(moveit_servo_lib_ros moveit_servo_lib_cpp)
-ament_target_dependencies(moveit_servo_lib_ros ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(
+  moveit_servo_lib_ros
+  PUBLIC moveit_servo_dependency_targets
+         moveit_servo_lib_cpp)
 
 # ##############################################################################
 # Components ##
@@ -67,27 +90,26 @@ rclcpp_components_register_node(moveit_servo_lib_ros PLUGIN
 
 # Executable node for the joint jog demo
 add_executable(demo_joint_jog demos/cpp_interface/demo_joint_jog.cpp)
-target_link_libraries(demo_joint_jog moveit_servo_lib_cpp)
-ament_target_dependencies(demo_joint_jog ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_joint_jog PRIVATE moveit_servo_lib_cpp)
 
 # Executable node for the twist demo
 add_executable(demo_twist demos/cpp_interface/demo_twist.cpp)
-target_link_libraries(demo_twist moveit_servo_lib_cpp)
-ament_target_dependencies(demo_twist ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_twist PRIVATE moveit_servo_lib_cpp)
 
 # Executable node for the pose demo
 add_executable(demo_pose demos/cpp_interface/demo_pose.cpp)
-target_link_libraries(demo_pose moveit_servo_lib_cpp)
-ament_target_dependencies(demo_pose ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_pose PRIVATE moveit_servo_lib_cpp)
 
 # Keyboard control example for servo
 add_executable(servo_keyboard_input demos/servo_keyboard_input.cpp)
 target_include_directories(servo_keyboard_input PUBLIC include)
-ament_target_dependencies(servo_keyboard_input ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(servo_keyboard_input PRIVATE moveit_servo_dependency_targets)
 
 # ##############################################################################
 # Install ##
 # ##############################################################################
+
+install(TARGETS moveit_servo_dependency_targets EXPORT moveit_servoTargets)
 
 # Install Libraries
 install(
@@ -120,26 +142,23 @@ if(BUILD_TESTING)
   find_package(ros_testing REQUIRED)
 
   ament_add_gtest_executable(moveit_servo_utils_test tests/test_utils.cpp)
-  target_link_libraries(moveit_servo_utils_test moveit_servo_lib_cpp)
-  ament_target_dependencies(moveit_servo_utils_test
-                            ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(moveit_servo_utils_test PRIVATE moveit_servo_lib_cpp)
   add_ros_test(tests/launch/servo_utils.test.py TIMEOUT 30 ARGS
                "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
   ament_add_gtest_executable(
     moveit_servo_cpp_integration_test tests/test_integration.cpp
     tests/servo_cpp_fixture.hpp)
-  target_link_libraries(moveit_servo_cpp_integration_test moveit_servo_lib_cpp)
-  ament_target_dependencies(moveit_servo_cpp_integration_test
-                            ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(moveit_servo_cpp_integration_test
+                        PRIVATE moveit_servo_lib_cpp)
   add_ros_test(tests/launch/servo_cpp_integration.test.py TIMEOUT 30 ARGS
                "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
   ament_add_gtest_executable(
     moveit_servo_ros_integration_test tests/test_ros_integration.cpp
     tests/servo_ros_fixture.hpp)
-  ament_target_dependencies(moveit_servo_ros_integration_test
-                            ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(moveit_servo_ros_integration_test
+                        PRIVATE moveit_servo_lib_ros)
   add_ros_test(tests/launch/servo_ros_integration.test.py TIMEOUT 120 ARGS
                "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/moveit_ros/planning/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning/moveit_cpp/CMakeLists.txt
@@ -1,10 +1,14 @@
 add_library(moveit_cpp SHARED src/moveit_cpp.cpp src/planning_component.cpp)
 set_target_properties(moveit_cpp PROPERTIES VERSION
                                             "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cpp rclcpp moveit_core)
 target_link_libraries(
-  moveit_cpp moveit_planning_scene_monitor moveit_planning_pipeline
-  moveit_planning_pipeline_interfaces moveit_trajectory_execution_manager)
+  moveit_cpp
+  PUBLIC rclcpp::rclcpp
+         moveit_core::moveit_core
+         moveit_planning_scene_monitor
+         moveit_planning_pipeline
+         moveit_planning_pipeline_interfaces
+         moveit_trajectory_execution_manager)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning)
 


### PR DESCRIPTION
### Description

Please explain the changes you made, including a reference to the related issue if applicable
https://github.com/ament/ament_cmake/pull/614
`ament_target_dependencies` is removed.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
