### PR TITLE
Use a separate node for the srv IK client

### DIFF
--- a/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.hpp
+++ b/moveit_kinematics/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.hpp
@@ -42,6 +42,7 @@
 #pragma once
 
 // ROS2
+#include <rclcpp/executor.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // System
@@ -150,6 +151,9 @@ private:
   int num_possible_redundant_joints_;
 
   rclcpp::Client<moveit_msgs::srv::GetPositionIK>::SharedPtr ik_service_client_;
+  rclcpp::Node::SharedPtr ik_node_;
+  rclcpp::Executor::SharedPtr ik_executor_;
+  std::thread ik_thread_;
 
   rclcpp::Node::SharedPtr node_;
 

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -124,9 +124,14 @@ bool SrvKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr& node, const 
   robot_state_ = std::make_shared<moveit::core::RobotState>(robot_model_);
   robot_state_->setToDefaultValues();
 
+  ik_node_ = std::make_shared<rclcpp::Node>("srv_ik_client", node_->get_namespace());
+
   // Create the ROS2 service client
   RCLCPP_DEBUG(getLogger(), "IK Service client topic : %s", params_.kinematics_solver_service_name.c_str());
-  ik_service_client_ = node_->create_client<moveit_msgs::srv::GetPositionIK>(params_.kinematics_solver_service_name);
+  ik_service_client_ = ik_node_->create_client<moveit_msgs::srv::GetPositionIK>(params_.kinematics_solver_service_name);
+  ik_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  ik_executor_->add_node(ik_node_);
+  ik_thread_ = std::thread([this]() { ik_executor_->spin(); });
 
   if (!ik_service_client_->wait_for_service(std::chrono::seconds(1)))
   {  // wait 0.1 seconds, blocking
@@ -312,8 +317,8 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg:
 
   RCLCPP_DEBUG(getLogger(), "Calling service: %s", ik_service_client_->get_service_name());
   auto result_future = ik_service_client_->async_send_request(ik_srv);
-  const auto& response = result_future.get();
-  if (rclcpp::spin_until_future_complete(node_, result_future) == rclcpp::FutureReturnCode::SUCCESS)
+  const auto response = result_future.get();
+  if (response)
   {
     // Check error code
     error_code.val = response->error_code.val;
@@ -352,7 +357,6 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg:
     error_code.val = error_code.FAILURE;
     return false;
   }
-
   // Get just the joints we are concerned about in our planning group
   robot_state_->copyJointGroupPositions(joint_model_group_, solution);
 
@@ -382,7 +386,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg:
     }
   }
 
-  RCLCPP_INFO(getLogger(), "IK Solver Succeeded!");
+  RCLCPP_DEBUG(getLogger(), "IK Solver Succeeded!");
   return true;
 }
 


### PR DESCRIPTION
### Description

The srv_kinematics_plugin doesn't seem to play that well with RViz.
It uses the same node for the ik client that RViz does, so spinning until future complete generates this kind of error:
```
Exception caught while handling end-effector update: Node '/rviz' has already been added to an executor.​
```

We probably don't want to spin until future is complete. We also don't want to block RViz either. So let's just make a new node and use that.

Also calm down a very spammy RCLCPP_INFO.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
