### PR TITLE
Fix/service availability race

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -96,7 +96,8 @@ class MoveGroupInterface::MoveGroupInterfaceImpl
 
 public:
   MoveGroupInterfaceImpl(const rclcpp::Node::SharedPtr& node, const Options& opt,
-                         const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers)
+                         const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const rclcpp::Duration& wait_for_servers,
+                         const rclcpp::Duration wait_for_services = rclcpp::Duration(10,0))
     : opt_(opt), node_(node), tf_buffer_(tf_buffer)
   {
     // We have no control on how the passed node is getting executed. To make sure MGI is functional, we're creating
@@ -167,8 +168,8 @@ public:
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
     
     // Function to check if the service server is available
-    auto wait_for_service = [this](auto& client, const std::string& service_name) {
-        if (!client->wait_for_service(std::chrono::seconds(10)))
+    auto wait_for_service = [this](auto& client, const std::string& service_name, const rclcpp::Duration& duration) {
+        if (!client->wait_for_service(duration.to_chrono<std::chrono::duration<double>>()))
         {
             throw std::runtime_error("Service server not available for service: " + service_name + 
                                     ". Is move_group running?");
@@ -191,10 +192,10 @@ public:
         rmw_qos_profile_services_default, callback_group_);
     
     // Check if service servers are available for all the clients
-    wait_for_service(query_service_, move_group::QUERY_PLANNERS_SERVICE_NAME);
-    wait_for_service(get_params_service_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
-    wait_for_service(set_params_service_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
-    wait_for_service(cartesian_path_service_, move_group::CARTESIAN_PATH_SERVICE_NAME);
+    wait_for_service(query_service_, move_group::QUERY_PLANNERS_SERVICE_NAME, wait_for_services);
+    wait_for_service(get_params_service_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME, wait_for_services);
+    wait_for_service(set_params_service_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME, wait_for_services);
+    wait_for_service(cartesian_path_service_, move_group::CARTESIAN_PATH_SERVICE_NAME, wait_for_services);
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -165,6 +165,16 @@ public:
     execute_action_client_ = rclcpp_action::create_client<moveit_msgs::action::ExecuteTrajectory>(
         node_, rclcpp::names::append(opt_.move_group_namespace_, move_group::EXECUTE_ACTION_NAME), callback_group_);
     execute_action_client_->wait_for_action_server(wait_for_servers.to_chrono<std::chrono::duration<double>>());
+    
+    // Function to check if the service server is available
+    auto wait_for_service = [this](auto& client, const std::string& service_name) {
+        if (!client->wait_for_service(std::chrono::seconds(10)))
+        {
+            throw std::runtime_error("Service server not available for service: " + service_name + 
+                                    ". Is move_group running?");
+        }
+        RCLCPP_INFO(node_->get_logger(), "Service '%s' found.", service_name.c_str());
+    };
 
     query_service_ = node_->create_client<moveit_msgs::srv::QueryPlannerInterfaces>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::QUERY_PLANNERS_SERVICE_NAME),
@@ -179,6 +189,12 @@ public:
     cartesian_path_service_ = node_->create_client<moveit_msgs::srv::GetCartesianPath>(
         rclcpp::names::append(opt_.move_group_namespace_, move_group::CARTESIAN_PATH_SERVICE_NAME),
         rmw_qos_profile_services_default, callback_group_);
+    
+    // Check if service servers are available for all the clients
+    wait_for_service(query_service_, move_group::QUERY_PLANNERS_SERVICE_NAME);
+    wait_for_service(get_params_service_, move_group::GET_PLANNER_PARAMS_SERVICE_NAME);
+    wait_for_service(set_params_service_, move_group::SET_PLANNER_PARAMS_SERVICE_NAME);
+    wait_for_service(cartesian_path_service_, move_group::CARTESIAN_PATH_SERVICE_NAME);
 
     // plan_grasps_service_ = pnode_->create_client<moveit_msgs::srv::GraspPlanning>(GRASP_PLANNING_SERVICE_NAME);
 


### PR DESCRIPTION
## Summary

Fix a race condition in `MoveGroupInterfaceImpl` initialization where service calls could be made before the corresponding service servers are available.

## Problem

During initialization, `MoveGroupInterfaceImpl` queries services such as `query_planner_interface`. In distributed setups, service discovery can be delayed due to asynchronous DDS initialization.

This can lead to a race condition where the service client attempts to call the service before it is available, resulting in incomplete initialization (e.g. missing markers in RViz) or blocking behavior.

This issue is more likely to appear in multi-machine setups and when additional discovery latency is introduced (e.g. DDS security).

For full reproduction details, see the related issue.

## Solution

Add a guard to ensure that required services are available before issuing service requests during initialization.

This is implemented by waiting for the service using `wait_for_service()` before making the call.

## Testing

- Tested in a multi-machine setup
- Confirmed that initialization is now consistent and no longer exhibits intermittent failures

## Related Issue

#3698