### PR TITLE
Migrate from deprecated QVariant::Type::Int to QMetaType::Int

### DIFF
--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
@@ -276,7 +276,7 @@ bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& s
 // define a fallback comparison operator for QVariants
 bool compareVariants(const QVariant& left, const QVariant& right)
 {
-  if (left.userType() == QVariant::Type::Int)
+  if (left.userType() == QMetaType::Int)
   {
     return left.toInt() < right.toInt();
   }


### PR DESCRIPTION
### Description

Addresses a QT type deprecation with new type available in Qt5 and Qt6.

```bash
  /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model 
.cpp: In function ‘bool moveit_setup::srdf_setup::compareVariants(const QVariant&, const QVariant&)’:                                       
  /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model 
.cpp:279:42: error: ‘Type’ is deprecated: Use QMetaType::Type instead. [-Werror=deprecated-declarations]                                    
    279 |   if (left.userType() == QVariant::Type::Int)                                                                                     
        |                                          ^~~                                                                                      
  In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qabstractitemmodel.h:11,                                                   
                   from /usr/include/x86_64-linux-gnu/qt6/QtCore/qabstractproxymodel.h:7,                                                   
                   from /usr/include/x86_64-linux-gnu/qt6/QtCore/QAbstractProxyModel:1,                                                     
                   from /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_setup_assistant/moveit_setup_srdf_plugins/incl 
ude/moveit_setup_srdf_plugins/collision_linear_model.hpp:39,                                                                                
                   from /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_setup_assistant/moveit_setup_srdf_plugins/src/ 
collision_linear_model.cpp:37:                                                                                                              
  /usr/include/x86_64-linux-gnu/qt6/QtCore/qvariant.h:61:70: note: declared here                                                            
     61 |     enum QT_DEPRECATED_VERSION_X_6_0("Use QMetaType::Type instead.") Type                                                         
        |                                                                      ^~~~                                                         
  At global scope:                                                                                                                          
  cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics       
  cc1plus: all warnings being treated as errors                                                                                             
  gmake[2]: *** [CMakeFiles/moveit_setup_srdf_plugins.dir/build.make:90:                                                                    
CMakeFiles/moveit_setup_srdf_plugins.dir/src/collision_linear_model.cpp.o] Error 1                                                          
  gmake[1]: *** [CMakeFiles/Makefile2:166: CMakeFiles/moveit_setup_srdf_plugins.dir/all] Error 2                                            
  gmake: *** [Makefile:146: all] Error 2                                                                                                    
  ---                                                                                                                                       
  Failed   <<< moveit_setup_srdf_plugins [41.2s, exited with code 2]  
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
