### PR TITLE
Support all groups in srv_kinematics_plugin

### DIFF
--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.hpp
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.hpp
@@ -127,6 +127,8 @@ public:
    */
   const std::vector<std::string>& getVariableNames() const;
 
+  bool supportsGroup(const moveit::core::JointModelGroup* jmg, std::string* error_text_out = nullptr) const override;
+
 protected:
   bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices) override;
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -422,4 +422,17 @@ const std::vector<std::string>& SrvKinematicsPlugin::getVariableNames() const
   return joint_model_group_->getVariableNames();
 }
 
+bool SrvKinematicsPlugin::supportsGroup(const moveit::core::JointModelGroup* jmg, std::string* error_text_out) const
+{
+  if (!jmg)
+  {
+    if (error_text_out)
+    {
+      *error_text_out = "No joint model group provided";
+    }
+    return false;
+  }
+  return true;
+}
+
 }  // namespace srv_kinematics_plugin


### PR DESCRIPTION
### Description

Srv_kinetmatics_plugin [claims to support any group](https://github.com/moveit/moveit2/blob/848c062a0454b104b72cb038d641a9eb0531f317/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.hpp#L63-L64), including non-chains.

However, it doesn't implement [supportsGroup](https://github.com/moveit/moveit2/blob/main/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.hpp#L510). This will default to [**not** supporting non-chains](https://github.com/moveit/moveit2/blob/main/moveit_core/kinematics_base/src/kinematics_base.cpp#L144-L152), which is contrary to the comment above.

This MR implements supportsGroup for srv_kinetmatics_plugin such that it supports pretty much anything.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
