### PR TITLE
Fix TrajectoryExecutionManager rejecting unrecognized parameters

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -260,10 +260,6 @@ void TrajectoryExecutionManager::initialize()
       {
         setWaitForTrajectoryCompletion(parameter.as_bool());
       }
-      else
-      {
-        result.successful = false;
-      }
     }
     return result;
   };


### PR DESCRIPTION


### Description

The `on_set_parameters_callback` in `TrajectoryExecutionManager::initialize()` has an else block that rejects all parameters that it doesn't recognize. This crashes MoveItPy with `use_sim_time = True`, resulting in the error message:
```
terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterValueException'
  what():  parameter 'qos_overrides./clock.subscription.durability' could not be set: 
Aborted (core dumped)
```

The else block itself seems to be an anti-pattern mentioned in the comments of rclcpp's [node.hpp](https://github.com/ros2/rclcpp/blob/87be5fbfd40deb0329c8e296fc41b6631358734f/rclcpp/include/rclcpp/node.hpp#L1104-L1105).

Tested on ROS2 Jazzy, Ubuntu 24.04.

Resolves #2940
Related #2220, ros2/rclcpp#1587

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
