### PR TITLE
fix(planning_scene_monitor): use SensorDataQoS for joint_states subscription

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor_middleware_handle.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor_middleware_handle.cpp
@@ -70,7 +70,7 @@ void CurrentStateMonitorMiddlewareHandle::createJointStateSubscription(const std
                                                                        JointStateUpdateCallback callback)
 {
   joint_state_subscription_ =
-      node_->create_subscription<sensor_msgs::msg::JointState>(topic, rclcpp::SystemDefaultsQoS(), callback);
+      node_->create_subscription<sensor_msgs::msg::JointState>(topic, rclcpp::SensorDataQoS(), callback);
 }
 
 void CurrentStateMonitorMiddlewareHandle::resetJointStateSubscription()


### PR DESCRIPTION
## Summary
- Switch `joint_states` subscription in `CurrentStateMonitorMiddlewareHandle` from `SystemDefaultsQoS` (reliable) to `SensorDataQoS` (best-effort)
- A reliable subscriber cannot receive from a best-effort publisher, causing silent message drops and planning_scene_monitor timeouts when robot drivers publish `joint_states` with best-effort QoS
- A best-effort subscriber can receive from both reliable and best-effort publishers, making this backward-compatible

Fixes #1190

## Test plan
- [ ] Verify joint_states are received from a reliable publisher (e.g. `ros2_controllers` `joint_state_broadcaster`)
- [ ] Verify joint_states are received from a best-effort publisher (e.g. drivers using `SensorDataQoS`)
- [ ] Confirm no regression in planning_scene_monitor startup / state monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)