### PR TITLE
Bugfix/move action capability consistent thread

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -82,13 +82,17 @@ void MoveGroupMoveAction::initialize()
 
 void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal)
 {
-  std::scoped_lock lock(queued_goal_mutex_);
-  queued_goal_ = goal;
+  {
+    std::scoped_lock lock(queued_goal_mutex_);
+    queued_goal_ = goal;
+  }
+  queued_lock_cvar_.notify_one();
 }
 
-std::shared_ptr<MGActionGoal> MoveGroupMoveAction::fetchQueuedGoal()
+std::shared_ptr<MGActionGoal> MoveGroupMoveAction::awaitQueuedGoal()
 {
   std::scoped_lock lock(queued_goal_mutex_);
+  queued_lock_cvar_.wait(lock, [this]() { return queued_goal_ != nullptr;})
   return std::move(queued_goal_);
 }
 
@@ -96,18 +100,13 @@ void MoveGroupMoveAction::executeQueuedGoals()
 {
   while (true)
   {
-    goal_ = fetchQueuedGoal();
+    goal_ = awaitQueuedGoal();
     executeMoveCallback();
   }
 }
 
 void MoveGroupMoveAction::executeMoveCallback()
 {
-  if (not goal_)
-  {
-    return;
-  }
-
   RCLCPP_INFO(getLogger(), "executing..");
   setMoveState(PLANNING, goal_);
   // before we start planning, ensure that we have the latest robot state received...

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -101,6 +101,7 @@ void MoveGroupMoveAction::executeQueuedGoals()
   {
     goal_ = awaitQueuedGoal();
     executeMoveCallback();
+    goal_.reset();
   }
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -82,17 +82,16 @@ void MoveGroupMoveAction::initialize()
 
 void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal)
 {
-  {
-    std::scoped_lock lock(queued_goal_mutex_);
+    std::unique_lock lock(queued_goal_mutex_);
     queued_goal_ = goal;
-  }
-  queued_goal_cvar_.notify_one();
+    lock.unlock();
+    queued_goal_cvar_.notify_one();
 }
 
 std::shared_ptr<MGActionGoal> MoveGroupMoveAction::awaitQueuedGoal()
 {
-  std::scoped_lock lock(queued_goal_mutex_);
-  queued_goal_cvar_.wait(lock, [this]() { return queued_goal_ != nullptr;});
+  std::unique_lock lock(queued_goal_mutex_);
+  queued_goal_cvar_.wait(lock, [this]() { return (queued_goal_ != nullptr);});
   return std::move(queued_goal_);
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -86,13 +86,13 @@ void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goa
     std::scoped_lock lock(queued_goal_mutex_);
     queued_goal_ = goal;
   }
-  queued_lock_cvar_.notify_one();
+  queued_goal_cvar_.notify_one();
 }
 
 std::shared_ptr<MGActionGoal> MoveGroupMoveAction::awaitQueuedGoal()
 {
   std::scoped_lock lock(queued_goal_mutex_);
-  queued_lock_cvar_.wait(lock, [this]() { return queued_goal_ != nullptr;})
+  queued_goal_cvar_.wait(lock, [this]() { return queued_goal_ != nullptr;});
   return std::move(queued_goal_);
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -86,17 +86,17 @@ void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goa
   queued_goal_ = goal;
 }
 
-std::shared_ptr<MGActionGoal> MoveGroupMoveAction::getQueuedGoal()
+std::shared_ptr<MGActionGoal> MoveGroupMoveAction::fetchQueuedGoal()
 {
   std::scoped_lock lock(queued_goal_mutex_);
-  return queued_goal_;
+  return std::move(queued_goal_);
 }
 
 void MoveGroupMoveAction::executeQueuedGoals()
 {
   while (true)
   {
-    goal_ = getQueuedGoal();
+    goal_ = fetchQueuedGoal();
     executeMoveCallback();
   }
 }

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -57,8 +57,9 @@ rclcpp::Logger getLogger()
 }  // namespace
 
 MoveGroupMoveAction::MoveGroupMoveAction()
-  : MoveGroupCapability("move_action"), move_state_(IDLE), preempt_requested_{ false }
+  : MoveGroupCapability("move_action"), move_state_(IDLE), preempt_requested_{ false }, queued_goal_{ nullptr }
 {
+  std::thread{ [this]() { executeQueuedGoals(); } }.detach();
 }
 
 void MoveGroupMoveAction::initialize()
@@ -76,15 +77,37 @@ void MoveGroupMoveAction::initialize()
         preemptMoveCallback();
         return rclcpp_action::CancelResponse::ACCEPT;
       },
-      [this](const std::shared_ptr<MGActionGoal>& goal) {
-        std::thread{ [this](const std::shared_ptr<move_group::MGActionGoal>& goal) { executeMoveCallback(goal); }, goal }
-            .detach();
-      });
+      [this](const std::shared_ptr<MGActionGoal>& goal) { setQueuedGoal(goal); });
 }
 
-void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal)
+void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal)
 {
-  goal_ = goal;
+  std::scoped_lock lock(queued_goal_mutex_);
+  queued_goal_ = goal;
+}
+
+std::shared_ptr<MGActionGoal> MoveGroupMoveAction::getQueuedGoal()
+{
+  std::scoped_lock lock(queued_goal_mutex_);
+  return queued_goal_;
+}
+
+void MoveGroupMoveAction::executeQueuedGoals()
+{
+  while (true)
+  {
+    goal_ = getQueuedGoal();
+    executeMoveCallback();
+  }
+}
+
+void MoveGroupMoveAction::executeMoveCallback()
+{
+  if (not goal_)
+  {
+    return;
+  }
+
   RCLCPP_INFO(getLogger(), "executing..");
   setMoveState(PLANNING, goal_);
   // before we start planning, ensure that we have the latest robot state received...
@@ -93,39 +116,38 @@ void MoveGroupMoveAction::executeMoveCallback(const std::shared_ptr<MGActionGoal
   context_->planning_scene_monitor_->updateFrameTransforms();
 
   auto action_res = std::make_shared<MGAction::Result>();
-  if (goal->get_goal()->planning_options.plan_only || !context_->allow_trajectory_execution_)
+  if (goal_->get_goal()->planning_options.plan_only || !context_->allow_trajectory_execution_)
   {
-    if (!goal->get_goal()->planning_options.plan_only)
+    if (!goal_->get_goal()->planning_options.plan_only)
     {
       RCLCPP_WARN(getLogger(), "This instance of MoveGroup is not allowed to execute trajectories "
                                "but the goal request has plan_only set to false. "
                                "Only a motion plan will be computed anyway.");
     }
-    executeMoveCallbackPlanOnly(goal, action_res);
+    executeMoveCallbackPlanOnly(goal_, action_res);
   }
   else
-    executeMoveCallbackPlanAndExecute(goal, action_res);
+    executeMoveCallbackPlanAndExecute(goal_, action_res);
 
   bool planned_trajectory_empty = trajectory_processing::isTrajectoryEmpty(action_res->planned_trajectory);
   // @todo: Response messages
   RCLCPP_INFO_STREAM(getLogger(), getActionResultString(action_res->error_code, planned_trajectory_empty,
-                                                        goal->get_goal()->planning_options.plan_only));
+                                                        goal_->get_goal()->planning_options.plan_only));
   if (action_res->error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
   {
-    goal->succeed(action_res);
+    goal_->succeed(action_res);
   }
   else if (action_res->error_code.val == moveit_msgs::msg::MoveItErrorCodes::PREEMPTED)
   {
-    goal->canceled(action_res);
+    goal_->canceled(action_res);
   }
   else
   {
-    goal->abort(action_res);
+    goal_->abort(action_res);
   }
 
   setMoveState(IDLE, goal_);
   preempt_requested_ = false;
-  goal_.reset();
 }
 
 void MoveGroupMoveAction::executeMoveCallbackPlanAndExecute(const std::shared_ptr<MGActionGoal>& goal,

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -82,16 +82,16 @@ void MoveGroupMoveAction::initialize()
 
 void MoveGroupMoveAction::setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal)
 {
-    std::unique_lock lock(queued_goal_mutex_);
-    queued_goal_ = goal;
-    lock.unlock();
-    queued_goal_cvar_.notify_one();
+  std::unique_lock lock(queued_goal_mutex_);
+  queued_goal_ = goal;
+  lock.unlock();
+  queued_goal_cvar_.notify_one();
 }
 
 std::shared_ptr<MGActionGoal> MoveGroupMoveAction::awaitQueuedGoal()
 {
   std::unique_lock lock(queued_goal_mutex_);
-  queued_goal_cvar_.wait(lock, [this]() { return (queued_goal_ != nullptr);});
+  queued_goal_cvar_.wait(lock, [this]() { return (queued_goal_ != nullptr); });
   return std::move(queued_goal_);
 }
 

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
@@ -40,6 +40,7 @@
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <moveit_msgs/action/move_group.hpp>
 #include <memory>
+#include <condition_variable>
 
 namespace move_group
 {
@@ -75,10 +76,11 @@ private:
   std::shared_ptr<MGActionGoal> goal_;
 
   std::mutex queued_goal_mutex_;
+  std::condition_variable queued_goal_cvar_;
   std::shared_ptr<MGActionGoal> queued_goal_;
 
   void setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal);
-  std::shared_ptr<MGActionGoal> fetchQueuedGoal();
+  std::shared_ptr<MGActionGoal> awaitQueuedGoal();
   void executeQueuedGoals();
 };
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
@@ -54,7 +54,7 @@ public:
   void initialize() override;
 
 private:
-  void executeMoveCallback(const std::shared_ptr<MGActionGoal>& goal);
+  void executeMoveCallback();
   void executeMoveCallbackPlanAndExecute(const std::shared_ptr<MGActionGoal>& goal,
                                          std::shared_ptr<MGAction::Result>& action_res);
   void executeMoveCallbackPlanOnly(const std::shared_ptr<MGActionGoal>& goal,
@@ -73,5 +73,12 @@ private:
   MoveGroupState move_state_;
   bool preempt_requested_;
   std::shared_ptr<MGActionGoal> goal_;
+
+  std::mutex queued_goal_mutex_;
+  std::shared_ptr<MGActionGoal> queued_goal_;
+
+  void setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal);
+  std::shared_ptr<MGActionGoal> getQueuedGoal();
+  void executeQueuedGoals();
 };
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.hpp
@@ -78,7 +78,7 @@ private:
   std::shared_ptr<MGActionGoal> queued_goal_;
 
   void setQueuedGoal(const std::shared_ptr<MGActionGoal>& goal);
-  std::shared_ptr<MGActionGoal> getQueuedGoal();
+  std::shared_ptr<MGActionGoal> fetchQueuedGoal();
   void executeQueuedGoals();
 };
 }  // namespace move_group


### PR DESCRIPTION
### Description

Uses a single persistent thread in the move action capability.
Should fix https://github.com/moveit/moveit2/issues/3691 for move action capabilities.

Update: now includes @riv-jkambites fix to make the persistent thread only use cpu when work is available.

When this is merged, could it be backported to Jazzy and Kilted?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
